### PR TITLE
Fixed `databricks_job` recreation on changed `docker_image` URL

### DIFF
--- a/clusters/clusters_api.go
+++ b/clusters/clusters_api.go
@@ -241,14 +241,14 @@ type LogSyncStatus struct {
 
 // DockerBasicAuth contains the auth information when fetching containers
 type DockerBasicAuth struct {
-	Username string `json:"username" tf:"force_new"`
-	Password string `json:"password" tf:"force_new"`
+	Username string `json:"username"`
+	Password string `json:"password" tf:"sensitive"`
 }
 
 // DockerImage contains the image url and the auth for DCS
 type DockerImage struct {
-	URL       string           `json:"url" tf:"force_new"`
-	BasicAuth *DockerBasicAuth `json:"basic_auth,omitempty" tf:"force_new"`
+	URL       string           `json:"url"`
+	BasicAuth *DockerBasicAuth `json:"basic_auth,omitempty"`
 }
 
 // SortOrder - constants for API

--- a/clusters/resource_cluster.go
+++ b/clusters/resource_cluster.go
@@ -69,10 +69,6 @@ func resourceClusterSchema() map[string]*schema.Schema {
 				return ss
 			})["library"]
 
-		p, err := common.SchemaPath(s, "docker_image", "basic_auth", "password")
-		if err == nil {
-			p.Sensitive = true
-		}
 		s["autotermination_minutes"].Default = 60
 		s["cluster_id"] = &schema.Schema{
 			Type:     schema.TypeString,

--- a/pools/resource_instance_pool.go
+++ b/pools/resource_instance_pool.go
@@ -185,6 +185,19 @@ func ResourceInstancePool() *schema.Resource {
 				clusters.EbsVolumeTypeThroughputOptimizedHdd,
 			}, false)
 		}
+		if v, err := common.SchemaPath(s, "preloaded_docker_image", "url"); err == nil {
+			v.ForceNew = true
+		}
+		if v, err := common.SchemaPath(s, "preloaded_docker_image", "basic_auth"); err == nil {
+			v.ForceNew = true
+		}
+		if v, err := common.SchemaPath(s, "preloaded_docker_image", "basic_auth", "username"); err == nil {
+			v.ForceNew = true
+		}
+		if v, err := common.SchemaPath(s, "preloaded_docker_image", "basic_auth", "password"); err == nil {
+			v.ForceNew = true
+		}
+
 		return s
 	})
 	return common.Resource{


### PR DESCRIPTION
Added use `tf:force_new` on Docker config only for `databricks_instance_pool`

this fixes #1434