### PR TITLE
add `force_destroy` flag to `databricks_schema` & `databricks_catalog`

### DIFF
--- a/catalog/resource_catalog.go
+++ b/catalog/resource_catalog.go
@@ -51,7 +51,9 @@ func (a CatalogsAPI) deleteCatalog(name string, force bool) error {
 			return err
 		}
 		for _, s := range schemas.Schemas {
-			schemasAPI.deleteSchema(s.Name, true)
+			if s.Name != name+".information_schema" {
+				schemasAPI.deleteSchema(s.FullName, true)
+			}
 		}
 	}
 	return a.client.Delete(a.context, "/unity-catalog/catalogs/"+name, nil)

--- a/catalog/resource_catalog_test.go
+++ b/catalog/resource_catalog_test.go
@@ -203,7 +203,8 @@ func TestForceDeleteCatalog(t *testing.T) {
 				Response: Schemas{
 					Schemas: []SchemaInfo{
 						{
-							Name: "b.a",
+							Name:     "a",
+							FullName: "b.a",
 						},
 					},
 				},

--- a/catalog/resource_catalog_test.go
+++ b/catalog/resource_catalog_test.go
@@ -193,3 +193,66 @@ func TestUpdateCatalog(t *testing.T) {
 		`,
 	}.ApplyNoError(t)
 }
+
+func TestForceDeleteCatalog(t *testing.T) {
+	qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "GET",
+				Resource: "/api/2.1/unity-catalog/schemas?catalog_name=b",
+				Response: Schemas{
+					Schemas: []SchemaInfo{
+						{
+							Name: "b.a",
+						},
+					},
+				},
+			},
+			{
+				Method:   "GET",
+				Resource: "/api/2.1/unity-catalog/tables/?catalog_name=b&schema_name=a",
+				Response: Tables{
+					Tables: []TableInfo{
+						{
+							CatalogName: "b",
+							SchemaName:  "a",
+							Name:        "c",
+							TableType:   "MANAGED",
+						},
+						{
+							CatalogName: "b",
+							SchemaName:  "a",
+							Name:        "d",
+							TableType:   "VIEW",
+						},
+					},
+				},
+			},
+			{
+				Method:   "DELETE",
+				Resource: "/api/2.1/unity-catalog/tables/b.a.c",
+			},
+			{
+				Method:   "DELETE",
+				Resource: "/api/2.1/unity-catalog/tables/b.a.d",
+			},
+			{
+				Method:   "DELETE",
+				Resource: "/api/2.1/unity-catalog/schemas/b.a",
+			},
+			{
+				Method:   "DELETE",
+				Resource: "/api/2.1/unity-catalog/catalogs/b",
+			},
+		},
+		Resource: ResourceCatalog(),
+		Delete:   true,
+		ID:       "b",
+		HCL: `
+		name = "b"
+		comment = "c"
+		owner = "administrators"
+		force_destroy = true
+		`,
+	}.ApplyNoError(t)
+}

--- a/catalog/resource_schema_test.go
+++ b/catalog/resource_schema_test.go
@@ -130,3 +130,52 @@ func TestUpdateSchema(t *testing.T) {
 		`,
 	}.ApplyNoError(t)
 }
+
+func TestForceDeleteSchema(t *testing.T) {
+	qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "GET",
+				Resource: "/api/2.1/unity-catalog/tables/?catalog_name=b&schema_name=a",
+				Response: Tables{
+					Tables: []TableInfo{
+						{
+							CatalogName: "b",
+							SchemaName:  "a",
+							Name:        "c",
+							TableType:   "MANAGED",
+						},
+						{
+							CatalogName: "b",
+							SchemaName:  "a",
+							Name:        "d",
+							TableType:   "VIEW",
+						},
+					},
+				},
+			},
+			{
+				Method:   "DELETE",
+				Resource: "/api/2.1/unity-catalog/tables/b.a.c",
+			},
+			{
+				Method:   "DELETE",
+				Resource: "/api/2.1/unity-catalog/tables/b.a.d",
+			},
+			{
+				Method:   "DELETE",
+				Resource: "/api/2.1/unity-catalog/schemas/b.a",
+			},
+		},
+		Resource: ResourceSchema(),
+		Delete:   true,
+		ID:       "b.a",
+		HCL: `
+		name = "a"
+		catalog_name = "b"
+		comment = "c"
+		owner = "administrators"
+		force_destroy = true
+		`,
+	}.ApplyNoError(t)
+}

--- a/docs/resources/catalog.md
+++ b/docs/resources/catalog.md
@@ -28,6 +28,7 @@ The following arguments are required:
 * `owner` - (Optional) Username/groupname/sp application_id of the catalog owner.
 * `comment` - (Optional) User-supplied free-form text.
 * `properties` - (Optional) Extensible Catalog properties.
+* `force_destroy` - (Optional) Delete catalog regardless of its contents.
 
 ## Import
 

--- a/docs/resources/schema.md
+++ b/docs/resources/schema.md
@@ -38,6 +38,7 @@ The following arguments are required:
 * `owner` - (Optional) Username/groupname/sp application_id of the schema owner.
 * `comment` - (Optional) User-supplied free-form text.
 * `properties` - (Optional) Extensible Schema properties.
+* `force_destroy` - (Optional) Delete schema regardless of its contents.
 
 ## Import
 


### PR DESCRIPTION
Add `force_destroy` flag to UC schema & catalog. This achieves the same functionality as the `purge` flag in the cli, which loop through all child schemas & tables and delete them before delete the parent securable

Closes #1576