### PR TITLE
Document `webhook_notifications` for `databricks_job` resource

### DIFF
--- a/docs/resources/job.md
+++ b/docs/resources/job.md
@@ -131,6 +131,7 @@ The following arguments are required:
 * `min_retry_interval_millis` - (Optional) (Integer) An optional minimal interval in milliseconds between the start of the failed run and the subsequent retry run. The default behavior is that unsuccessful runs are immediately retried.
 * `max_concurrent_runs` - (Optional) (Integer) An optional maximum allowed number of concurrent runs of the job. Defaults to *1*.
 * `email_notifications` - (Optional) (List) An optional set of email addresses notified when runs of this job begin and complete and when this job is deleted. The default behavior is to not send any emails. This field is a block and is documented below.
+* `webhook_notifications` - (Optional) A collection of system notification IDs to notify when the run begins or completes. The default behavior is to not send any system notifications. This field is a block and is documented below.
 * `schedule` - (Optional) (List) An optional periodic schedule for this job. The default behavior is that the job runs when triggered by clicking Run Now in the Jobs UI or sending an API request to runNow. This field is a block and is documented below.
 * `tags` - (Optional) (Map) An optional map of the tags associated with the job. Specified tags will be used as cluster tags for job clusters.
 
@@ -208,6 +209,18 @@ One of the `query`, `dashboard` or `alert` needs to be provided.
 * `no_alert_for_skipped_runs` - (Optional) (Bool) don't send alert for skipped runs
 * `on_start` - (Optional) (List) list of emails to notify on failure
 * `on_success` - (Optional) (List) list of emails to notify on failure
+
+### webhook_notifications Configuration Block
+
+Each entry in `webhook_notification` block takes a list `webhook` blocks. The field is documented below.
+
+* `on_failure` - (Optional) (List) An optional list of system notification IDs to call when the run fails. A maximum of 3 destinations can be specified for the `on_failure` property.
+* `on_start` - (Optional) (List) An optional list of system notification IDs to call when the run starts. A maximum of 3 destinations can be specified for the `on_start` property.
+* `on_success` - (Optional) (List) An optional list of system notification IDs to call when the run completes successfully. A maximum of 3 destinations can be specified for the `on_success` property.
+
+### webhook Confiuration Block
+
+* `id` - ID of the destination that is notified when an event defined in `webhook_notifications` is triggered.
 
 ### git_source Configuration Block
 

--- a/docs/resources/job.md
+++ b/docs/resources/job.md
@@ -220,7 +220,7 @@ Each entry in `webhook_notification` block takes a list `webhook` blocks. The fi
 
 ### webhook Confiuration Block
 
-* `id` - ID of the destination that is notified when an event defined in `webhook_notifications` is triggered.
+* `id` - ID of the system notification that is notified when an event defined in `webhook_notifications` is triggered.
 
 ### git_source Configuration Block
 

--- a/jobs/resource_job.go
+++ b/jobs/resource_job.go
@@ -105,6 +105,19 @@ type WebhookNotifications struct {
 	OnFailure []Webhook `json:"on_failure,omitempty"`
 }
 
+func (wn *WebhookNotifications) Sort() {
+	if wn == nil {
+		return
+	}
+
+	notifs := [][]Webhook{wn.OnStart, wn.OnFailure, wn.OnSuccess}
+	for _, ns := range notifs {
+		sort.Slice(ns, func(i, j int) bool {
+			return ns[i].ID < ns[j].ID
+		})
+	}
+}
+
 // Webhook contains a reference by id to one of the centrally configured webhooks.
 type Webhook struct {
 	ID string `json:"id"`
@@ -210,16 +223,7 @@ func (js *JobSettings) sortTasksByKey() {
 }
 
 func (js *JobSettings) sortWebhooksByID() {
-	if js.WebhookNotifications == nil {
-		return
-	}
-
-	notifs := [][]Webhook{js.WebhookNotifications.OnStart, js.WebhookNotifications.OnFailure, js.WebhookNotifications.OnSuccess}
-	for _, ns := range notifs {
-		sort.Slice(ns, func(i, j int) bool {
-			return ns[i].ID < ns[j].ID
-		})
-	}
+	js.WebhookNotifications.Sort()
 }
 
 // JobList returns a list of all jobs

--- a/jobs/resource_job.go
+++ b/jobs/resource_job.go
@@ -210,6 +210,10 @@ func (js *JobSettings) sortTasksByKey() {
 }
 
 func (js *JobSettings) sortWebhooksByID() {
+	if js.WebhookNotifications == nil {
+		return
+	}
+
 	notifs := [][]Webhook{js.WebhookNotifications.OnStart, js.WebhookNotifications.OnFailure, js.WebhookNotifications.OnSuccess}
 	for _, ns := range notifs {
 		sort.Slice(ns, func(i, j int) bool {

--- a/jobs/resource_job.go
+++ b/jobs/resource_job.go
@@ -105,19 +105,6 @@ type WebhookNotifications struct {
 	OnFailure []Webhook `json:"on_failure,omitempty"`
 }
 
-func (wn *WebhookNotifications) Sort() {
-	if wn == nil {
-		return
-	}
-
-	notifs := [][]Webhook{wn.OnStart, wn.OnFailure, wn.OnSuccess}
-	for _, ns := range notifs {
-		sort.Slice(ns, func(i, j int) bool {
-			return ns[i].ID < ns[j].ID
-		})
-	}
-}
-
 // Webhook contains a reference by id to one of the centrally configured webhooks.
 type Webhook struct {
 	ID string `json:"id"`
@@ -223,13 +210,17 @@ func (js *JobSettings) sortTasksByKey() {
 }
 
 func (js *JobSettings) sortWebhooksByID() {
-	js.WebhookNotifications.Sort()
+	notifs := [][]Webhook{js.WebhookNotifications.OnStart, js.WebhookNotifications.OnFailure, js.WebhookNotifications.OnSuccess}
+	for _, ns := range notifs {
+		sort.Slice(ns, func(i, j int) bool {
+			return ns[i].ID < ns[j].ID
+		})
+	}
 }
 
-// JobListResponse returns a list of all jobs
-type JobListResponse struct {
-	Jobs    []Job `json:"jobs"`
-	HasMore bool  `json:"has_more,omitempty"`
+// JobList returns a list of all jobs
+type JobList struct {
+	Jobs []Job `json:"jobs"`
 }
 
 // Job contains the information when using a GET request from the Databricks Jobs api

--- a/jobs/resource_job.go
+++ b/jobs/resource_job.go
@@ -226,9 +226,10 @@ func (js *JobSettings) sortWebhooksByID() {
 	js.WebhookNotifications.Sort()
 }
 
-// JobList returns a list of all jobs
-type JobList struct {
-	Jobs []Job `json:"jobs"`
+// JobListResponse returns a list of all jobs
+type JobListResponse struct {
+	Jobs    []Job `json:"jobs"`
+	HasMore bool  `json:"has_more,omitempty"`
 }
 
 // Job contains the information when using a GET request from the Databricks Jobs api


### PR DESCRIPTION
Document `webhook_notifications` field. Webhooks are configured in TF as follows:

```
webhook_notifications {
	on_start {
		id = "id3"
	}
	on_start {
		id = "id1"
	}
	on_start {
		id = "id2"
	}
	on_success {
		id = "id2"
	}
	on_failure {
		id = "id3"
	}
}
```

OpenAPI spec added [here](https://go/pr/236233).