### PR TITLE
Fix `databricks_user` creation with `force` on account

### DIFF
--- a/scim/resource_user.go
+++ b/scim/resource_user.go
@@ -10,6 +10,14 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
+func userExistsErrorMessage(userName string, isAccount bool) string {
+	if isAccount {
+		return fmt.Sprintf("User with email %s already exists in this account", userName)
+	} else {
+		return fmt.Sprintf("User with username %s already exists.", userName)
+	}
+}
+
 // ResourceUser manages users within workspace
 func ResourceUser() *schema.Resource {
 	type entity struct {
@@ -85,9 +93,7 @@ func createForceOverridesManuallyAddedUser(err error, d *schema.ResourceData, us
 	}
 	// corner-case for overriding manually provisioned users
 	userName := strings.ReplaceAll(u.UserName, "'", "")
-	force := fmt.Sprintf("User with email %s already exists in this account", userName)
-	force_account := "User already exists in another account"
-	if (err.Error() != force) && (err.Error() != force_account) {
+	if (err.Error() != userExistsErrorMessage(userName, false)) && (err.Error() != userExistsErrorMessage(userName, true)) {
 		return err
 	}
 	userList, err := usersAPI.Filter(fmt.Sprintf("userName eq '%s'", userName))

--- a/scim/resource_user.go
+++ b/scim/resource_user.go
@@ -85,7 +85,7 @@ func createForceOverridesManuallyAddedUser(err error, d *schema.ResourceData, us
 	}
 	// corner-case for overriding manually provisioned users
 	userName := strings.ReplaceAll(u.UserName, "'", "")
-	force := fmt.Sprintf("User with username %s already exists.", userName)
+	force := fmt.Sprintf("User with email %s already exists in this account", userName)
 	force_account := "User already exists in another account"
 	if (err.Error() != force) && (err.Error() != force_account) {
 		return err

--- a/scim/resource_user_test.go
+++ b/scim/resource_user_test.go
@@ -459,7 +459,7 @@ func TestCreateForceOverwriteCannotListUsers(t *testing.T) {
 		d := ResourceUser().TestResourceData()
 		d.Set("force", true)
 		err := createForceOverridesManuallyAddedUser(
-			fmt.Errorf("User with email me@example.com already exists in this account"),
+			fmt.Errorf(userExistsErrorMessage("me@example.com", false)),
 			d, NewUsersAPI(ctx, client), User{
 				UserName: "me@example.com",
 			})
@@ -480,7 +480,7 @@ func TestCreateForceOverwriteCannotListAccUsers(t *testing.T) {
 		d := ResourceUser().TestResourceData()
 		d.Set("force", true)
 		err := createForceOverridesManuallyAddedUser(
-			fmt.Errorf("User already exists in another account"),
+			fmt.Errorf(userExistsErrorMessage("me@example.com", true)),
 			d, NewUsersAPI(ctx, client), User{
 				UserName: "me@example.com",
 			})
@@ -521,7 +521,7 @@ func TestCreateForceOverwriteFindsAndSetsID(t *testing.T) {
 		d.Set("force", true)
 		d.Set("user_name", "me@example.com")
 		err := createForceOverridesManuallyAddedUser(
-			fmt.Errorf("User with email me@example.com already exists in this account"),
+			fmt.Errorf(userExistsErrorMessage("me@example.com", false)),
 			d, NewUsersAPI(ctx, client), User{
 				UserName: "me@example.com",
 			})
@@ -563,7 +563,7 @@ func TestCreateForceOverwriteFindsAndSetsAccID(t *testing.T) {
 		d.Set("force", true)
 		d.Set("user_name", "me@example.com")
 		err := createForceOverridesManuallyAddedUser(
-			fmt.Errorf("User already exists in another account"),
+			fmt.Errorf(userExistsErrorMessage("me@example.com", true)),
 			d, NewUsersAPI(ctx, client), User{
 				UserName: "me@example.com",
 			})

--- a/scim/resource_user_test.go
+++ b/scim/resource_user_test.go
@@ -459,7 +459,7 @@ func TestCreateForceOverwriteCannotListUsers(t *testing.T) {
 		d := ResourceUser().TestResourceData()
 		d.Set("force", true)
 		err := createForceOverridesManuallyAddedUser(
-			fmt.Errorf("User with username me@example.com already exists."),
+			fmt.Errorf("User with email me@example.com already exists in this account"),
 			d, NewUsersAPI(ctx, client), User{
 				UserName: "me@example.com",
 			})
@@ -521,7 +521,7 @@ func TestCreateForceOverwriteFindsAndSetsID(t *testing.T) {
 		d.Set("force", true)
 		d.Set("user_name", "me@example.com")
 		err := createForceOverridesManuallyAddedUser(
-			fmt.Errorf("User with username me@example.com already exists."),
+			fmt.Errorf("User with email me@example.com already exists in this account"),
 			d, NewUsersAPI(ctx, client), User{
 				UserName: "me@example.com",
 			})


### PR DESCRIPTION
Backend API changes error messages, updating code to match

Closes #1549