### PR TITLE
small syntax fix for enable_serverless_compute description in sql_global_config resource

### DIFF
--- a/docs/resources/sql_global_config.md
+++ b/docs/resources/sql_global_config.md
@@ -46,7 +46,7 @@ The following arguments are supported (see [documentation](https://docs.databric
 
 * `security_policy` (Optional, String) - The policy for controlling access to datasets. Default value: `DATA_ACCESS_CONTROL`, consult documentation for list of possible values
 * `data_access_config` (Optional, Map) - Data access configuration for [databricks_sql_endpoint](sql_endpoint.md), such as configuration for an external Hive metastore, Hadoop Filesystem configuration, etc.  Please note that the list of supported configuration properties is limited, so refer to the [documentation](https://docs.databricks.com/sql/admin/data-access-configuration.html#supported-properties) for a full list.  Apply will fail if you're specifying not permitted configuration.
-* `enable_serverless_compute` (optional, Boolean) - Allows the possibility to create Serverlell SQL warehouses. Default value: false.
+* `enable_serverless_compute` (optional, Boolean) - Allows the possibility to create Serverless SQL warehouses. Default value: false.
 * `instance_profile_arn` (Optional, String) - [databricks_instance_profile](instance_profile.md) used to access storage from [databricks_sql_endpoint](sql_endpoint.md). Please note that this parameter is only for AWS, and will generate an error if used on other clouds. 
 * `sql_config_params` (Optional, Map) - SQL Configuration Parameters let you override the default behavior for all sessions with all endpoints.
 


### PR DESCRIPTION
It got me wondering if `Serverlell` is an actual word at one point.