### PR TITLE
[DRAFT] Retry storage credential create/update to allow for IAM propagation

### DIFF
--- a/catalog/resource_storage_credential.go
+++ b/catalog/resource_storage_credential.go
@@ -63,6 +63,10 @@ func ResourceStorageCredential() *schema.Resource {
 		return nil
 	}
 	return common.Resource{
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(2 * time.Minute),
+			Update: schema.DefaultTimeout(2 * time.Minute),
+		},
 		Schema: s,
 		Create: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
 			var sci StorageCredentialInfo

--- a/catalog/resource_storage_credential_test.go
+++ b/catalog/resource_storage_credential_test.go
@@ -67,8 +67,10 @@ func TestCreateStorageCredentials_waitIAMPropagation(t *testing.T) {
 				},
 				Response: common.APIErrorBody{
 					ErrorCode: "PERMISSION_DENIED",
-					Message: "Failed to get credentials: " +
-						"AWS IAM role in the metastore Data Access Configuration is not configured correctly.",
+					Message: "/api/2.1/unity-catalog/storage-credentials/a:403 - \n       Failed to get credentials: " +
+						"AWS IAM role in the metastore Data Access Configuration is not\n       configured correctly. " +
+						"Please contact your account admin to update the configuration.\n    . " +
+						"Using pat auth: host=https://some-workspace.cloud.databricks.com, token=***REDACTED***.",
 				},
 				Status: 403,
 			},
@@ -210,8 +212,10 @@ func TestUpdateStorageCredentials_waitIAMPropagation(t *testing.T) {
 				},
 				Response: common.APIErrorBody{
 					ErrorCode: "PERMISSION_DENIED",
-					Message: "Failed to get credentials: " +
-						"AWS IAM role in the metastore Data Access Configuration is not configured correctly.",
+					Message: "/api/2.1/unity-catalog/storage-credentials/a:403 - \n       Failed to get credentials: " +
+						"AWS IAM role in the metastore Data Access Configuration is not\n       configured correctly. " +
+						"Please contact your account admin to update the configuration.\n    . " +
+						"Using pat auth: host=https://some-workspace.cloud.databricks.com, token=***REDACTED***.",
 				},
 				Status: 403,
 			},

--- a/catalog/resource_storage_credential_test.go
+++ b/catalog/resource_storage_credential_test.go
@@ -52,7 +52,7 @@ func TestCreateStorageCredentials(t *testing.T) {
 	}.ApplyNoError(t)
 }
 
-func TestCreateStorageCredentials_waitIAMPropagation(t *testing.T) {
+func TestCreateStorageCredentials_waitForIAMPropagation(t *testing.T) {
 	qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
 			{
@@ -199,7 +199,7 @@ func TestUpdateStorageCredentials(t *testing.T) {
 	}.ApplyNoError(t)
 }
 
-func TestUpdateStorageCredentials_waitIAMPropagation(t *testing.T) {
+func TestUpdateStorageCredentials_waitForIAMPropagation(t *testing.T) {
 	qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
 			{

--- a/common/http.go
+++ b/common/http.go
@@ -6,7 +6,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/google/go-querystring/query"
+	"github.com/hashicorp/go-retryablehttp"
 	"io"
 	"log"
 	"net/http"
@@ -15,10 +16,6 @@ import (
 	"regexp"
 	"sort"
 	"strings"
-	"time"
-
-	"github.com/google/go-querystring/query"
-	"github.com/hashicorp/go-retryablehttp"
 )
 
 var (
@@ -592,18 +589,4 @@ func onlyNBytes(j string, numBytes int) string {
 		return fmt.Sprintf("%s... (%d more bytes)", j[:numBytes], diff)
 	}
 	return j
-}
-
-func RetryOnError(ctx context.Context, timeout time.Duration, errorCondition func(error) bool, f func() error) error {
-	return resource.RetryContext(ctx, timeout,
-		func() *resource.RetryError {
-			err := f()
-			if errorCondition(err) {
-				return resource.RetryableError(err)
-			}
-			if err != nil {
-				return resource.NonRetryableError(err)
-			}
-			return nil
-		})
 }


### PR DESCRIPTION
Retry the create/update operation for storage credentials if the error indicates that we may have to allow more time for IAM propagation. The timeout of 2 minutes could be further decreased, the current number is taken from corresponding timeouts for the IAM propagation case in the AWS Terraform provider.