### PR TITLE
Custom suppress diff for `storage` in `databricks_pipeline`

### DIFF
--- a/pipelines/resource_pipeline_test.go
+++ b/pipelines/resource_pipeline_test.go
@@ -591,3 +591,11 @@ func TestListPipelinesWithFilter(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, len(data))
 }
+
+func TestStorageSuppressDiff(t *testing.T) {
+	k := "storage"
+	generated := "dbfs:/pipelines/c609bbb0-2e42-4bc8-bb4e-a1c26d6e9403"
+	require.True(t, suppressStorageDiff(k, generated, "", nil))
+	require.False(t, suppressStorageDiff(k, generated, "/tmp/abc", nil))
+	require.False(t, suppressStorageDiff(k, "/tmp/abc", "", nil))
+}


### PR DESCRIPTION
When the `storage` option isn't provided, DLT generates a temp one in the form of
`dbfs:/pipelines/<uuid>`.  But in the sequential apply the drift was detected, and
pipeline was recreated.  Marking it with `computed` or `suppress_diff` doesn't help
because it prevents the pipeline from the detection of change of `storage` from value
to null.