### PR TITLE
Use correct id for abfs mounts in the docs

### DIFF
--- a/docs/resources/mount.md
+++ b/docs/resources/mount.md
@@ -206,7 +206,7 @@ resource "azurerm_storage_container" "this" {
 
 resource "databricks_mount" "marketing" {
   name        = "marketing"
-  resource_id = azurerm_storage_container.this.id
+  resource_id = azurerm_storage_container.this.resource_manager_id
   abfs {
     client_id              = data.azurerm_client_config.current.client_id
     client_secret_scope    = databricks_secret_scope.terraform.name


### PR DESCRIPTION
Change the input of `resource_id` to `azurerm_storage_container.this.resource_manager_id`, since the `resource_id` of `databricks_mount` expects an azure id.

`id` returns this format
`https://xxx.blob.core.windows.net/xxx`

while `resource_manager_id` returns this format
`/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxx/resourceGroups/xxx/providers/Microsoft.Storage/storageAccounts/xxxx/blobServices/default/containers/xxx`

which is expected by `resource_id`.

In the current setup, you get the following error:
`Error: parsing failed for https://xxx.blob.core.windows.net/xxx. Invalid container resource Id format`