### PR TITLE
Fixed the issue of simple named objects not appearing in .tf output files

### DIFF
--- a/exporter/importables.go
+++ b/exporter/importables.go
@@ -174,7 +174,7 @@ var resourcesMap map[string]importable = map[string]importable{
 				ic.Emit(&resource{
 					Resource: "databricks_permissions",
 					ID:       fmt.Sprintf("/instance-pools/%s", r.ID),
-					Name:     "inst_pool_" + ic.Importables["databricks_instance_pool"].Name(ic, r.Data),
+					Name:     "inst-pool_" + ic.Importables["databricks_instance_pool"].Name(ic, r.Data),
 				})
 			}
 			return nil
@@ -256,7 +256,7 @@ var resourcesMap map[string]importable = map[string]importable{
 				ic.Emit(&resource{
 					Resource: "databricks_permissions",
 					ID:       fmt.Sprintf("/clusters/%s", r.ID),
-					Name:     "cluster_" + ic.Importables["databricks_cluster"].Name(ic, r.Data),
+					Name:     "cluster-" + ic.Importables["databricks_cluster"].Name(ic, r.Data),
 				})
 			}
 			return ic.importLibraries(r.Data, s)
@@ -324,7 +324,7 @@ var resourcesMap map[string]importable = map[string]importable{
 				ic.Emit(&resource{
 					Resource: "databricks_permissions",
 					ID:       fmt.Sprintf("/jobs/%s", r.ID),
-					Name:     "job_" + ic.Importables["databricks_job"].Name(ic, r.Data),
+					Name:     "job-" + ic.Importables["databricks_job"].Name(ic, r.Data),
 				})
 			}
 			if job.SparkPythonTask != nil {
@@ -461,7 +461,7 @@ var resourcesMap map[string]importable = map[string]importable{
 				ic.Emit(&resource{
 					Resource: "databricks_permissions",
 					ID:       fmt.Sprintf("/cluster-policies/%s", r.ID),
-					Name:     "cluster_policy_" + ic.Importables["databricks_cluster_policy"].Name(ic, r.Data),
+					Name:     "cluster-policy_" + ic.Importables["databricks_cluster_policy"].Name(ic, r.Data),
 				})
 			}
 			var definition map[string]map[string]any
@@ -595,7 +595,7 @@ var resourcesMap map[string]importable = map[string]importable{
 						ic.Emit(&resource{
 							Resource: "databricks_group_member",
 							ID:       fmt.Sprintf("%s|%s", parent.Value, g.ID),
-							Name:     fmt.Sprintf("%s_%s_%s", parent.Display, parent.Value, g.DisplayName),
+							Name:     strings.ToUpper(fmt.Sprintf("%s_%s_%s", parent.Display, parent.Value, g.DisplayName)), //strings.ToUpper fixes 1838
 						})
 					}
 				}
