### PR TITLE
[DRAFT] DBFS remote tracking

### DIFF
--- a/storage/dbfs.go
+++ b/storage/dbfs.go
@@ -16,9 +16,10 @@ type FileList struct {
 
 // FileInfo contains information when listing files or fetching files from DBFS api
 type FileInfo struct {
-	Path     string `json:"path,omitempty"`
-	IsDir    bool   `json:"is_dir,omitempty"`
-	FileSize int64  `json:"file_size,omitempty"`
+	Path             string `json:"path,omitempty"`
+	IsDir            bool   `json:"is_dir,omitempty"`
+	FileSize         int64  `json:"file_size,omitempty"`
+	ModificationTime int64  `json:"modification_time,omitempty"`
 }
 
 // createHandle contains the payload to create a handle which is a connection for uploading blocks of file data


### PR DESCRIPTION
This PR is aiming at re-creating DBFS file from local resource if modification is detected on remote storage. Current state 
![image](https://user-images.githubusercontent.com/259697/126613047-3268e880-d089-4a19-bcb9-a5c479877aca.png)
