### PR TITLE
Deploy E2 with 1 NAT Gateway only by default

### DIFF
--- a/docs/guides/aws-workspace.md
+++ b/docs/guides/aws-workspace.md
@@ -127,7 +127,7 @@ module "vpc" {
 
   enable_dns_hostnames = true
   enable_nat_gateway   = true
-  single_nat_gateway = true
+  single_nat_gateway   = true
   create_igw           = true
 
   public_subnets  = [cidrsubnet(var.cidr_block, 3, 0)]


### PR DESCRIPTION
Adding 
1. single_nat_gateway = true
2. one extra public subnet to host the single nat gateway inside the VPC module 

for E2 workspace creation