### PR TITLE
Remove "Public Preview" marker from Unity Catalog resources docs

### DIFF
--- a/docs/resources/catalog.md
+++ b/docs/resources/catalog.md
@@ -3,8 +3,6 @@ subcategory: "Unity Catalog"
 ---
 # databricks_catalog Resource
 
--> **Public Preview** This feature is in [Public Preview](https://docs.databricks.com/release-notes/release-types.html). Contact your Databricks representative to request access. 
-
 Within a metastore, Unity Catalog provides a 3-level namespace for organizing data: Catalogs, Databases (also called Schemas), and Tables / Views.
 
 A `databricks_catalog` is contained within [databricks_metastore](metastore.md) and can contain [databricks_schema](schema.md). By default, Databricks creates `default` schema for every new catalog, but Terraform plugin is removing this auto-created schema, so that resource destruction could be done in a clean way.

--- a/docs/resources/external_location.md
+++ b/docs/resources/external_location.md
@@ -3,8 +3,6 @@ subcategory: "Unity Catalog"
 ---
 # databricks_external_location Resource
 
--> **Public Preview** This feature is in [Public Preview](https://docs.databricks.com/release-notes/release-types.html). Contact your Databricks representative to request access.
-
 To work with external tables, Unity Catalog introduces two new objects to access and work with external cloud storage:
 
 - [databricks_storage_credential](storage_credential.md) represent authentication methods to access cloud storage (e.g. an IAM role for Amazon S3 or a service principal for Azure Storage). Storage credentials are access-controlled to determine which users can use the credential.

--- a/docs/resources/grants.md
+++ b/docs/resources/grants.md
@@ -3,8 +3,6 @@ subcategory: "Unity Catalog"
 ---
 # databricks_grants Resource
 
--> **Public Preview** This feature is in [Public Preview](https://docs.databricks.com/release-notes/release-types.html). Contact your Databricks representative to request access.
-
 In Unity Catalog all users initially have no access to data. Only Metastore Admins can create objects and can grant/revoke access on individual objects to users and groups. Every securable object in Unity Catalog has an owner. The owner can be any account-level user or group, called principals in general. The principal that creates an object becomes its owner. Owners receive all privileges on the securable object (e.g., `SELECT` and `MODIFY` on a table), as well as the permission to grant privileges to other principals.
 
 Unity Catalog supports the following privileges on securable objects:

--- a/docs/resources/metastore.md
+++ b/docs/resources/metastore.md
@@ -3,8 +3,6 @@ subcategory: "Unity Catalog"
 ---
 # databricks_metastore Resource
 
--> **Public Preview** This feature is in [Public Preview](https://docs.databricks.com/release-notes/release-types.html). Contact your Databricks representative to request access. 
-
 A metastore is the top-level container of objects in Unity Catalog. It stores data assets (tables and views) and the permissions that govern access to them. Databricks account admins can create metastores and assign them to Databricks workspaces in order to control which workloads use each metastore.
 
 Unity Catalog offers a new metastore with built in security and auditing. This is distinct to the metastore used in previous versions of Databricks (based on the Hive Metastore).

--- a/docs/resources/metastore_assignment.md
+++ b/docs/resources/metastore_assignment.md
@@ -3,8 +3,6 @@ subcategory: "Unity Catalog"
 ---
 # databricks_metastore_assignment (Resource)
 
--> **Public Preview** This feature is in [Public Preview](https://docs.databricks.com/release-notes/release-types.html). Contact your Databricks representative to request access. 
-
 A single [databricks_metastore](docs/resources/metastore.md) can be shared across Databricks workspaces, and each linked workspace has a consistent view of the data and a single set of access policies. It is only recommended to have multiple metastores when organizations wish to have hard isolation boundaries between data (note that data cannot be easily joined/queried across metastores).
 
 ## Example Usage

--- a/docs/resources/metastore_data_access.md
+++ b/docs/resources/metastore_data_access.md
@@ -3,8 +3,6 @@ subcategory: "Unity Catalog"
 ---
 # databricks_metastore_data_access (Resource)
 
--> **Public Preview** This feature is in [Public Preview](https://docs.databricks.com/release-notes/release-types.html). Contact your Databricks representative to request access.
-
 Each [databricks_metastore](docs/resources/metastore.md) requires an IAM role that will be assumed by Unity Catalog to access data. `databricks_metastore_data_access` defines this
 
 ## Example Usage

--- a/docs/resources/schema.md
+++ b/docs/resources/schema.md
@@ -3,8 +3,6 @@ subcategory: "Unity Catalog"
 ---
 # databricks_schema Resource
 
--> **Public Preview** This feature is in [Public Preview](https://docs.databricks.com/release-notes/release-types.html). Contact your Databricks representative to request access. 
-
 Within a metastore, Unity Catalog provides a 3-level namespace for organizing data: Catalogs, Databases (also called Schemas), and Tables / Views.
 
 A `databricks_schema` is contained within [databricks_catalog](catalog.md) and can contain tables & views.

--- a/docs/resources/storage_credential.md
+++ b/docs/resources/storage_credential.md
@@ -3,8 +3,6 @@ subcategory: "Unity Catalog"
 ---
 # databricks_storage_credential Resource
 
--> **Public Preview** This feature is in [Public Preview](https://docs.databricks.com/release-notes/release-types.html). Contact your Databricks representative to request access.
-
 To work with external tables, Unity Catalog introduces two new objects to access and work with external cloud storage:
 
 - `databricks_storage_credential` represents authentication methods to access cloud storage (e.g. an IAM role for Amazon S3 or a service principal/managed identity for Azure Storage). Storage credentials are access-controlled to determine which users can use the credential.


### PR DESCRIPTION
Unity Catalog (UC) moved to General Availability last week, so we need to remove Public Preview marker from documentation for UC resources