### PR TITLE
Add support to update mounts - phase 1

### DIFF
--- a/storage/acceptance/aws_s3_mount_test.go
+++ b/storage/acceptance/aws_s3_mount_test.go
@@ -2,143 +2,19 @@ package acceptance
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/databrickslabs/terraform-provider-databricks/aws"
 	"github.com/databrickslabs/terraform-provider-databricks/clusters"
 	"github.com/databrickslabs/terraform-provider-databricks/common"
-	"github.com/databrickslabs/terraform-provider-databricks/internal/acceptance"
 	"github.com/databrickslabs/terraform-provider-databricks/internal/compute"
 	"github.com/databrickslabs/terraform-provider-databricks/qa"
 	"github.com/databrickslabs/terraform-provider-databricks/storage"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func getRunningClusterWithInstanceProfile(t *testing.T, client *common.DatabricksClient) (clusters.ClusterInfo, error) {
-	clusterName := "TerraformIntegrationTestIAM"
-	ctx := context.Background()
-	clustersAPI := clusters.NewClustersAPI(ctx, client)
-	instanceProfile := qa.GetEnvOrSkipTest(t, "TEST_EC2_INSTANCE_PROFILE")
-	return clustersAPI.GetOrCreateRunningCluster(clusterName, clusters.Cluster{
-		NumWorkers:             1,
-		ClusterName:            clusterName,
-		SparkVersion:           clustersAPI.LatestSparkVersionOrDefault(clusters.SparkVersionRequest{Latest: true, LongTermSupport: true}),
-		InstancePoolID:         compute.CommonInstancePoolID(),
-		AutoterminationMinutes: 10,
-		AwsAttributes: &clusters.AwsAttributes{
-			InstanceProfileArn: instanceProfile,
-		},
-	})
-}
-
-func TestAwsAccS3IamMount_WithCluster(t *testing.T) {
-	client := common.NewClientFromEnvironment()
-	arn := qa.GetEnvOrSkipTest(t, "TEST_EC2_INSTANCE_PROFILE")
-	ctx := context.WithValue(context.Background(), common.Current, t.Name())
-	instanceProfilesAPI := aws.NewInstanceProfilesAPI(ctx, client)
-	instanceProfilesAPI.Synchronized(arn, func() bool {
-		if instanceProfilesAPI.IsRegistered(arn) {
-			return false
-		}
-		config := qa.EnvironmentTemplate(t, `
-		resource "databricks_instance_profile" "this" {
-			instance_profile_arn = "{env.TEST_EC2_INSTANCE_PROFILE}"
-		}
-		data "databricks_spark_version" "latest" {
-		}
-		resource "databricks_cluster" "this" {
-			cluster_name = "ready-{var.RANDOM}"
-			spark_version = data.databricks_spark_version.latest.id
-			instance_pool_id = "{var.COMMON_INSTANCE_POOL_ID}"
-			autotermination_minutes = 5
-			num_workers = 1
-			aws_attributes {
-				instance_profile_arn = databricks_instance_profile.this.id
-			}
-		}
-		resource "databricks_aws_s3_mount" "mount" {
-			cluster_id     = databricks_cluster.this.id
-			mount_name     = "{var.RANDOM}"
-			s3_bucket_name = "{env.TEST_S3_BUCKET}"
-		}`)
-		acceptance.AccTest(t, resource.TestCase{
-			Steps: []resource.TestStep{
-				{
-					Config: config,
-					Check: mountResourceCheck("databricks_aws_s3_mount.mount",
-						func(client *common.DatabricksClient, mp storage.MountPoint) error {
-							source, err := mp.Source()
-							assert.NoError(t, err)
-							assert.Equal(t, fmt.Sprintf("s3a://%s",
-								qa.FirstKeyValue(t, config, "s3_bucket_name")), source)
-							return nil
-						}),
-				},
-			},
-		})
-		return true
-	})
-}
-
-func TestAwsAccS3IamMount_NoClusterGiven(t *testing.T) {
-	client := common.NewClientFromEnvironment()
-	arn := qa.GetEnvOrSkipTest(t, "TEST_EC2_INSTANCE_PROFILE")
-	ctx := context.WithValue(context.Background(), common.Current, t.Name())
-	instanceProfilesAPI := aws.NewInstanceProfilesAPI(ctx, client)
-	instanceProfilesAPI.Synchronized(arn, func() bool {
-		config := qa.EnvironmentTemplate(t, `
-		resource "databricks_instance_profile" "this" {
-			instance_profile_arn = "{env.TEST_EC2_INSTANCE_PROFILE}"
-		}
-		resource "databricks_aws_s3_mount" "mount" {
-			mount_name        = "{var.RANDOM}"
-			s3_bucket_name    = "{env.TEST_S3_BUCKET}"
-			instance_profile  = databricks_instance_profile.this.id
-		}`)
-		acceptance.AccTest(t, resource.TestCase{
-			Steps: []resource.TestStep{
-				{
-					Config: config,
-					Check: mountResourceCheck("databricks_aws_s3_mount.mount",
-						func(client *common.DatabricksClient, mp storage.MountPoint) error {
-							source, err := mp.Source()
-							assert.NoError(t, err)
-							assert.Equal(t, fmt.Sprintf("s3a://%s",
-								qa.FirstKeyValue(t, config, "s3_bucket_name")), source)
-							return nil
-						}),
-				},
-				{
-					PreConfig: func() {
-						client := compute.CommonEnvironmentClientWithRealCommandExecutor()
-						clusterInfo, err := getRunningClusterWithInstanceProfile(t, client)
-						assert.NoError(t, err)
-
-						ctx := context.Background()
-						mp := storage.NewMountPoint(client.CommandExecutor(ctx),
-							qa.FirstKeyValue(t, config, "mount_name"),
-							clusterInfo.ClusterID)
-						err = mp.Delete()
-						assert.NoError(t, err)
-					},
-					Config:             config,
-					PlanOnly:           true,
-					ExpectNonEmptyPlan: true,
-				},
-				{
-					// Prior PreConfig deleted the mount so this one should attempt to recreate the mount
-					Config: config,
-				},
-			},
-		})
-		return true
-	})
-}
-
-func TestAwsAccS3Mount(t *testing.T) {
+func TestAccS3Mount(t *testing.T) {
 	client := common.NewClientFromEnvironment()
 	instanceProfile := qa.GetEnvOrSkipTest(t, "TEST_EC2_INSTANCE_PROFILE")
 	ctx := context.WithValue(context.Background(), common.Current, t.Name())

--- a/storage/acceptance/azure_blob_mount_test.go
+++ b/storage/acceptance/azure_blob_mount_test.go
@@ -1,19 +1,11 @@
 package acceptance
 
 import (
-	"context"
-	"fmt"
-	"os"
 	"testing"
 
-	"github.com/databrickslabs/terraform-provider-databricks/common"
-	"github.com/databrickslabs/terraform-provider-databricks/internal/acceptance"
-	"github.com/databrickslabs/terraform-provider-databricks/internal/compute"
 	"github.com/databrickslabs/terraform-provider-databricks/storage"
 
 	"github.com/databrickslabs/terraform-provider-databricks/qa"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestAzureAccBlobMount(t *testing.T) {
@@ -30,58 +22,4 @@ func TestAzureAccBlobMount(t *testing.T) {
 			Directory:          "/",
 		})
 	}, client, mp.Name, accountKey)
-}
-
-func TestAzureAccBlobMount_correctly_mounts(t *testing.T) {
-	if _, ok := os.LookupEnv("CLOUD_ENV"); !ok {
-		t.Skip("Acceptance tests skipped unless env 'CLOUD_ENV' is set")
-	}
-	config := qa.EnvironmentTemplate(t, `
-	resource "databricks_secret_scope" "terraform" {
-		name                     = "terraform-{var.RANDOM}"
-		initial_manage_principal = "users"
-	}
-	resource "databricks_secret" "storage_key" {
-		key          = "blob_storage_key"
-		string_value = "{env.TEST_STORAGE_V2_KEY}"
-		scope        = databricks_secret_scope.terraform.name
-	}
-	resource "databricks_azure_blob_mount" "mount" {
-		storage_account_name = "{env.TEST_STORAGE_V2_ACCOUNT}"
-		container_name       = "{env.TEST_STORAGE_V2_WASBS}"
-		mount_name           = "{var.RANDOM}"
-		auth_type            = "ACCESS_KEY"
-		token_secret_scope   = databricks_secret_scope.terraform.name
-		token_secret_key     = databricks_secret.storage_key.key
-	}`)
-	acceptance.AccTest(t, resource.TestCase{
-		Steps: []resource.TestStep{
-			{
-				Config: config,
-				Check: mountResourceCheck("databricks_azure_blob_mount.mount",
-					func(client *common.DatabricksClient, mp storage.MountPoint) error {
-						source, err := mp.Source()
-						assert.NoError(t, err)
-						assert.Equal(t, fmt.Sprintf(
-							"wasbs://%s@%s.blob.core.windows.net/",
-							qa.FirstKeyValue(t, config, "container_name"),
-							qa.FirstKeyValue(t, config, "storage_account_name")), source)
-						return nil
-					}),
-			},
-			{
-				PreConfig: func() {
-					client := compute.CommonEnvironmentClientWithRealCommandExecutor()
-					clusterInfo := compute.NewTinyClusterInCommonPoolPossiblyReused()
-					mp := storage.NewMountPoint(client.CommandExecutor(context.Background()),
-						qa.FirstKeyValue(t, config, "mount_name"),
-						clusterInfo.ClusterID)
-					err := mp.Delete()
-					assert.NoError(t, err)
-				},
-				Config: config,
-				// Destroy: true,
-			},
-		},
-	})
 }

