### PR TITLE
add support for pipeline tasks in jobs

### DIFF
--- a/compute/model.go
+++ b/compute/model.go
@@ -517,6 +517,11 @@ type SparkSubmitTask struct {
 	Parameters []string `json:"parameters,omitempty"`
 }
 
+// PipelineTask contains the information for pipeline jobs
+type PipelineTask struct {
+	PipelineID string `json:"pipeline_id"`
+}
+
 // EmailNotifications contains the information for email notifications after job completion
 type EmailNotifications struct {
 	OnStart               []string `json:"on_start,omitempty"`
@@ -541,7 +546,7 @@ type JobTaskSettings struct {
 	Description string           `json:"description,omitempty"`
 	DependsOn   []TaskDependency `json:"depends_on,omitempty"`
 
-	// TODO: add PipelineTask, PythonWheelTask
+	// TODO: add PythonWheelTask
 	ExistingClusterID      string              `json:"existing_cluster_id,omitempty" tf:"group:cluster_type"`
 	NewCluster             *Cluster            `json:"new_cluster,omitempty" tf:"group:cluster_type"`
 	Libraries              []Library           `json:"libraries,omitempty" tf:"slice_set,alias:library"`
@@ -549,6 +554,7 @@ type JobTaskSettings struct {
 	SparkJarTask           *SparkJarTask       `json:"spark_jar_task,omitempty" tf:"group:task_type"`
 	SparkPythonTask        *SparkPythonTask    `json:"spark_python_task,omitempty" tf:"group:task_type"`
 	SparkSubmitTask        *SparkSubmitTask    `json:"spark_submit_task,omitempty" tf:"group:task_type"`
+	PipelineTask           *PipelineTask       `json:"pipeline_task,omitempty" tf:"group:task_type"`
 	EmailNotifications     *EmailNotifications `json:"email_notifications,omitempty" tf:"suppress_diff"`
 	TimeoutSeconds         int32               `json:"timeout_seconds,omitempty"`
 	MaxRetries             int32               `json:"max_retries,omitempty"`
@@ -567,6 +573,7 @@ type JobSettings struct {
 	SparkJarTask           *SparkJarTask    `json:"spark_jar_task,omitempty" tf:"group:task_type"`
 	SparkPythonTask        *SparkPythonTask `json:"spark_python_task,omitempty" tf:"group:task_type"`
 	SparkSubmitTask        *SparkSubmitTask `json:"spark_submit_task,omitempty" tf:"group:task_type"`
+	PipelineTask           *PipelineTask    `json:"pipeline_task,omitempty" tf:"group:task_type"`
 	Libraries              []Library        `json:"libraries,omitempty" tf:"slice_set,alias:library"`
 	TimeoutSeconds         int32            `json:"timeout_seconds,omitempty"`
 	MaxRetries             int32            `json:"max_retries,omitempty"`

--- a/compute/resource_pipeline.go
+++ b/compute/resource_pipeline.go
@@ -209,6 +209,10 @@ func adjustPipelineResourceSchema(m map[string]*schema.Schema) map[string]*schem
 	delete(awsAttributesSchema, "ebs_volume_size")
 
 	m["library"].MinItems = 1
+	m["url"] = &schema.Schema{
+		Type:     schema.TypeString,
+		Computed: true,
+	}
 
 	return m
 }
@@ -230,6 +234,7 @@ func ResourcePipeline() *schema.Resource {
 				return err
 			}
 			d.SetId(id)
+			d.Set("url", c.FormatURL("#joblist/pipelines/", d.Id()))
 			return nil
 		},
 		Read: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {


### PR DESCRIPTION
Closes #864 

I see an existing PR for this in #866. I apologize if I'm stomping on that work but I would very much like to use this functionality as well.

I have also added support to output the url of the pipeline.

I've tested this locally against our databricks workspace with the following hcl:

`main.tf`
```hcl
terraform {
    required_providers {
        databricks = {
            source = "databrickslabs/databricks"
            version = "0.3.10"
        }
    }
}

provider "databricks" {
    host = "redacted"
    token = "redacted"
}

resource "databricks_pipeline" "test" {
    name = "terraform_test"
    
    cluster {
        label = "default"
        autoscale {
            min_workers = 1
            max_workers = 3
        }
    }
    
    library {
        notebook {
            path = "/testing/dlt"
        }
    }
    
    filters {
        include = ["com.databricks.include"]
        exclude = ["com.databricks.exclude"]
    }
    
    target = "test"
    continuous = false
}

resource "databricks_job" "test" {
    name = "terraform_test"
    
    schedule {
        quartz_cron_expression = "0 0 * * * ? *"
        timezone_id = "America/New_York"
        pause_status = "UNPAUSED"
    }

    pipeline_task {
        pipeline_id = databricks_pipeline.test.id
    }
}

output "pipeline_url" {
    value = databricks_pipeline.test.url
}

output "job_url" {
    value = databricks_job.test.url
}
```

Below is the output from a `terraform apply`.

```bash
[cflynn] /Users/cflynn/terraform-provider-databricks/scripts/test ᚴ [master] 2M
$ terraform apply

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # databricks_job.test will be created
  + resource "databricks_job" "test" {
      + always_running      = false
      + format              = (known after apply)
      + id                  = (known after apply)
      + max_concurrent_runs = 1
      + name                = "terraform_test"
      + url                 = (known after apply)

      + pipeline_task {
          + pipeline_id = (known after apply)
        }

      + schedule {
          + pause_status           = "UNPAUSED"
          + quartz_cron_expression = "0 0 * * * ? *"
          + timezone_id            = "America/New_York"
        }
    }

  # databricks_pipeline.test will be created
  + resource "databricks_pipeline" "test" {
      + continuous = false
      + id         = (known after apply)
      + name       = "terraform_test"
      + target     = "test"
      + url        = (known after apply)

      + cluster {
          + driver_node_type_id = (known after apply)
          + label               = "default"
          + node_type_id        = (known after apply)
          + ssh_public_keys     = []

          + autoscale {
              + max_workers = 3
              + min_workers = 1
            }
        }

      + filters {
          + exclude = [
              + "com.databricks.exclude",
            ]
          + include = [
              + "com.databricks.include",
            ]
        }

      + library {

          + notebook {
              + path = "/testing/dlt"
            }
        }
    }

Plan: 2 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + job_url      = (known after apply)
  + pipeline_url = (known after apply)

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

databricks_pipeline.test: Creating...
databricks_pipeline.test: Creation complete after 1s [id=50a0c98c-20ff-46d8-8894-5123ce783730]
databricks_job.test: Creating...
databricks_job.test: Creation complete after 0s [id=66666]

Apply complete! Resources: 2 added, 0 changed, 0 destroyed.

Outputs:

job_url = "https://redacted.cloud.databricks.com/#job/66666"
pipeline_url = "https://redacted.cloud.databricks.com/#joblist/pipelines/50a0c98c-20ff-46d8-8894-5123ce783730"
```

I can confirm that the resources were created successfully in our workspace.