### PR TITLE
Release v1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Version changelog
 
+## 1.5.0
+
+ * Added `enable_serverless_compute` in the documentation for the [databricks_sql_global_config](https://registry.terraform.io/providers/databricks/databricks/latest/docs/resources/sql_global_config) ([#1655](https://github.com/databricks/terraform-provider-databricks/pull/1655)).
+ * Update [databricks_grants](https://registry.terraform.io/providers/databricks/databricks/latest/docs/resources/grants) with new permissions model ([#1657](https://github.com/databricks/terraform-provider-databricks/pull/1657)).
+ * Exporter now adds the `force` flag to  users and groups ([#1661](https://github.com/databricks/terraform-provider-databricks/pull/1661)).
+
+Updated dependency versions:
+
+ * Bump google.golang.org/api from 0.97.0 to 0.98.0 ([#1652](https://github.com/databricks/terraform-provider-databricks/pull/1652)).
+
 ## 1.4.0
 
  * Added [databricks_job](https://registry.terraform.io/providers/databricks/databricks/latest/docs/data-sources/job) data resource ([#1509](https://github.com/databricks/terraform-provider-databricks/pull/1509)).

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ terraform {
   required_providers {
     databricks = {
       source  = "databricks/databricks"
-      version = "1.4.0"
+      version = "1.5.0"
     }
   }
 }

--- a/catalog/acceptance/external_location_test.go
+++ b/catalog/acceptance/external_location_test.go
@@ -31,7 +31,7 @@ func TestUcAccExternalLocation(t *testing.T) {
 				external_location = databricks_external_location.some.id
 				grant {
 					principal  = "{env.TEST_DATA_ENG_GROUP}"
-					privileges = ["CREATE_TABLE", "READ_FILES"]
+					privileges = ["CREATE_EXTERNAL_TABLE", "READ_FILES"]
 				}
 			}`,
 		},

--- a/catalog/acceptance/schema_test.go
+++ b/catalog/acceptance/schema_test.go
@@ -28,11 +28,11 @@ func TestUcAccSchema(t *testing.T) {
 				catalog = databricks_catalog.sandbox.name
 				grant {
 					principal  = "{env.TEST_DATA_SCI_GROUP}"
-					privileges = ["USAGE", "CREATE"]
+					privileges = ["USE_CATALOG", "CREATE_SCHEMA"]
 				}
 				grant {
 					principal  = "{env.TEST_DATA_ENG_GROUP}"
-					privileges = ["USAGE"]
+					privileges = ["USE_CATALOG"]
 				}
 			}
 			
@@ -54,7 +54,7 @@ func TestUcAccSchema(t *testing.T) {
 				schema = databricks_schema.things.id
 				grant {
 				  principal  = "{env.TEST_DATA_ENG_GROUP}"
-				  privileges = ["USAGE"]
+				  privileges = ["USE_SCHEMA"]
 				}
 			}`,
 		},

--- a/common/version.go
+++ b/common/version.go
@@ -3,7 +3,7 @@ package common
 import "context"
 
 var (
-	version = "1.4.0"
+	version = "1.5.0"
 	// ResourceName is resource name without databricks_ prefix
 	ResourceName contextKey = 1
 	// Provider is the current instance of provider


### PR DESCRIPTION
# Version changelog

## 1.5.0

 * Added `enable_serverless_compute` in the documentation for the [databricks_sql_global_config](https://registry.terraform.io/providers/databricks/databricks/latest/docs/resources/sql_global_config) ([#1655](https://github.com/databricks/terraform-provider-databricks/pull/1655)).
 * Update [databricks_grants](https://registry.terraform.io/providers/databricks/databricks/latest/docs/resources/grants) with new permissions model ([#1657](https://github.com/databricks/terraform-provider-databricks/pull/1657)).
 * Exporter now adds the `force` flag to  users and groups ([#1661](https://github.com/databricks/terraform-provider-databricks/pull/1661)).

Updated dependency versions:

 * Bump google.golang.org/api from 0.97.0 to 0.98.0 ([#1652](https://github.com/databricks/terraform-provider-databricks/pull/1652)).
