### PR TITLE
Escape database name in sql_permissions resource

### DIFF
--- a/access/resource_sql_permissions.go
+++ b/access/resource_sql_permissions.go
@@ -50,7 +50,7 @@ func (ta *SqlPermissions) typeAndKey() (string, string) {
 		return "VIEW", fmt.Sprintf("`%s`.`%s`", ta.actualDatabase(), ta.View)
 	}
 	if ta.Database != "" {
-		return "DATABASE", ta.Database
+		return "DATABASE", fmt.Sprintf("`%s`", ta.Database)
 	}
 	if ta.Catalog {
 		return "CATALOG", ""


### PR DESCRIPTION
Fixes #1729

We have an issue using the sql_permissions with database names that require escaping. Putting backticks in the database name seems to get filtered out somewhere in Terraform.

This change explicitly escapes every database name to avoid that issue, similar to the escaping we do for Tables and Views.

I would like to add a test case for this but I'll need some pointers on how the CommandMock works.