### PR TITLE
Sanitize host field prior to auth flow

### DIFF
--- a/common/client.go
+++ b/common/client.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"net/url"
 	"os"
 	"reflect"
 	"strings"
@@ -237,6 +238,11 @@ func (c *DatabricksClient) Authenticate(ctx context.Context) error {
 	if c.authVisitor != nil {
 		return nil
 	}
+	// Fix host prior to auth, because it may be used in the OIDC flow as "audience" field.
+	// If necessary, this function adds a scheme and strips a trailing slash.
+	if err := c.fixHost(); err != nil {
+		return err
+	}
 	type auth struct {
 		configure func(context.Context) (func(*http.Request) error, error)
 		name      string
@@ -271,7 +277,6 @@ func (c *DatabricksClient) Authenticate(ctx context.Context) error {
 		log.Printf("[INFO] Configured %s auth: %s", auth.name, c.configDebugString()) // lgtm[go/clear-text-logging]
 		c.authVisitor = authorizer
 		c.AuthType = auth.name
-		c.fixHost()
 		return nil
 	}
 	if c.AuthType != "" {
@@ -326,12 +331,37 @@ func (c *DatabricksClient) niceAuthError(message string) error {
 	return fmt.Errorf("%s%s. Please check %s for details", message, info, docUrl)
 }
 
-func (c *DatabricksClient) fixHost() {
-	if c.Host != "" && !(strings.HasPrefix(c.Host, "https://") || strings.HasPrefix(c.Host, "http://")) {
-		// azurerm_databricks_workspace.*.workspace_url is giving URL without scheme
-		// so that is why this line is here
-		c.Host = "https://" + c.Host
+func (c *DatabricksClient) fixHost() error {
+	if c.Host != "" {
+		u, err := url.Parse(c.Host)
+		if err != nil {
+			return err
+		}
+
+		// If the scheme is not specified, default to https.
+		scheme := u.Scheme
+		if scheme == "" {
+			scheme = "https"
+		}
+
+		// If the host was specified without scheme, it is parsed as path.
+		// For example, azurerm_databricks_workspace.*.workspace_url returns an URL without scheme.
+		host := u.Host
+		if host == "" {
+			host = u.Path
+		}
+
+		// Create new instance to ensure other fields are initialized as empty.
+		u = &url.URL{
+			Scheme: scheme,
+			Host:   host,
+		}
+
+		// Store sanitized version of c.Host.
+		c.Host = u.String()
 	}
+
+	return nil
 }
 
 func (c *DatabricksClient) configureWithPat(ctx context.Context) (func(*http.Request) error, error) {

--- a/common/client.go
+++ b/common/client.go
@@ -332,30 +332,32 @@ func (c *DatabricksClient) niceAuthError(message string) error {
 }
 
 func (c *DatabricksClient) fixHost() error {
-	if c.Host != "" {
-		u, err := url.Parse(c.Host)
+	// Nothing to fix if the host isn't set.
+	if c.Host == "" {
+		return nil
+	}
+
+	u, err := url.Parse(c.Host)
+	if err != nil {
+		return err
+	}
+
+	// If the host is empty, assume the scheme wasn't included.
+	if u.Host == "" {
+		u, err = url.Parse("https://" + c.Host)
 		if err != nil {
 			return err
 		}
-
-		// If the host is empty, assume the scheme wasn't included.
-		if u.Host == "" {
-			u, err = url.Parse("https://" + c.Host)
-			if err != nil {
-				return err
-			}
-		}
-
-		// Create new instance to ensure other fields are initialized as empty.
-		u = &url.URL{
-			Scheme: u.Scheme,
-			Host:   u.Host,
-		}
-
-		// Store sanitized version of c.Host.
-		c.Host = u.String()
 	}
 
+	// Create new instance to ensure other fields are initialized as empty.
+	u = &url.URL{
+		Scheme: u.Scheme,
+		Host:   u.Host,
+	}
+
+	// Store sanitized version of c.Host.
+	c.Host = u.String()
 	return nil
 }
 

--- a/common/client.go
+++ b/common/client.go
@@ -277,6 +277,7 @@ func (c *DatabricksClient) Authenticate(ctx context.Context) error {
 		log.Printf("[INFO] Configured %s auth: %s", auth.name, c.configDebugString()) // lgtm[go/clear-text-logging]
 		c.authVisitor = authorizer
 		c.AuthType = auth.name
+		c.fixHost()
 		return nil
 	}
 	if c.AuthType != "" {

--- a/common/client.go
+++ b/common/client.go
@@ -338,23 +338,18 @@ func (c *DatabricksClient) fixHost() error {
 			return err
 		}
 
-		// If the scheme is not specified, default to https.
-		scheme := u.Scheme
-		if scheme == "" {
-			scheme = "https"
-		}
-
-		// If the host was specified without scheme, it is parsed as path.
-		// For example, azurerm_databricks_workspace.*.workspace_url returns an URL without scheme.
-		host := u.Host
-		if host == "" {
-			host = u.Path
+		// If the host is empty, assume the scheme wasn't included.
+		if u.Host == "" {
+			u, err = url.Parse("https://" + c.Host)
+			if err != nil {
+				return err
+			}
 		}
 
 		// Create new instance to ensure other fields are initialized as empty.
 		u = &url.URL{
-			Scheme: scheme,
-			Host:   host,
+			Scheme: u.Scheme,
+			Host:   u.Host,
 		}
 
 		// Store sanitized version of c.Host.

--- a/common/client_test.go
+++ b/common/client_test.go
@@ -331,6 +331,13 @@ func TestDatabricksClientFixHost(t *testing.T) {
 	}
 
 	{
+		// Default scheme with port.
+		out, err := hostForInput("accounts.gcp.databricks.com:443")
+		assert.Nil(t, err)
+		assert.Equal(t, out, "https://accounts.gcp.databricks.com:443")
+	}
+
+	{
 		// Return error.
 		_, err := hostForInput("://@@@accounts.gcp.databricks.com/")
 		assert.NotNil(t, err)

--- a/common/client_test.go
+++ b/common/client_test.go
@@ -297,3 +297,42 @@ func TestConfigAttributeSetNonsense(t *testing.T) {
 	}).Set(&DatabricksClient{}, 1)
 	assert.EqualError(t, err, "cannot set  of unknown type Chan")
 }
+
+func TestDatabricksClientFixHost(t *testing.T) {
+	hostForInput := func(in string) (string, error) {
+		client := &DatabricksClient{
+			Host: in,
+		}
+		if err := client.fixHost(); err != nil {
+			return "", err
+		}
+		return client.Host, nil
+	}
+
+	{
+		// Strip trailing slash.
+		out, err := hostForInput("https://accounts.gcp.databricks.com/")
+		assert.Nil(t, err)
+		assert.Equal(t, out, "https://accounts.gcp.databricks.com")
+	}
+
+	{
+		// Keep port.
+		out, err := hostForInput("https://accounts.gcp.databricks.com:443")
+		assert.Nil(t, err)
+		assert.Equal(t, out, "https://accounts.gcp.databricks.com:443")
+	}
+
+	{
+		// Default scheme.
+		out, err := hostForInput("accounts.gcp.databricks.com")
+		assert.Nil(t, err)
+		assert.Equal(t, out, "https://accounts.gcp.databricks.com")
+	}
+
+	{
+		// Return error.
+		_, err := hostForInput("://@@@accounts.gcp.databricks.com/")
+		assert.NotNil(t, err)
+	}
+}

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -244,7 +244,7 @@ func TestConfig_PatFromDatabricksCfg(t *testing.T) {
 		env: map[string]string{
 			"HOME": "../common/testdata",
 		},
-		assertHost: "https://dbc-XXXXXXXX-YYYY.cloud.databricks.com/",
+		assertHost: "https://dbc-XXXXXXXX-YYYY.cloud.databricks.com",
 		assertAuth: "databricks-cli",
 	}.apply(t)
 }

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -198,7 +198,7 @@ func TestConfig_AzurePAT(t *testing.T) {
 		host:        "https://adb-xxx.y.azuredatabricks.net/",
 		token:       "y",
 		assertAzure: true,
-		assertHost:  "https://adb-xxx.y.azuredatabricks.net/",
+		assertHost:  "https://adb-xxx.y.azuredatabricks.net",
 		assertAuth:  "pat",
 	}.apply(t)
 }


### PR DESCRIPTION
I was getting 401s when trying to use the accounts API on GCP, until I realized the host field in the provider configuration had a trailing slash. Removing the trailing slash fixed the issue. To improve the UX here, this PR removes a trailing slash prior to the authentication flow.