### PR TITLE
clarify that `databricks_mws_permission_assignment` should be used for assigning account-level users/groups

### DIFF
--- a/docs/resources/group.md
+++ b/docs/resources/group.md
@@ -5,6 +5,8 @@ subcategory: "Security"
 
 This resource allows you to manage [groups in Databricks Workspace](https://docs.databricks.com/administration-guide/users-groups/groups.html), [Databricks Account Console](https://accounts.cloud.databricks.com/) or [Azure Databricks Account Console](https://accounts.azuredatabricks.net). You can also [associate](group_member.md) Databricks users and [service principals](service_principal.md) to groups. This is useful if you are using an application to sync users & groups with SCIM API.
 
+-> **Note** To assign account level groups to workspace use [databricks_mws_permission_assignment](mws_permission_assignment.md).
+
 To create groups in the Databricks account, the provider must be configured with `host = "https://accounts.cloud.databricks.com"` on AWS deployments or `host = "https://accounts.azuredatabricks.net"` and authenticate using [AAD tokens](https://registry.terraform.io/providers/databricks/databricks/latest/docs#special-configurations-for-azure) on Azure deployments
 
 Recommended to use along with Identity Provider SCIM provisioning to populate users into those groups:

--- a/docs/resources/service_principal.md
+++ b/docs/resources/service_principal.md
@@ -5,6 +5,8 @@ subcategory: "Security"
 
 Directly manage [Service Principals](https://docs.databricks.com/administration-guide/users-groups/service-principals.html) that could be added to [databricks_group](group.md) in Databricks workspace or account.
 
+-> **Note** To assign account level service principals to workspace use [databricks_mws_permission_assignment](mws_permission_assignment.md).
+
 To create service principals in the Databricks account, the provider must be configured with `host = "https://accounts.cloud.databricks.com"` on AWS deployments or `host = "https://accounts.azuredatabricks.net"` and authenticate using [AAD tokens](https://registry.terraform.io/providers/databricks/databricks/latest/docs#special-configurations-for-azure) on Azure deployments
 
 ## Example Usage

--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -5,6 +5,8 @@ subcategory: "Security"
 
 This resource allows you to manage [users in Databricks Workspace](https://docs.databricks.com/administration-guide/users-groups/users.html), [Databricks Account Console](https://accounts.cloud.databricks.com/) or [Azure Databricks Account Console](https://accounts.azuredatabricks.net). You can also [associate](group_member.md) Databricks users to [databricks_group](group.md). Upon user creation the user will receive a password reset email. You can also get information about caller identity using [databricks_current_user](../data-sources/current_user.md) data source.
 
+-> **Note** To assign account level users to workspace use [databricks_mws_permission_assignment](mws_permission_assignment.md).
+
 To create users in the Databricks account, the provider must be configured with `host = "https://accounts.cloud.databricks.com"` on AWS deployments or `host = "https://accounts.azuredatabricks.net"` and authenticate using [AAD tokens](https://registry.terraform.io/providers/databricks/databricks/latest/docs#special-configurations-for-azure) on Azure deployments
 
 ## Example Usage


### PR DESCRIPTION
Raised in #1705 & #1703