### PR TITLE
Fixed `member_id` reference of nested groups and `databricks_group_member` for exporter

### DIFF
--- a/exporter/context.go
+++ b/exporter/context.go
@@ -498,11 +498,10 @@ func (ic *importContext) reference(i importable, path []string, value string) hc
 			Attribute: attr,
 			Value:     value,
 		}, attr)
-
-		if traversal == nil {
-			break
+		//at least one invocation of ic.Find will assign Nil to traversal if resource with value is not found
+		if traversal != nil {
+			return hclwrite.TokensForTraversal(traversal)
 		}
-		return hclwrite.TokensForTraversal(traversal)
 	}
 	return hclwrite.TokensForValue(cty.StringVal(value))
 }

--- a/exporter/importables.go
+++ b/exporter/importables.go
@@ -627,7 +627,7 @@ var resourcesMap map[string]importable = map[string]importable{
 						ic.Emit(&resource{
 							Resource: "databricks_group_member",
 							ID:       fmt.Sprintf("%s|%s", g.ID, x.Value),
-							Name:     fmt.Sprintf("%s_%s_%s", g.DisplayName, x.Value, x.Display),
+							Name:     fmt.Sprintf("%s_%s_%s", g.DisplayName, g.ID, x.Display),
 						})
 					}
 					if len(g.Members) > 10 {


### PR DESCRIPTION
Fix for issue #1720 
Problem with old code shown below is that, it checks **only one** class of resources before quitting. The fixed code checks all references from Depends:
```
if traversal != nil {
   break
}
```