### PR TITLE
Fix Azure CLI tests on Go 1.19

### DIFF
--- a/common/azure_auth_test.go
+++ b/common/azure_auth_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -29,7 +30,8 @@ func TestAddSpManagementTokenVisitor(t *testing.T) {
 
 func TestAddSpManagementTokenVisitor_Refreshed(t *testing.T) {
 	defer CleanupEnvironment()()
-	os.Setenv("PATH", "testdata:/bin")
+	p, _ := filepath.Abs("./testdata")
+	os.Setenv("PATH", p+":/bin")
 
 	aa := DatabricksClient{}
 	r := httptest.NewRequest("GET", "/a/b/c", http.NoBody)
@@ -45,7 +47,8 @@ func TestAddSpManagementTokenVisitor_Refreshed(t *testing.T) {
 
 func TestAddSpManagementTokenVisitor_RefreshedError(t *testing.T) {
 	defer CleanupEnvironment()()
-	os.Setenv("PATH", "testdata:/bin")
+	p, _ := filepath.Abs("./testdata")
+	os.Setenv("PATH", p+":/bin")
 	os.Setenv("FAIL", "yes")
 
 	aa := DatabricksClient{}
@@ -274,7 +277,8 @@ func TestMaybeExtendError(t *testing.T) {
 
 func TestGetJWTProperty_AzureCLI_SP(t *testing.T) {
 	defer CleanupEnvironment()()
-	os.Setenv("PATH", "testdata:/bin")
+	p, _ := filepath.Abs("./testdata")
+	os.Setenv("PATH", p+":/bin")
 
 	aa := DatabricksClient{
 		AzureClientID:     "a",
@@ -289,7 +293,8 @@ func TestGetJWTProperty_AzureCLI_SP(t *testing.T) {
 
 func TestGetJWTProperty_NonAzure(t *testing.T) {
 	defer CleanupEnvironment()()
-	os.Setenv("PATH", "testdata:/bin")
+	p, _ := filepath.Abs("./testdata")
+	os.Setenv("PATH", p+":/bin")
 
 	aa := DatabricksClient{
 		Host:  "https://abc.cloud.databricks.com",
@@ -301,7 +306,8 @@ func TestGetJWTProperty_NonAzure(t *testing.T) {
 
 func TestGetJWTProperty_AzureCli_Error(t *testing.T) {
 	defer CleanupEnvironment()()
-	os.Setenv("PATH", "testdata:/bin")
+	p, _ := filepath.Abs("./testdata")
+	os.Setenv("PATH", p+":/bin")
 
 	// token without expiry in this case
 	client, server := singleRequestServer(t, "POST", "/api/2.0/token/create", `{
@@ -350,7 +356,8 @@ func newTestJwt(t *testing.T, claims jwt.MapClaims) string {
 
 func TestGetJWTProperty_AzureCli(t *testing.T) {
 	defer CleanupEnvironment()()
-	os.Setenv("PATH", "testdata:/bin")
+	p, _ := filepath.Abs("./testdata")
+	os.Setenv("PATH", p+":/bin")
 	os.Setenv("TF_AAD_TOKEN", newTestJwt(t, jwt.MapClaims{
 		"tid": "some-tenant",
 	}))
@@ -367,7 +374,8 @@ func TestGetJWTProperty_AzureCli(t *testing.T) {
 
 func TestGetJWTProperty_Authenticate_Fail(t *testing.T) {
 	defer CleanupEnvironment()()
-	os.Setenv("PATH", "testdata:/bin")
+	p, _ := filepath.Abs("./testdata")
+	os.Setenv("PATH", p+":/bin")
 	os.Setenv("FAIL", "yes")
 
 	client := &DatabricksClient{
@@ -383,7 +391,8 @@ func TestGetJWTProperty_Authenticate_Fail(t *testing.T) {
 
 func TestGetJWTProperty_makeGetRequest_Fail(t *testing.T) {
 	defer CleanupEnvironment()()
-	os.Setenv("PATH", "testdata:/bin")
+	p, _ := filepath.Abs("./testdata")
+	os.Setenv("PATH", p+":/bin")
 	os.Setenv("TF_AAD_TOKEN", newTestJwt(t, jwt.MapClaims{
 		"tid": "some-tenant",
 	}))
@@ -400,7 +409,8 @@ func TestGetJWTProperty_makeGetRequest_Fail(t *testing.T) {
 
 func TestGetJWTProperty_authVisitor_Fail(t *testing.T) {
 	defer CleanupEnvironment()()
-	os.Setenv("PATH", "testdata:/bin")
+	p, _ := filepath.Abs("./testdata")
+	os.Setenv("PATH", p+":/bin")
 
 	client := &DatabricksClient{
 		Host: "https://adb-1232.azuredatabricks.net",
@@ -414,7 +424,8 @@ func TestGetJWTProperty_authVisitor_Fail(t *testing.T) {
 
 func TestGetJWTProperty_AzureCli_Error_DB_PAT(t *testing.T) {
 	defer CleanupEnvironment()()
-	os.Setenv("PATH", "testdata:/bin")
+	p, _ := filepath.Abs("./testdata")
+	os.Setenv("PATH", p+":/bin")
 	os.Setenv("TF_AAD_TOKEN", "dapi123")
 
 	srv, client := setupJwtTestClient()
@@ -428,7 +439,8 @@ func TestGetJWTProperty_AzureCli_Error_DB_PAT(t *testing.T) {
 
 func TestGetJWTProperty_AzureCli_Error_No_TenantID(t *testing.T) {
 	defer CleanupEnvironment()()
-	os.Setenv("PATH", "testdata:/bin")
+	p, _ := filepath.Abs("./testdata")
+	os.Setenv("PATH", p+":/bin")
 	os.Setenv("TF_AAD_TOKEN", newTestJwt(t, jwt.MapClaims{
 		"something": "else",
 	}))
@@ -444,7 +456,8 @@ func TestGetJWTProperty_AzureCli_Error_No_TenantID(t *testing.T) {
 
 func TestGetJWTProperty_AzureCli_Error_EmptyToken(t *testing.T) {
 	defer CleanupEnvironment()()
-	os.Setenv("PATH", "testdata:/bin")
+	p, _ := filepath.Abs("./testdata")
+	os.Setenv("PATH", p+":/bin")
 	os.Setenv("TF_AAD_TOKEN", "   ")
 
 	srv, client := setupJwtTestClient()

--- a/common/azure_cli_auth_test.go
+++ b/common/azure_cli_auth_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -17,7 +18,8 @@ import (
 
 func TestAzureCliAuth(t *testing.T) {
 	defer CleanupEnvironment()()
-	os.Setenv("PATH", "testdata:/bin")
+	p, _ := filepath.Abs("./testdata")
+	os.Setenv("PATH", p+":/bin")
 	// fake expiration date for az mock cli
 	os.Setenv("EXPIRE", "15M")
 
@@ -67,7 +69,8 @@ func TestOAuthToken_CornerCases(t *testing.T) {
 
 func TestEnsureFreshWithContext(t *testing.T) {
 	defer CleanupEnvironment()()
-	os.Setenv("PATH", "testdata:/bin")
+	p, _ := filepath.Abs("./testdata")
+	os.Setenv("PATH", p+":/bin")
 
 	rct := refreshableCliToken{
 		token: &adal.Token{
@@ -81,7 +84,8 @@ func TestEnsureFreshWithContext(t *testing.T) {
 
 func TestRefreshWithContext(t *testing.T) {
 	defer CleanupEnvironment()()
-	os.Setenv("PATH", "testdata:/bin")
+	p, _ := filepath.Abs("./testdata")
+	os.Setenv("PATH", p+":/bin")
 
 	rct := refreshableCliToken{
 		token: &adal.Token{
@@ -95,7 +99,8 @@ func TestRefreshWithContext(t *testing.T) {
 
 func TestRefreshExchangeWithContext(t *testing.T) {
 	defer CleanupEnvironment()()
-	os.Setenv("PATH", "testdata:/bin")
+	p, _ := filepath.Abs("./testdata")
+	os.Setenv("PATH", p+":/bin")
 
 	rct := refreshableCliToken{
 		token: &adal.Token{
@@ -109,7 +114,8 @@ func TestRefreshExchangeWithContext(t *testing.T) {
 
 func TestInternalRefresh_ExitError(t *testing.T) {
 	defer CleanupEnvironment()()
-	os.Setenv("PATH", "testdata:/bin")
+	p, _ := filepath.Abs("./testdata")
+	os.Setenv("PATH", p+":/bin")
 	os.Setenv("FAIL", "yes")
 
 	rct := refreshableCliToken{
@@ -138,7 +144,8 @@ func TestInternalRefresh_OtherError(t *testing.T) {
 
 func TestInternalRefresh_Corrupt(t *testing.T) {
 	defer CleanupEnvironment()()
-	os.Setenv("PATH", "testdata:/bin")
+	p, _ := filepath.Abs("./testdata")
+	os.Setenv("PATH", p+":/bin")
 	os.Setenv("FAIL", "corrupt")
 
 	rct := refreshableCliToken{
@@ -153,7 +160,8 @@ func TestInternalRefresh_Corrupt(t *testing.T) {
 
 func TestInternalRefresh_CorruptExpire(t *testing.T) {
 	defer CleanupEnvironment()()
-	os.Setenv("PATH", "testdata:/bin")
+	p, _ := filepath.Abs("./testdata")
+	os.Setenv("PATH", p+":/bin")
 	os.Setenv("EXPIRE", "corrupt")
 
 	rct := refreshableCliToken{

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -286,14 +287,15 @@ func TestConfig_ConfigProfileAndPassword(t *testing.T) {
 var azResourceID = "/subscriptions/a/resourceGroups/b/providers/Microsoft.Databricks/workspaces/c"
 
 func TestConfig_AzureCliHost(t *testing.T) {
+	p, _ := filepath.Abs("../common/testdata")
 	providerFixture{
 		// this test will skip ensureWorkspaceUrl
 		host:            "x",
 		azureResourceID: azResourceID,
 		env: map[string]string{
 			// // these may fail on windows. use docker container for testing.
-			"PATH": "../common/testdata",
-			"HOME": "../common/testdata",
+			"PATH": p,
+			"HOME": p,
 		},
 		assertAzure: true,
 		assertHost:  "https://x",
@@ -302,12 +304,13 @@ func TestConfig_AzureCliHost(t *testing.T) {
 }
 
 func TestConfig_AzureCliHost_Fail(t *testing.T) {
+	p, _ := filepath.Abs("../common/testdata")
 	providerFixture{
 		azureResourceID: azResourceID,
 		env: map[string]string{
 			// these may fail on windows. use docker container for testing.
-			"PATH": "../common/testdata",
-			"HOME": "../common/testdata",
+			"PATH": p,
+			"HOME": p,
 			"FAIL": "yes",
 		},
 		assertError: "cannot configure azure-cli auth: Invoking Azure CLI " +
@@ -328,27 +331,29 @@ func TestConfig_AzureCliHost_AzNotInstalled(t *testing.T) {
 }
 
 func TestConfig_AzureCliHost_PatConflict(t *testing.T) {
+	p, _ := filepath.Abs("../common/testdata")
 	providerFixture{
 		azureResourceID: azResourceID,
 		token:           "x",
 		env: map[string]string{
 			// these may fail on windows. use docker container for testing.
-			"PATH": "../common/testdata",
-			"HOME": "../common/testdata",
+			"PATH": p,
+			"HOME": p,
 		},
 		assertError: "More than one authorization method configured: azure and token",
 	}.apply(t)
 }
 
 func TestConfig_AzureCliHostAndResourceID(t *testing.T) {
+	p, _ := filepath.Abs("../common/testdata")
 	providerFixture{
 		// omit request to management endpoint to get workspace properties
 		azureResourceID: azResourceID,
 		host:            "x",
 		env: map[string]string{
 			// these may fail on windows. use docker container for testing.
-			"PATH": "../common/testdata",
-			"HOME": "../common/testdata",
+			"PATH": p,
+			"HOME": p,
 		},
 		assertAzure: true,
 		assertHost:  "https://x",
@@ -357,13 +362,14 @@ func TestConfig_AzureCliHostAndResourceID(t *testing.T) {
 }
 
 func TestConfig_AzureAndPasswordConflict(t *testing.T) {
+	p, _ := filepath.Abs("../common/testdata")
 	providerFixture{
 		host:            "x",
 		azureResourceID: azResourceID,
 		env: map[string]string{
 			// these may fail on windows. use docker container for testing.
-			"PATH":                "../common/testdata",
-			"HOME":                "../common/testdata",
+			"PATH":                p,
+			"HOME":                p,
 			"DATABRICKS_USERNAME": "x",
 		},
 		assertError: "More than one authorization method configured: azure and password",


### PR DESCRIPTION
In Go 1.19 the Command and LookPath no longer allow results from a PATH search to be found relative to the current directory. https://go.dev/doc/go1.19#os-exec-path