### PR TITLE
Added `tf:"force_new"` for `databricks_mws_networks.vpc_endpoints`

### DIFF
--- a/mws/mws.go
+++ b/mws/mws.go
@@ -53,7 +53,7 @@ type Network struct {
 	NetworkName      string               `json:"network_name"`
 	VPCID            string               `json:"vpc_id"`
 	SubnetIds        []string             `json:"subnet_ids" tf:"slice_set"`
-	VPCEndpoints     *NetworkVPCEndpoints `json:"vpc_endpoints,omitempty" tf:"computed"`
+	VPCEndpoints     *NetworkVPCEndpoints `json:"vpc_endpoints,omitempty" tf:"computed,force_new"`
 	SecurityGroupIds []string             `json:"security_group_ids" tf:"slice_set"`
 	VPCStatus        string               `json:"vpc_status,omitempty" tf:"computed"`
 	ErrorMessages    []NetworkHealth      `json:"error_messages,omitempty" tf:"computed"`


### PR DESCRIPTION
- Databricks network config API does not support updating resources. https://docs.databricks.com/dev-tools/api/latest/account.html#tag/Network-configurations
- We need to handle it in Terraform itself by performing REPLACE instead of IN-PLACE-UPDATE when `vpc_endpoints` is added/updated in an existing `databricks_mws_networks` resource.
- At the moment we get `Error: doesn't support update` like below


```
databricks_mws_networks.ravi_test_tf_network: Refreshing state... [id=xxxxx/yyyyy]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # databricks_mws_networks.ravi_test_tf_network will be updated in-place
  ~ resource "databricks_mws_networks" "ravi_test_tf_network" {
        id                 = "xxxxx/yyyyy"
        # (9 unchanged attributes hidden)

      + vpc_endpoints {
          + dataplane_relay = [
              + "vpce-xxx",
            ]
          + rest_api        = [
              + "vpce-yyy",
            ]
        }
    }

Plan: 0 to add, 1 to change, 0 to destroy.
databricks_mws_networks.ravi_test_tf_network: Modifying... [id=xxxxx/yyyyy]
╷
│ Error: doesn't support update
│ 
│   with databricks_mws_networks.ravi_test_tf_network,
│   on main_aws.tf line 26, in resource "databricks_mws_networks" "ravi_test_tf_network":
│   26: resource "databricks_mws_networks" "ravi_test_tf_network" {
│ 
```
