### PR TITLE
Fix unity catalog docs to use correct metastore

### DIFF
--- a/docs/guides/unity-catalog.md
+++ b/docs/guides/unity-catalog.md
@@ -187,8 +187,8 @@ resource "aws_iam_policy" "unity_metastore" {
           "s3:GetBucketLocation"
         ],
         "Resource" : [
-          aws_s3_bucket.unity_metastore.arn,
-          "${aws_s3_bucket.unity_metastore.arn}/*"
+          aws_s3_bucket.metastore.arn,
+          "${aws_s3_bucket.metastore.arn}/*"
         ],
         "Effect" : "Allow"
       }


### PR DESCRIPTION
aws_iam_policy.unity_metastore is referencing
aws_s3_bucket.unity_metastore.arn, which is non-existent. Fix to use aws_s3_bucket.metastore.arn instead. This also matches with the online tutorial.

https://docs.databricks.com/data-governance/unity-catalog/automate.html