### PR TITLE
removed unneeded brace from integration test that causes the plan to fail for int test

### DIFF
--- a/catalog/acceptance/provider_test.go
+++ b/catalog/acceptance/provider_test.go
@@ -19,7 +19,7 @@ func TestUcAccCreateProviderDb2Open(t *testing.T) {
 			  recipient_profile_str = jsonencode({
 					"shareCredentialsVersion":1,
 					"bearerToken":"dapiabcdefghijklmonpqrstuvwxyz",
-					"endpoint":"https://sharing.delta.io/delta-sharing/"}
+					"endpoint":"https://sharing.delta.io/delta-sharing/"
 				}
 			  )
 			}`,


### PR DESCRIPTION
Can you confirm that the acceptance test run on acceptance env.