### PR TITLE
Exporter: fail fast in `import.sh` when can't import resource

### DIFF
--- a/exporter/context.go
+++ b/exporter/context.go
@@ -184,7 +184,7 @@ func (ic *importContext) Run() error {
 	}
 	defer sh.Close()
 	// nolint
-	sh.WriteString("#!/bin/sh\n\n")
+	sh.WriteString("#!/bin/sh\n\nset -e\n\n")
 
 	if ic.generateDeclaration {
 		dcfile, err := os.Create(fmt.Sprintf("%s/databricks.tf", ic.Directory))


### PR DESCRIPTION
Use `set -e` to fail on the first invalid resource - it will help detecting incorrect resources in the big imports