### PR TITLE
Fix missing attributes from `databricks_job` data source

### DIFF
--- a/jobs/data_job_test.go
+++ b/jobs/data_job_test.go
@@ -10,9 +10,29 @@ import (
 func commonFixtures(name string) []qa.HTTPFixture {
 	resource := "/api/2.1/jobs/list?expand_tasks=false&limit=25&offset=0"
 	if name != "" {
-		resource = fmt.Sprintf("/api/2.1/jobs/list?expand_tasks=false&limit=25&name=%s&offset=0", name)
+		resource = fmt.Sprintf("/api/2.1/jobs/list?expand_tasks=true&limit=25&name=%s&offset=0", name)
 	}
 	return []qa.HTTPFixture{
+		{
+			Method:   "GET",
+			Resource: resource,
+			Response: JobListResponse{
+				Jobs: []Job{
+					{
+						JobID: 123,
+						Settings: &JobSettings{
+							Name: "First",
+						},
+					},
+					{
+						JobID: 234,
+						Settings: &JobSettings{
+							Name: "Second",
+						},
+					},
+				},
+			},
+		},
 		{
 			Method:   "GET",
 			Resource: resource,
@@ -38,7 +58,7 @@ func commonFixtures(name string) []qa.HTTPFixture {
 }
 func TestDataSourceQueryableJobMatchesId(t *testing.T) {
 	qa.ResourceFixture{
-		Fixtures:    commonFixtures(""),
+		Fixtures:    append(commonFixtures(""), commonFixtures("Second")...),
 		Resource:    DataSourceJob(),
 		Read:        true,
 		New:         true,
@@ -70,7 +90,7 @@ func TestDataSourceQueryableJobNoMatchName(t *testing.T) {
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   "GET",
-				Resource: "/api/2.1/jobs/list?expand_tasks=false&limit=25&name=Third&offset=0",
+				Resource: "/api/2.1/jobs/list?expand_tasks=true&limit=25&name=Third&offset=0",
 				Response: JobListResponse{
 					Jobs: []Job{},
 				},

--- a/jobs/data_job_test.go
+++ b/jobs/data_job_test.go
@@ -112,5 +112,5 @@ func TestDataSourceQueryableJobNoMatchId(t *testing.T) {
 		NonWritable: true,
 		HCL:         `job_id= "567"`,
 		ID:          "_",
-	}.ExpectError(t, "no job found with specified name or id")
+	}.ExpectError(t, "no job found with specified id")
 }


### PR DESCRIPTION
This happens because we did not set expandTasks to the API when listing the jobs. For search by id, list without expandTasks and then re-search when job name is found 

This closes #1797