### PR TITLE
Allow to override resource ID for specific data source

### DIFF
--- a/common/resource.go
+++ b/common/resource.go
@@ -199,6 +199,8 @@ func DataResource(sc any, read func(context.Context, any, *DatabricksClient) err
 				diags = diag.FromErr(err)
 			}
 			StructToData(ptr.Elem().Interface(), s, d)
+			// check if the resource schema has the `id` attribute (marked with `json:"id"` in the provided structure).
+			// and if yes, then use it as resource ID. If not, then use default value for resource ID (`_`)
 			if _, ok := s["id"]; ok {
 				d.SetId(d.Get("id").(string))
 			} else {

--- a/common/resource.go
+++ b/common/resource.go
@@ -199,7 +199,11 @@ func DataResource(sc any, read func(context.Context, any, *DatabricksClient) err
 				diags = diag.FromErr(err)
 			}
 			StructToData(ptr.Elem().Interface(), s, d)
-			d.SetId("_")
+			if _, ok := s["id"]; ok {
+				d.SetId(d.Get("id").(string))
+			} else {
+				d.SetId("_")
+			}
 			return
 		},
 	}

--- a/docs/data-sources/service_principal.md
+++ b/docs/data-sources/service_principal.md
@@ -38,7 +38,6 @@ Data source allows you to pick service principals by the following attributes
 Data source exposes the following attributes:
 
 - `id` - The id of the service principal.
-- `sp_id` - The id of the service principal (deprecated, kept for compatibility with earlier versions).
 - `external_id` - ID of the service principal in an external identity provider.
 - `display_name` - Display name of the [service principal](../resources/service_principal.md), e.g. `Foo SPN`.
 - `home` - Home folder of the [service principal](../resources/service_principal.md), e.g. `/Users/11111111-2222-3333-4444-555666777888`.

--- a/docs/data-sources/service_principal.md
+++ b/docs/data-sources/service_principal.md
@@ -23,7 +23,7 @@ data "databricks_service_principal" "spn" {
 
 resource "databricks_group_member" "my_member_a" {
   group_id  = data.databricks_group.admins.id
-  member_id = data.databricks_service_principal.spn.sp_id
+  member_id = data.databricks_service_principal.spn.id
 }
 ```
 
@@ -37,7 +37,8 @@ Data source allows you to pick service principals by the following attributes
 
 Data source exposes the following attributes:
 
-- `sp_id` - The id of the service principal.
+- `id` - The id of the service principal.
+- `sp_id` - The id of the service principal (deprecated, kept for compatibility with earlier versions).
 - `external_id` - ID of the service principal in an external identity provider.
 - `display_name` - Display name of the [service principal](../resources/service_principal.md), e.g. `Foo SPN`.
 - `home` - Home folder of the [service principal](../resources/service_principal.md), e.g. `/Users/11111111-2222-3333-4444-555666777888`.

--- a/scim/data_service_principal.go
+++ b/scim/data_service_principal.go
@@ -14,6 +14,7 @@ func DataSourceServicePrincipal() *schema.Resource {
 		ApplicationID string `json:"application_id,omitempty" tf:"computed"`
 		DisplayName   string `json:"display_name,omitempty" tf:"computed"`
 		SpID          string `json:"sp_id,omitempty" tf:"computed"`
+		ID            string `json:"id,omitempty" tf:"computed"`
 		Home          string `json:"home,omitempty" tf:"computed"`
 		Repos         string `json:"repos,omitempty" tf:"computed"`
 		Active        bool   `json:"active,omitempty" tf:"computed"`
@@ -36,6 +37,7 @@ func DataSourceServicePrincipal() *schema.Resource {
 		response.ExternalID = sp.ExternalID
 		response.Active = sp.Active
 		response.SpID = sp.ID
+		response.ID = sp.ID
 		return nil
 	})
 }

--- a/scim/data_service_principal_test.go
+++ b/scim/data_service_principal_test.go
@@ -39,9 +39,10 @@ func TestDataServicePrincipalReadByAppId(t *testing.T) {
 		HCL:         `application_id = "abc"`,
 		Read:        true,
 		NonWritable: true,
-		ID:          "_",
+		ID:          "abc",
 	}.ApplyAndExpectData(t, map[string]any{
 		"sp_id":          "abc",
+		"id":             "abc",
 		"application_id": "abc",
 		"display_name":   "Example Service Principal",
 		"active":         true,


### PR DESCRIPTION
The `DataResource` function now checks if the provided schema has the field with name `id` and set its value as resource ID.  This will allow to have uniform references between normal resources and data sources. If this change is ok, then I'll proceed with other data sources. (See https://github.com/hashicorp/terraform-plugin-sdk/issues/607 for reference about definition of `id` attribute).

This change was already applied to the `databricks_service_principal` data source where old attribute (`sp_id`) was left for backward compatibility.