### PR TITLE
Allow updating `private_access_settings_id` for `databricks_mws_workspaces`

### DIFF
--- a/docs/guides/aws-private-link-workspace.md
+++ b/docs/guides/aws-private-link-workspace.md
@@ -2,9 +2,7 @@
 page_title: "Provisioning Databricks on AWS with PrivateLink"
 ---
 
-# Deploying pre-requisite resources and enabling PrivateLink connections (AWS Preview)
-
--> **Public Preview** This feature is in [Public Preview](https://docs.databricks.com/release-notes/release-types.html). Contact your Databricks representative to request access.
+# Deploying pre-requisite resources and enabling PrivateLink connections
 
 Databricks PrivateLink support enables private connectivity between users and their Databricks workspaces and between clusters on the data plane and core services on the control plane within the Databricks workspace infrastructure. You can use Terraform to deploy the underlying cloud resources and the private access settings resources automatically, using a programmatic approach. This guide assumes you are deploying into an existing VPC and you have set up credentials and storage configurations as per prior examples, notably here.
 

--- a/docs/resources/mws_private_access_settings.md
+++ b/docs/resources/mws_private_access_settings.md
@@ -3,8 +3,6 @@ subcategory: "AWS"
 ---
 # databricks_mws_private_access_settings Resource
 
--> **Public Preview** This feature is in [Public Preview](https://docs.databricks.com/release-notes/release-types.html). Contact your Databricks representative to request access. 
-
 Allows you to create a [Private Access Setting](https://docs.databricks.com/administration-guide/cloud-configurations/aws/privatelink.html#step-5-create-a-private-access-settings-configuration-using-the-databricks-account-api) that can be used as part of a [databricks_mws_workspaces](mws_workspaces.md) resource to create a [Databricks Workspace that leverages AWS PrivateLink](https://docs.databricks.com/administration-guide/cloud-configurations/aws/privatelink.html).
 
 It is strongly recommended that customers read the [Enable Private Link](https://docs.databricks.com/administration-guide/cloud-configurations/aws/privatelink.html) documentation before trying to leverage this resource.

--- a/docs/resources/mws_vpc_endpoint.md
+++ b/docs/resources/mws_vpc_endpoint.md
@@ -3,8 +3,6 @@ subcategory: "AWS"
 ---
 # databricks_mws_vpc_endpoint Resource
 
--> **Public Preview** This feature is in [Public Preview](https://docs.databricks.com/release-notes/release-types.html). Contact your Databricks representative to request access. 
-
 Enables you to register [aws_vpc_endpoint](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint) resources with Databricks such that they can be used as part of a [databricks_mws_networks](mws_networks.md) configuration.
 
 It is strongly recommended that customers read the [Enable Private Link](https://docs.databricks.com/administration-guide/cloud-configurations/aws/privatelink.html) documentation before trying to leverage this resource.

--- a/docs/resources/mws_workspaces.md
+++ b/docs/resources/mws_workspaces.md
@@ -208,7 +208,6 @@ The following arguments are available and cannot be changed after workspace is c
 * `workspace_name` - name of the workspace, will appear on UI
 * `aws_region` - AWS region of VPC
 * `storage_configuration_id` - `storage_configuration_id` from [storage configuration](mws_storage_configurations.md)
-* `private_access_settings_id` - (Optional) Canonical unique identifier of [databricks_mws_private_access_settings](mws_private_access_settings.md) in Databricks Account
 
 ## token block
 
@@ -225,7 +224,7 @@ The following arguments could be modified after the workspace is running:
 * `network_id` - (Optional) `network_id` from [networks](mws_networks.md). Modifying [networks on running workspaces](mws_networks.md#modifying-networks-on-running-workspaces) would require three separate `terraform apply` steps.
 * `credentials_id` - `credentials_id` from [credentials](mws_credentials.md)
 * `storage_customer_managed_key_id` - (Optional) `customer_managed_key_id` from [customer managed keys](mws_customer_managed_keys.md) with `use_cases` set to `STORAGE`. This is used to encrypt the DBFS Storage & Cluster EBS Volumes.
-
+* `private_access_settings_id` - (Optional) Canonical unique identifier of [databricks_mws_private_access_settings](mws_private_access_settings.md) in Databricks Account
 
 ## Attribute Reference
 

--- a/mws/resource_mws_workspaces.go
+++ b/mws/resource_mws_workspaces.go
@@ -243,7 +243,7 @@ func (a WorkspacesAPI) WaitForRunning(ws Workspace, timeout time.Duration) error
 	})
 }
 
-var workspaceRunningUpdatesAllowed = []string{"credentials_id", "network_id", "storage_customer_managed_key_id"}
+var workspaceRunningUpdatesAllowed = []string{"credentials_id", "network_id", "storage_customer_managed_key_id", "private_access_settings_id"}
 
 // UpdateRunning will update running workspace with couple of possible fields
 func (a WorkspacesAPI) UpdateRunning(ws Workspace, timeout time.Duration) error {
@@ -257,6 +257,9 @@ func (a WorkspacesAPI) UpdateRunning(ws Workspace, timeout time.Duration) error 
 		// update in this API to add support for PrivateLink (in Public Preview). To add PrivateLink to an existing
 		// workspace, contact your Databricks representative.
 		"network_id": ws.NetworkID,
+	}
+	if ws.PrivateAccessSettingsID != "" {
+		request["private_access_settings_id"] = ws.PrivateAccessSettingsID
 	}
 	if ws.StorageCustomerManagedKeyID != "" {
 		request["storage_customer_managed_key_id"] = ws.StorageCustomerManagedKeyID

--- a/mws/resource_mws_workspaces.go
+++ b/mws/resource_mws_workspaces.go
@@ -253,9 +253,7 @@ func (a WorkspacesAPI) UpdateRunning(ws Workspace, timeout time.Duration) error 
 		// The ID of the workspace's network configuration object. Used only if you already use a customer-managed VPC.
 		// This change is supported only if you specified a network configuration ID when the workspace was created.
 		// In other words, you cannot switch from a Databricks-managed VPC to a customer-managed VPC. This parameter
-		// is available for updating both failed and running workspaces. Note: You cannot use a network configuration
-		// update in this API to add support for PrivateLink (in Public Preview). To add PrivateLink to an existing
-		// workspace, contact your Databricks representative.
+		// is available for updating both failed and running workspaces.
 		"network_id": ws.NetworkID,
 	}
 	if ws.PrivateAccessSettingsID != "" {

--- a/mws/resource_mws_workspaces.go
+++ b/mws/resource_mws_workspaces.go
@@ -255,10 +255,9 @@ func (a WorkspacesAPI) UpdateRunning(ws Workspace, timeout time.Duration) error 
 		// In other words, you cannot switch from a Databricks-managed VPC to a customer-managed VPC. This parameter
 		// is available for updating both failed and running workspaces.
 		"network_id": ws.NetworkID,
-		// The ID of the workspace's private access settings. Used only if you already enable PrivateLink.
-		// This change is supported if you are adding/updating a private access setting.
-		// In other words, you cannot remove the private access setting from a workspace
-		"private_access_settings_id": ws.PrivateAccessSettingsID,
+	}
+	if ws.PrivateAccessSettingsID != "" {
+		request["private_access_settings_id"] = ws.PrivateAccessSettingsID
 	}
 	if ws.StorageCustomerManagedKeyID != "" {
 		request["storage_customer_managed_key_id"] = ws.StorageCustomerManagedKeyID

--- a/mws/resource_mws_workspaces_test.go
+++ b/mws/resource_mws_workspaces_test.go
@@ -502,6 +502,7 @@ func TestResourceWorkspaceUpdate(t *testing.T) {
 					"credentials_id":                  "bcd",
 					"network_id":                      "fgh",
 					"storage_customer_managed_key_id": "def",
+					"private_access_settings_id":      "pas",
 				},
 			},
 			{
@@ -518,6 +519,7 @@ func TestResourceWorkspaceUpdate(t *testing.T) {
 					NetworkID:                           "fgh",
 					ManagedServicesCustomerManagedKeyID: "def",
 					StorageCustomerManagedKeyID:         "def",
+					PrivateAccessSettingsID:             "pas",
 					AccountID:                           "abc",
 					WorkspaceID:                         1234,
 				},
@@ -548,6 +550,7 @@ func TestResourceWorkspaceUpdate(t *testing.T) {
 			"is_no_public_ip_enabled":                  true,
 			"network_id":                               "fgh",
 			"storage_configuration_id":                 "ghi",
+			"private_access_settings_id":               "pas",
 			"workspace_id":                             1234,
 		},
 		Update: true,

--- a/mws/resource_mws_workspaces_test.go
+++ b/mws/resource_mws_workspaces_test.go
@@ -602,8 +602,9 @@ func TestResourceWorkspaceUpdateLegacyConfig(t *testing.T) {
 				Method:   "PATCH",
 				Resource: "/api/2.0/accounts/abc/workspaces/1234",
 				ExpectedRequest: map[string]any{
-					"credentials_id": "bcd",
-					"network_id":     "fgh",
+					"credentials_id":             "bcd",
+					"network_id":                 "fgh",
+					"private_access_settings_id": "",
 				},
 			},
 			{
@@ -1236,4 +1237,41 @@ func TestExplainWorkspaceFailureCornerCase(t *testing.T) {
 			NetworkID: "abc",
 		}), "failed to start workspace. Cannot read network: 🐜")
 	})
+}
+
+func TestResourceWorkspaceRemovePAS_NotAllowed(t *testing.T) {
+	qa.ResourceFixture{
+		Resource: ResourceMwsWorkspaces(),
+		InstanceState: map[string]string{
+			"account_id":     "abc",
+			"aws_region":     "us-east-1",
+			"credentials_id": "bcd",
+			"managed_services_customer_managed_key_id": "def",
+			"storage_customer_managed_key_id":          "def",
+			"deployment_name":                          "900150983cd24fb0",
+			"workspace_name":                           "labdata",
+			"is_no_public_ip_enabled":                  "true",
+			"network_id":                               "fgh",
+			"storage_configuration_id":                 "ghi",
+			"workspace_id":                             "1234",
+			"private_access_settings_id":               "pas",
+		},
+		State: map[string]any{
+			"account_id": "abc",
+
+			"aws_region":     "us-east-1",
+			"credentials_id": "bcd",
+			"managed_services_customer_managed_key_id": "def",
+			"storage_customer_managed_key_id":          "def",
+			"deployment_name":                          "900150983cd24fb0",
+			"workspace_name":                           "labdata",
+			"is_no_public_ip_enabled":                  true,
+			"network_id":                               "fgh",
+			"storage_configuration_id":                 "ghi",
+			"workspace_id":                             1234,
+			"private_access_settings_id":               "",
+		},
+		Update: true,
+		ID:     "abc/1234",
+	}.ExpectError(t, "cannot remove private access setting from workspace")
 }

--- a/mws/resource_mws_workspaces_test.go
+++ b/mws/resource_mws_workspaces_test.go
@@ -602,9 +602,8 @@ func TestResourceWorkspaceUpdateLegacyConfig(t *testing.T) {
 				Method:   "PATCH",
 				Resource: "/api/2.0/accounts/abc/workspaces/1234",
 				ExpectedRequest: map[string]any{
-					"credentials_id":             "bcd",
-					"network_id":                 "fgh",
-					"private_access_settings_id": "",
+					"credentials_id": "bcd",
+					"network_id":     "fgh",
 				},
 			},
 			{

--- a/mws/resource_mws_workspaces_test.go
+++ b/mws/resource_mws_workspaces_test.go
@@ -502,7 +502,6 @@ func TestResourceWorkspaceUpdate(t *testing.T) {
 					"credentials_id":                  "bcd",
 					"network_id":                      "fgh",
 					"storage_customer_managed_key_id": "def",
-					"private_access_settings_id":      "pas",
 				},
 			},
 			{
@@ -519,7 +518,6 @@ func TestResourceWorkspaceUpdate(t *testing.T) {
 					NetworkID:                           "fgh",
 					ManagedServicesCustomerManagedKeyID: "def",
 					StorageCustomerManagedKeyID:         "def",
-					PrivateAccessSettingsID:             "pas",
 					AccountID:                           "abc",
 					WorkspaceID:                         1234,
 				},
@@ -550,7 +548,6 @@ func TestResourceWorkspaceUpdate(t *testing.T) {
 			"is_no_public_ip_enabled":                  true,
 			"network_id":                               "fgh",
 			"storage_configuration_id":                 "ghi",
-			"private_access_settings_id":               "pas",
 			"workspace_id":                             1234,
 		},
 		Update: true,
@@ -1236,6 +1233,74 @@ func TestExplainWorkspaceFailureCornerCase(t *testing.T) {
 			NetworkID: "abc",
 		}), "failed to start workspace. Cannot read network: 🐜")
 	})
