### PR TITLE
Feature/add disable unity option

### DIFF
--- a/docs/resources/sql_endpoint.md
+++ b/docs/resources/sql_endpoint.md
@@ -39,6 +39,7 @@ The following arguments are supported:
 * `enable_serverless_compute` - Whether this SQL endpoint is a Serverless endpoint. To use a Serverless SQL endpoint, you must enable Serverless SQL endpoints for the workspace.
 * `channel` block, consisting of following fields:
   * `name` - Name of the Databricks SQL release channel. Possible values are: `CHANNEL_NAME_PREVIEW` and `CHANNEL_NAME_CURRENT`. Default is `CHANNEL_NAME_CURRENT`.
+* `disable_unity` - Whether to enable Unity Catalog. This field is optional and is disabled by default.
  
 ## Attribute Reference
 

--- a/docs/resources/sql_endpoint.md
+++ b/docs/resources/sql_endpoint.md
@@ -39,7 +39,7 @@ The following arguments are supported:
 * `enable_serverless_compute` - Whether this SQL endpoint is a Serverless endpoint. To use a Serverless SQL endpoint, you must enable Serverless SQL endpoints for the workspace.
 * `channel` block, consisting of following fields:
   * `name` - Name of the Databricks SQL release channel. Possible values are: `CHANNEL_NAME_PREVIEW` and `CHANNEL_NAME_CURRENT`. Default is `CHANNEL_NAME_CURRENT`.
-* `disable_unity` - Whether to enable Unity Catalog. This field is optional and is disabled by default.
+* `disable_uc` - Whether to enable Unity Catalog. This field is optional and is disabled by default.
  
 ## Attribute Reference
 

--- a/sql/resource_sql_endpoint.go
+++ b/sql/resource_sql_endpoint.go
@@ -37,7 +37,7 @@ type SQLEndpoint struct {
 	Tags                    *Tags           `json:"tags,omitempty" tf:"suppress_diff"`
 	SpotInstancePolicy      string          `json:"spot_instance_policy,omitempty" tf:"default:COST_OPTIMIZED"`
 	Channel                 *ReleaseChannel `json:"channel,omitempty" tf:"suppress_diff"`
-	DisableUnity            bool            `json:"disable_unity" tf:"optional,default:false"`
+	DisableUC               bool            `json:"disable_uc" tf:"optional,default:false"`
 
 	// The data source ID is not part of the endpoint API response.
 	// We manually resolve it by retrieving the list of data sources

--- a/sql/resource_sql_endpoint.go
+++ b/sql/resource_sql_endpoint.go
@@ -37,6 +37,7 @@ type SQLEndpoint struct {
 	Tags                    *Tags           `json:"tags,omitempty" tf:"suppress_diff"`
 	SpotInstancePolicy      string          `json:"spot_instance_policy,omitempty" tf:"default:COST_OPTIMIZED"`
 	Channel                 *ReleaseChannel `json:"channel,omitempty" tf:"suppress_diff"`
+	DisableUnity            bool            `json:"disable_unity" tf:"optional,default:false"`
 
 	// The data source ID is not part of the endpoint API response.
 	// We manually resolve it by retrieving the list of data sources


### PR DESCRIPTION
Adds the option to disable the unity catalog feature for SQL warehouses
This is current set to false by default whenever terraform is run for a given SQL warehouse but will impact users trying to interact with the hive_metastore outside of the Databricks UI. This behaviour has been observed specifically in users attempting to query the hive_metastore via a SQL warehouse using Databricks SQL Connector for Python. 