### PR TITLE
Fix update logic for storage credentials

### DIFF
--- a/catalog/resource_storage_credential.go
+++ b/catalog/resource_storage_credential.go
@@ -49,7 +49,7 @@ func ResourceStorageCredential() *schema.Resource {
 			return m
 		})
 	update := updateFunctionFactory("/unity-catalog/storage-credentials", []string{
-		"owner", "comment", "aws_iam_role", "azure_service_principal"})
+		"owner", "comment", "aws_iam_role", "azure_service_principal", "azure_managed_identity"})
 	return common.Resource{
 		Schema: s,
 		Create: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {

--- a/catalog/resource_storage_credential_test.go
+++ b/catalog/resource_storage_credential_test.go
@@ -104,9 +104,9 @@ func TestUpdateStorageCredentials(t *testing.T) {
 				Method:   "PATCH",
 				Resource: "/api/2.0/unity-catalog/storage-credentials/a",
 				ExpectedRequest: map[string]interface{}{
-					"aws_iam_role": []interface{}{map[string]interface{}{
+					"aws_iam_role": map[string]interface{}{
 						"role_arn": "CHANGED",
-					}},
+					},
 				},
 			},
 			{
@@ -173,6 +173,53 @@ func TestCreateStorageCredentialWithAzMI(t *testing.T) {
 		name = "a"
 		azure_managed_identity {
 			access_connector_id = "def"
+		}
+		comment = "c"
+		`,
+	}.ApplyNoError(t)
+}
+
+func TestUpdateAzStorageCredentials(t *testing.T) {
+	qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "PATCH",
+				Resource: "/api/2.0/unity-catalog/storage-credentials/a",
+				ExpectedRequest: map[string]interface{}{
+					"azure_service_principal": map[string]interface{}{
+						"directory_id":   "CHANGED",
+						"application_id": "CHANGED",
+						"client_secret":  "CHANGED",
+					},
+				},
+			},
+			{
+				Method:   "GET",
+				Resource: "/api/2.0/unity-catalog/storage-credentials/a",
+				Response: StorageCredentialInfo{
+					Name: "a",
+					Azure: &AzureServicePrincipal{
+						DirectoryID:   "CHANGED",
+						ApplicationID: "CHANGED",
+						ClientSecret:  "CHANGED",
+					},
+					MetastoreID: "d",
+				},
+			},
+		},
+		Resource: ResourceStorageCredential(),
+		Update:   true,
+		ID:       "a",
+		InstanceState: map[string]string{
+			"name":    "a",
+			"comment": "c",
+		},
+		HCL: `
+		name = "a"
+		azure_service_principal {
+			directory_id   = "CHANGED"
+			application_id = "CHANGED"
+			client_secret  = "CHANGED"
 		}
 		comment = "c"
 		`,

--- a/catalog/update.go
+++ b/catalog/update.go
@@ -33,10 +33,20 @@ func updateFunctionFactory(pathPrefix string, updatable []string) func(context.C
 			if !d.HasChange(field) {
 				continue
 			}
+			if contains([]string{
+				"aws_iam_role",
+				"azure_service_principal",
+				"azure_managed_identity",
+			}, field) {
+				patch[field] = d.Get(field).([]interface{})[0]
+				continue
+			}
+
 			if field == "delta_sharing_enabled" && old != new && new == true &&
 				!d.HasChange("delta_sharing_recipient_token_lifetime_in_seconds") {
 				patch["delta_sharing_recipient_token_lifetime_in_seconds"] =
 					d.Get("delta_sharing_recipient_token_lifetime_in_seconds")
+				continue
 			}
 			patch[field] = new
 		}


### PR DESCRIPTION
This fixes #1402 by making the fields `azure_service_principal`, `aws_iam_role` and `azure_managed_identity` non-array in an update

Add extra tests for update logic, and fix the previous update test for `aws_iam_role`