### PR TITLE
replace the incorrect 'id' attribute with the correct 'sp_id' attribute

### DIFF
--- a/docs/data-sources/service_principal.md
+++ b/docs/data-sources/service_principal.md
@@ -23,7 +23,7 @@ data "databricks_service_principal" "spn" {
 
 resource "databricks_group_member" "my_member_a" {
   group_id  = data.databricks_group.admins.id
-  member_id = data.databricks_service_principal.spn.id
+  member_id = data.databricks_service_principal.spn.sp_id
 }
 ```
 


### PR DESCRIPTION
replace the incorrect 'id' attribute with the correct 'sp_id' attribute in service principal data source docs example