### PR TITLE
Altering parameter on Azure `data_access_config`

### DIFF
--- a/docs/resources/sql_global_config.md
+++ b/docs/resources/sql_global_config.md
@@ -29,7 +29,7 @@ resource "databricks_sql_global_config" "this" {
   data_access_config = {
     "spark.hadoop.fs.azure.account.auth.type" : "OAuth",
     "spark.hadoop.fs.azure.account.oauth.provider.type" : "org.apache.hadoop.fs.azurebfs.oauth2.ClientCredsTokenProvider",
-    "spark.hadoop.fs.azure.account.oauth2.client.id" : "${var.tenant_id}",
+    "spark.hadoop.fs.azure.account.oauth2.client.id" : "${var.application_id}",
     "spark.hadoop.fs.azure.account.oauth2.client.secret" : "{{secrets/${local.secret_scope}/${local.secret_key}}}",
     "spark.hadoop.fs.azure.account.oauth2.client.endpoint" : "https://login.microsoftonline.com/${var.tenant_id}/oauth2/token"
   }


### PR DESCRIPTION
Altered parameter value for the setting `spark.hadoop.fs.azure.account.oauth2.client.id` from `tenant_id` to `application_id` (the client_id should be the `Application (client) ID` for the service principal application on AzureAD and not the tenant_id