### PR TITLE
[BUG-FIX] Fix vscode runtime debugger mode for vscode

### DIFF
--- a/main.go
+++ b/main.go
@@ -37,6 +37,7 @@ https://registry.terraform.io/providers/databricks/databricks/latest/docs
 `, common.Version())
 	plugin.Serve(&plugin.ServeOpts{
 		ProviderFunc: provider.DatabricksProvider,
+		ProviderAddr: "registry.terraform.io/databricks/databricks",
 		Debug:        debug,
 	})
 }


### PR DESCRIPTION
Updates to SDK now require `ProviderAddr: "registry.terraform.io/databricks/databricks"` to make vscode runtime debugging work

Tested manually