### PR TITLE
Use NVMe disk size for selection in the `databricks_node_type` data source

### DIFF
--- a/clusters/data_node_type.go
+++ b/clusters/data_node_type.go
@@ -16,6 +16,7 @@ type NodeTypeRequest struct {
 	MinCores              int32  `json:"min_cores,omitempty"`
 	MinGPUs               int32  `json:"min_gpus,omitempty"`
 	LocalDisk             bool   `json:"local_disk,omitempty"`
+	LocalDiskMinSize      int32  `json:"local_disk_min_size,omitempty"`
 	Category              string `json:"category,omitempty"`
 	PhotonWorkerCapable   bool   `json:"photon_worker_capable,omitempty"`
 	PhotonDriverCapable   bool   `json:"photon_driver_capable,omitempty"`
@@ -33,17 +34,21 @@ type NodeTypeList struct {
 // Sort NodeTypes within this struct
 func (l *NodeTypeList) Sort() {
 	sortByChain(l.NodeTypes, func(i int) sortCmp {
-		var localDisks, localDiskSizeGB int32
+		var localDisks, localDiskSizeGB, localNVMeDisk, localNVMeDiskSizeGB int32
 		if l.NodeTypes[i].NodeInstanceType != nil {
 			localDisks = l.NodeTypes[i].NodeInstanceType.LocalDisks
+			localNVMeDisk = l.NodeTypes[i].NodeInstanceType.LocalNVMeDisks
 			localDiskSizeGB = l.NodeTypes[i].NodeInstanceType.LocalDiskSizeGB
+			localNVMeDiskSizeGB = l.NodeTypes[i].NodeInstanceType.LocalNVMeDiskSizeGB
 		}
 		return sortChain{
 			boolAsc(l.NodeTypes[i].IsDeprecated),
+			intAsc(l.NodeTypes[i].NumCores),
+			intAsc(l.NodeTypes[i].MemoryMB),
 			intAsc(localDisks),
 			intAsc(localDiskSizeGB),
-			intAsc(l.NodeTypes[i].MemoryMB),
-			intAsc(l.NodeTypes[i].NumCores),
+			intAsc(localNVMeDisk),
+			intAsc(localNVMeDiskSizeGB),
 			intAsc(l.NodeTypes[i].NumGPUs),
 			strAsc(l.NodeTypes[i].InstanceTypeID),
 		}
@@ -157,9 +162,13 @@ func (a ClustersAPI) GetSmallestNodeType(r NodeTypeRequest) string {
 		if r.MinGPUs > 0 && nt.NumGPUs < r.MinGPUs {
 			continue
 		}
-		if r.LocalDisk && nt.NodeInstanceType != nil &&
+		if (r.LocalDisk || r.LocalDiskMinSize > 0) && nt.NodeInstanceType != nil &&
 			(nt.NodeInstanceType.LocalDisks < 1 &&
 				nt.NodeInstanceType.LocalNVMeDisks < 1) {
+			continue
+		}
+		if r.LocalDiskMinSize > 0 && nt.NodeInstanceType != nil &&
+			(nt.NodeInstanceType.LocalDiskSizeGB+nt.NodeInstanceType.LocalNVMeDiskSizeGB) < r.LocalDiskMinSize {
 			continue
 		}
 		if r.Category != "" && !strings.EqualFold(nt.Category, r.Category) {

--- a/clusters/data_node_type_test.go
+++ b/clusters/data_node_type_test.go
@@ -106,10 +106,10 @@ func TestNodeType(t *testing.T) {
 		Resource:    DataSourceNodeType(),
 		NonWritable: true,
 		State: map[string]any{
-			"local_disk":    true,
-			"min_memory_gb": 8,
-			"min_cores":     8,
-			"min_gpus":      1,
+			"local_disk_min_size": 200,
+			"min_memory_gb":       8,
+			"min_cores":           8,
+			"min_gpus":            1,
 		},
 		ID: ".",
 	}.Apply(t)

--- a/docs/data-sources/node_type.md
+++ b/docs/data-sources/node_type.md
@@ -45,6 +45,7 @@ Data source allows you to pick groups by the following attributes
 * `min_cores` - (Optional) Minimum number of CPU cores available on instance. Defaults to *0*.
 * `min_gpus` - (Optional) Minimum number of GPU's attached to instance. Defaults to *0*.
 * `local_disk` - (Optional) Pick only nodes with local storage. Defaults to *false*.
+* `local_disk_min_size` - (Optional) Pick only nodes that have size local storage greater or equal to given value. Defaults to *0*.
 * `category` - (Optional, case insensitive string) Node category, which can be one of (depending on the cloud environment, could be checked with `databricks clusters list-node-types|jq '.node_types[]|.category'|sort |uniq`):
   * `General Purpose` (all clouds)
   * `General Purpose (HDD)` (Azure)


### PR DESCRIPTION
Due not completely correct sorting, instead of real smallest node, other node type was returned as smallest. For example, on Azure it was `L8` series.

Also added the `local_disk_min_size` selector to allow to select nodes with local disks not smaller than specified.