### PR TITLE
add `PHOTON` runtime engine to cluster configuration

### DIFF
--- a/clusters/clusters_api.go
+++ b/clusters/clusters_api.go
@@ -96,6 +96,14 @@ const (
 	ClusterStateUnknown = "UNKNOWN"
 )
 
+// RuntimeEngine is for describing whether the Photon runtime engine was used
+type RuntimeEngine string
+
+const (
+	// Photon indicates that the Photon runtime engine is being used
+	Photon = "PHOTON"
+)
+
 var stateMachine = map[ClusterState][]ClusterState{
 	ClusterStatePending:     {ClusterStateRunning, ClusterStateTerminating},
 	ClusterStateRunning:     {ClusterStateResizing, ClusterStateRestarting, ClusterStateTerminating},
@@ -375,9 +383,10 @@ type Cluster struct {
 	ClusterLogConf *StorageInfo            `json:"cluster_log_conf,omitempty"`
 	DockerImage    *DockerImage            `json:"docker_image,omitempty"`
 
-	DataSecurityMode string `json:"data_security_mode,omitempty"`
-	SingleUserName   string `json:"single_user_name,omitempty"`
-	IdempotencyToken string `json:"idempotency_token,omitempty" tf:"force_new"`
+	DataSecurityMode string        `json:"data_security_mode,omitempty"`
+	SingleUserName   string        `json:"single_user_name,omitempty"`
+	IdempotencyToken string        `json:"idempotency_token,omitempty" tf:"force_new"`
+	RuntimeEngine    RuntimeEngine `json:"runtime_engine,omitempty"`
 }
 
 func (cluster Cluster) Validate() error {
@@ -470,6 +479,7 @@ type ClusterInfo struct {
 	ClusterLogStatus          *LogSyncStatus     `json:"cluster_log_status,omitempty"`
 	TerminationReason         *TerminationReason `json:"termination_reason,omitempty"`
 	DataSecurityMode          string             `json:"data_security_mode,omitempty"`
+	RuntimeEngine             RuntimeEngine      `json:"runtime_engine,omitempty"`
 }
 
 // IsRunningOrResizing returns true if cluster is running or resizing

--- a/clusters/resource_cluster_test.go
+++ b/clusters/resource_cluster_test.go
@@ -25,10 +25,12 @@ func TestResourceClusterCreate(t *testing.T) {
 					SparkVersion:           "7.1-scala12",
 					NodeTypeID:             "i3.xlarge",
 					AutoterminationMinutes: 15,
+					RuntimeEngine:          Photon,
 				},
 				Response: ClusterInfo{
-					ClusterID: "abc",
-					State:     ClusterStateRunning,
+					ClusterID:     "abc",
+					State:         ClusterStateRunning,
+					RuntimeEngine: Photon,
 				},
 			},
 			{

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -48,6 +48,7 @@ resource "databricks_cluster" "shared_autoscaling" {
 * `custom_tags` - (Optional) Additional tags for cluster resources. Databricks will tag all cluster resources (e.g., AWS EC2 instances and EBS volumes) with these tags in addition to `default_tags`.
 * `spark_conf` - (Optional) Map with key-value pairs to fine-tune Spark clusters, where you can provide custom [Spark configuration properties](https://spark.apache.org/docs/latest/configuration.html) in a cluster configuration.
 * `is_pinned` - (Optional) boolean value specifying if the cluster is pinned (not pinned by default). You must be a Databricks administrator to use this.  The pinned clusters' maximum number is [limited to 70](https://docs.databricks.com/clusters/clusters-manage.html#pin-a-cluster), so `apply` may fail if you have more than that.
+* `runtime_engine` - (Optional) Select the Runtime engine used by the cluster. Only `PHOTON` is permitted. Omitting this value uses the default Catalyst runtime engine.
 
 The following example demonstrates how to create an autoscaling cluster with [Delta Cache](https://docs.databricks.com/delta/optimizations/delta-cache.html) enabled:
 


### PR DESCRIPTION
The PHOTON runtime engine feature may still be flagged as preview, but it is available for selection through both the UI and API, at least on AWS and the latest DBR releases.