### PR TITLE
Delete empty host odbc parameter

### DIFF
--- a/sql/resource_sql_endpoint.go
+++ b/sql/resource_sql_endpoint.go
@@ -56,10 +56,6 @@ type OdbcParams struct {
 	Path     string `json:"path"`
 	Protocol string `json:"protocol"`
 	Port     int32  `json:"port"`
-
-	// TODO: eventually remove this column,
-	// as it doesn't seem to be populated
-	Host string `json:"host,omitempty"`
 }
 
 // Tags ...


### PR DESCRIPTION
As the comment says, `host` never gets populated, but `Hostname` does. It the UI it is called "Server hostname". Let's finally remove it in the Terraform module as it looks broken when it is simply not set.