--- a/storage/acceptance/common_test.go
+++ b/storage/acceptance/common_test.go
@@ -70,7 +70,7 @@ func testWithNewSecretScope(t *testing.T, callback func(string, string),
 func TestAccSourceOnInvalidMountFails(t *testing.T) {
 	client, mp := mountPointThroughReusedCluster(t)
 	source, err := mp.Source(&storage.AzureADLSGen2MountGeneric{
-		ContainerName: "a",
+		ContainerName:      "a",
 		StorageAccountName: "b",
 	}, client)
 	assert.Equal(t, "", source)

--- a/storage/acceptance/common_test.go
+++ b/storage/acceptance/common_test.go
@@ -33,14 +33,14 @@ func mountResourceCheck(name string,
 
 func testMounting(t *testing.T, mp storage.MountPoint, m storage.Mount) {
 	client := common.CommonEnvironmentClient()
-	source, err := mp.Mount(m, client)
-	assert.Equal(t, m.Source(), source)
+	info, err := mp.Mount(m, client)
+	assert.Equal(t, m.Source(), info.Source)
 	assert.NoError(t, err)
 	defer func() {
 		err = mp.Delete()
 		assert.NoError(t, err)
 	}()
-	source, err = mp.Source()
+	source, err := mp.Source()
 	require.Equalf(t, m.Source(), source, "Error: %v", err)
 }
 
@@ -93,7 +93,7 @@ func TestAccSourceOnInvalidMountFails(t *testing.T) {
 func TestAccInvalidSecretScopeFails(t *testing.T) {
 	_, mp := mountPointThroughReusedCluster(t)
 	client := common.CommonEnvironmentClient()
-	source, err := mp.Mount(storage.AzureADLSGen1Mount{
+	info, err := mp.Mount(storage.AzureADLSGen1Mount{
 		ClientID:        "abc",
 		TenantID:        "bcd",
 		PrefixType:      "dfs.adls",
@@ -102,6 +102,6 @@ func TestAccInvalidSecretScopeFails(t *testing.T) {
 		SecretKey:       "key",
 		SecretScope:     "y",
 	}, client)
-	assert.Equal(t, "", source)
+	assert.Equal(t, "", info.Source)
 	qa.AssertErrorStartsWith(t, err, "Secret does not exist with scope: y and key: key")
 }

--- a/storage/adls_gen1_mount_test.go
+++ b/storage/adls_gen1_mount_test.go
@@ -34,10 +34,7 @@ func TestResourceAdlsGen1Mount_Create(t *testing.T) {
 				assert.Contains(t, trunc, `"fs.adl.oauth2.credential":dbutils.secrets.get("c", "d")`)
 			}
 			assert.Contains(t, trunc, "/mnt/this_mount")
-			return common.CommandResults{
-				ResultType: "text",
-				Data:       testS3BucketPath,
-			}
+			return mockMountInfo("adl://test-adls.azuredatalakestore.net", "a1b2c3")
 		},
 		State: map[string]interface{}{
 			"cluster_id":            "this_cluster",
@@ -52,5 +49,5 @@ func TestResourceAdlsGen1Mount_Create(t *testing.T) {
 	}.Apply(t)
 	require.NoError(t, err, err)
 	assert.Equal(t, "this_mount", d.Id())
-	assert.Equal(t, testS3BucketPath, d.Get("source"))
+	assert.Equal(t, "adl://test-adls.azuredatalakestore.net", d.Get("source"))
 }

--- a/storage/adls_gen2_mount_test.go
+++ b/storage/adls_gen2_mount_test.go
@@ -34,10 +34,7 @@ func TestResourceAdlsGen2Mount_Create(t *testing.T) {
 				assert.Contains(t, trunc, `"fs.azure.account.oauth2.client.secret":dbutils.secrets.get("c", "d")`)
 			}
 			assert.Contains(t, trunc, "/mnt/this_mount")
-			return common.CommandResults{
-				ResultType: "text",
-				Data:       "abfss://e@test-adls-gen2.dfs.core.windows.net",
-			}
+			return mockMountInfo("abfss://e@test-adls-gen2.dfs.core.windows.net", "a1b2c3")
 		},
 		State: map[string]interface{}{
 			"cluster_id":             "this_cluster",

--- a/storage/aws_s3_mount_test.go
+++ b/storage/aws_s3_mount_test.go
@@ -43,10 +43,7 @@ func TestResourceAwsS3MountCreate(t *testing.T) {
 				assert.Contains(t, trunc, `{}`)             // empty brackets for empty config
 			}
 			assert.Contains(t, trunc, "/mnt/this_mount")
-			return common.CommandResults{
-				ResultType: "text",
-				Data:       testS3BucketPath,
-			}
+			return mockMountInfo(testS3BucketPath, "a1b2c3")
 		},
 		State: map[string]interface{}{
 			"cluster_id":     "this_cluster",
@@ -106,10 +103,7 @@ func TestResourceAwsS3MountRead(t *testing.T) {
 			t.Logf("Received command:\n%s", trunc)
 			assert.Contains(t, trunc, "dbutils.fs.mounts()")
 			assert.Contains(t, trunc, `mount.mountPoint == "/mnt/this_mount"`)
-			return common.CommandResults{
-				ResultType: "text",
-				Data:       testS3BucketPath,
-			}
+			return mockMountInfo(testS3BucketPath, "a1b2c3")
 		},
 		State: map[string]interface{}{
 			"cluster_id":     "this_cluster",

--- a/storage/azure_blob_mount_test.go
+++ b/storage/azure_blob_mount_test.go
@@ -35,10 +35,7 @@ func TestResourceAzureBlobMountCreate(t *testing.T) {
 				assert.Contains(t, trunc, `"fs.azure.account.key.f.blob.core.windows.net":dbutils.secrets.get("h", "g")`)
 			}
 			assert.Contains(t, trunc, "/mnt/e")
-			return common.CommandResults{
-				ResultType: "text",
-				Data:       "wasbs://c@f.blob.core.windows.net/d",
-			}
+			return mockMountInfo("wasbs://c@f.blob.core.windows.net/d", "a1b2c3")
 		},
 		State: map[string]interface{}{
 			"auth_type":            "ACCESS_KEY",
@@ -74,10 +71,7 @@ func TestResourceAzureBlobMountRead(t *testing.T) {
 			t.Logf("Received command:\n%s", trunc)
 			assert.Contains(t, trunc, "dbutils.fs.mounts()")
 			assert.Contains(t, trunc, `mount.mountPoint == "/mnt/e"`)
-			return common.CommandResults{
-				ResultType: "text",
-				Data:       "wasbs://c@f.blob.core.windows.net/d",
-			}
+			return mockMountInfo("wasbs://c@f.blob.core.windows.net/d", "a1b2c3")
 		},
 		State: map[string]interface{}{
 			"auth_type":            "ACCESS_KEY",

--- a/storage/azure_blob_mount_test.go
+++ b/storage/azure_blob_mount_test.go
@@ -57,41 +57,6 @@ func TestResourceAzureBlobMountCreate(t *testing.T) {
 	assert.Equal(t, "wasbs://c@f.blob.core.windows.net/d", d.Get("source"))
 }
 
-func TestResourceAzureBlobMountCreate_Error(t *testing.T) {
-	d, err := qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:   "GET",
-				Resource: "/api/2.0/clusters/get?cluster_id=b",
-				Response: clusters.ClusterInfo{
-					State: clusters.ClusterStateRunning,
-				},
-			},
-		},
-		Resource: ResourceAzureBlobMount(),
-		CommandMock: func(commandStr string) common.CommandResults {
-			return common.CommandResults{
-				ResultType: "error",
-				Summary:    "Some error",
-			}
-		},
-		State: map[string]interface{}{
-			"auth_type":            "ACCESS_KEY",
-			"cluster_id":           "b",
-			"container_name":       "c",
-			"directory":            "/d",
-			"mount_name":           "e",
-			"storage_account_name": "f",
-			"token_secret_key":     "g",
-			"token_secret_scope":   "h",
-		},
-		Create: true,
-	}.Apply(t)
-	require.EqualError(t, err, "Some error")
-	assert.Equal(t, "e", d.Id())
-	assert.Equal(t, "", d.Get("source"))
-}
-
 func TestResourceAzureBlobMountRead(t *testing.T) {
 	d, err := qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{

--- a/storage/generic_mounts.go
+++ b/storage/generic_mounts.go
@@ -21,7 +21,7 @@ type GenericMount struct {
 	Wasb    *AzureBlobMountGeneric     `json:"wasb,omitempty" tf:"suppress_diff"`
 	Gs      *GSMount                   `json:"gs,omitempty" tf:"suppress_diff"`
 
-	ClusterID      string `json:"cluster_id,omitempty" tf:"computed"`
+	ClusterID      string `json:"cluster_id,omitempty" tf:"computed,force_new"`
 	MountName      string `json:"name,omitempty" tf:"computed,force_new"`
 	ResourceID     string `json:"resource_id,omitempty"`
 	EncryptionType string `json:"encryption_type,omitempty" tf:"force_new"`
@@ -131,7 +131,7 @@ type AzureADLSGen2MountGeneric struct {
 	TenantID             string `json:"tenant_id,omitempty"`
 	SecretScope          string `json:"client_secret_scope"`
 	SecretKey            string `json:"client_secret_key"`
-	InitializeFileSystem bool   `json:"initialize_file_system"`
+	InitializeFileSystem bool   `json:"initialize_file_system,omitempty"`
 }
 
 // Source returns ABFSS URI backing the mount
@@ -186,13 +186,13 @@ func (m *AzureADLSGen2MountGeneric) Config(client *common.DatabricksClient) map[
 
 // AzureADLSGen1Mount describes the object for a azure datalake gen 1 storage mount
 type AzureADLSGen1MountGeneric struct {
-	StorageResource string `json:"storage_resource_name,omitempty" tf:"computed,force_new"`
-	Directory       string `json:"directory,omitempty" tf:"force_new"`
-	PrefixType      string `json:"spark_conf_prefix,omitempty" tf:"default:fs.adl,force_new"`
-	ClientID        string `json:"client_id" tf:"force_new"`
-	TenantID        string `json:"tenant_id,omitempty" tf:"computed,force_new"`
-	SecretScope     string `json:"client_secret_scope" tf:"force_new"`
-	SecretKey       string `json:"client_secret_key" tf:"force_new"`
+	StorageResource string `json:"storage_resource_name,omitempty" tf:"computed"`
+	Directory       string `json:"directory,omitempty"`
+	PrefixType      string `json:"spark_conf_prefix,omitempty" tf:"default:fs.adl"`
+	ClientID        string `json:"client_id"`
+	TenantID        string `json:"tenant_id,omitempty" tf:"computed"`
+	SecretScope     string `json:"client_secret_scope"`
+	SecretKey       string `json:"client_secret_key"`
 }
 
 // Source ...
@@ -250,12 +250,12 @@ func (m *AzureADLSGen1MountGeneric) Config(client *common.DatabricksClient) map[
 
 // AzureBlobMount describes the object for a azure blob storage mount - a.k.a. NativeAzureFileSystem
 type AzureBlobMountGeneric struct {
-	ContainerName      string `json:"container_name,omitempty" tf:"computed,force_new"`
-	StorageAccountName string `json:"storage_account_name,omitempty" tf:"computed,force_new"`
-	Directory          string `json:"directory,omitempty" tf:"force_new"`
-	AuthType           string `json:"auth_type" tf:"force_new"`
-	SecretScope        string `json:"token_secret_scope" tf:"force_new"`
-	SecretKey          string `json:"token_secret_key" tf:"force_new"`
+	ContainerName      string `json:"container_name,omitempty" tf:"computed"`
+	StorageAccountName string `json:"storage_account_name,omitempty" tf:"computed"`
+	Directory          string `json:"directory,omitempty"`
+	AuthType           string `json:"auth_type"`
+	SecretScope        string `json:"token_secret_scope"`
+	SecretKey          string `json:"token_secret_key"`
 }
 
 // Source ...

--- a/storage/generic_mounts.go
+++ b/storage/generic_mounts.go
@@ -13,17 +13,17 @@ import (
 
 // TODO: add support for encryption parameters in S3
 type GenericMount struct {
-	URI     string                     `json:"uri,omitempty" tf:"force_new"`
-	Options map[string]string          `json:"extra_configs,omitempty" tf:"force_new"`
-	Abfs    *AzureADLSGen2MountGeneric `json:"abfs,omitempty" tf:"force_new,suppress_diff"`
-	S3      *S3IamMount                `json:"s3,omitempty" tf:"force_new,suppress_diff"`
-	Adl     *AzureADLSGen1MountGeneric `json:"adl,omitempty" tf:"force_new,suppress_diff"`
-	Wasb    *AzureBlobMountGeneric     `json:"wasb,omitempty" tf:"force_new,suppress_diff"`
-	Gs      *GSMount                   `json:"gs,omitempty" tf:"force_new,suppress_diff"`
+	URI     string                     `json:"uri,omitempty"`
+	Options map[string]string          `json:"extra_configs,omitempty"`
+	Abfs    *AzureADLSGen2MountGeneric `json:"abfs,omitempty" tf:"suppress_diff"`
+	S3      *S3IamMount                `json:"s3,omitempty" tf:"suppress_diff"`
+	Adl     *AzureADLSGen1MountGeneric `json:"adl,omitempty" tf:"suppress_diff"`
+	Wasb    *AzureBlobMountGeneric     `json:"wasb,omitempty" tf:"suppress_diff"`
+	Gs      *GSMount                   `json:"gs,omitempty" tf:"suppress_diff"`
 
-	ClusterID      string `json:"cluster_id,omitempty" tf:"computed,force_new"`
+	ClusterID      string `json:"cluster_id,omitempty" tf:"computed"`
 	MountName      string `json:"name,omitempty" tf:"computed,force_new"`
-	ResourceID     string `json:"resource_id,omitempty" tf:"force_new"`
+	ResourceID     string `json:"resource_id,omitempty"`
 	EncryptionType string `json:"encryption_type,omitempty" tf:"force_new"`
 }
 

--- a/storage/generic_mounts.go
+++ b/storage/generic_mounts.go
@@ -124,14 +124,14 @@ func getTenantID(client *common.DatabricksClient) (string, error) {
 
 // AzureADLSGen2Mount describes the object for a azure datalake gen 2 storage mount
 type AzureADLSGen2MountGeneric struct {
-	ContainerName        string `json:"container_name,omitempty" tf:"computed,force_new"`
-	StorageAccountName   string `json:"storage_account_name,omitempty" tf:"computed,force_new"`
-	Directory            string `json:"directory,omitempty" tf:"force_new"`
-	ClientID             string `json:"client_id" tf:"force_new"`
-	TenantID             string `json:"tenant_id,omitempty" tf:"computed,force_new"`
-	SecretScope          string `json:"client_secret_scope" tf:"force_new"`
-	SecretKey            string `json:"client_secret_key" tf:"force_new"`
-	InitializeFileSystem bool   `json:"initialize_file_system" tf:"force_new"`
+	ContainerName        string `json:"container_name,omitempty"`
+	StorageAccountName   string `json:"storage_account_name,omitempty"`
+	Directory            string `json:"directory,omitempty"`
+	ClientID             string `json:"client_id"`
+	TenantID             string `json:"tenant_id,omitempty"`
+	SecretScope          string `json:"client_secret_scope"`
+	SecretKey            string `json:"client_secret_key"`
+	InitializeFileSystem bool   `json:"initialize_file_system"`
 }
 
 // Source returns ABFSS URI backing the mount
@@ -145,6 +145,7 @@ func (m *AzureADLSGen2MountGeneric) Name() string {
 }
 
 func (m *AzureADLSGen2MountGeneric) ValidateAndApplyDefaults(d *schema.ResourceData, client *common.DatabricksClient) error {
+	// TODO: add validation for client, secret scope & key.
 	if m.ContainerName == "" || m.StorageAccountName == "" {
 		acc, cont, err := getContainerDefaults(d, []string{"abfs", "abfss"}, "dfs.core.windows.net")
 		if err != nil {

--- a/storage/generic_mounts_test.go
+++ b/storage/generic_mounts_test.go
@@ -1,0 +1,236 @@
+package storage
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/databrickslabs/terraform-provider-databricks/common"
+	"github.com/databrickslabs/terraform-provider-databricks/qa"
+	"github.com/golang-jwt/jwt/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNames(t *testing.T) {
+	mount_name := "abc"
+	gm := GenericMount{MountName: mount_name}
+	assert.Equal(t, gm.Name(), mount_name)
+	assert.Equal(t, GenericMount{}.Name(), "")
+	gm = GenericMount{Abfs: &AzureADLSGen2MountGeneric{ContainerName: mount_name}}
+	assert.Equal(t, gm.Name(), mount_name)
+	gm = GenericMount{Wasb: &AzureBlobMountGeneric{ContainerName: mount_name}}
+	assert.Equal(t, gm.Name(), mount_name)
+	gm = GenericMount{Adl: &AzureADLSGen1MountGeneric{StorageResource: mount_name}}
+	assert.Equal(t, gm.Name(), mount_name)
+}
+
+func TestGenericMountDefaults(t *testing.T) {
+	client := &common.DatabricksClient{}
+
+	gm := GenericMount{URI: "foo://bar", Options: map[string]string{"foo": "bar"}}
+	assert.Equal(t, "foo://bar", gm.Source())
+	assert.Len(t, gm.Config(client), 1)
+	assert.Equal(t, "bar", gm.Config(client)["foo"])
+
+	gm = GenericMount{MountName: "test"}
+	d := ResourceMount().TestResourceData()
+	err := gm.ValidateAndApplyDefaults(d, client)
+	assert.EqualError(t, err, "value of name is not specified or empty")
+
+	d.Set("name", "X")
+	err = gm.ValidateAndApplyDefaults(d, client)
+	assert.EqualError(t, err, "value of uri is not specified or empty")
+
+	d.Set("uri", "s3://abc/")
+	err = gm.ValidateAndApplyDefaults(d, client)
+	assert.NoError(t, err)
+
+	gm = GenericMount{Abfs: &AzureADLSGen2MountGeneric{}}
+	err = gm.ValidateAndApplyDefaults(d, client)
+	assert.EqualError(t, err, "container_name or storage_account_name are empty, and resource_id or uri aren't specified")
+}
+
+const containerResourceID = "/subscriptions/5363c143-2af7-4fb5-8a9d-ab1b2c8e756e/resourceGroups/test-rg/providers/Microsoft.Storage/storageAccounts/lrs-acc/blobServices/default/containers/test"
+const adlResourceID = "/subscriptions/6369c148-f8a9-4fb5-8a9d-ac1b2c8e756e/resourceGroups/alexott-rg/providers/Microsoft.DataLakeStore/accounts/aottgen1"
+
+func TestARMParsing(t *testing.T) {
+	acc, container, err := parseStorageContainerId(containerResourceID)
+	require.NoError(t, err, err)
+	assert.Equal(t, acc, "lrs-acc")
+	assert.Equal(t, container, "test")
+}
+
+func TestARMParsingError(t *testing.T) {
+	_, _, err := parseStorageContainerId("abc")
+	qa.AssertErrorStartsWith(t, err, "parsing failed for ")
+}
+
+func TestARMParsing2(t *testing.T) {
+	res, err := azure.ParseResourceID(adlResourceID)
+	require.NoError(t, err, err)
+	assert.Equal(t, res.ResourceName, "aottgen1")
+}
+
+func TestGetContainerDefaults(t *testing.T) {
+	d := ResourceMount().TestResourceData()
+	d.Set("resource_id", "..")
+	_, _, err := getContainerDefaults(d, []string{}, "")
+	assert.EqualError(t, err, "parsing failed for ... Invalid container resource Id format")
+}
+
+func TestAzureADLSGen2MountGeneric_Resource_NoTenant(t *testing.T) {
+	d := ResourceMount().TestResourceData()
+	d.Set("resource_id", containerResourceID)
+	x := &AzureADLSGen2MountGeneric{}
+	err := x.ValidateAndApplyDefaults(d, &common.DatabricksClient{})
+	assert.EqualError(t, err, "tenant_id is not defined, and we can't extract it: can't get Azure JWT token in non-Azure environment")
+}
+
+func newTestJwt(t *testing.T, claims jwt.MapClaims) string {
+	token := jwt.NewWithClaims(jwt.GetSigningMethod("HS256"), claims)
+	result, err := token.SignedString([]byte("_"))
+	assert.NoError(t, err)
+	return result
+}
+
+func setupJwtTestClient() (*httptest.Server, *common.DatabricksClient) {
+	client := &common.DatabricksClient{InsecureSkipVerify: true,
+		Host: "https://adb-1232.azuredatabricks.net",
+	}
+	server := httptest.NewUnstartedServer(http.HandlerFunc(
+		func(rw http.ResponseWriter, req *http.Request) {
+		}))
+	server.StartTLS()
+	// resource management endpoints end with a trailing slash in url
+	client.AzureEnvironment = &azure.Environment{
+		ResourceManagerEndpoint: fmt.Sprintf("%s/", server.URL),
+		ActiveDirectoryEndpoint: "http://mock-aad/",
+	}
+	ctx := context.Background()
+	err := client.Authenticate(ctx)
+	if err != nil {
+		log.Printf("[ERROR] Can't auth: %s", err)
+		return nil, nil
+	}
+	return server, client
+}
+
+func TestGetTenantIDCannotBeDetected(t *testing.T) {
+	defer common.CleanupEnvironment()()
+	os.Setenv("PATH", "../common/testdata:/bin")
+	os.Setenv("TF_AAD_TOKEN", newTestJwt(t, jwt.MapClaims{
+		"tid": "",
+	}))
+
+	srv, client := setupJwtTestClient()
+	require.NotNil(t, srv)
+	defer srv.Close()
+
+	_, err := getTenantID(client)
+	assert.EqualError(t, err, "tenant_id isn't provided & we can't detect it")
+}
+
+func TestAzureADLSGen2MountGeneric_NameAndTenant(t *testing.T) {
+	defer common.CleanupEnvironment()()
+	os.Setenv("PATH", "../common/testdata:/bin")
+	os.Setenv("TF_AAD_TOKEN", newTestJwt(t, jwt.MapClaims{
+		"tid": "some-tenant",
+	}))
+
+	srv, client := setupJwtTestClient()
+	require.NotNil(t, srv)
+	defer srv.Close()
+
+	d := ResourceMount().TestResourceData()
+	d.Set("resource_id", containerResourceID)
+	x := &AzureADLSGen2MountGeneric{
+		SecretScope: "a",
+		SecretKey:   "b",
+		ClientID:    "c",
+	}
+
+	err := x.ValidateAndApplyDefaults(d, client)
+	assert.NoError(t, err)
+	assert.Equal(t, "abfss://test@lrs-acc.dfs.core.windows.net", x.Source())
+
+	config := x.Config(client)
+	assert.Len(t, config, 6)
+	assert.Equal(t, "OAuth", config["fs.azure.account.auth.type"])
+	assert.Equal(t, "c", config["fs.azure.account.oauth2.client.id"])
+	assert.Equal(t, "{{secrets/a/b}}", config["fs.azure.account.oauth2.client.secret"])
+	assert.Equal(t, "http://mock-aad/some-tenant/oauth2/token", config["fs.azure.account.oauth2.client.endpoint"])
+	assert.Equal(t, "false", config["fs.azure.createRemoteFileSystemDuringInitialization"])
+}
+
+func TestAzureADLSGen1MountGeneric(t *testing.T) {
+	defer common.CleanupEnvironment()()
+	os.Setenv("PATH", "../common/testdata:/bin")
+	os.Setenv("TF_AAD_TOKEN", newTestJwt(t, jwt.MapClaims{
+		"tid": "some-tenant",
+	}))
+
+	srv, client := setupJwtTestClient()
+	require.NotNil(t, srv)
+	defer srv.Close()
+
+	d := ResourceMount().TestResourceData()
+	x := &AzureADLSGen1MountGeneric{
+		PrefixType:  "X",
+		SecretScope: "a",
+		SecretKey:   "b",
+		ClientID:    "c",
+	}
+
+	d.Set("resource_id", "..")
+	err := x.ValidateAndApplyDefaults(d, client)
+	assert.EqualError(t, err, "parsing failed for ... Invalid resource Id format")
+
+	d.Set("resource_id", containerResourceID)
+	err = x.ValidateAndApplyDefaults(d, client)
+	assert.EqualError(t, err, "incorrect resource type or provider in resource_id: "+containerResourceID)
+
+	d.Set("resource_id", adlResourceID)
+	err = x.ValidateAndApplyDefaults(d, &common.DatabricksClient{})
+	assert.EqualError(t, err, "tenant_id is not defined, and we can't extract it: can't get Azure JWT token in non-Azure environment")
+
+	d.Set("resource_id", adlResourceID)
+	err = x.ValidateAndApplyDefaults(d, client)
+	assert.NoError(t, err)
+	assert.Equal(t, "adl://aottgen1.azuredatalakestore.net", x.Source())
+
+	config := x.Config(client)
+	assert.Len(t, config, 4)
+	assert.Equal(t, "ClientCredential", config["X.oauth2.access.token.provider.type"])
+	assert.Equal(t, "c", config["X.oauth2.client.id"])
+	assert.Equal(t, "{{secrets/a/b}}", config["X.oauth2.credential"])
+	assert.Equal(t, "http://mock-aad/some-tenant/oauth2/token", config["X.oauth2.refresh.url"])
+}
+
+func TestAzureBlobMount(t *testing.T) {
+	d := ResourceMount().TestResourceData()
+	d.Set("resource_id", containerResourceID)
+	x := &AzureBlobMountGeneric{
+		SecretScope: "a",
+		SecretKey:   "b",
+	}
+
+	client := &common.DatabricksClient{}
+	err := x.ValidateAndApplyDefaults(d, client)
+	assert.NoError(t, err)
+	assert.Equal(t, "wasbs://test@lrs-acc.blob.core.windows.net", x.Source())
+
+	config := x.Config(client)
+	assert.Len(t, config, 1)
+	assert.Equal(t, "{{secrets/a/b}}", config["fs.azure.account.key.lrs-acc.blob.core.windows.net"])
+
+	x.AuthType = "SAS"
+	config = x.Config(client)
+	assert.Len(t, config, 1)
+	assert.Equal(t, "{{secrets/a/b}}", config["fs.azure.sas.test.lrs-acc.blob.core.windows.net"])
+}

--- a/storage/gs.go
+++ b/storage/gs.go
@@ -13,7 +13,7 @@ import (
 
 // GSMount describes the object for a GS mount using google service account
 type GSMount struct {
-	BucketName     string `json:"bucket_name" tf:"force_new"`
+	BucketName     string `json:"bucket_name"`
 	ServiceAccount string `json:"service_account,omitempty" tf:"force_new"`
 }
 

--- a/storage/gs_test.go
+++ b/storage/gs_test.go
@@ -2,12 +2,238 @@ package storage
 
 import (
 	"context"
+	"strings"
 	"testing"
 
+	"github.com/databrickslabs/terraform-provider-databricks/clusters"
 	"github.com/databrickslabs/terraform-provider-databricks/common"
+	"github.com/databrickslabs/terraform-provider-databricks/internal"
 	"github.com/databrickslabs/terraform-provider-databricks/qa"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+const testGcsBucketPath = "gs://" + testS3BucketName
+
+func TestGSMountDefaults(t *testing.T) {
+	s := ResourceDatabricksMountSchema()
+	d := schema.TestResourceDataRaw(t, s, map[string]interface{}{})
+	client, server, err := qa.HttpFixtureClient(t, []qa.HTTPFixture{})
+	defer server.Close()
+	require.NoError(t, err, err)
+
+	err = GSMount{}.ValidateAndApplyDefaults(d, client)
+	qa.AssertErrorStartsWith(t, err, "'name' is not detected & it's impossible to infer it")
+
+	d = schema.TestResourceDataRaw(t, s, map[string]interface{}{"name": "test"})
+	err = GSMount{}.ValidateAndApplyDefaults(d, client)
+	require.NoError(t, err, err)
+	assert.Equal(t, d.Get("name").(string), "test")
+	d = schema.TestResourceDataRaw(t, s, map[string]interface{}{})
+	err = GSMount{BucketName: "abc"}.ValidateAndApplyDefaults(d, client)
+	require.NoError(t, err, err)
+	assert.Equal(t, d.Get("name").(string), "abc")
+}
+
+func TestResourceGcsMountGenericCreate_WithCluster(t *testing.T) {
+	google_account := "acc@acc-dbx.iam.gserviceaccount.com"
+	d, err := qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:       "GET",
+				ReuseRequest: true,
+				Resource:     "/api/2.0/clusters/get?cluster_id=this_cluster",
+				Response: clusters.ClusterInfo{
+					State: clusters.ClusterStateRunning,
+					GcpAttributes: &clusters.GcpAttributes{
+						GoogleServiceAccount: google_account,
+					},
+				},
+			},
+		},
+		Resource: ResourceMount(),
+		CommandMock: func(commandStr string) common.CommandResults {
+			trunc := internal.TrimLeadingWhitespace(commandStr)
+			t.Logf("Received command:\n%s", trunc)
+			if strings.HasPrefix(trunc, "def safe_mount") {
+				assert.Contains(t, trunc, testGcsBucketPath) // bucketname
+				assert.Contains(t, trunc, `{}`)              // empty brackets for empty config
+			}
+			assert.Contains(t, trunc, "/mnt/this_mount")
+			return mockMountInfo(testGcsBucketPath, "a1b2c3")
+		},
+		State: map[string]interface{}{
+			"cluster_id": "this_cluster",
+			"name":       "this_mount",
+			"gs": []interface{}{map[string]interface{}{
+				"bucket_name": testS3BucketName,
+			}},
+		},
+		Create: true,
+	}.Apply(t)
+	require.NoError(t, err, err)
+	assert.Equal(t, "this_mount", d.Id())
+	assert.Equal(t, testGcsBucketPath, d.Get("source"))
+}
+
+func TestResourceGcsMountGenericCreate_WithCluster_NoName(t *testing.T) {
+	google_account := "acc@acc-dbx.iam.gserviceaccount.com"
+	d, err := qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:       "GET",
+				ReuseRequest: true,
+				Resource:     "/api/2.0/clusters/get?cluster_id=this_cluster",
+				Response: clusters.ClusterInfo{
+					State: clusters.ClusterStateRunning,
+					GcpAttributes: &clusters.GcpAttributes{
+						GoogleServiceAccount: google_account,
+					},
+				},
+			},
+		},
+		Resource: ResourceMount(),
+		CommandMock: func(commandStr string) common.CommandResults {
+			trunc := internal.TrimLeadingWhitespace(commandStr)
+			t.Logf("Received command:\n%s", trunc)
+			if strings.HasPrefix(trunc, "def safe_mount") {
+				assert.Contains(t, trunc, testGcsBucketPath) // bucketname
+				assert.Contains(t, trunc, `{}`)              // empty brackets for empty config
+			}
+			assert.Contains(t, trunc, "/mnt/"+testS3BucketName)
+			return mockMountInfo(testGcsBucketPath, "a1b2c3")
+		},
+		State: map[string]interface{}{
+			"cluster_id": "this_cluster",
+			"gs": []interface{}{map[string]interface{}{
+				"bucket_name": testS3BucketName,
+			}},
+		},
+		Create: true,
+	}.Apply(t)
+	require.NoError(t, err, err)
+	assert.Equal(t, testS3BucketName, d.Id())
+	assert.Equal(t, testGcsBucketPath, d.Get("source"))
+}
+
+func TestResourceGcsMountGenericCreate_WithServiceAccount(t *testing.T) {
+	googleAccount := "acc@acc-dbx.iam.gserviceaccount.com"
+	clusterName := "terraform-mount-gcs-bcb24f32098efa4172f435adbed2dae2"
+	d, err := qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:       "GET",
+				ReuseRequest: true,
+				Resource:     "/api/2.0/clusters/get?cluster_id=abcd",
+				Response: clusters.ClusterInfo{
+					ClusterID: "abcd",
+					State:     clusters.ClusterStateRunning,
+					GcpAttributes: &clusters.GcpAttributes{
+						GoogleServiceAccount: googleAccount,
+					},
+				},
+			},
+			{
+				Method:   "GET",
+				Resource: "/api/2.0/clusters/list",
+				Response: map[string]interface{}{},
+			},
+			{
+				Method:   "GET",
+				Resource: "/api/2.0/clusters/list",
+				Response: clusters.ClusterList{
+					Clusters: []clusters.ClusterInfo{
+						{
+							ClusterID: "abcd",
+							State:     clusters.ClusterStateRunning,
+							GcpAttributes: &clusters.GcpAttributes{
+								GoogleServiceAccount: googleAccount,
+							},
+							AutoterminationMinutes: 10,
+							SparkConf: map[string]string{"spark.databricks.cluster.profile": "singleNode",
+								"spark.master": "local[*]", "spark.scheduler.mode": "FIFO"},
+							CustomTags:   map[string]string{"ResourceClass": "SingleNode"},
+							ClusterName:  clusterName,
+							SparkVersion: "7.3.x-scala2.12",
+							NumWorkers:   0,
+						},
+					},
+				},
+			},
+			{
+				Method:       "GET",
+				Resource:     "/api/2.0/clusters/spark-versions",
+				Response:     sparkVersionsResponse,
+				ReuseRequest: true,
+			},
+			{
+				Method:       "GET",
+				Resource:     "/api/2.0/clusters/list-node-types",
+				ReuseRequest: true,
+				Response:     nodeListResponse,
+			},
+			{
+				Method:       "POST",
+				Resource:     "/api/2.0/clusters/create",
+				ReuseRequest: true,
+				ExpectedRequest: clusters.Cluster{
+					NodeTypeID: "Standard_F4s",
+					GcpAttributes: &clusters.GcpAttributes{
+						GoogleServiceAccount: "acc@acc-dbx.iam.gserviceaccount.com",
+					},
+					AutoterminationMinutes: 10,
+					SparkConf: map[string]string{"spark.databricks.cluster.profile": "singleNode",
+						"spark.master": "local[*]", "spark.scheduler.mode": "FIFO"},
+					CustomTags:   map[string]string{"ResourceClass": "SingleNode"},
+					ClusterName:  clusterName,
+					SparkVersion: "7.3.x-scala2.12",
+					NumWorkers:   0,
+				},
+				Response: clusters.ClusterID{
+					ClusterID: "abcd",
+				},
+			},
+		},
+		Resource: ResourceMount(),
+		CommandMock: func(commandStr string) common.CommandResults {
+			trunc := internal.TrimLeadingWhitespace(commandStr)
+			t.Logf("Received command:\n%s", trunc)
+			if strings.HasPrefix(trunc, "def safe_mount") {
+				assert.Contains(t, trunc, testGcsBucketPath) // bucketname
+				assert.Contains(t, trunc, `{}`)              // empty brackets for empty config
+			}
+			assert.Contains(t, trunc, "/mnt/this_mount")
+			return mockMountInfo(testGcsBucketPath, "a1b2c3")
+		},
+		State: map[string]interface{}{
+			"name": "this_mount",
+			"gs": []interface{}{map[string]interface{}{
+				"bucket_name":     testS3BucketName,
+				"service_account": googleAccount,
+			}},
+		},
+		Create: true,
+	}.Apply(t)
+	require.NoError(t, err, err)
+	assert.Equal(t, "this_mount", d.Id())
+	assert.Equal(t, "abcd", d.Get("cluster_id"))
+	assert.Equal(t, testGcsBucketPath, d.Get("source"))
+}
+
+func TestResourceGcsMountGenericCreate_nothing_specified(t *testing.T) {
+	_, err := qa.ResourceFixture{
+		Resource: ResourceMount(),
+		State: map[string]interface{}{
+			"name": "this_mount",
+			"gs": []interface{}{map[string]interface{}{
+				"bucket_name": testS3BucketName,
+			}},
+		},
+		Create: true,
+	}.Apply(t)
+	require.EqualError(t, err, "either cluster_id or service_account must be specified to mount GCS bucket")
+}
 
 func TestCreateOrValidateClusterForGoogleStorage_Failures(t *testing.T) {
 	qa.HTTPFixturesApply(t, []qa.HTTPFixture{

--- a/storage/mounts.go
+++ b/storage/mounts.go
@@ -78,8 +78,7 @@ func (mp MountPoint) Mount(mo Mount, client *common.DatabricksClient) (info moun
 		mount_source = safe_mount("/mnt/`+mp.Name+`", "`+mo.Source()+`", extra_configs, "`+mp.EncryptionType+`")
 		dbutils.notebook.exit(json.dumps({
 			"source": mount_source,
-			"config_hash": hashlib.sha256(','.join(f'{k}:{v}' for k,v
-				in sorted(extra_configs.items())).encode('utf-8')).hexdigest()
+			"config_hash": `+configHashCode+`
 		}))`) // lgtm[go/unsafe-quoting]
 	if result.Failed() {
 		return mountRemoteInfo{}, result.Err()
@@ -120,8 +119,7 @@ func (mp MountPoint) Update(mo Mount, client *common.DatabricksClient) (info mou
 			extra_configs = extra_configs)
 		dbutils.notebook.exit(json.dumps({
 			"source": mount_source,
-			"config_hash": hashlib.sha256(','.join(f'{k}:{v}' for k,v
-				in sorted(extra_configs.items())).encode('utf-8')).hexdigest()
+			"config_hash": `+configHashCode+`
 		}))`) // lgtm[go/unsafe-quoting]
 	if result.Failed() {
 		return mountRemoteInfo{}, result.Err()

--- a/storage/mounts_test.go
+++ b/storage/mounts_test.go
@@ -89,7 +89,9 @@ func TestMountPoint_Mount(t *testing.T) {
 				if mount.mountPoint == mount_point and mount.source == mount_source:
 					return
 			try:
-				dbutils.fs.mount(mount_source, mount_point, extra_configs=configs, encryption_type=encryptionType)
+				dbutils.fs.mount(mount_source, mount_point, 
+					extra_configs=configs, 
+					encryption_type=encryptionType)
 				dbutils.fs.refreshMounts()
 				dbutils.fs.ls(mount_point)
 				return mount_source
@@ -103,11 +105,10 @@ func TestMountPoint_Mount(t *testing.T) {
 		dbutils.notebook.exit(mount_source)
 	`, mountName, expectedMountSource, expectedMountConfig)
 	testMountFuncHelper(t, func(mp MountPoint, mount Mount) (string, error) {
-		client := common.DatabricksClient{
+		info, err := mp.Mount(mount, &common.DatabricksClient{
 			Host:  ".",
 			Token: ".",
-		}
-		info, err := mp.Mount(mount, &client)
+		})
 		return info.Source, err
 	}, mount, mountName, expectedCommand)
 }
@@ -121,8 +122,12 @@ func TestMountPoint_Source(t *testing.T) {
 				dbutils.notebook.exit(mount.source)
 		raise Exception("Mount not found")
 	`, mountName)
-	testMountFuncHelper(t, func(mp MountPoint, mount Mount) (s string, e error) {
-		return mp.Source()
+	testMountFuncHelper(t, func(mp MountPoint, mount Mount) (string, error) {
+		i, err := mp.Source(mount, &common.DatabricksClient{
+			Host:  ".",
+			Token: ".",
+		})
+		return i.Source, err
 	}, nil, mountName, expectedCommand)
 }
 

--- a/storage/mounts_test.go
+++ b/storage/mounts_test.go
@@ -102,12 +102,13 @@ func TestMountPoint_Mount(t *testing.T) {
 		mount_source = safe_mount("/mnt/%s", %q, %s, "")
 		dbutils.notebook.exit(mount_source)
 	`, mountName, expectedMountSource, expectedMountConfig)
-	testMountFuncHelper(t, func(mp MountPoint, mount Mount) (s string, e error) {
+	testMountFuncHelper(t, func(mp MountPoint, mount Mount) (string, error) {
 		client := common.DatabricksClient{
 			Host:  ".",
 			Token: ".",
 		}
-		return mp.Mount(mount, &client)
+		info, err := mp.Mount(mount, &client)
+		return info.Source, err
 	}, mount, mountName, expectedCommand)
 }
 

--- a/storage/mounts_test.go
+++ b/storage/mounts_test.go
@@ -339,7 +339,7 @@ func TestGetMountingClusterID_Failures(t *testing.T) {
 	})
 }
 
-func TestMountCRD(t *testing.T) {
+func TestMountCrudErrors(t *testing.T) {
 	qa.HTTPFixturesApply(t, []qa.HTTPFixture{
 		{
 			MatchAny:     true,
@@ -358,6 +358,10 @@ func TestMountCRD(t *testing.T) {
 		assert.Equal(t, "failed to get mouting cluster: nope", diags[0].Summary)
 
 		diags = mountRead(nil, r)(ctx, d, client)
+		assert.True(t, diags.HasError())
+		assert.Equal(t, "failed to get mouting cluster: nope", diags[0].Summary)
+
+		diags = mountUpdate(nil, r)(ctx, d, client)
 		assert.True(t, diags.HasError())
 		assert.Equal(t, "failed to get mouting cluster: nope", diags[0].Summary)
 

--- a/storage/resource_mount.go
+++ b/storage/resource_mount.go
@@ -43,6 +43,11 @@ func ResourceDatabricksMountSchema() map[string]*schema.Schema {
 			Type:     schema.TypeString,
 			Computed: true,
 		}
+		s["config_hash"] = &schema.Schema{
+			Type:     schema.TypeString,
+			Default:  "",
+			Optional: true,
+		}
 		s["uri"].ConflictsWith = []string{"abfs", "wasb", "s3", "adl", "gs"}
 		s["extra_configs"].ConflictsWith = []string{"abfs", "wasb", "s3", "adl", "gs"}
 		s["abfs"].ConflictsWith = []string{"uri", "extra_configs", "wasb", "s3", "adl", "gs"}
@@ -62,6 +67,7 @@ func ResourceMount() *schema.Resource {
 	r := commonMountResource(tpl, ResourceDatabricksMountSchema())
 	r.CreateContext = mountCallback(mountCreate).preProcess(r)
 	r.ReadContext = mountCallback(mountRead).preProcess(r)
+	r.UpdateContext = mountCallback(mountUpdate).preProcess(r)
 	r.DeleteContext = mountCallback(mountDelete).preProcess(r)
 	r.Importer = nil
 	return r

--- a/storage/resource_mount_test.go
+++ b/storage/resource_mount_test.go
@@ -994,7 +994,7 @@ func TestResourceAzureBlobMountCreateGeneric_Resource_ID_Error(t *testing.T) {
 }
 
 func TestResourceAzureBlobMountCreateGeneric_Error(t *testing.T) {
-	d, err := qa.ResourceFixture{
+	qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   "GET",
@@ -1023,10 +1023,7 @@ func TestResourceAzureBlobMountCreateGeneric_Error(t *testing.T) {
 				"token_secret_scope":   "h",
 			}}},
 		Create: true,
-	}.Apply(t)
-	require.EqualError(t, err, "Some error")
-	assert.Equal(t, "e", d.Id())
-	assert.Equal(t, "", d.Get("source"))
+	}.ExpectError(t, "Some error")
 }
 
 func TestResourceAzureBlobMountCreateGeneric_Error_NoResourceID(t *testing.T) {

--- a/storage/resource_mount_test.go
+++ b/storage/resource_mount_test.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -8,8 +9,6 @@ import (
 	"github.com/databrickslabs/terraform-provider-databricks/common"
 	"github.com/databrickslabs/terraform-provider-databricks/internal"
 	"github.com/databrickslabs/terraform-provider-databricks/qa"
-
-	"github.com/Azure/go-autorest/autorest/azure"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
@@ -67,8 +66,17 @@ func TestS3MountDefaults(t *testing.T) {
 	assert.Equal(t, d.Get("name").(string), "abc")
 }
 
+func mockMountInfo(source, hash string) common.CommandResults {
+	return common.CommandResults{
+		ResultType: "text",
+		Data:       fmt.Sprintf(
+			`{"source":"%s","config_hash":"%s"}`, 
+			source, hash),
+	}
+}
+
 func TestResourceAwsS3MountGenericCreate(t *testing.T) {
-	d, err := qa.ResourceFixture{
+	qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:       "GET",
@@ -91,10 +99,7 @@ func TestResourceAwsS3MountGenericCreate(t *testing.T) {
 				assert.Contains(t, trunc, `{}`)             // empty brackets for empty config
 			}
 			assert.Contains(t, trunc, "/mnt/this_mount")
-			return common.CommandResults{
-				ResultType: "text",
-				Data:       testS3BucketPath,
-			}
+			return mockMountInfo(testS3BucketPath, "a1b2c3")
 		},
 		State: map[string]interface{}{
 			"cluster_id": "this_cluster",
@@ -104,14 +109,11 @@ func TestResourceAwsS3MountGenericCreate(t *testing.T) {
 			}},
 		},
 		Create: true,
-	}.Apply(t)
-	require.NoError(t, err, err)
-	assert.Equal(t, "this_mount", d.Id())
-	assert.Equal(t, testS3BucketPath, d.Get("source"))
+	}.ApplyNoError(t)
 }
 
 func TestResourceAwsS3MountGenericCreate_NoName(t *testing.T) {
-	d, err := qa.ResourceFixture{
+	qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:       "GET",
@@ -134,10 +136,7 @@ func TestResourceAwsS3MountGenericCreate_NoName(t *testing.T) {
 				assert.Contains(t, trunc, `{}`)             // empty brackets for empty config
 			}
 			assert.Contains(t, trunc, "/mnt/"+testS3BucketName)
-			return common.CommandResults{
-				ResultType: "text",
-				Data:       testS3BucketPath,
-			}
+			return mockMountInfo(testS3BucketPath, "a1b2c3")
 		},
 		State: map[string]interface{}{
 			"cluster_id": "this_cluster",
@@ -146,16 +145,13 @@ func TestResourceAwsS3MountGenericCreate_NoName(t *testing.T) {
 			}},
 		},
 		Create: true,
-	}.Apply(t)
-	require.NoError(t, err, err)
-	assert.Equal(t, testS3BucketName, d.Id())
-	assert.Equal(t, testS3BucketPath, d.Get("source"))
+	}.ApplyNoError(t)
 }
 
 func TestResourceAwsS3MountGenericCreate_WithInstanceProfile(t *testing.T) {
 	instance_profile := "arn:aws:iam::1234567:instance-profile/s3-access"
 	clusterName := "terraform-mount-s3-access"
-	d, err := qa.ResourceFixture{
+	qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:       "GET",
@@ -242,10 +238,7 @@ func TestResourceAwsS3MountGenericCreate_WithInstanceProfile(t *testing.T) {
 				assert.Contains(t, trunc, `{}`)             // empty brackets for empty config
 			}
 			assert.Contains(t, trunc, "/mnt/this_mount")
-			return common.CommandResults{
-				ResultType: "text",
-				Data:       testS3BucketPath,
-			}
+			return mockMountInfo(testS3BucketPath, "a1b2c3")
 		},
 		State: map[string]interface{}{
 			"name": "this_mount",
@@ -255,15 +248,11 @@ func TestResourceAwsS3MountGenericCreate_WithInstanceProfile(t *testing.T) {
 			}},
 		},
 		Create: true,
-	}.Apply(t)
-	require.NoError(t, err, err)
-	assert.Equal(t, "this_mount", d.Id())
-	assert.Equal(t, "abcd", d.Get("cluster_id"))
-	assert.Equal(t, testS3BucketPath, d.Get("source"))
+	}.ApplyNoError(t)
 }
 
 func TestResourceAwsS3MountGenericCreate_nothing_specified(t *testing.T) {
-	_, err := qa.ResourceFixture{
+	qa.ResourceFixture{
 		Resource: ResourceMount(),
 		State: map[string]interface{}{
 			"name": "this_mount",
@@ -272,12 +261,11 @@ func TestResourceAwsS3MountGenericCreate_nothing_specified(t *testing.T) {
 			}},
 		},
 		Create: true,
-	}.Apply(t)
-	require.EqualError(t, err, "either cluster_id or instance_profile must be specified to mount S3 bucket")
+	}.ExpectError(t, "either cluster_id or instance_profile must be specified to mount S3 bucket")
 }
 
 func TestResourceAwsS3MountGenericCreate_invalid_arn(t *testing.T) {
-	_, err := qa.ResourceFixture{
+	qa.ResourceFixture{
 		Resource: ResourceMount(),
 		State: map[string]interface{}{
 			"name": "this_mount",
@@ -287,12 +275,11 @@ func TestResourceAwsS3MountGenericCreate_invalid_arn(t *testing.T) {
 			}},
 		},
 		Create: true,
-	}.Apply(t)
-	require.EqualError(t, err, "invalid arn: this_mount")
+	}.ExpectError(t, "invalid arn: this_mount")
 }
 
 func TestResourceAwsS3MountGenericRead(t *testing.T) {
-	d, err := qa.ResourceFixture{
+	qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:       "GET",
@@ -312,10 +299,7 @@ func TestResourceAwsS3MountGenericRead(t *testing.T) {
 			t.Logf("Received command:\n%s", trunc)
 			assert.Contains(t, trunc, "dbutils.fs.mounts()")
 			assert.Contains(t, trunc, `mount.mountPoint == "/mnt/this_mount"`)
-			return common.CommandResults{
-				ResultType: "text",
-				Data:       testS3BucketPath,
-			}
+			return mockMountInfo(testS3BucketPath, "a1b2c3")
 		},
 		State: map[string]interface{}{
 			"cluster_id": "this_cluster",
@@ -326,10 +310,7 @@ func TestResourceAwsS3MountGenericRead(t *testing.T) {
 		},
 		ID:   "this_mount",
 		Read: true,
-	}.Apply(t)
-	require.NoError(t, err)
-	assert.Equal(t, "this_mount", d.Id())
-	assert.Equal(t, testS3BucketPath, d.Get("source"))
+	}.ApplyNoError(t)
 }
 
 func TestResourceAwsS3MountGenericRead_NotFound(t *testing.T) {
@@ -370,7 +351,7 @@ func TestResourceAwsS3MountGenericRead_NotFound(t *testing.T) {
 }
 
 func TestResourceAwsS3MountGenericRead_Error(t *testing.T) {
-	d, err := qa.ResourceFixture{
+	qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:       "GET",
@@ -402,14 +383,11 @@ func TestResourceAwsS3MountGenericRead_Error(t *testing.T) {
 		},
 		ID:   "this_mount",
 		Read: true,
-	}.Apply(t)
-	require.EqualError(t, err, "Some error")
-	assert.Equal(t, "this_mount", d.Id())
-	assert.Equal(t, "", d.Get("source"))
+	}.ExpectError(t, "Some error")
 }
 
 func TestResourceAwsS3MountDeleteGeneric(t *testing.T) {
-	d, err := qa.ResourceFixture{
+	qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:       "GET",
@@ -443,1109 +421,5 @@ func TestResourceAwsS3MountDeleteGeneric(t *testing.T) {
 		},
 		ID:     "this_mount",
 		Delete: true,
-	}.Apply(t)
-	require.NoError(t, err)
-	assert.Equal(t, "this_mount", d.Id())
-	assert.Equal(t, "", d.Get("source"))
-}
-
-// ============================== ADLS Gen1 Tests ==============================
-
-func TestResourceAdlsGen1MountGeneric_Create(t *testing.T) {
-	d, err := qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:       "GET",
-				ReuseRequest: true,
-				Resource:     "/api/2.0/clusters/get?cluster_id=this_cluster",
-				Response: clusters.ClusterInfo{
-					State: clusters.ClusterStateRunning,
-				},
-			},
-		},
-		Resource: ResourceMount(),
-		CommandMock: func(commandStr string) common.CommandResults {
-			trunc := internal.TrimLeadingWhitespace(commandStr)
-			t.Logf("Received command:\n%s", trunc)
-			if strings.HasPrefix(trunc, "def safe_mount") {
-				assert.Contains(t, trunc, "adl://test-adls.azuredatalakestore.net")
-				assert.Contains(t, trunc, `"fs.adl.oauth2.credential":dbutils.secrets.get("c", "d")`)
-			}
-			assert.Contains(t, trunc, "/mnt/this_mount")
-			return common.CommandResults{
-				ResultType: "text",
-				Data:       testS3BucketPath,
-			}
-		},
-		State: map[string]interface{}{
-			"cluster_id": "this_cluster",
-			"name":       "this_mount",
-			"adl": []interface{}{map[string]interface{}{
-				"storage_resource_name": "test-adls",
-				"tenant_id":             "a",
-				"client_id":             "b",
-				"client_secret_scope":   "c",
-				"client_secret_key":     "d",
-				"spark_conf_prefix":     "fs.adl",
-			}},
-		},
-		Create: true,
-	}.Apply(t)
-	require.NoError(t, err, err)
-	assert.Equal(t, "this_mount", d.Id())
-}
-
-func TestResourceAdlsGen1MountGeneric_Create_ResourceID(t *testing.T) {
-	d, err := qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:       "GET",
-				ReuseRequest: true,
-				Resource:     "/api/2.0/clusters/get?cluster_id=this_cluster",
-				Response: clusters.ClusterInfo{
-					State: clusters.ClusterStateRunning,
-				},
-			},
-		},
-		Resource: ResourceMount(),
-		CommandMock: func(commandStr string) common.CommandResults {
-			trunc := internal.TrimLeadingWhitespace(commandStr)
-			t.Logf("Received command:\n%s", trunc)
-			if strings.HasPrefix(trunc, "def safe_mount") {
-				assert.Contains(t, trunc, "adl://gen1.azuredatalakestore.net")
-				assert.Contains(t, trunc, `"fs.adl.oauth2.credential":dbutils.secrets.get("c", "d")`)
-			}
-			assert.Contains(t, trunc, "/mnt/gen1")
-			return common.CommandResults{
-				ResultType: "text",
-				Data:       testS3BucketPath,
-			}
-		},
-		State: map[string]interface{}{
-			"cluster_id":  "this_cluster",
-			"resource_id": "/subscriptions/123/resourceGroups/some-rg/providers/Microsoft.DataLakeStore/accounts/gen1",
-			"adl": []interface{}{map[string]interface{}{
-				"tenant_id":           "a",
-				"client_id":           "b",
-				"client_secret_scope": "c",
-				"client_secret_key":   "d",
-				"spark_conf_prefix":   "fs.adl",
-			}},
-		},
-		Create: true,
-	}.Apply(t)
-	require.NoError(t, err, err)
-	assert.Equal(t, "gen1", d.Id())
-}
-
-func TestResourceAdlsGen1MountGeneric_Create_ResourceID_Error1(t *testing.T) {
-	_, err := qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{},
-		Resource: ResourceMount(),
-		State: map[string]interface{}{
-			"resource_id": "/subscriptions/123/resourceGroups/some-rg/providers/Microsoft.DataLakeStore/acc/gen1",
-			"adl": []interface{}{map[string]interface{}{
-				"tenant_id":           "a",
-				"client_id":           "b",
-				"client_secret_scope": "c",
-				"client_secret_key":   "d",
-				"spark_conf_prefix":   "fs.adl",
-			}},
-		},
-		Create: true,
-	}.Apply(t)
-	qa.AssertErrorStartsWith(t, err, "incorrect resource type or provider in resource_id:")
-}
-
-func TestResourceAdlsGen1MountGeneric_Create_ResourceID_Error2(t *testing.T) {
-	_, err := qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{},
-		Resource: ResourceMount(),
-		State: map[string]interface{}{
-			"adl": []interface{}{map[string]interface{}{
-				"tenant_id":           "a",
-				"client_id":           "b",
-				"client_secret_scope": "c",
-				"client_secret_key":   "d",
-				"spark_conf_prefix":   "fs.adl",
-			}},
-		},
-		Create: true,
-	}.Apply(t)
-	qa.AssertErrorStartsWith(t, err, "storage_resource_name is empty, and resource_id or uri aren't specified")
-}
-
-func TestResourceAdlsGen1MountGeneric_Create_NoTenantID_Error(t *testing.T) {
-	_, err := qa.ResourceFixture{
-		Resource: ResourceMount(),
-		Azure:    true,
-		State: map[string]interface{}{
-			"resource_id": "/subscriptions/123/resourceGroups/some-rg/providers/Microsoft.DataLakeStore/accounts/gen1",
-			"cluster_id":  "this_cluster",
-			"name":        "this_mount",
-			"adl": []interface{}{map[string]interface{}{
-				"client_id":           "b",
-				"client_secret_scope": "c",
-				"client_secret_key":   "d",
-				"spark_conf_prefix":   "fs.adl",
-			}}},
-		Create: true,
-	}.Apply(t)
-	qa.AssertErrorStartsWith(t, err, "tenant_id is not defined, and we can't extract it: token contains an invalid number of segments")
-}
-
-func TestResourceAdlsGen1MountGeneric_Create_NoTenantID_Error_EmptyTenant(t *testing.T) {
-	_, err := qa.ResourceFixture{
-		Resource: ResourceMount(),
-		Token:    "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE2MzU3ODQxNTYsImV4cCI6MTY2NzMyMDE1NiwiYXVkIjoid3d3LmV4YW1wbGUuY29tIiwic3ViIjoianJvY2tldEBleGFtcGxlLmNvbSIsInRpZCI6IiAgIn0.faxuGAFghVxa1epYnovOxoQrzju7-z_EJj3oZtwIxdk",
-		Azure:    true,
-		State: map[string]interface{}{
-			"resource_id": "/subscriptions/123/resourceGroups/some-rg/providers/Microsoft.DataLakeStore/accounts/gen1",
-			"cluster_id":  "this_cluster",
-			"name":        "this_mount",
-			"adl": []interface{}{map[string]interface{}{
-				"client_id":           "b",
-				"client_secret_scope": "c",
-				"client_secret_key":   "d",
-				"spark_conf_prefix":   "fs.adl",
-			}}},
-		Create: true,
-	}.Apply(t)
-	qa.AssertErrorStartsWith(t, err, "tenant_id is not defined, and we can't extract it: tenant_id isn't provided & we can't detect it")
-}
-
-// ============================== ADLS Gen2 Tests ==============================
-
-func TestResourceAdlsGen2MountGeneric_Create(t *testing.T) {
-	d, err := qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:       "GET",
-				ReuseRequest: true,
-				Resource:     "/api/2.0/clusters/get?cluster_id=this_cluster",
-				Response: clusters.ClusterInfo{
-					State: clusters.ClusterStateRunning,
-				},
-			},
-		},
-		Resource: ResourceMount(),
-		CommandMock: func(commandStr string) common.CommandResults {
-			trunc := internal.TrimLeadingWhitespace(commandStr)
-			t.Logf("Received command:\n%s", trunc)
-			if strings.HasPrefix(trunc, "def safe_mount") {
-				assert.Contains(t, trunc, "abfss://e@test-adls-gen2.dfs.core.windows.net")
-				assert.Contains(t, trunc, `"fs.azure.account.oauth2.client.secret":dbutils.secrets.get("c", "d")`)
-			}
-			assert.Contains(t, trunc, "/mnt/this_mount")
-			return common.CommandResults{
-				ResultType: "text",
-				Data:       "abfss://e@test-adls-gen2.dfs.core.windows.net",
-			}
-		},
-		State: map[string]interface{}{
-			"cluster_id": "this_cluster",
-			"name":       "this_mount",
-			"abfs": []interface{}{map[string]interface{}{
-				"storage_account_name":   "test-adls-gen2",
-				"container_name":         "e",
-				"tenant_id":              "a",
-				"client_id":              "b",
-				"client_secret_scope":    "c",
-				"client_secret_key":      "d",
-				"initialize_file_system": true,
-			}}},
-		Create: true,
-	}.Apply(t)
-	require.NoError(t, err, err)
-	assert.Equal(t, "this_mount", d.Id())
-	assert.Equal(t, "abfss://e@test-adls-gen2.dfs.core.windows.net", d.Get("source"))
-}
-
-func TestResourceAdlsGen2MountGeneric_Create_ResourceID(t *testing.T) {
-	d, err := qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:       "GET",
-				ReuseRequest: true,
-				Resource:     "/api/2.0/clusters/get?cluster_id=this_cluster",
-				Response: clusters.ClusterInfo{
-					State: clusters.ClusterStateRunning,
-				},
-			},
-		},
-		Resource: ResourceMount(),
-		CommandMock: func(commandStr string) common.CommandResults {
-			trunc := internal.TrimLeadingWhitespace(commandStr)
-			t.Logf("Received command:\n%s", trunc)
-			if strings.HasPrefix(trunc, "def safe_mount") {
-				assert.Contains(t, trunc, "abfss://e@test-adls-gen2.dfs.core.windows.net")
-				assert.Contains(t, trunc, `"fs.azure.account.oauth2.client.secret":dbutils.secrets.get("c", "d")`)
-			}
-			assert.Contains(t, trunc, "/mnt/e")
-			return common.CommandResults{
-				ResultType: "text",
-				Data:       "abfss://e@test-adls-gen2.dfs.core.windows.net",
-			}
-		},
-		State: map[string]interface{}{
-			"cluster_id":  "this_cluster",
-			"resource_id": "/subscriptions/123/resourceGroups/some-rg/providers/Microsoft.Storage/storageAccounts/test-adls-gen2/blobServices/default/containers/e",
-			"abfs": []interface{}{map[string]interface{}{
-				"tenant_id":              "a",
-				"client_id":              "b",
-				"client_secret_scope":    "c",
-				"client_secret_key":      "d",
-				"initialize_file_system": true,
-			}}},
-		Create: true,
-	}.Apply(t)
-	require.NoError(t, err, err)
-	assert.Equal(t, "e", d.Id())
-	assert.Equal(t, "abfss://e@test-adls-gen2.dfs.core.windows.net", d.Get("source"))
-}
-
-func TestResourceAdlsGen2MountGeneric_Create_NoTenantID_SPN(t *testing.T) {
-	d, err := qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:       "GET",
-				ReuseRequest: true,
-				Resource:     "/api/2.0/clusters/get?cluster_id=this_cluster",
-				Response: clusters.ClusterInfo{
-					State: clusters.ClusterStateRunning,
-				},
-			},
-		},
-		Resource: ResourceMount(),
-		CommandMock: func(commandStr string) common.CommandResults {
-			trunc := internal.TrimLeadingWhitespace(commandStr)
-			t.Logf("Received command:\n%s", trunc)
-			if strings.HasPrefix(trunc, "def safe_mount") {
-				assert.Contains(t, trunc, "abfss://e@test-adls-gen2.dfs.core.windows.net")
-				assert.Contains(t, trunc, `"fs.azure.account.oauth2.client.secret":dbutils.secrets.get("c", "d")`)
-				assert.Contains(t, trunc, "https://login.microsoftonline.com/c/oauth2/token")
-			}
-			assert.Contains(t, trunc, "/mnt/this_mount")
-			return common.CommandResults{
-				ResultType: "text",
-				Data:       "abfss://e@test-adls-gen2.dfs.core.windows.net",
-			}
-		},
-		AzureSPN: true,
-		State: map[string]interface{}{
-			"cluster_id": "this_cluster",
-			"name":       "this_mount",
-			"abfs": []interface{}{map[string]interface{}{
-				"storage_account_name":   "test-adls-gen2",
-				"container_name":         "e",
-				"client_id":              "b",
-				"client_secret_scope":    "c",
-				"client_secret_key":      "d",
-				"initialize_file_system": true,
-			}}},
-		Create: true,
-	}.Apply(t)
-	require.NoError(t, err, err)
-	assert.Equal(t, "this_mount", d.Id())
-	assert.Equal(t, "abfss://e@test-adls-gen2.dfs.core.windows.net", d.Get("source"))
-}
-
-func TestResourceAdlsGen2MountGeneric_Create_NoTenantID_CLI(t *testing.T) {
-	d, err := qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:       "GET",
-				ReuseRequest: true,
-				Resource:     "/api/2.0/clusters/get?cluster_id=this_cluster",
-				Response: clusters.ClusterInfo{
-					State: clusters.ClusterStateRunning,
-				},
-			},
-		},
-		Resource: ResourceMount(),
-		CommandMock: func(commandStr string) common.CommandResults {
-			trunc := internal.TrimLeadingWhitespace(commandStr)
-			t.Logf("Received command:\n%s", trunc)
-			if strings.HasPrefix(trunc, "def safe_mount") {
-				assert.Contains(t, trunc, "abfss://e@test-adls-gen2.dfs.core.windows.net")
-				assert.Contains(t, trunc, `"fs.azure.account.oauth2.client.secret":dbutils.secrets.get("c", "d")`)
-				assert.Contains(t, trunc, "https://login.microsoftonline.com/abc/oauth2/token")
-			}
-			assert.Contains(t, trunc, "/mnt/this_mount")
-			return common.CommandResults{
-				ResultType: "text",
-				Data:       "abfss://e@test-adls-gen2.dfs.core.windows.net",
-			}
-		},
-		Azure: true,
-		// sample JWT token for testing
-		Token: "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE2MzU2OTU4MzksImV4cCI6MTY2NzIzMTgzOSwiYXVkIjoid3d3LmV4YW1wbGUuY29tIiwic3ViIjoianJvY2tldEBleGFtcGxlLmNvbSIsInRpZCI6ImFiYyJ9._G1DrR4DspidISpsra8UnecV_FV4zMlJDtSNzaS0UxI",
-		State: map[string]interface{}{
-			"cluster_id": "this_cluster",
-			"name":       "this_mount",
-			"abfs": []interface{}{map[string]interface{}{
-				"storage_account_name":   "test-adls-gen2",
-				"container_name":         "e",
-				"client_id":              "b",
-				"client_secret_scope":    "c",
-				"client_secret_key":      "d",
-				"initialize_file_system": true,
-			}}},
-		Create: true,
-	}.Apply(t)
-	require.NoError(t, err, err)
-	assert.Equal(t, "this_mount", d.Id())
-	assert.Equal(t, "abfss://e@test-adls-gen2.dfs.core.windows.net", d.Get("source"))
-}
-
-func TestResourceAdlsGen2MountGeneric_Create_NoTenantID_Error(t *testing.T) {
-	_, err := qa.ResourceFixture{
-		Resource: ResourceMount(),
-		Azure:    true,
-		State: map[string]interface{}{
-			"name": "this_mount",
-			"abfs": []interface{}{map[string]interface{}{
-				"storage_account_name":   "test-adls-gen2",
-				"container_name":         "e",
-				"client_id":              "b",
-				"client_secret_scope":    "c",
-				"client_secret_key":      "d",
-				"initialize_file_system": true,
-			}}},
-		Create: true,
-	}.Apply(t)
-	qa.AssertErrorStartsWith(t, err, "tenant_id is not defined, and we can't extract it: token contains an invalid number of segments")
-}
-
-func TestResourceAdlsGen2MountGeneric_Create_NoTenantID_Error_EmptyTenant(t *testing.T) {
-	_, err := qa.ResourceFixture{
-		Resource: ResourceMount(),
-		Token:    "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE2MzU3ODQxNTYsImV4cCI6MTY2NzMyMDE1NiwiYXVkIjoid3d3LmV4YW1wbGUuY29tIiwic3ViIjoianJvY2tldEBleGFtcGxlLmNvbSIsInRpZCI6IiAgIn0.faxuGAFghVxa1epYnovOxoQrzju7-z_EJj3oZtwIxdk",
-		Azure:    true,
-		State: map[string]interface{}{
-			"name": "this_mount",
-			"abfs": []interface{}{map[string]interface{}{
-				"storage_account_name":   "test-adls-gen2",
-				"container_name":         "e",
-				"client_id":              "b",
-				"client_secret_scope":    "c",
-				"client_secret_key":      "d",
-				"initialize_file_system": true,
-			}}},
-		Create: true,
-	}.Apply(t)
-	qa.AssertErrorStartsWith(t, err, "tenant_id is not defined, and we can't extract it: tenant_id isn't provided & we can't detect it")
-}
-
-// ============================== Azure Blob Storage Tests ==============================
-
-func TestResourceAzureBlobMountCreateGeneric(t *testing.T) {
-	d, err := qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:   "GET",
-				Resource: "/api/2.0/clusters/get?cluster_id=b",
-				Response: clusters.ClusterInfo{
-					State: clusters.ClusterStateRunning,
-				},
-				ReuseRequest: true,
-			},
-		},
-		Resource: ResourceMount(),
-		CommandMock: func(commandStr string) common.CommandResults {
-			trunc := internal.TrimLeadingWhitespace(commandStr)
-			t.Logf("Received command:\n%s", trunc)
-
-			if strings.HasPrefix(trunc, "def safe_mount") {
-				assert.Contains(t, trunc, "wasbs://c@f.blob.core.windows.net/d")
-				assert.Contains(t, trunc, `"fs.azure.account.key.f.blob.core.windows.net":dbutils.secrets.get("h", "g")`)
-			}
-			assert.Contains(t, trunc, "/mnt/e")
-			return common.CommandResults{
-				ResultType: "text",
-				Data:       "wasbs://c@f.blob.core.windows.net/d",
-			}
-		},
-		State: map[string]interface{}{
-			"cluster_id": "b",
-			"name":       "e",
-			"wasb": []interface{}{map[string]interface{}{
-				"auth_type":            "ACCESS_KEY",
-				"storage_account_name": "f",
-				"token_secret_key":     "g",
-				"token_secret_scope":   "h",
-				"container_name":       "c",
-				"directory":            "/d",
-			},
-			}},
-		Create: true,
-	}.Apply(t)
-	require.NoError(t, err, err)
-	assert.Equal(t, "e", d.Id())
-	assert.Equal(t, "wasbs://c@f.blob.core.windows.net/d", d.Get("source"))
-}
-
-func TestResourceAzureBlobMountCreateGeneric_SAS(t *testing.T) {
-	d, err := qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:   "GET",
-				Resource: "/api/2.0/clusters/get?cluster_id=b",
-				Response: clusters.ClusterInfo{
-					State: clusters.ClusterStateRunning,
-				},
-				ReuseRequest: true,
-			},
-		},
-		Resource: ResourceMount(),
-		CommandMock: func(commandStr string) common.CommandResults {
-			trunc := internal.TrimLeadingWhitespace(commandStr)
-			t.Logf("Received command:\n%s", trunc)
-
-			if strings.HasPrefix(trunc, "def safe_mount") {
-				assert.Contains(t, trunc, "wasbs://c@f.blob.core.windows.net/d")
-				assert.Contains(t, trunc, `"fs.azure.sas.c.f.blob.core.windows.net":dbutils.secrets.get("h", "g")`)
-			}
-			assert.Contains(t, trunc, "/mnt/e")
-			return common.CommandResults{
-				ResultType: "text",
-				Data:       "wasbs://c@f.blob.core.windows.net/d",
-			}
-		},
-		State: map[string]interface{}{
-			"cluster_id": "b",
-			"name":       "e",
-			"wasb": []interface{}{map[string]interface{}{
-				"auth_type":            "SAS",
-				"storage_account_name": "f",
-				"token_secret_key":     "g",
-				"token_secret_scope":   "h",
-				"container_name":       "c",
-				"directory":            "/d",
-			},
-			}},
-		Create: true,
-	}.Apply(t)
-	require.NoError(t, err, err)
-	assert.Equal(t, "e", d.Id())
-	assert.Equal(t, "wasbs://c@f.blob.core.windows.net/d", d.Get("source"))
-}
-
-func TestResourceAzureBlobMountCreateGeneric_Resource_ID(t *testing.T) {
-	d, err := qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:   "GET",
-				Resource: "/api/2.0/clusters/get?cluster_id=b",
-				Response: clusters.ClusterInfo{
-					State: clusters.ClusterStateRunning,
-				},
-				ReuseRequest: true,
-			},
-		},
-		Resource: ResourceMount(),
-		CommandMock: func(commandStr string) common.CommandResults {
-			trunc := internal.TrimLeadingWhitespace(commandStr)
-			t.Logf("Received command:\n%s", trunc)
-
-			if strings.HasPrefix(trunc, "def safe_mount") {
-				assert.Contains(t, trunc, "wasbs://c@f.blob.core.windows.net/d")
-				assert.Contains(t, trunc, `"fs.azure.account.key.f.blob.core.windows.net":dbutils.secrets.get("h", "g")`)
-			}
-			assert.Contains(t, trunc, "/mnt/c")
-			return common.CommandResults{
-				ResultType: "text",
-				Data:       "wasbs://c@f.blob.core.windows.net/d",
-			}
-		},
-		State: map[string]interface{}{
-			"cluster_id":  "b",
-			"resource_id": "/subscriptions/123/resourceGroups/some-rg/providers/Microsoft.Storage/storageAccounts/f/blobServices/default/containers/c",
-			"wasb": []interface{}{map[string]interface{}{
-				"auth_type":          "ACCESS_KEY",
-				"token_secret_key":   "g",
-				"token_secret_scope": "h",
-				"directory":          "/d",
-			},
-			}},
-		Create: true,
-	}.Apply(t)
-	require.NoError(t, err, err)
-	assert.Equal(t, "c", d.Id())
-	assert.Equal(t, "wasbs://c@f.blob.core.windows.net/d", d.Get("source"))
-}
-
-func TestResourceAzureBlobMountCreateGeneric_Resource_ID_Error(t *testing.T) {
-	_, err := qa.ResourceFixture{
-		Resource: ResourceMount(),
-		State: map[string]interface{}{
-			"cluster_id":  "b",
-			"resource_id": "abc",
-			"wasb": []interface{}{map[string]interface{}{
-				"auth_type":          "ACCESS_KEY",
-				"token_secret_key":   "g",
-				"token_secret_scope": "h",
-				"directory":          "/d",
-			},
-			}},
-		Create: true,
-	}.Apply(t)
-	qa.AssertErrorStartsWith(t, err, "parsing failed for abc. Invalid container resource Id format")
-}
-
-func TestResourceAzureBlobMountCreateGeneric_Error(t *testing.T) {
-	qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:   "GET",
-				Resource: "/api/2.0/clusters/get?cluster_id=b",
-				Response: clusters.ClusterInfo{
-					State: clusters.ClusterStateRunning,
-				},
-			},
-		},
-		Resource: ResourceMount(),
-		CommandMock: func(commandStr string) common.CommandResults {
-			return common.CommandResults{
-				ResultType: "error",
-				Summary:    "Some error",
-			}
-		},
-		State: map[string]interface{}{
-			"cluster_id": "b",
-			"name":       "e",
-			"wasb": []interface{}{map[string]interface{}{
-				"container_name":       "c",
-				"auth_type":            "ACCESS_KEY",
-				"directory":            "/d",
-				"storage_account_name": "f",
-				"token_secret_key":     "g",
-				"token_secret_scope":   "h",
-			}}},
-		Create: true,
-	}.ExpectError(t, "Some error")
-}
-
-func TestResourceAzureBlobMountCreateGeneric_Error_NoResourceID(t *testing.T) {
-	d, err := qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:   "GET",
-				Resource: "/api/2.0/clusters/get?cluster_id=b",
-				Response: clusters.ClusterInfo{
-					State: clusters.ClusterStateRunning,
-				},
-			},
-		},
-		Resource: ResourceMount(),
-		CommandMock: func(commandStr string) common.CommandResults {
-			return common.CommandResults{
-				ResultType: "error",
-				Summary:    "Some error",
-			}
-		},
-		State: map[string]interface{}{
-			"cluster_id": "b",
-			"name":       "e",
-			"wasb": []interface{}{map[string]interface{}{
-				"auth_type":          "ACCESS_KEY",
-				"directory":          "/d",
-				"token_secret_key":   "g",
-				"token_secret_scope": "h",
-			}}},
-		Create: true,
-	}.Apply(t)
-	require.EqualError(t, err, "container_name or storage_account_name are empty, and resource_id or uri aren't specified")
-	assert.Equal(t, "", d.Get("source"))
-}
-
-func TestResourceAzureBlobMountGeneric_Read(t *testing.T) {
-	d, err := qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:   "GET",
-				Resource: "/api/2.0/clusters/get?cluster_id=b",
-				Response: clusters.ClusterInfo{
-					State: clusters.ClusterStateRunning,
-				},
-			},
-		},
-		Resource: ResourceMount(),
-		CommandMock: func(commandStr string) common.CommandResults {
-			trunc := internal.TrimLeadingWhitespace(commandStr)
-			t.Logf("Received command:\n%s", trunc)
-			assert.Contains(t, trunc, "dbutils.fs.mounts()")
-			assert.Contains(t, trunc, `mount.mountPoint == "/mnt/e"`)
-			return common.CommandResults{
-				ResultType: "text",
-				Data:       "wasbs://c@f.blob.core.windows.net/d",
-			}
-		},
-		State: map[string]interface{}{
-			"cluster_id": "b",
-			"name":       "e",
-			"wasb": []interface{}{map[string]interface{}{
-				"auth_type":            "ACCESS_KEY",
-				"container_name":       "c",
-				"directory":            "/d",
-				"storage_account_name": "f",
-				"token_secret_key":     "g",
-				"token_secret_scope":   "h",
-			}},
-		},
-		ID:   "e",
-		Read: true,
-	}.Apply(t)
-	require.NoError(t, err)
-	assert.Equal(t, "e", d.Id())
-	assert.Equal(t, "wasbs://c@f.blob.core.windows.net/d", d.Get("source"))
-}
-
-func TestResourceAzureBlobMountGenericRead_NotFound(t *testing.T) {
-	qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:   "GET",
-				Resource: "/api/2.0/clusters/get?cluster_id=b",
-				Response: clusters.ClusterInfo{
-					State: clusters.ClusterStateRunning,
-				},
-			},
-		},
-		Resource: ResourceMount(),
-		CommandMock: func(commandStr string) common.CommandResults {
-			trunc := internal.TrimLeadingWhitespace(commandStr)
-			t.Logf("Received command:\n%s", trunc)
-			return common.CommandResults{
-				ResultType: "error",
-				Summary:    "Mount not found",
-			}
-		},
-		State: map[string]interface{}{
-			"cluster_id": "b",
-			"name":       "e",
-			"wasb": []interface{}{map[string]interface{}{
-				"auth_type":            "ACCESS_KEY",
-				"container_name":       "c",
-				"directory":            "/d",
-				"storage_account_name": "f",
-				"token_secret_key":     "g",
-				"token_secret_scope":   "h",
-			}},
-		},
-		ID:      "e",
-		Read:    true,
-		Removed: true,
 	}.ApplyNoError(t)
-}
-
-func TestResourceAzureBlobMountGenericRead_Error(t *testing.T) {
-	d, err := qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:   "GET",
-				Resource: "/api/2.0/clusters/get?cluster_id=b",
-				Response: clusters.ClusterInfo{
-					State: clusters.ClusterStateRunning,
-				},
-			},
-		},
-		Resource: ResourceMount(),
-		CommandMock: func(commandStr string) common.CommandResults {
-			trunc := internal.TrimLeadingWhitespace(commandStr)
-			t.Logf("Received command:\n%s", trunc)
-			return common.CommandResults{
-				ResultType: "error",
-				Summary:    "Some error",
-			}
-		},
-		State: map[string]interface{}{
-			"cluster_id": "b",
-			"name":       "e",
-			"wasb": []interface{}{map[string]interface{}{
-				"auth_type":            "ACCESS_KEY",
-				"container_name":       "c",
-				"directory":            "/d",
-				"storage_account_name": "f",
-				"token_secret_key":     "g",
-				"token_secret_scope":   "h",
-			}},
-		},
-		ID:   "e",
-		Read: true,
-	}.Apply(t)
-	require.EqualError(t, err, "Some error")
-	assert.Equal(t, "e", d.Id())
-	assert.Equal(t, "", d.Get("source"))
-}
-
-func TestResourceAzureBlobMountGenericDelete(t *testing.T) {
-	d, err := qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:   "GET",
-				Resource: "/api/2.0/clusters/get?cluster_id=b",
-				Response: clusters.ClusterInfo{
-					State: clusters.ClusterStateRunning,
-				},
-			},
-		},
-		Resource: ResourceMount(),
-		CommandMock: func(commandStr string) common.CommandResults {
-			trunc := internal.TrimLeadingWhitespace(commandStr)
-			t.Logf("Received command:\n%s", trunc)
-			assert.Contains(t, trunc, "dbutils.fs.unmount(mount_point)")
-			return common.CommandResults{
-				ResultType: "Text",
-				Data:       "",
-			}
-		},
-		State: map[string]interface{}{
-			"cluster_id": "b",
-			"name":       "e",
-			"wasb": []interface{}{map[string]interface{}{
-				"auth_type":            "ACCESS_KEY",
-				"container_name":       "c",
-				"directory":            "/d",
-				"storage_account_name": "f",
-				"token_secret_key":     "g",
-				"token_secret_scope":   "h",
-			}},
-		},
-		ID:     "e",
-		Delete: true,
-	}.Apply(t)
-	require.NoError(t, err)
-	assert.Equal(t, "e", d.Id())
-	assert.Equal(t, "", d.Get("source"))
-}
-
-// ============================== Google Cloud Storage Tests ==============================
-
-const testGcsBucketPath = "gs://" + testS3BucketName
-
-func TestGSMountDefaults(t *testing.T) {
-	s := ResourceDatabricksMountSchema()
-	d := schema.TestResourceDataRaw(t, s, map[string]interface{}{})
-	client, server, err := qa.HttpFixtureClient(t, []qa.HTTPFixture{})
-	defer server.Close()
-	require.NoError(t, err, err)
-
-	err = GSMount{}.ValidateAndApplyDefaults(d, client)
-	qa.AssertErrorStartsWith(t, err, "'name' is not detected & it's impossible to infer it")
-
-	d = schema.TestResourceDataRaw(t, s, map[string]interface{}{"name": "test"})
-	err = GSMount{}.ValidateAndApplyDefaults(d, client)
-	require.NoError(t, err, err)
-	assert.Equal(t, d.Get("name").(string), "test")
-	d = schema.TestResourceDataRaw(t, s, map[string]interface{}{})
-	err = GSMount{BucketName: "abc"}.ValidateAndApplyDefaults(d, client)
-	require.NoError(t, err, err)
-	assert.Equal(t, d.Get("name").(string), "abc")
-}
-
-func TestResourceGcsMountGenericCreate_WithCluster(t *testing.T) {
-	google_account := "acc@acc-dbx.iam.gserviceaccount.com"
-	d, err := qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:       "GET",
-				ReuseRequest: true,
-				Resource:     "/api/2.0/clusters/get?cluster_id=this_cluster",
-				Response: clusters.ClusterInfo{
-					State: clusters.ClusterStateRunning,
-					GcpAttributes: &clusters.GcpAttributes{
-						GoogleServiceAccount: google_account,
-					},
-				},
-			},
-		},
-		Resource: ResourceMount(),
-		CommandMock: func(commandStr string) common.CommandResults {
-			trunc := internal.TrimLeadingWhitespace(commandStr)
-			t.Logf("Received command:\n%s", trunc)
-			if strings.HasPrefix(trunc, "def safe_mount") {
-				assert.Contains(t, trunc, testGcsBucketPath) // bucketname
-				assert.Contains(t, trunc, `{}`)              // empty brackets for empty config
-			}
-			assert.Contains(t, trunc, "/mnt/this_mount")
-			return common.CommandResults{
-				ResultType: "text",
-				Data:       testGcsBucketPath,
-			}
-		},
-		State: map[string]interface{}{
-			"cluster_id": "this_cluster",
-			"name":       "this_mount",
-			"gs": []interface{}{map[string]interface{}{
-				"bucket_name": testS3BucketName,
-			}},
-		},
-		Create: true,
-	}.Apply(t)
-	require.NoError(t, err, err)
-	assert.Equal(t, "this_mount", d.Id())
-	assert.Equal(t, testGcsBucketPath, d.Get("source"))
-}
-
-func TestResourceGcsMountGenericCreate_WithCluster_NoName(t *testing.T) {
-	google_account := "acc@acc-dbx.iam.gserviceaccount.com"
-	d, err := qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:       "GET",
-				ReuseRequest: true,
-				Resource:     "/api/2.0/clusters/get?cluster_id=this_cluster",
-				Response: clusters.ClusterInfo{
-					State: clusters.ClusterStateRunning,
-					GcpAttributes: &clusters.GcpAttributes{
-						GoogleServiceAccount: google_account,
-					},
-				},
-			},
-		},
-		Resource: ResourceMount(),
-		CommandMock: func(commandStr string) common.CommandResults {
-			trunc := internal.TrimLeadingWhitespace(commandStr)
-			t.Logf("Received command:\n%s", trunc)
-			if strings.HasPrefix(trunc, "def safe_mount") {
-				assert.Contains(t, trunc, testGcsBucketPath) // bucketname
-				assert.Contains(t, trunc, `{}`)              // empty brackets for empty config
-			}
-			assert.Contains(t, trunc, "/mnt/"+testS3BucketName)
-			return common.CommandResults{
-				ResultType: "text",
-				Data:       testGcsBucketPath,
-			}
-		},
-		State: map[string]interface{}{
-			"cluster_id": "this_cluster",
-			"gs": []interface{}{map[string]interface{}{
-				"bucket_name": testS3BucketName,
-			}},
-		},
-		Create: true,
-	}.Apply(t)
-	require.NoError(t, err, err)
-	assert.Equal(t, testS3BucketName, d.Id())
-	assert.Equal(t, testGcsBucketPath, d.Get("source"))
-}
-
-func TestResourceGcsMountGenericCreate_WithServiceAccount(t *testing.T) {
-	googleAccount := "acc@acc-dbx.iam.gserviceaccount.com"
-	clusterName := "terraform-mount-gcs-bcb24f32098efa4172f435adbed2dae2"
-	d, err := qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:       "GET",
-				ReuseRequest: true,
-				Resource:     "/api/2.0/clusters/get?cluster_id=abcd",
-				Response: clusters.ClusterInfo{
-					ClusterID: "abcd",
-					State:     clusters.ClusterStateRunning,
-					GcpAttributes: &clusters.GcpAttributes{
-						GoogleServiceAccount: googleAccount,
-					},
-				},
-			},
-			{
-				Method:   "GET",
-				Resource: "/api/2.0/clusters/list",
-				Response: map[string]interface{}{},
-			},
-			{
-				Method:   "GET",
-				Resource: "/api/2.0/clusters/list",
-				Response: clusters.ClusterList{
-					Clusters: []clusters.ClusterInfo{
-						{
-							ClusterID: "abcd",
-							State:     clusters.ClusterStateRunning,
-							GcpAttributes: &clusters.GcpAttributes{
-								GoogleServiceAccount: googleAccount,
-							},
-							AutoterminationMinutes: 10,
-							SparkConf: map[string]string{"spark.databricks.cluster.profile": "singleNode",
-								"spark.master": "local[*]", "spark.scheduler.mode": "FIFO"},
-							CustomTags:   map[string]string{"ResourceClass": "SingleNode"},
-							ClusterName:  clusterName,
-							SparkVersion: "7.3.x-scala2.12",
-							NumWorkers:   0,
-						},
-					},
-				},
-			},
-			{
-				Method:       "GET",
-				Resource:     "/api/2.0/clusters/spark-versions",
-				Response:     sparkVersionsResponse,
-				ReuseRequest: true,
-			},
-			{
-				Method:       "GET",
-				Resource:     "/api/2.0/clusters/list-node-types",
-				ReuseRequest: true,
-				Response:     nodeListResponse,
-			},
-			{
-				Method:       "POST",
-				Resource:     "/api/2.0/clusters/create",
-				ReuseRequest: true,
-				ExpectedRequest: clusters.Cluster{
-					NodeTypeID: "Standard_F4s",
-					GcpAttributes: &clusters.GcpAttributes{
-						GoogleServiceAccount: "acc@acc-dbx.iam.gserviceaccount.com",
-					},
-					AutoterminationMinutes: 10,
-					SparkConf: map[string]string{"spark.databricks.cluster.profile": "singleNode",
-						"spark.master": "local[*]", "spark.scheduler.mode": "FIFO"},
-					CustomTags:   map[string]string{"ResourceClass": "SingleNode"},
-					ClusterName:  clusterName,
-					SparkVersion: "7.3.x-scala2.12",
-					NumWorkers:   0,
-				},
-				Response: clusters.ClusterID{
-					ClusterID: "abcd",
-				},
-			},
-		},
-		Resource: ResourceMount(),
-		CommandMock: func(commandStr string) common.CommandResults {
-			trunc := internal.TrimLeadingWhitespace(commandStr)
-			t.Logf("Received command:\n%s", trunc)
-			if strings.HasPrefix(trunc, "def safe_mount") {
-				assert.Contains(t, trunc, testGcsBucketPath) // bucketname
-				assert.Contains(t, trunc, `{}`)              // empty brackets for empty config
-			}
-			assert.Contains(t, trunc, "/mnt/this_mount")
-			return common.CommandResults{
-				ResultType: "text",
-				Data:       testGcsBucketPath,
-			}
-		},
-		State: map[string]interface{}{
-			"name": "this_mount",
-			"gs": []interface{}{map[string]interface{}{
-				"bucket_name":     testS3BucketName,
-				"service_account": googleAccount,
-			}},
-		},
-		Create: true,
-	}.Apply(t)
-	require.NoError(t, err, err)
-	assert.Equal(t, "this_mount", d.Id())
-	assert.Equal(t, "abcd", d.Get("cluster_id"))
-	assert.Equal(t, testGcsBucketPath, d.Get("source"))
-}
-
-func TestResourceGcsMountGenericCreate_nothing_specified(t *testing.T) {
-	_, err := qa.ResourceFixture{
-		Resource: ResourceMount(),
-		State: map[string]interface{}{
-			"name": "this_mount",
-			"gs": []interface{}{map[string]interface{}{
-				"bucket_name": testS3BucketName,
-			}},
-		},
-		Create: true,
-	}.Apply(t)
-	require.EqualError(t, err, "either cluster_id or service_account must be specified to mount GCS bucket")
-}
-
-// ============================== Tests for Generic Configuration options ==============================
-
-func TestResourceMountGenericCreate_WithUriAndOpts(t *testing.T) {
-	abfssPath := "abfss://test@$test.dfs.core.windows.net"
-	d, err := qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:       "GET",
-				ReuseRequest: true,
-				Resource:     "/api/2.0/clusters/get?cluster_id=this_cluster",
-				Response: clusters.ClusterInfo{
-					State: clusters.ClusterStateRunning,
-				},
-			},
-		},
-		Resource: ResourceMount(),
-		CommandMock: func(commandStr string) common.CommandResults {
-			trunc := internal.TrimLeadingWhitespace(commandStr)
-			t.Logf("Received command:\n%s", trunc)
-			if strings.HasPrefix(trunc, "def safe_mount") {
-				assert.Contains(t, trunc, abfssPath) // URI
-				assert.Contains(t, trunc, `{"fs.azure.account.auth.type":"CustomAccessToken"}`)
-			}
-			assert.Contains(t, trunc, "/mnt/this_mount")
-			return common.CommandResults{
-				ResultType: "text",
-				Data:       abfssPath,
-			}
-		},
-		State: map[string]interface{}{
-			"cluster_id": "this_cluster",
-			"name":       "this_mount",
-			"uri":        abfssPath,
-			"extra_configs": map[string]interface{}{
-				"fs.azure.account.auth.type": "CustomAccessToken",
-			},
-		},
-		Create: true,
-	}.Apply(t)
-	require.NoError(t, err, err)
-	assert.Equal(t, "this_mount", d.Id())
-	assert.Equal(t, abfssPath, d.Get("source"))
-}
-
-func TestNames(t *testing.T) {
-	mount_name := "abc"
-	gm := GenericMount{MountName: mount_name}
-	assert.Equal(t, gm.Name(), mount_name)
-	assert.Equal(t, GenericMount{}.Name(), "")
-	gm = GenericMount{Abfs: &AzureADLSGen2MountGeneric{ContainerName: mount_name}}
-	assert.Equal(t, gm.Name(), mount_name)
-	gm = GenericMount{Wasb: &AzureBlobMountGeneric{ContainerName: mount_name}}
-	assert.Equal(t, gm.Name(), mount_name)
-	gm = GenericMount{Adl: &AzureADLSGen1MountGeneric{StorageResource: mount_name}}
-	assert.Equal(t, gm.Name(), mount_name)
-}
-
-func TestARMParsing(t *testing.T) {
-	acc, container, err := parseStorageContainerId("/subscriptions/5363c143-2af7-4fb5-8a9d-ab1b2c8e756e/resourceGroups/test-rg/providers/Microsoft.Storage/storageAccounts/lrs-acc/blobServices/default/containers/test")
-	require.NoError(t, err, err)
-	assert.Equal(t, acc, "lrs-acc")
-	assert.Equal(t, container, "test")
-}
-
-func TestARMParsingError(t *testing.T) {
-	_, _, err := parseStorageContainerId("abc")
-	qa.AssertErrorStartsWith(t, err, "parsing failed for ")
-}
-
-func TestARMParsing2(t *testing.T) {
-	res, err := azure.ParseResourceID("/subscriptions/6369c148-f8a9-4fb5-8a9d-ac1b2c8e756e/resourceGroups/alexott-rg/providers/Microsoft.DataLakeStore/accounts/aottgen1")
-	require.NoError(t, err, err)
-	assert.Equal(t, res.ResourceName, "aottgen1")
-}
-
-func TestGenericMountDefaults(t *testing.T) {
-	s := ResourceDatabricksMountSchema()
-	d := schema.TestResourceDataRaw(t, s, map[string]interface{}{})
-	client, server, err := qa.HttpFixtureClient(t, []qa.HTTPFixture{})
-	defer server.Close()
-	require.NoError(t, err, err)
-
-	gm := GenericMount{MountName: "test"}
-	err = common.StructToData(gm, s, d)
-	require.NoError(t, err, err)
-	err = gm.ValidateAndApplyDefaults(d, client)
-	qa.AssertErrorStartsWith(t, err, "value of uri is not specified or empty")
-
-	d = schema.TestResourceDataRaw(t, s, map[string]interface{}{"uri": "s3://abc/"})
-	err = gm.ValidateAndApplyDefaults(d, client)
-	qa.AssertErrorStartsWith(t, err, "value of name is not specified or empty")
-
-	gm = GenericMount{Abfs: &AzureADLSGen2MountGeneric{}}
-	d = schema.TestResourceDataRaw(t, s, map[string]interface{}{"abfs": map[string]interface{}{}})
-	err = gm.ValidateAndApplyDefaults(d, client)
-	qa.AssertErrorStartsWith(t, err, "container_name or storage_account_name are empty, and resource_id or uri aren't specified")
 }

--- a/storage/s3.go
+++ b/storage/s3.go
@@ -12,7 +12,7 @@ import (
 
 // S3IamMount describes the object for a aws mount using iam role
 type S3IamMount struct {
-	BucketName      string `json:"bucket_name" tf:"force_new"`
+	BucketName      string `json:"bucket_name"`
 	InstanceProfile string `json:"instance_profile,omitempty" tf:"force_new"`
 }
 


### PR DESCRIPTION
* Return `mountRemoteInfo` from MountPoint#Mount
* Change signature of MountPoint#Source - expect `Mount`/`Client` as arguments, return `mountRemoteInfo` instead of mount source string
* remote acceptance tests for deprecated resources, that are otherwise making this feature more complicated
* all mounting clusters have to be re-created (or updated to DBR 10.2+) in case `updateMount` functionality is required.

Fix #513