### PR TITLE
Clarify that service principals are possible

### DIFF
--- a/docs/resources/grants.md
+++ b/docs/resources/grants.md
@@ -12,7 +12,7 @@ Securable objects are hierarchical and privileges are inherited downward. The hi
 
 Every `databricks_grants` resource must have exactly one securable identifier and one or more `grant` blocks with the following arguments:
 
-- `principal` - User or group name.
+- `principal` - User name, group name or service principal application ID.
 - `privileges` - One or more privileges that are specific to a securable type.
 
 The securable objects are:


### PR DESCRIPTION
In the rest of Databricks documentation, service principals are viewed as distinct entities from users. For example in the [databricks_permission resource](https://registry.terraform.io/providers/databricks/databricks/latest/docs/resources/permissions#access-control-argument). It is best to clarify that this possible here and to clarify how to reference it.