### PR TITLE
Add `databricks_group_role` resource

### DIFF
--- a/aws/resource_group_instance_profile.go
+++ b/aws/resource_group_instance_profile.go
@@ -12,7 +12,7 @@ import (
 
 // ResourceGroupInstanceProfile defines group role resource
 func ResourceGroupInstanceProfile() *schema.Resource {
-	return common.NewPairID("group_id", "instance_profile_id").Schema(func(
+	r := common.NewPairID("group_id", "instance_profile_id").Schema(func(
 		m map[string]*schema.Schema) map[string]*schema.Schema {
 		m["instance_profile_id"].ValidateDiagFunc = ValidInstanceProfile
 		return m
@@ -33,4 +33,6 @@ func ResourceGroupInstanceProfile() *schema.Resource {
 				"remove", fmt.Sprintf(`roles[value eq "%s"]`, roleARN), ""))
 		},
 	})
+	r.DeprecationMessage = "Please migrate to `databricks_group_role`. This resource will be removed in v1.2.x"
+	return r
 }

--- a/aws/resource_group_instance_profile.go
+++ b/aws/resource_group_instance_profile.go
@@ -33,6 +33,6 @@ func ResourceGroupInstanceProfile() *schema.Resource {
 				"remove", fmt.Sprintf(`roles[value eq "%s"]`, roleARN), ""))
 		},
 	})
-	r.DeprecationMessage = "Please migrate to `databricks_group_role`. This resource will be removed in v1.2.x"
+	r.DeprecationMessage = "Please migrate to `databricks_group_role`"
 	return r
 }

--- a/aws/resource_group_instance_profile_test.go
+++ b/aws/resource_group_instance_profile_test.go
@@ -94,7 +94,7 @@ func TestResourceGroupInstanceProfileCreate_Error_InvalidARN(t *testing.T) {
 		},
 		Create: true,
 	}.Apply(t)
-	assert.EqualError(t, err, "invalid config supplied. [instance_profile_id] Invalid ARN")
+	assert.EqualError(t, err, "invalid config supplied. [instance_profile_id] Invalid ARN. Deprecated Resource")
 }
 
 func TestResourceGroupInstanceProfileCreate_Error_OtherARN(t *testing.T) {
@@ -117,7 +117,7 @@ func TestResourceGroupInstanceProfileCreate_Error_OtherARN(t *testing.T) {
 		},
 		Create: true,
 	}.Apply(t)
