### PR TITLE
Fixed `databricks_permissions` for calling user to `CAN_MANAGE` on `databricks_cluster`

### DIFF
--- a/permissions/resource_permissions.go
+++ b/permissions/resource_permissions.go
@@ -129,7 +129,7 @@ func urlPathForObjectID(objectID string) string {
 // permissions when POSTing permissions changes through the REST API, to avoid accidentally
 // revoking the calling user's ability to manage the current object.
 func (a PermissionsAPI) shouldExplicitlyGrantCallingUserManagePermissions(objectID string) bool {
-	for _, prefix := range [...]string{"/registered-models/"} {
+	for _, prefix := range [...]string{"/registered-models/", "/clusters/"} {
 		if strings.HasPrefix(objectID, prefix) {
 			return true
 		}

--- a/permissions/resource_permissions_test.go
+++ b/permissions/resource_permissions_test.go
@@ -567,9 +567,16 @@ func TestResourcePermissionsDelete(t *testing.T) {
 				},
 			},
 			{
-				Method:          http.MethodPut,
-				Resource:        "/api/2.0/permissions/clusters/abc",
-				ExpectedRequest: ObjectACL{},
+				Method:   http.MethodPut,
+				Resource: "/api/2.0/permissions/clusters/abc",
+				ExpectedRequest: AccessControlChangeList{
+					AccessControlList: []AccessControlChange{
+						{
+							UserName:        TestingAdminUser,
+							PermissionLevel: "CAN_MANAGE",
+						},
+					},
+				},
 			},
 		},
 		Resource: ResourcePermissions(),
@@ -613,9 +620,16 @@ func TestResourcePermissionsDelete_error(t *testing.T) {
 				},
 			},
 			{
-				Method:          http.MethodPut,
-				Resource:        "/api/2.0/permissions/clusters/abc",
-				ExpectedRequest: ObjectACL{},
+				Method:   http.MethodPut,
+				Resource: "/api/2.0/permissions/clusters/abc",
+				ExpectedRequest: AccessControlChangeList{
+					AccessControlList: []AccessControlChange{
+						{
+							UserName:        TestingAdminUser,
+							PermissionLevel: "CAN_MANAGE",
+						},
+					},
+				},
 				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
@@ -696,6 +710,10 @@ func TestResourcePermissionsCreate(t *testing.T) {
 						{
 							UserName:        TestingUser,
 							PermissionLevel: "CAN_ATTACH_TO",
+						},
+						{
+							UserName:        TestingAdminUser,
+							PermissionLevel: "CAN_MANAGE",
 						},
 					},
 				},


### PR DESCRIPTION
extend #1507 to `databricks_cluster`
closes #1139