+}
+
+func TestResourceWorkspaceUpdatePrivateAccessSettings(t *testing.T) {
+	d, err := qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "PATCH",
+				Resource: "/api/2.0/accounts/abc/workspaces/1234",
+				ExpectedRequest: map[string]any{
+					"credentials_id":                  "bcd",
+					"network_id":                      "fgh",
+					"storage_customer_managed_key_id": "def",
+					"private_access_settings_id":      "pas",
+				},
+			},
+			{
+				Method:       "GET",
+				ReuseRequest: true,
+				Resource:     "/api/2.0/accounts/abc/workspaces/1234",
+				Response: Workspace{
+					WorkspaceStatus:                     WorkspaceStatusRunning,
+					WorkspaceName:                       "labdata",
+					DeploymentName:                      "900150983cd24fb0",
+					AwsRegion:                           "us-east-1",
+					CredentialsID:                       "bcd",
+					StorageConfigurationID:              "ghi",
+					NetworkID:                           "fgh",
+					ManagedServicesCustomerManagedKeyID: "def",
+					StorageCustomerManagedKeyID:         "def",
+					PrivateAccessSettingsID:             "pas",
+					AccountID:                           "abc",
+					WorkspaceID:                         1234,
+				},
+			},
+		},
+		Resource: ResourceMwsWorkspaces(),
+		InstanceState: map[string]string{
+			"account_id":     "abc",
+			"aws_region":     "us-east-1",
+			"credentials_id": "__OLDER__",
+			"managed_services_customer_managed_key_id": "def",
+			"storage_customer_managed_key_id":          "__OLDER__",
+			"deployment_name":                          "900150983cd24fb0",
+			"workspace_name":                           "labdata",
+			"is_no_public_ip_enabled":                  "true",
+			"network_id":                               "fgh",
+			"storage_configuration_id":                 "ghi",
+			"workspace_id":                             "1234",
+		},
+		State: map[string]any{
+			"account_id":     "abc",
+			"aws_region":     "us-east-1",
+			"credentials_id": "bcd",
+			"managed_services_customer_managed_key_id": "def",
+			"storage_customer_managed_key_id":          "def",
+			"deployment_name":                          "900150983cd24fb0",
+			"workspace_name":                           "labdata",
+			"is_no_public_ip_enabled":                  true,
+			"network_id":                               "fgh",
+			"storage_configuration_id":                 "ghi",
+			"private_access_settings_id":               "pas",
+			"workspace_id":                             1234,
+		},
+		Update: true,
+		ID:     "abc/1234",
+	}.Apply(t)
+	assert.NoError(t, err, err)
+	assert.Equal(t, "abc/1234", d.Id(), "Id should be the same as in reading")
 }
 
 func TestResourceWorkspaceRemovePAS_NotAllowed(t *testing.T) {


### PR DESCRIPTION
- allow updating `private_access_settings_id` for `databricks_mws_workspaces`
- update docs to reflect AWS PL GA status