### PR TITLE
Improve `databricks_grants` error messages

### DIFF
--- a/catalog/resource_grants.go
+++ b/catalog/resource_grants.go
@@ -153,6 +153,9 @@ func (sm securableMapping) validate(d attributeGetter, pl PermissionsList) error
 	}
 	for _, v := range pl.Assignments {
 		for _, priv := range v.Privileges {
+			if allowed[strings.ReplaceAll(priv, " ", "_")] {
+				return fmt.Errorf(`%s is not allowed on %s. Did you mean %s?`, priv, securable, strings.ReplaceAll(priv, " ", "_"))
+			}
 			if !allowed[strings.ToUpper(priv)] {
 				return fmt.Errorf(`%s is not allowed on %s`, priv, securable)
 			}

--- a/catalog/resource_grants.go
+++ b/catalog/resource_grants.go
@@ -153,10 +153,11 @@ func (sm securableMapping) validate(d attributeGetter, pl PermissionsList) error
 	}
 	for _, v := range pl.Assignments {
 		for _, priv := range v.Privileges {
-			if allowed[strings.ReplaceAll(priv, " ", "_")] {
-				return fmt.Errorf(`%s is not allowed on %s. Did you mean %s?`, priv, securable, strings.ReplaceAll(priv, " ", "_"))
-			}
 			if !allowed[strings.ToUpper(priv)] {
+				// check if user uses spaces instead of underscores
+				if allowed[strings.ReplaceAll(priv, " ", "_")] {
+					return fmt.Errorf(`%s is not allowed on %s. Did you mean %s?`, priv, securable, strings.ReplaceAll(priv, " ", "_"))
+				}
 				return fmt.Errorf(`%s is not allowed on %s`, priv, securable)
 			}
 		}

--- a/catalog/resource_grants_test.go
+++ b/catalog/resource_grants_test.go
@@ -347,3 +347,27 @@ func TestShareGrantUpdate(t *testing.T) {
 		}`,
 	}.ApplyNoError(t)
 }
+
+func TestPrivilegeWithSpace(t *testing.T) {
+	d := data{"table": "me"}
+	err := mapping.validate(d, PermissionsList{
+		Assignments: []PrivilegeAssignment{
+			{
+				Principal:  "me",
+				Privileges: []string{"ALL PRIVILEGES"},
+			},
+		},
+	})
+	assert.EqualError(t, err, "ALL PRIVILEGES is not allowed on table. Did you mean ALL_PRIVILEGES?")
+
+	d = data{"external_location": "me"}
+	err = mapping.validate(d, PermissionsList{
+		Assignments: []PrivilegeAssignment{
+			{
+				Principal:  "me",
+				Privileges: []string{"CREATE TABLE"},
+			},
+		},
+	})
+	assert.EqualError(t, err, "CREATE TABLE is not allowed on external_location. Did you mean CREATE_TABLE?")
+}

--- a/docs/resources/grants.md
+++ b/docs/resources/grants.md
@@ -33,7 +33,7 @@ Terraform will handle any configuration drift on every `terraform apply` run, ev
 
 It is required to define all permissions for a securable in a single resource, otherwise Terraform cannot guarantee config drift prevention.
 
-Below summarizes which privilege types apply to each securable object in the catalog:
+Unlike the [SQL specification](https://docs.databricks.com/sql/language-manual/sql-ref-privileges.html#privilege-types), all privileges to be written with underscore instead of space, e.g. `CREATE_TABLE` and not `CREATE TABLE`. Below summarizes which privilege types apply to each securable object in the catalog:
 
 ## Metastore grants
 


### PR DESCRIPTION
Provider now warns user when they use spaces instead of underscores for grants.

Closes #1820