### PR TITLE
Use Jobs API 2.1 with name filter for `databricks_job` data source

### DIFF
--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -341,8 +341,8 @@ func TestImportingUsersGroupsSecretScopes(t *testing.T) {
 			},
 			{
 				Method:   "GET",
-				Resource: "/api/2.0/jobs/list",
-				Response: jobs.JobList{},
+				Resource: "/api/2.1/jobs/list?expand_tasks=false&limit=25&offset=0",
+				Response: jobs.JobListResponse{},
 			},
 			{
 				Method:   "GET",
@@ -441,8 +441,8 @@ func TestImportingNoResourcesError(t *testing.T) {
 			},
 			{
 				Method:   "GET",
-				Resource: "/api/2.0/jobs/list",
-				Response: jobs.JobList{},
+				Resource: "/api/2.1/jobs/list?expand_tasks=false&limit=25&offset=0",
+				Response: jobs.JobListResponse{},
 			},
 			{
 				Method:   "GET",
@@ -484,8 +484,8 @@ func TestImportingClusters(t *testing.T) {
 			},
 			{
 				Method:   "GET",
-				Resource: "/api/2.0/jobs/list",
-				Response: jobs.JobList{},
+				Resource: "/api/2.1/jobs/list?expand_tasks=false&limit=25&offset=0",
+				Response: jobs.JobListResponse{},
 			},
 			{
 				Method:   "GET",
@@ -628,8 +628,8 @@ func TestImportingJobs_JobList(t *testing.T) {
 			emptyRepos,
 			{
 				Method:   "GET",
-				Resource: "/api/2.0/jobs/list",
-				Response: jobs.JobList{
+				Resource: "/api/2.1/jobs/list?expand_tasks=false&limit=25&offset=0",
+				Response: jobs.JobListResponse{
 					Jobs: []jobs.Job{
 						{
 							JobID: 14,
@@ -842,8 +842,8 @@ func TestImportingJobs_JobListMultiTask(t *testing.T) {
 			emptyRepos,
 			{
 				Method:   "GET",
-				Resource: "/api/2.0/jobs/list",
-				Response: jobs.JobList{
+				Resource: "/api/2.1/jobs/list?expand_tasks=false&limit=25&offset=0",
+				Response: jobs.JobListResponse{
 					Jobs: []jobs.Job{
 						{
 							JobID: 14,
@@ -1085,8 +1085,8 @@ func TestImportingSecrets(t *testing.T) {
 			},
 			{
 				Method:   "GET",
-				Resource: "/api/2.0/jobs/list",
-				Response: jobs.JobList{},
+				Resource: "/api/2.1/jobs/list?expand_tasks=false&limit=25&offset=0",
+				Response: jobs.JobListResponse{},
 			},
 			{
 				Method:   "GET",

--- a/exporter/importables.go
+++ b/exporter/importables.go
@@ -445,10 +445,10 @@ var resourcesMap map[string]importable = map[string]importable{
 					}
 				}
 				if task.DbtTask != nil {
-					if task.SqlTask.WarehouseID != "" {
+					if task.DbtTask.WarehouseId != "" {
 						ic.Emit(&resource{
 							Resource: "databricks_sql_endpoint",
-							ID:       task.SqlTask.WarehouseID,
+							ID:       task.DbtTask.WarehouseId,
 						})
 					}
 				}

--- a/exporter/importables_test.go
+++ b/exporter/importables_test.go
@@ -227,12 +227,10 @@ func TestClusterList_NoNameMatch(t *testing.T) {
 func TestJobListNoNameMatch(t *testing.T) {
 	ic := importContextForTest()
 	ic.match = "bcd"
-	ic.importJobs(jobs.JobList{
-		Jobs: []jobs.Job{
-			{
-				Settings: &jobs.JobSettings{
-					Name: "abc",
-				},
+	ic.importJobs([]jobs.Job{
+		{
+			Settings: &jobs.JobSettings{
+				Name: "abc",
 			},
 		},
 	})
@@ -251,13 +249,11 @@ func TestJobList_FailGetRuns(t *testing.T) {
 		ic := importContextForTest()
 		ic.Client = client
 		ic.Context = ctx
-		ic.importJobs(jobs.JobList{
-			Jobs: []jobs.Job{
-				{
-					JobID: 1,
-					Settings: &jobs.JobSettings{
-						Name: "abc",
-					},
+		ic.importJobs([]jobs.Job{
+			{
+				JobID: 1,
+				Settings: &jobs.JobSettings{
+					Name: "abc",
 				},
 			},
 		})

--- a/exporter/util.go
+++ b/exporter/util.go
@@ -281,12 +281,12 @@ func eitherString(a any, b any) string {
 	return ""
 }
 
-func (ic *importContext) importJobs(l jobs.JobList) {
+func (ic *importContext) importJobs(l []jobs.Job) {
 	nowSeconds := time.Now().Unix()
 	a := jobs.NewJobsAPI(ic.Context, ic.Client)
 	starterAfter := (nowSeconds - (ic.lastActiveDays * 24 * 60 * 60)) * 1000
 	i := 0
-	for _, job := range l.Jobs {
+	for _, job := range l {
 		if !ic.MatchesName(job.Settings.Name) {
 			log.Printf("[INFO] Job name %s doesn't match selection %s", job.Settings.Name, ic.match)
 			continue
@@ -317,7 +317,7 @@ func (ic *importContext) importJobs(l jobs.JobList) {
 			ID:       job.ID(),
 		})
 		i++
-		log.Printf("[INFO] Imported %d of total %d jobs", i, len(l.Jobs))
+		log.Printf("[INFO] Imported %d of total %d jobs", i, len(l))
 	}
 }
 

--- a/jobs/data_job.go
+++ b/jobs/data_job.go
@@ -3,6 +3,7 @@ package jobs
 import (
 	"context"
 	"fmt"
+
 	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -16,11 +17,17 @@ func DataSourceJob() *schema.Resource {
 	return common.DataResource(queryableJobData{}, func(ctx context.Context, e any, c *common.DatabricksClient) error {
 		data := e.(*queryableJobData)
 		jobsAPI := NewJobsAPI(ctx, c)
-		list, err := jobsAPI.List()
+		var list []Job
+		var err error
+		if data.Name != "" {
+			list, err = jobsAPI.ListByName(data.Name, false)
+		} else {
+			list, err = jobsAPI.List()
+		}
 		if err != nil {
 			return err
 		}
-		for _, job := range list.Jobs {
+		for _, job := range list {
 			currentJob := job // De-referencing the temp variable used by the loop
 			currentJobId := currentJob.ID()
 			currentJobName := currentJob.Settings.Name

--- a/jobs/data_jobs.go
+++ b/jobs/data_jobs.go
@@ -20,7 +20,7 @@ func DataSourceJobs() *schema.Resource {
 			return err
 		}
 		response.Ids = map[string]string{}
-		for _, v := range list.Jobs {
+		for _, v := range list {
 			name := v.Settings.Name
 			_, duplicateName := response.Ids[name]
 			if duplicateName {

--- a/jobs/data_jobs_test.go
+++ b/jobs/data_jobs_test.go
@@ -11,8 +11,8 @@ func TestJobsData(t *testing.T) {
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   "GET",
-				Resource: "/api/2.0/jobs/list",
-				Response: JobList{
+				Resource: "/api/2.1/jobs/list?expand_tasks=false&limit=25&offset=0",
+				Response: JobListResponse{
 					Jobs: []Job{
 						{
 							JobID: 123,

--- a/jobs/resource_job_test.go
+++ b/jobs/resource_job_test.go
@@ -1323,8 +1323,8 @@ func TestJobsAPIList(t *testing.T) {
 	qa.HTTPFixturesApply(t, []qa.HTTPFixture{
 		{
 			Method:   "GET",
-			Resource: "/api/2.0/jobs/list",
-			Response: JobList{
+			Resource: "/api/2.1/jobs/list?expand_tasks=false&limit=25&offset=0",
+			Response: JobListResponse{
 				Jobs: []Job{
 					{
 						JobID: 1,
@@ -1336,7 +1336,62 @@ func TestJobsAPIList(t *testing.T) {
 		a := NewJobsAPI(ctx, client)
 		l, err := a.List()
 		require.NoError(t, err)
-		assert.Len(t, l.Jobs, 1)
+		assert.Len(t, l, 1)
+	})
+}
+
+func TestJobsAPIListMultiplePages(t *testing.T) {
+	qa.HTTPFixturesApply(t, []qa.HTTPFixture{
+		{
+			Method:   "GET",
+			Resource: "/api/2.1/jobs/list?expand_tasks=false&limit=25&offset=0",
+			Response: JobListResponse{
+				Jobs: []Job{
+					{
+						JobID: 1,
+					},
+				},
+				HasMore: true,
+			},
+		},
+		{
+			Method:   "GET",
+			Resource: "/api/2.1/jobs/list?expand_tasks=false&limit=25&offset=1",
+			Response: JobListResponse{
+				Jobs: []Job{
+					{
+						JobID: 2,
+					},
+				},
+				HasMore: false,
+			},
+		},
+	}, func(ctx context.Context, client *common.DatabricksClient) {
+		a := NewJobsAPI(ctx, client)
+		l, err := a.List()
+		require.NoError(t, err)
+		assert.Len(t, l, 2)
+	})
+}
+
+func TestJobsAPIListByName(t *testing.T) {
+	qa.HTTPFixturesApply(t, []qa.HTTPFixture{
+		{
+			Method:   "GET",
+			Resource: "/api/2.1/jobs/list?expand_tasks=false&limit=25&name=test&offset=0",
+			Response: JobListResponse{
+				Jobs: []Job{
+					{
+						JobID: 1,
+					},
+				},
+			},
+		},
+	}, func(ctx context.Context, client *common.DatabricksClient) {
+		a := NewJobsAPI(ctx, client)
+		l, err := a.ListByName("test", false)
+		require.NoError(t, err)
+		assert.Len(t, l, 1)
 	})
 }
 


### PR DESCRIPTION
This patch switches to 2.1 version of Jobs API for List operation so we can more efficiently handle workspaces with huge number of jobs (> 3000).  It also uses new `name` parameter to search jobs by name in the `databricks_job` data source.