-	assert.EqualError(t, err, "invalid config supplied. [instance_profile_id] Invalid ARN")
+	assert.EqualError(t, err, "invalid config supplied. [instance_profile_id] Invalid ARN. Deprecated Resource")
 }
 
 func TestResourceGroupInstanceProfileRead(t *testing.T) {

--- a/docs/resources/group_instance_profile.md
+++ b/docs/resources/group_instance_profile.md
@@ -3,7 +3,7 @@ subcategory: "Security"
 ---
 # databricks_group_instance_profile Resource
 
--> **Deprecated** Please rewrite with [databricks_group_role](group_role.md). This resource will be removed in v1.2.x
+-> **Deprecated** Please migrate to [databricks_group_role](group_role.md).
 
 This resource allows you to attach [databricks_instance_profile](instance_profile.md) (AWS) to [databricks_group](group.md).
 

--- a/docs/resources/group_instance_profile.md
+++ b/docs/resources/group_instance_profile.md
@@ -3,7 +3,7 @@ subcategory: "Security"
 ---
 # databricks_group_instance_profile Resource
 
--> **Note** This resource has an evolving API, which may change in future versions of the provider.
+-> **Deprecated** Please rewrite with [databricks_group_role](group_role.md). This resource will be removed in v1.2.x
 
 This resource allows you to attach [databricks_instance_profile](instance_profile.md) (AWS) to [databricks_group](group.md).
 

--- a/docs/resources/group_role.md
+++ b/docs/resources/group_role.md
@@ -1,0 +1,52 @@
+---
+subcategory: "Security"
+---
+# databricks_group_role Resource
+
+-> **Note** This resource has an evolving API, which may change in future versions of the provider.
+
+This resource allows you to attach Role ARN (AWS) to [databricks_group](group.md).
+
+## Example Usage
+
+```hcl
+resource "databricks_group" "my_group" {
+  display_name = "my_group_name"
+}
+
+resource "databricks_group_role" "my_group_role" {
+  group_id  = databricks_group.my_group.id
+  role_arn  = "arn:aws:iam::000000000000:role/my-role"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `group_id` - (Required) This is the id of the [group](group.md) resource.
+* `role_arn` - (Required) This is the AWS role ARN.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The id for the `databricks_group_role` object which is in the format `<group_id>|<role_arn>`.
+
+## Import
+
+-> **Note** Importing this resource is not currently supported.
+
+## Related Resources
+
+The following resources are often used in the same context:
+
+* [End to end workspace management](../guides/workspace-management.md) guide.
+* [databricks_aws_bucket_policy](../data-sources/aws_bucket_policy.md) data to configure a simple access policy for AWS S3 buckets, so that Databricks can access data in it.
+* [databricks_cluster_policy](cluster_policy.md) to create a [databricks_cluster](cluster.md) policy, which limits the ability to create clusters based on a set of rules.
+* [databricks_group](group.md) to manage [groups in Databricks Workspace](https://docs.databricks.com/administration-guide/users-groups/groups.html) or [Account Console](https://accounts.cloud.databricks.com/) (for AWS deployments).
+* [databricks_group](../data-sources/group.md) data to retrieve information about [databricks_group](group.md) members, entitlements and instance profiles.
+* [databricks_group_member](group_member.md) to attach [users](user.md) and [groups](group.md) as group members.
+* [databricks_instance_pool](instance_pool.md) to manage [instance pools](https://docs.databricks.com/clusters/instance-pools/index.html) to reduce [cluster](cluster.md) start and auto-scaling times by maintaining a set of idle, ready-to-use instances.
+* [databricks_instance_profile](instance_profile.md) to manage AWS EC2 instance profiles that users can launch [databricks_cluster](cluster.md) and access data, like [databricks_mount](mount.md).
+* [databricks_user_instance_profile](user_instance_profile.md) to attach [databricks_instance_profile](instance_profile.md) (AWS) to [databricks_user](user.md).

--- a/docs/resources/group_role.md
+++ b/docs/resources/group_role.md
@@ -3,8 +3,6 @@ subcategory: "Security"
 ---
 # databricks_group_role Resource
 
--> **Note** This resource has an evolving API, which may change in future versions of the provider.
-
 This resource allows you to attach Role ARN (AWS) to [databricks_group](group.md).
 
 ## Example Usage
@@ -16,7 +14,7 @@ resource "databricks_group" "my_group" {
 
 resource "databricks_group_role" "my_group_role" {
   group_id  = databricks_group.my_group.id
-  role_arn  = "arn:aws:iam::000000000000:role/my-role"
+  role  = "arn:aws:iam::000000000000:role/my-role"
 }
 ```
 
@@ -25,13 +23,13 @@ resource "databricks_group_role" "my_group_role" {
 The following arguments are supported:
 
 * `group_id` - (Required) This is the id of the [group](group.md) resource.
-* `role_arn` - (Required) This is the AWS role ARN.
+* `role` - (Required) This is the AWS role ARN.
 
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - The id for the `databricks_group_role` object which is in the format `<group_id>|<role_arn>`.
+* `id` - The id for the `databricks_group_role` object which is in the format `<group_id>|<role>`.
 
 ## Import
 

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -79,6 +79,7 @@ func DatabricksProvider() *schema.Provider {
 			"databricks_group":                       scim.ResourceGroup(),
 			"databricks_group_instance_profile":      aws.ResourceGroupInstanceProfile(),
 			"databricks_group_member":                scim.ResourceGroupMember(),
+			"databricks_group_role":                  scim.ResourceGroupRole(),
 			"databricks_instance_pool":               pools.ResourceInstancePool(),
 			"databricks_instance_profile":            aws.ResourceInstanceProfile(),
 			"databricks_ip_access_list":              access.ResourceIPAccessList(),

--- a/scim/resource_group_role.go
+++ b/scim/resource_group_role.go
@@ -1,0 +1,30 @@
+package scim
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/databricks/terraform-provider-databricks/common"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// ResourceGroupRole bind group with role
+func ResourceGroupRole() *schema.Resource {
+	return common.NewPairID("group_id", "role_arn").BindResource(common.BindResource{
+		CreateContext: func(ctx context.Context, groupID, roleARN string, c *common.DatabricksClient) error {
+			return NewGroupsAPI(ctx, c).Patch(groupID, PatchRequest("add", "roles", roleARN))
+		},
+		ReadContext: func(ctx context.Context, groupID, roleARN string, c *common.DatabricksClient) error {
+			group, err := NewGroupsAPI(ctx, c).Read(groupID)
+			hasRole := ComplexValues(group.Roles).HasValue(roleARN)
+			if err == nil && !hasRole {
+				return common.NotFound("Group has no roleARN")
+			}
+			return err
+		},
+		DeleteContext: func(ctx context.Context, groupID, roleARN string, c *common.DatabricksClient) error {
+			return NewGroupsAPI(ctx, c).Patch(groupID, PatchRequest(
+				"remove", fmt.Sprintf(`roles[value eq "%s"]`, roleARN), ""))
+		},
+	})
+}

--- a/scim/resource_group_role.go
+++ b/scim/resource_group_role.go
@@ -10,21 +10,21 @@ import (
 
 // ResourceGroupRole bind group with role
 func ResourceGroupRole() *schema.Resource {
-	return common.NewPairID("group_id", "role_arn").BindResource(common.BindResource{
-		CreateContext: func(ctx context.Context, groupID, roleARN string, c *common.DatabricksClient) error {
-			return NewGroupsAPI(ctx, c).Patch(groupID, PatchRequest("add", "roles", roleARN))
+	return common.NewPairID("group_id", "role").BindResource(common.BindResource{
+		CreateContext: func(ctx context.Context, groupID, role string, c *common.DatabricksClient) error {
+			return NewGroupsAPI(ctx, c).Patch(groupID, PatchRequest("add", "roles", role))
 		},
-		ReadContext: func(ctx context.Context, groupID, roleARN string, c *common.DatabricksClient) error {
+		ReadContext: func(ctx context.Context, groupID, role string, c *common.DatabricksClient) error {
 			group, err := NewGroupsAPI(ctx, c).Read(groupID)
-			hasRole := ComplexValues(group.Roles).HasValue(roleARN)
+			hasRole := ComplexValues(group.Roles).HasValue(role)
 			if err == nil && !hasRole {
-				return common.NotFound("Group has no roleARN")
+				return common.NotFound("Group has no role")
 			}
 			return err
 		},
-		DeleteContext: func(ctx context.Context, groupID, roleARN string, c *common.DatabricksClient) error {
+		DeleteContext: func(ctx context.Context, groupID, role string, c *common.DatabricksClient) error {
 			return NewGroupsAPI(ctx, c).Patch(groupID, PatchRequest(
-				"remove", fmt.Sprintf(`roles[value eq "%s"]`, roleARN), ""))
+				"remove", fmt.Sprintf(`roles[value eq "%s"]`, role), ""))
 		},
 	})
 }

--- a/scim/resource_group_role_test.go
+++ b/scim/resource_group_role_test.go
@@ -6,11 +6,10 @@ import (
 	"github.com/databricks/terraform-provider-databricks/common"
 
 	"github.com/databricks/terraform-provider-databricks/qa"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestResourceGroupRoleCreate(t *testing.T) {
-	d, err := qa.ResourceFixture{
+	qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:          "PATCH",
@@ -38,16 +37,14 @@ func TestResourceGroupRoleCreate(t *testing.T) {
 		Resource: ResourceGroupRole(),
 		State: map[string]any{
 			"group_id": "abc",
-			"role_arn": "arn:aws:iam::000000000000:role/test-role",
+			"role":     "arn:aws:iam::000000000000:role/test-role",
 		},
 		Create: true,
-	}.Apply(t)
-	assert.NoError(t, err, err)
-	assert.Equal(t, "abc|arn:aws:iam::000000000000:role/test-role", d.Id())
+	}.ApplyAndExpectData(t, map[string]any{"id": "abc|arn:aws:iam::000000000000:role/test-role"})
 }
 
 func TestResourceGroupRoleCreate_Error(t *testing.T) {
-	d, err := qa.ResourceFixture{
+	qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   "PATCH",
@@ -62,16 +59,14 @@ func TestResourceGroupRoleCreate_Error(t *testing.T) {
 		Resource: ResourceGroupRole(),
 		State: map[string]any{
 			"group_id": "abc",
-			"role_arn": "arn:aws:iam::000000000000:role/test-role",
+			"role":     "arn:aws:iam::000000000000:role/test-role",
 		},
 		Create: true,
-	}.Apply(t)
-	qa.AssertErrorStartsWith(t, err, "Internal error happened")
-	assert.Equal(t, "", d.Id(), "Id should be empty for error creates")
+	}.ExpectError(t, "Internal error happened")
 }
 
 func TestResourceGroupRoleRead(t *testing.T) {
-	d, err := qa.ResourceFixture{
+	qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   "GET",
@@ -91,9 +86,7 @@ func TestResourceGroupRoleRead(t *testing.T) {
 		Resource: ResourceGroupRole(),
 		Read:     true,
 		ID:       "abc|arn:aws:iam::000000000000:role/test-role",
-	}.Apply(t)
-	assert.NoError(t, err, err)
-	assert.Equal(t, "abc|arn:aws:iam::000000000000:role/test-role", d.Id(), "Id should not be empty")
+	}.ApplyAndExpectData(t, map[string]any{"id": "abc|arn:aws:iam::000000000000:role/test-role"})
 }
 
 func TestResourceGroupRoleRead_NoRole(t *testing.T) {
@@ -137,7 +130,7 @@ func TestResourceGroupRoleRead_NotFound(t *testing.T) {
 }
 
 func TestResourceGroupRoleRead_Error(t *testing.T) {
-	d, err := qa.ResourceFixture{
+	qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   "GET",
@@ -152,13 +145,11 @@ func TestResourceGroupRoleRead_Error(t *testing.T) {
 		Resource: ResourceGroupRole(),
 		Read:     true,
 		ID:       "abc|arn:aws:iam::000000000000:role/test-role",
-	}.Apply(t)
-	qa.AssertErrorStartsWith(t, err, "Internal error happened")
-	assert.Equal(t, "abc|arn:aws:iam::000000000000:role/test-role", d.Id(), "Id should not be empty for error reads")
+	}.ExpectError(t, "Internal error happened")
 }
 
 func TestResourceGroupRoleDelete(t *testing.T) {
-	d, err := qa.ResourceFixture{
+	qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   "PATCH",
@@ -172,13 +163,11 @@ func TestResourceGroupRoleDelete(t *testing.T) {
 		Resource: ResourceGroupRole(),
 		Delete:   true,
 		ID:       "abc|arn:aws:iam::000000000000:role/test-role",
-	}.Apply(t)
-	assert.NoError(t, err, err)
-	assert.Equal(t, "abc|arn:aws:iam::000000000000:role/test-role", d.Id())
+	}.ApplyNoError(t)
 }
 
 func TestResourceGroupRoleDelete_Error(t *testing.T) {
-	d, err := qa.ResourceFixture{
+	qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   "PATCH",
@@ -193,7 +182,5 @@ func TestResourceGroupRoleDelete_Error(t *testing.T) {
 		Resource: ResourceGroupRole(),
 		Delete:   true,
 		ID:       "abc|arn:aws:iam::000000000000:role/test-role",
-	}.Apply(t)
-	qa.AssertErrorStartsWith(t, err, "Internal error happened")
-	assert.Equal(t, "abc|arn:aws:iam::000000000000:role/test-role", d.Id())
+	}.ExpectError(t, "Internal error happened")
 }

--- a/scim/resource_group_role_test.go
+++ b/scim/resource_group_role_test.go
@@ -1,0 +1,199 @@
+package scim
+
+import (
+	"testing"
+
+	"github.com/databricks/terraform-provider-databricks/common"
+
+	"github.com/databricks/terraform-provider-databricks/qa"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResourceGroupRoleCreate(t *testing.T) {
+	d, err := qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:          "PATCH",
+				Resource:        "/api/2.0/preview/scim/v2/Groups/abc",
+				ExpectedRequest: PatchRequest("add", "roles", "arn:aws:iam::000000000000:role/test-role"),
+				Response: Group{
+					ID: "abc",
+				},
+			},
+			{
+				Method:   "GET",
+				Resource: "/api/2.0/preview/scim/v2/Groups/abc",
+				Response: Group{
+					Schemas:     []URN{"urn:ietf:params:scim:schemas:core:2.0:Group"},
+					DisplayName: "Data Scientists",
+					Roles: []ComplexValue{
+						{
+							Value: "arn:aws:iam::000000000000:role/test-role",
+						},
+					},
+					ID: "abc",
+				},
+			},
+		},
+		Resource: ResourceGroupRole(),
+		State: map[string]any{
+			"group_id": "abc",
+			"role_arn": "arn:aws:iam::000000000000:role/test-role",
+		},
+		Create: true,
+	}.Apply(t)
+	assert.NoError(t, err, err)
+	assert.Equal(t, "abc|arn:aws:iam::000000000000:role/test-role", d.Id())
+}
+
+func TestResourceGroupRoleCreate_Error(t *testing.T) {
+	d, err := qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "PATCH",
+				Resource: "/api/2.0/preview/scim/v2/Groups/abc",
+				Response: common.APIErrorBody{
+					ErrorCode: "INVALID_REQUEST",
+					Message:   "Internal error happened",
+				},
+				Status: 400,
+			},
+		},
+		Resource: ResourceGroupRole(),
+		State: map[string]any{
+			"group_id": "abc",
+			"role_arn": "arn:aws:iam::000000000000:role/test-role",
+		},
+		Create: true,
+	}.Apply(t)
+	qa.AssertErrorStartsWith(t, err, "Internal error happened")
+	assert.Equal(t, "", d.Id(), "Id should be empty for error creates")
+}
+
+func TestResourceGroupRoleRead(t *testing.T) {
+	d, err := qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "GET",
+				Resource: "/api/2.0/preview/scim/v2/Groups/abc",
+				Response: Group{
+					Schemas:     []URN{"urn:ietf:params:scim:schemas:core:2.0:Group"},
+					DisplayName: "Data Scientists",
+					Roles: []ComplexValue{
+						{
+							Value: "arn:aws:iam::000000000000:role/test-role",
+						},
+					},
+					ID: "abc",
+				},
+			},
+		},
+		Resource: ResourceGroupRole(),
+		Read:     true,
+		ID:       "abc|arn:aws:iam::000000000000:role/test-role",
+	}.Apply(t)
+	assert.NoError(t, err, err)
+	assert.Equal(t, "abc|arn:aws:iam::000000000000:role/test-role", d.Id(), "Id should not be empty")
+}
+
+func TestResourceGroupRoleRead_NoRole(t *testing.T) {
+	qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "GET",
+				Resource: "/api/2.0/preview/scim/v2/Groups/abc",
+				Response: Group{
+					Schemas:     []URN{"urn:ietf:params:scim:schemas:core:2.0:Group"},
+					DisplayName: "Data Scientists",
+					ID:          "abc",
+				},
+			},
+		},
+		Resource: ResourceGroupRole(),
+		Read:     true,
+		Removed:  true,
+		ID:       "abc|arn:aws:iam::000000000000:role/test-role",
+	}.ApplyNoError(t)
+}
+
+func TestResourceGroupRoleRead_NotFound(t *testing.T) {
+	qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "GET",
+				Resource: "/api/2.0/preview/scim/v2/Groups/abc",
+				Response: common.APIErrorBody{
+					ErrorCode: "NOT_FOUND",
+					Message:   "Item not found",
+				},
+				Status: 404,
+			},
+		},
+		Resource: ResourceGroupRole(),
+		Read:     true,
+		Removed:  true,
+		ID:       "abc|arn:aws:iam::000000000000:role/test-role",
+	}.ApplyNoError(t)
+}
+
+func TestResourceGroupRoleRead_Error(t *testing.T) {
+	d, err := qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "GET",
+				Resource: "/api/2.0/preview/scim/v2/Groups/abc",
+				Response: common.APIErrorBody{
+					ErrorCode: "INVALID_REQUEST",
+					Message:   "Internal error happened",
+				},
+				Status: 400,
+			},
+		},
+		Resource: ResourceGroupRole(),
+		Read:     true,
+		ID:       "abc|arn:aws:iam::000000000000:role/test-role",
+	}.Apply(t)
+	qa.AssertErrorStartsWith(t, err, "Internal error happened")
+	assert.Equal(t, "abc|arn:aws:iam::000000000000:role/test-role", d.Id(), "Id should not be empty for error reads")
+}
+
+func TestResourceGroupRoleDelete(t *testing.T) {
+	d, err := qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "PATCH",
+				Resource: "/api/2.0/preview/scim/v2/Groups/abc",
+				ExpectedRequest: PatchRequest(
+					"remove",
+					`roles[value eq "arn:aws:iam::000000000000:role/test-role"]`,
+					""),
+			},
+		},
+		Resource: ResourceGroupRole(),
+		Delete:   true,
+		ID:       "abc|arn:aws:iam::000000000000:role/test-role",
+	}.Apply(t)
+	assert.NoError(t, err, err)
+	assert.Equal(t, "abc|arn:aws:iam::000000000000:role/test-role", d.Id())
+}
+
+func TestResourceGroupRoleDelete_Error(t *testing.T) {
+	d, err := qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "PATCH",
+				Resource: "/api/2.0/preview/scim/v2/Groups/abc",
+				Response: common.APIErrorBody{
+					ErrorCode: "INVALID_REQUEST",
+					Message:   "Internal error happened",
+				},
+				Status: 400,
+			},
+		},
+		Resource: ResourceGroupRole(),
+		Delete:   true,
+		ID:       "abc|arn:aws:iam::000000000000:role/test-role",
+	}.Apply(t)
+	qa.AssertErrorStartsWith(t, err, "Internal error happened")
+	assert.Equal(t, "abc|arn:aws:iam::000000000000:role/test-role", d.Id())
+}


### PR DESCRIPTION
Major changes:
- Add databricks_group_role resource to allow attaching an AWS Role ARN to an existing group. Implementation for SCIM group role API https://docs.databricks.com/dev-tools/api/latest/scim/scim-groups.html#add-role-to-a-group-by-id