### PR TITLE
Exporter: fix issue with exporting of resources with simple name

### DIFF
--- a/exporter/context.go
+++ b/exporter/context.go
@@ -352,9 +352,6 @@ func (ic *importContext) Has(r *resource) bool {
 }
 
 func (ic *importContext) Add(r *resource) {
-	if ic.Has(r) {
-		return
-	}
 	state := r.Data.State()
 	if state == nil {
 		log.Printf("[ERROR] state is nil for %s", r)

--- a/exporter/importables.go
+++ b/exporter/importables.go
@@ -777,7 +777,8 @@ var resourcesMap map[string]importable = map[string]importable{
 	"databricks_secret_scope": {
 		Service: "secrets",
 		Name: func(ic *importContext, d *schema.ResourceData) string {
-			return d.Get("name").(string)
+			name := d.Get("name").(string)
+			return name + "_" + generateUniqueID(name)
 		},
 		List: func(ic *importContext) error {
 			ssAPI := secrets.NewSecretScopesAPI(ic.Context, ic.Client)
@@ -791,7 +792,6 @@ var resourcesMap map[string]importable = map[string]importable{
 					ic.Emit(&resource{
 						Resource: "databricks_secret_scope",
 						ID:       scope.Name,
-						Name:     scope.Name,
 					})
 					log.Printf("[INFO] Imported %d of %d secret scopes", i+1, len(scopes))
 				}
@@ -832,7 +832,8 @@ var resourcesMap map[string]importable = map[string]importable{
 			{Path: "string_value", Resource: "aws_secretsmanager_secret_version", Match: "secret_string"},
 		},
 		Name: func(ic *importContext, d *schema.ResourceData) string {
-			return fmt.Sprintf("%s_%s", d.Get("scope"), d.Get("key"))
+			name := fmt.Sprintf("%s_%s", d.Get("scope"), d.Get("key"))
+			return name + "_" + generateUniqueID(name)
 		},
 	},
 	"databricks_secret_acl": {

--- a/exporter/importables_test.go
+++ b/exporter/importables_test.go
@@ -194,7 +194,7 @@ func TestSecretScope(t *testing.T) {
 	d.Set("name", "abc")
 	ic := importContextForTest()
 	name := ic.Importables["databricks_secret_scope"].Name(ic, d)
-	assert.Equal(t, "abc", name)
+	assert.Equal(t, "abc_a9993e3647", name)
 }
 
 func TestInstancePoolNameFromID(t *testing.T) {
@@ -769,8 +769,8 @@ func TestSecretGen(t *testing.T) {
 
 		ic.generateHclForResources(nil)
 		assert.Equal(t, commands.TrimLeadingWhitespace(`
-		resource "databricks_secret" "a_b" {
-		  string_value = var.string_value_a_b
+		resource "databricks_secret" "a_b_eb2980a5a2" {
+		  string_value = var.string_value_a_b_eb2980a5a2
 		  scope        = "a"
 		  key          = "b"
 		}`), string(ic.Files["secrets"].Bytes()))

--- a/exporter/util.go
+++ b/exporter/util.go
@@ -1,6 +1,7 @@
 package exporter
 
 import (
+	"crypto/sha1"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -481,4 +482,8 @@ func resourceOrDataBlockBody(ic *importContext, body *hclwrite.Body, r *resource
 	resourceBlock := body.AppendNewBlock(blockType, []string{r.Resource, r.Name})
 	return ic.dataToHcl(ic.Importables[r.Resource],
 		[]string{}, ic.Resources[r.Resource], r.Data, resourceBlock.Body())
+}
+
+func generateUniqueID(v string) string {
+	return fmt.Sprintf("%x", sha1.Sum([]byte(v)))[:10]
 }


### PR DESCRIPTION
The `Add` function is called only from the `Emit` so it's safe to remove the check if resource was already imported or not.

this fixes #1838