### PR TITLE
Revert `PRO` as default `warehouse_type` in `databricks_sql_endpoint`

### DIFF
--- a/docs/resources/sql_endpoint.md
+++ b/docs/resources/sql_endpoint.md
@@ -39,7 +39,7 @@ The following arguments are supported:
 * `enable_serverless_compute` - Whether this SQL endpoint is a Serverless endpoint. To use a Serverless SQL endpoint, you must enable Serverless SQL endpoints for the workspace.
 * `channel` block, consisting of following fields:
   * `name` - Name of the Databricks SQL release channel. Possible values are: `CHANNEL_NAME_PREVIEW` and `CHANNEL_NAME_CURRENT`. Default is `CHANNEL_NAME_CURRENT`.
-* `warehouse_type` - [SQL Warehouse Type](https://docs.databricks.com/sql/admin/sql-endpoints.html#switch-the-sql-warehouse-type-pro-classic-or-serverless): `PRO` (default) or `CLASSIC`.  If Serverless SQL is enabled, you can only specify `PRO`.
+* `warehouse_type` - [SQL Warehouse Type](https://docs.databricks.com/sql/admin/sql-endpoints.html#switch-the-sql-warehouse-type-pro-classic-or-serverless): `PRO` or `CLASSIC` (default).  If Serverless SQL is enabled, you can only specify `PRO`.
  
 ## Attribute Reference
 

--- a/sql/resource_sql_endpoint.go
+++ b/sql/resource_sql_endpoint.go
@@ -37,7 +37,7 @@ type SQLEndpoint struct {
 	Tags                    *Tags           `json:"tags,omitempty" tf:"suppress_diff"`
 	SpotInstancePolicy      string          `json:"spot_instance_policy,omitempty" tf:"default:COST_OPTIMIZED"`
 	Channel                 *ReleaseChannel `json:"channel,omitempty" tf:"suppress_diff"`
-	WarehouseType           string          `json:"warehouse_type,omitempty" tf:"default:PRO"`
+	WarehouseType           string          `json:"warehouse_type,omitempty" tf:"suppress_diff"`
 
 	// The data source ID is not part of the endpoint API response.
 	// We manually resolve it by retrieving the list of data sources

--- a/sql/resource_sql_endpoint_test.go
+++ b/sql/resource_sql_endpoint_test.go
@@ -81,7 +81,6 @@ func TestResourceSQLEndpointCreate(t *testing.T) {
 					NumClusters:        1,
 					EnablePhoton:       true,
 					SpotInstancePolicy: "COST_OPTIMIZED",
-					WarehouseType:      "PRO",
 				},
 				Response: SQLEndpoint{
 					ID: "abc",
@@ -129,7 +128,6 @@ func TestResourceSQLEndpointCreateNoAutoTermination(t *testing.T) {
 					NumClusters:        1,
 					EnablePhoton:       true,
 					SpotInstancePolicy: "COST_OPTIMIZED",
-					WarehouseType:      "PRO",
 				},
 				Response: SQLEndpoint{
 					ID: "abc",
@@ -230,7 +228,6 @@ func TestResourceSQLEndpointUpdate(t *testing.T) {
 					NumClusters:        1,
 					EnablePhoton:       true,
 					SpotInstancePolicy: "COST_OPTIMIZED",
-					WarehouseType:      "PRO",
 				},
 			},
 			{


### PR DESCRIPTION
Rely on the platform to specify the default `warehouse_type`