### PR TITLE
Added `CAN_VIEW` permissions for `databricks_sql_dashboard` and `databricks_sql_query`

### DIFF
--- a/docs/resources/permissions.md
+++ b/docs/resources/permissions.md
@@ -572,7 +572,7 @@ resource "databricks_permissions" "endpoint_usage" {
 
 ## SQL Dashboard usage
 
-[SQL dashboards](https://docs.databricks.com/sql/user/security/access-control/dashboard-acl.html) have two possible permissions: `CAN_RUN` and `CAN_MANAGE`:
+[SQL dashboards](https://docs.databricks.com/sql/user/security/access-control/dashboard-acl.html) have three possible permissions: `CAN_VIEW`, `CAN_RUN` and `CAN_MANAGE`:
 
 ```hcl
 resource "databricks_group" "auto" {
@@ -600,7 +600,7 @@ resource "databricks_permissions" "endpoint_usage" {
 
 ## SQL Query usage
 
-[SQL queries](https://docs.databricks.com/sql/user/security/access-control/query-acl.html) have two possible permissions: `CAN_RUN` and `CAN_MANAGE`:
+[SQL queries](https://docs.databricks.com/sql/user/security/access-control/query-acl.html) have three possible permissions: `CAN_VIEW`, `CAN_RUN` and `CAN_MANAGE`:
 
 
 -> **Note** If you do not define an `access_control` block granting `CAN_MANAGE` explictly for the user calling this provider, Databricks Terraform Provider will add `CAN_MANAGE` permission for the caller. This is a failsafe to prevent situations where the caller is locked out from making changes to the targeted `databricks_sql_query` resource when backend API do not apply permission inheritance correctly.
@@ -631,7 +631,7 @@ resource "databricks_permissions" "endpoint_usage" {
 
 ## SQL Alert usage
 
-[SQL alerts](https://docs.databricks.com/sql/user/security/access-control/alert-acl.html) have two possible permissions: `CAN_RUN` and `CAN_MANAGE`:
+[SQL alerts](https://docs.databricks.com/sql/user/security/access-control/alert-acl.html) have three possible permissions: `CAN_VIEW`, `CAN_RUN` and `CAN_MANAGE`:
 
 ```hcl
 resource "databricks_group" "auto" {

--- a/permissions/resource_permissions.go
+++ b/permissions/resource_permissions.go
@@ -287,9 +287,9 @@ func permissionsResourceIDFields() []permissionsIDFieldMapping {
 		{"authorization", "tokens", "authorization", []string{"CAN_USE"}, SIMPLE},
 		{"authorization", "passwords", "authorization", []string{"CAN_USE"}, SIMPLE},
 		{"sql_endpoint_id", "warehouses", "sql/warehouses", []string{"CAN_USE", "CAN_MANAGE"}, SIMPLE},
-		{"sql_dashboard_id", "dashboard", "sql/dashboards", []string{"CAN_EDIT", "CAN_RUN", "CAN_MANAGE"}, SIMPLE},
-		{"sql_alert_id", "alert", "sql/alerts", []string{"CAN_EDIT", "CAN_RUN", "CAN_MANAGE"}, SIMPLE},
-		{"sql_query_id", "query", "sql/queries", []string{"CAN_EDIT", "CAN_RUN", "CAN_MANAGE"}, SIMPLE},
+		{"sql_dashboard_id", "dashboard", "sql/dashboards", []string{"CAN_EDIT", "CAN_RUN", "CAN_MANAGE", "CAN_VIEW"}, SIMPLE},
+		{"sql_alert_id", "alert", "sql/alerts", []string{"CAN_EDIT", "CAN_RUN", "CAN_MANAGE", "CAN_VIEW"}, SIMPLE},
+		{"sql_query_id", "query", "sql/queries", []string{"CAN_EDIT", "CAN_RUN", "CAN_MANAGE", "CAN_VIEW"}, SIMPLE},
 		{"experiment_id", "mlflowExperiment", "experiments", []string{"CAN_READ", "CAN_EDIT", "CAN_MANAGE"}, SIMPLE},
 		{"registered_model_id", "registered-model", "registered-models", []string{
 			"CAN_READ", "CAN_EDIT", "CAN_MANAGE_STAGING_VERSIONS", "CAN_MANAGE_PRODUCTION_VERSIONS", "CAN_MANAGE"}, SIMPLE},


### PR DESCRIPTION
[DBSQL Workspace Browser](https://docs.databricks.com/sql/user/workspace-browser/index.html) is recently released, which adds `CAN_VIEW` permissions for DBSQL objects

Close #1679