### PR TITLE
Fix bug in `privilege_assignment` of `databricks_sql_permissions`

### DIFF
--- a/access/resource_sql_permissions.go
+++ b/access/resource_sql_permissions.go
@@ -148,9 +148,12 @@ func (ta *SqlPermissions) read() error {
 		if !strings.EqualFold(currentType, thisType) {
 			continue
 		}
-		if !strings.EqualFold(currentKey, thisKey) {
+
+		noBackticks := strings.ReplaceAll(thisKey, "`", "")
+		if !strings.EqualFold(currentKey, thisKey) && !strings.EqualFold(currentKey, noBackticks) {
 			continue
 		}
+
 		if strings.HasPrefix(currentAction, "DENIED_") {
 			// DENY statements are intentionally not supported.
 			continue

--- a/access/resource_sql_permissions_test.go
+++ b/access/resource_sql_permissions_test.go
@@ -89,6 +89,22 @@ func TestTableACLGrants(t *testing.T) {
 	assert.Len(t, ta.PrivilegeAssignments[0].Privileges, 2)
 }
 
+func TestDatabaseACLGrants(t *testing.T) {
+	ta := SqlPermissions{ Database: "default",
+	exec: mockData{
+		"SHOW GRANT ON DATABASE `default`": {
+			// principal, actionType, objType, objectKey
+			// Test with and without backticks
+			{"users", "SELECT", "database", "default"},
+			{"users", "USAGE", "database", "`default`"},
+		},
+	}}
+	err := ta.read()
+	assert.NoError(t, err)
+	assert.Len(t, ta.PrivilegeAssignments, 1)
+	assert.Len(t, ta.PrivilegeAssignments[0].Privileges, 2)
+}
+
 type failedCommand string
 
 func (fc failedCommand) Execute(clusterID, language, commandStr string) common.CommandResults {


### PR DESCRIPTION
…ed code to correctly assign permissions without causing infinite loop
