### PR TITLE
prevent stripping of `CAN_MANAGE` permission from caller of `sql_query` resource

### DIFF
--- a/docs/resources/permissions.md
+++ b/docs/resources/permissions.md
@@ -602,6 +602,9 @@ resource "databricks_permissions" "endpoint_usage" {
 
 [SQL queries](https://docs.databricks.com/sql/user/security/access-control/query-acl.html) have two possible permissions: `CAN_RUN` and `CAN_MANAGE`:
 
+
+-> **Note** If you do not define an `access_control` block granting `CAN_MANAGE` explictly for the user calling this provider, Databricks Terraform Provider will add `CAN_MANAGE` permission for the caller. This is a failsafe to prevent situations where the caller is locked out from making changes to the targeted `databricks_sql_query` resource when backend API do not apply permission inheritance correctly.
+
 ```hcl
 resource "databricks_group" "auto" {
   display_name = "Automation"

--- a/permissions/resource_permissions.go
+++ b/permissions/resource_permissions.go
@@ -129,7 +129,7 @@ func urlPathForObjectID(objectID string) string {
 // permissions when POSTing permissions changes through the REST API, to avoid accidentally
 // revoking the calling user's ability to manage the current object.
 func (a PermissionsAPI) shouldExplicitlyGrantCallingUserManagePermissions(objectID string) bool {
-	for _, prefix := range [...]string{"/registered-models/", "/clusters/"} {
+	for _, prefix := range [...]string{"/registered-models/", "/clusters/", "/queries/"} {
 		if strings.HasPrefix(objectID, prefix) {
 			return true
 		}

--- a/permissions/resource_permissions_test.go
+++ b/permissions/resource_permissions_test.go
@@ -1401,7 +1401,7 @@ func TestResourcePermissionsCreate_RepoPath(t *testing.T) {
 	assert.Equal(t, "CAN_READ", firstElem["permission_level"])
 }
 
-//when caller does not specify CAN_MANAGE permission during create, it should be explictly added
+// when caller does not specify CAN_MANAGE permission during create, it should be explictly added
 func TestResourcePermissionsCreate_Sql_Queries(t *testing.T) {
 	d, err := qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
@@ -1461,7 +1461,7 @@ func TestResourcePermissionsCreate_Sql_Queries(t *testing.T) {
 	assert.Equal(t, "CAN_RUN", firstElem["permission_level"])
 }
 
-//when caller does not specify CAN_MANAGE permission during update, it should be explictly added
+// when caller does not specify CAN_MANAGE permission during update, it should be explictly added
 func TestResourcePermissionsUpdate_Sql_Queries(t *testing.T) {
 	d, err := qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
@@ -1505,11 +1505,12 @@ func TestResourcePermissionsUpdate_Sql_Queries(t *testing.T) {
 			"sql_query_id": "id111",
 		},
 		HCL: `
-		"sql_query_id" = "id111",
-		"access_control" = {
-				"user_name"			= "ben",
-				"permission_level"	= "CAN_RUN",
-				}
+		sql_query_id = "id111",
+
+		access_control = {
+			user_name = "ben",
+			permission_level = "CAN_RUN",
+			}
 		`,
 		Resource: ResourcePermissions(),
 		Update:   true,

--- a/permissions/resource_permissions_test.go
+++ b/permissions/resource_permissions_test.go
@@ -1400,3 +1400,125 @@ func TestResourcePermissionsCreate_RepoPath(t *testing.T) {
 	assert.Equal(t, TestingUser, firstElem["user_name"])
 	assert.Equal(t, "CAN_READ", firstElem["permission_level"])
 }
+
+//when caller does not specify CAN_MANAGE permission during create, it should be explictly added
+func TestResourcePermissionsCreate_Sql_Queries(t *testing.T) {
+	d, err := qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			me,
+			{
+				Method:   http.MethodPost,
+				Resource: "/api/2.0/preview/sql/permissions/queries/id111",
+				ExpectedRequest: AccessControlChangeList{
+					AccessControlList: []AccessControlChange{
+						{
+							UserName:        TestingUser,
+							PermissionLevel: "CAN_RUN",
+						},
+						{
+							UserName:        TestingAdminUser,
+							PermissionLevel: "CAN_MANAGE",
+						},
+					},
+				},
+			},
+			{
+				Method:   http.MethodGet,
+				Resource: "/api/2.0/preview/sql/permissions/queries/id111",
+				Response: ObjectACL{
+					ObjectID:   "/sql/queries/id111",
+					ObjectType: "query",
+					AccessControlList: []AccessControl{
+						{
+							UserName:        TestingUser,
+							PermissionLevel: "CAN_RUN",
+						},
+						{
+							UserName:        TestingAdminUser,
+							PermissionLevel: "CAN_MANAGE",
+						},
+					},
+				},
+			},
+		},
+		Resource: ResourcePermissions(),
+		State: map[string]any{
+			"sql_query_id": "id111",
+			"access_control": []any{
+				map[string]any{
+					"user_name":        TestingUser,
+					"permission_level": "CAN_RUN",
+				},
+			},
+		},
+		Create: true,
+	}.Apply(t)
+	assert.NoError(t, err, err)
+	ac := d.Get("access_control").(*schema.Set)
+	require.Equal(t, 1, len(ac.List()))
+	firstElem := ac.List()[0].(map[string]any)
+	assert.Equal(t, TestingUser, firstElem["user_name"])
+	assert.Equal(t, "CAN_RUN", firstElem["permission_level"])
+}
+
+//when caller does not specify CAN_MANAGE permission during update, it should be explictly added
+func TestResourcePermissionsUpdate_Sql_Queries(t *testing.T) {
+	d, err := qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			me,
+			{
+				Method:   http.MethodPost,
+				Resource: "/api/2.0/preview/sql/permissions/queries/id111",
+				ExpectedRequest: AccessControlChangeList{
+					AccessControlList: []AccessControlChange{
+						{
+							UserName:        TestingUser,
+							PermissionLevel: "CAN_RUN",
+						},
+						{
+							UserName:        TestingAdminUser,
+							PermissionLevel: "CAN_MANAGE",
+						},
+					},
+				},
+			},
+			{
+				Method:   http.MethodGet,
+				Resource: "/api/2.0/preview/sql/permissions/queries/id111",
+				Response: ObjectACL{
+					ObjectID:   "/sql/queries/id111",
+					ObjectType: "query",
+					AccessControlList: []AccessControl{
+						{
+							UserName:        TestingUser,
+							PermissionLevel: "CAN_RUN",
+						},
+						{
+							UserName:        TestingAdminUser,
+							PermissionLevel: "CAN_MANAGE",
+						},
+					},
+				},
+			},
+		},
+		InstanceState: map[string]string{
+			"sql_query_id": "id111",
+		},
+		HCL: `
+		"sql_query_id" = "id111",
+		"access_control" = {
+				"user_name"			= "ben",
+				"permission_level"	= "CAN_RUN",
+				}
+		`,
+		Resource: ResourcePermissions(),
+		Update:   true,
+		ID:       "/sql/queries/id111",
+	}.Apply(t)
+	assert.NoError(t, err, err)
+	ac := d.Get("access_control").(*schema.Set)
+	require.Equal(t, 1, len(ac.List()))
+	firstElem := ac.List()[0].(map[string]any)
+	assert.Equal(t, TestingUser, firstElem["user_name"])
+	assert.Equal(t, "CAN_RUN", firstElem["permission_level"])
+}


### PR DESCRIPTION
relates to https://github.com/databricks/terraform-provider-databricks/issues/1615

this PR uses the fix from https://github.com/databricks/terraform-provider-databricks/issues/1504 to append `CAN_MANAGE` perms to the caller explicitly when modifying permissions on `databricks sql queries`