### PR TITLE
Replacing `go get` with `go install` in .devcontainer/DockerFile

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -39,4 +39,4 @@ RUN \
     # # --> Static checker
     && go install honnef.co/go/tools/cmd/staticcheck@v0.3.2 \
     # # --> TF formatter
-    && go get github.com/katbyte/terrafmt
+    && go install github.com/katbyte/terrafmt@latest


### PR DESCRIPTION
According to the [official documentation](https://go.dev/doc/go-get-install-deprecation), `go get` has been deprecated for installing executables since v1.17. I see that the Go version has (relatively) recently been bumped to v1.18, but this causes the container building process to fail (since it looks for a `go.mod` that cannot possibly be there).

<img width="483" alt="image" src="https://user-images.githubusercontent.com/57634402/206583816-1dcbd8ae-cb69-484d-b174-1b2f1224ae69.png">

I also see that the other imports have successfully been fixed in [40c1d53c](https://github.com/databricks/terraform-provider-databricks/commit/40c1d53c3e3ebc9f3b48c7f423fe1f90e1fd7233), but then the TF formatter was added by using the old notation. Fortunately, the fix is relatively simple: changing `get` with `install` makes the container buildable once again without any issue.

I know it's a small one, and container support is not the top priority, but I thought it would be nice to propose this fix for fellow devcontainers users.

Cheers 👋🏻