@@ -620,7 +620,7 @@ var resourcesMap map[string]importable = map[string]importable{
 						ic.Emit(&resource{
 							Resource: "databricks_group_member",
 							ID:       fmt.Sprintf("%s|%s", g.ID, x.Value),
-							Name:     fmt.Sprintf("%s_%s_%s", g.DisplayName, g.ID, x.Display),
+							Name:     strings.ToUpper(fmt.Sprintf("%s_%s_%s", g.DisplayName, g.ID, x.Display)), //strings.ToUpper fixes 1838
 						})
 					}
 					if len(g.Members) > 10 {
@@ -790,7 +790,7 @@ var resourcesMap map[string]importable = map[string]importable{
 					ic.Emit(&resource{
 						Resource: "databricks_secret_scope",
 						ID:       scope.Name,
-						Name:     scope.Name,
+						Name:     strings.ToUpper(scope.Name), //strings.ToUpper fixes 1838
 					})
 					log.Printf("[INFO] Imported %d of %d secret scopes", i, len(scopes))
 				}
@@ -980,7 +980,7 @@ var resourcesMap map[string]importable = map[string]importable{
 				ic.Emit(&resource{
 					Resource: "databricks_permissions",
 					ID:       fmt.Sprintf("/repos/%s", r.ID),
-					Name:     "repo_" + ic.Importables["databricks_repo"].Name(ic, r.Data),
+					Name:     "repo-" + ic.Importables["databricks_repo"].Name(ic, r.Data),
 				})
 			}
 			return nil
@@ -1169,7 +1169,7 @@ var resourcesMap map[string]importable = map[string]importable{
 				ic.Emit(&resource{
 					Resource: "databricks_permissions",
 					ID:       fmt.Sprintf("/sql/queries/%s", r.ID),
-					Name:     "sql_query_" + ic.Importables["databricks_sql_query"].Name(ic, r.Data),
+					Name:     "sql-query_" + ic.Importables["databricks_sql_query"].Name(ic, r.Data),
 				})
 			}
 			return nil
@@ -1210,7 +1210,7 @@ var resourcesMap map[string]importable = map[string]importable{
 				ic.Emit(&resource{
 					Resource: "databricks_permissions",
 					ID:       fmt.Sprintf("/sql/warehouses/%s", r.ID),
-					Name:     "sql_endpoint_" + ic.Importables["databricks_sql_endpoint"].Name(ic, r.Data),
+					Name:     "sql-endpoint_" + ic.Importables["databricks_sql_endpoint"].Name(ic, r.Data),
 				})
 				ic.Emit(&resource{
 					Resource: "databricks_sql_global_config",
@@ -1276,7 +1276,7 @@ var resourcesMap map[string]importable = map[string]importable{
 				ic.Emit(&resource{
 					Resource: "databricks_permissions",
 					ID:       fmt.Sprintf("/sql/dashboards/%s", r.ID),
-					Name:     "sql_dashboard_" + ic.Importables["databricks_sql_dashboard"].Name(ic, r.Data),
+					Name:     "sql-dashboard_" + ic.Importables["databricks_sql_dashboard"].Name(ic, r.Data),
 				})
 			}
 			dashboardID := r.ID
@@ -1432,7 +1432,7 @@ var resourcesMap map[string]importable = map[string]importable{
 				ic.Emit(&resource{
 					Resource: "databricks_permissions",
 					ID:       fmt.Sprintf("/pipelines/%s", r.ID),
-					Name:     "pipeline_" + ic.Importables["databricks_pipeline"].Name(ic, r.Data),
+					Name:     "pipeline-" + ic.Importables["databricks_pipeline"].Name(ic, r.Data),
 				})
 			}
 			return nil

--- a/exporter/importables_test.go
+++ b/exporter/importables_test.go
@@ -55,7 +55,7 @@ func TestInstancePool(t *testing.T) {
 		Data: d,
 	})
 	assert.NoError(t, err)
-	assert.True(t, ic.testEmits["databricks_permissions[inst_pool_def] (id: /instance-pools/abc)"])
+	assert.True(t, ic.testEmits["databricks_permissions[inst-pool_def] (id: /instance-pools/abc)"])
 }
 
 func TestClusterPolicy(t *testing.T) {
@@ -83,7 +83,7 @@ func TestClusterPolicy(t *testing.T) {
 	})
 	assert.NoError(t, err)
 	assert.Len(t, ic.testEmits, 4)
-	assert.True(t, ic.testEmits["databricks_permissions[cluster_policy_bcd] (id: /cluster-policies/abc)"])
+	assert.True(t, ic.testEmits["databricks_permissions[cluster-policy_bcd] (id: /cluster-policies/abc)"])
 	assert.True(t, ic.testEmits["databricks_instance_pool[<unknown>] (id: efg)"])
 	assert.True(t, ic.testEmits["databricks_instance_profile[<unknown>] (id: def)"])
 	assert.True(t, ic.testEmits["databricks_dbfs_file[<unknown>] (id: dbfs:/FileStore/init-script.sh)"])
@@ -152,7 +152,7 @@ func TestGroup(t *testing.T) {
 	assert.True(t, ic.testEmits["databricks_group_instance_profile[<unknown>] (id: 123|abc)"])
 	assert.True(t, ic.testEmits["databricks_instance_profile[<unknown>] (id: abc)"])
 	assert.True(t, ic.testEmits["databricks_group[<unknown>] (id: parent-group)"])
-	assert.True(t, ic.testEmits["databricks_group_member[_parent-group_foo] (id: parent-group|123)"])
+	assert.True(t, ic.testEmits["databricks_group_member[_PARENT-GROUP_FOO] (id: parent-group|123)"])
 }
 
 func TestPermissions(t *testing.T) {

--- a/exporter/util.go
+++ b/exporter/util.go
@@ -96,7 +96,7 @@ func (ic *importContext) emitGroups(u scim.User, principal string) {
 		ic.Emit(&resource{
 			Resource: "databricks_group_member",
 			ID:       fmt.Sprintf("%s|%s", g.Value, u.ID),
-			Name:     fmt.Sprintf("%s_%s_%s", g.Display, g.Value, principal),
+			Name:     strings.ToUpper(fmt.Sprintf("%s_%s_%s", g.Display, g.Value, principal)), //strings.ToUpper fixes 1838
 		})
 	}
 }


### PR DESCRIPTION
Changes were made to the `importables.go`, and `util.go` such that the `ResourceName(r)` function in context.go would return a normalized but **changed** name
Changes to the supplied names were very basic: 1) either changed an underscore `_` to a dash `-` or 2) `upper`cased the name.