### PR TITLE
Export predefined `databricks_cluster_policy` as data sources

### DIFF
--- a/exporter/importables_test.go
+++ b/exporter/importables_test.go
@@ -68,19 +68,38 @@ func TestClusterPolicy(t *testing.T) {
 		"instance_pool_id": {
 			"defaultValue": "efg",
 		},
+		"init_scripts.0.dbfs.destination": {
+			"type":  "fixed",
+			"value": "dbfs:/FileStore/init-script.sh",
+		},
 	}
 	policy, _ := json.Marshal(definition)
 	d.Set("definition", string(policy))
 	ic := importContextForTest()
+	ic.meAdmin = true
 	err := ic.Importables["databricks_cluster_policy"].Import(ic, &resource{
 		ID:   "abc",
 		Data: d,
 	})
 	assert.NoError(t, err)
-	assert.Len(t, ic.testEmits, 3)
+	assert.Len(t, ic.testEmits, 4)
 	assert.True(t, ic.testEmits["databricks_permissions[clust_policy_bcd] (id: /cluster-policies/abc)"])
 	assert.True(t, ic.testEmits["databricks_instance_pool[<unknown>] (id: efg)"])
 	assert.True(t, ic.testEmits["databricks_instance_profile[<unknown>] (id: def)"])
+	assert.True(t, ic.testEmits["databricks_dbfs_file[<unknown>] (id: dbfs:/FileStore/init-script.sh)"])
+}
+
+func TestPredefinedClusterPolicy(t *testing.T) {
+	d := policies.ResourceClusterPolicy().TestResourceData()
+	d.Set("name", "Job Compute")
+	policy, _ := json.Marshal(map[string]map[string]string{})
+	d.Set("definition", string(policy))
+	ic := importContextForTest()
+	r := resource{ID: "abc", Data: d}
+	err := ic.Importables["databricks_cluster_policy"].Import(ic, &r)
+	assert.NoError(t, err)
+	assert.Equal(t, "data", r.Mode)
+	assert.Equal(t, "", r.Data.Get("definition").(string))
 }
 
 func TestGroup(t *testing.T) {
@@ -285,6 +304,7 @@ func TestClusterPolicyNoValues(t *testing.T) {
 	d.Set("name", "abc")
 	d.Set("definition", `{"foo": {}}`)
 	ic := importContextForTest()
+	ic.meAdmin = true
 	err := resourcesMap["databricks_cluster_policy"].Import(ic, &resource{
 		ID:   "x",
 		Data: d,

--- a/exporter/importables_test.go
+++ b/exporter/importables_test.go
@@ -83,7 +83,7 @@ func TestClusterPolicy(t *testing.T) {
 	})
 	assert.NoError(t, err)
 	assert.Len(t, ic.testEmits, 4)
-	assert.True(t, ic.testEmits["databricks_permissions[clust_policy_bcd] (id: /cluster-policies/abc)"])
+	assert.True(t, ic.testEmits["databricks_permissions[cluster_policy_bcd] (id: /cluster-policies/abc)"])
 	assert.True(t, ic.testEmits["databricks_instance_pool[<unknown>] (id: efg)"])
 	assert.True(t, ic.testEmits["databricks_instance_profile[<unknown>] (id: def)"])
 	assert.True(t, ic.testEmits["databricks_dbfs_file[<unknown>] (id: dbfs:/FileStore/init-script.sh)"])

--- a/exporter/util.go
+++ b/exporter/util.go
@@ -20,6 +20,7 @@ import (
 	"github.com/databricks/terraform-provider-databricks/sql"
 	"github.com/databricks/terraform-provider-databricks/storage"
 
+	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -456,4 +457,14 @@ func makeShouldOmitFieldForCluster(regex *regexp.Regexp) func(ic *importContext,
 
 		return defaultShouldOmitFieldFunc(ic, pathString, as, d)
 	}
+}
+
+func resourceOrDataBlockBody(ic *importContext, body *hclwrite.Body, r *resource) error {
+	blockType := "resource"
+	if r.Mode == "data" {
+		blockType = r.Mode
+	}
+	resourceBlock := body.AppendNewBlock(blockType, []string{r.Resource, r.Name})
+	return ic.dataToHcl(ic.Importables[r.Resource],
+		[]string{}, ic.Resources[r.Resource], r.Data, resourceBlock.Body())
 }

--- a/go.mod
+++ b/go.mod
@@ -72,6 +72,7 @@ require (
 	github.com/vmihailenco/tagparser v0.1.1 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	golang.org/x/crypto v0.1.0 // indirect
+	golang.org/x/exp v0.0.0-20221204150635-6dcec336b2bb // indirect
 	golang.org/x/net v0.1.0 // indirect
 	golang.org/x/sys v0.1.0 // indirect
 	golang.org/x/text v0.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -256,6 +256,8 @@ golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa/go.mod h1:IxCIyHEi3zRg3s0
 golang.org/x/crypto v0.1.0 h1:MDRAIl0xIo9Io2xV565hzXHw3zVseKrJKodhohM5CjU=
 golang.org/x/crypto v0.1.0/go.mod h1:RecgLatLF4+eUMCP1PoPZQb+cVrJcOPbHkTkbkB9sbw=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
+golang.org/x/exp v0.0.0-20221204150635-6dcec336b2bb h1:QIsP/NmClBICkqnJ4rSIhnrGiGR7Yv9ZORGGnmmLTPk=
+golang.org/x/exp v0.0.0-20221204150635-6dcec336b2bb/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=


### PR DESCRIPTION
Also, emit init scripts defined in the cluster policies

This fixes #1785