### PR TITLE
Export `admin` and `users` groups as `databricks_group` data, not resource

### DIFF
--- a/exporter/importables.go
+++ b/exporter/importables.go
@@ -543,10 +543,14 @@ var resourcesMap map[string]importable = map[string]importable{
 			return nil
 		},
 		Import: func(ic *importContext, r *resource) error {
-			if r.Name == "admins" || r.Name == "users" {
+			groupName := r.Data.Get("display_name").(string)
+			if groupName == "admins" || groupName == "users" {
 				// admins & users are to be imported through "data block"
-				// TODO: it doesn't work, fix it...
 				r.Mode = "data"
+				r.Data.Set("workspace_access", false)
+				r.Data.Set("databricks_sql_access", false)
+				r.Data.Set("allow_instance_pool_create", false)
+				r.Data.Set("allow_cluster_create", false)
 				r.Data.State().Set(&terraform.InstanceState{
 					ID: r.ID,
 					Attributes: map[string]string{

--- a/exporter/importables_test.go
+++ b/exporter/importables_test.go
@@ -135,9 +135,12 @@ func TestGroup(t *testing.T) {
 			},
 		},
 	}
+	d := scim.ResourceGroup().TestResourceData()
+	d.Set("display_name", "foo")
 	r := &resource{
 		Value:     "foo",
 		Attribute: "display_name",
+		Data:      d,
 	}
 	err := ic.Importables["databricks_group"].Search(ic, r)
 	assert.NoError(t, err)
@@ -333,9 +336,11 @@ func TestGroupCacheError(t *testing.T) {
 			ID: "nonsense",
 		})
 		assert.EqualError(t, err, "nope")
-
+		d := scim.ResourceGroup().TestResourceData()
+		d.Set("display_name", "nonsense")
 		err = resourcesMap["databricks_group"].Import(ic, &resource{
-			ID: "nonsense",
+			ID:   "nonsense",
+			Data: d,
 		})
 		assert.EqualError(t, err, "nope")
 	})


### PR DESCRIPTION
Fix for issue #1654

TF exporter creatingdatabricks_group resource, not data block for admins and users