### PR TITLE
Added `home` & `repos` attributes to `databricks_user` and `databricks_service_principal`

### DIFF
--- a/docs/resources/service_principal.md
+++ b/docs/resources/service_principal.md
@@ -100,6 +100,8 @@ The following arguments are available:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - Canonical unique identifier for the service principal.
+- `home` - Home folder of the service principal, e.g. `/Users/00000000-0000-0000-0000-000000000000`.
+- `repos` - Personal Repos location of the service principal, e.g. `/Repos/00000000-0000-0000-0000-000000000000`.
 
 ## Import
 

--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -99,6 +99,8 @@ The following arguments are available:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - Canonical unique identifier for the user.
+- `home` - Home folder of the user, e.g. `/Users/mr.foo@example.com`.
+- `repos` - Personal Repos location of the user, e.g. `/Repos/mr.foo@example.com`.
 
 ## Import
 

--- a/scim/resource_service_principal.go
+++ b/scim/resource_service_principal.go
@@ -98,6 +98,16 @@ func ResourceServicePrincipal() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 			}
+			m["home"] = &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			}
+			m["repos"] = &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			}
 			return m
 		})
 	spFromData := func(d *schema.ResourceData) User {
@@ -128,6 +138,8 @@ func ResourceServicePrincipal() *schema.Resource {
 			if err != nil {
 				return err
 			}
+			d.Set("home", fmt.Sprintf("/Users/%s", sp.ApplicationID))
+			d.Set("repos", fmt.Sprintf("/Repos/%s", sp.ApplicationID))
 			err = common.StructToData(sp, servicePrincipalSchema, d)
 			if err != nil {
 				return err

--- a/scim/resource_service_principal_test.go
+++ b/scim/resource_service_principal_test.go
@@ -79,6 +79,8 @@ func TestResourceServicePrincipalRead(t *testing.T) {
 		"display_name":         "Example Service Principal",
 		"application_id":       "bcd",
 		"allow_cluster_create": true,
+		"home":                 "/Users/bcd",
+		"repos":                "/Repos/bcd",
 	})
 }
 

--- a/scim/resource_user.go
+++ b/scim/resource_user.go
@@ -34,6 +34,16 @@ func ResourceUser() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 			}
+			m["home"] = &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			}
+			m["repos"] = &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			}
 			return m
 		})
 	scimUserFromData := func(d *schema.ResourceData) (user User, err error) {
@@ -71,6 +81,8 @@ func ResourceUser() *schema.Resource {
 			d.Set("display_name", user.DisplayName)
 			d.Set("active", user.Active)
 			d.Set("external_id", user.ExternalID)
+			d.Set("home", fmt.Sprintf("/Users/%s", user.UserName))
+			d.Set("repos", fmt.Sprintf("/Repos/%s", user.UserName))
 			return user.Entitlements.readIntoData(d)
 		},
 		Update: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {

--- a/scim/resource_user_test.go
+++ b/scim/resource_user_test.go
@@ -45,6 +45,8 @@ func TestResourceUserRead(t *testing.T) {
 	assert.Equal(t, "me@example.com", d.Get("user_name"))
 	assert.Equal(t, "Example user", d.Get("display_name"))
 	assert.Equal(t, false, d.Get("allow_cluster_create"))
+	assert.Equal(t, "/Users/me@example.com", d.Get("home"))
+	assert.Equal(t, "/Repos/me@example.com", d.Get("repos"))
 }
 
 func TestResourceUserRead_NotFound(t *testing.T) {
@@ -146,6 +148,8 @@ func TestResourceUserCreate(t *testing.T) {
 	assert.Equal(t, "me@example.com", d.Get("user_name"))
 	assert.Equal(t, "Example user", d.Get("display_name"))
 	assert.Equal(t, true, d.Get("allow_cluster_create"))
+	assert.Equal(t, "/Users/me@example.com", d.Get("home"))
+	assert.Equal(t, "/Repos/me@example.com", d.Get("repos"))
 }
 
 func TestResourceUserCreateInactive(t *testing.T) {


### PR DESCRIPTION
They will be used in Exporter to simplify references in paths, etc.