### PR TITLE
Exporter: add command-line flag to export all users and service principals

### DIFF
--- a/docs/guides/experimental-exporter.md
+++ b/docs/guides/experimental-exporter.md
@@ -44,6 +44,7 @@ All arguments are optional and they tune what code is being generated.
 * `-prefix` - optional prefix that will be added to the name of all exported resources - that's useful for exporting resources multiple workspaces for merging into a single one.
 * `-skip-interactive` - optionally run in a non-interactive mode.
 * `-includeUserDomains` - optionally include domain name into generated resource name for `databricks_user` resource.
+* `-importAllUsers` - optionally include all users and service principals even if they only part of the `users` group.
 
 ## Services
 

--- a/exporter/command.go
+++ b/exporter/command.go
@@ -88,6 +88,8 @@ func Run(args ...string) error {
 	var skipInteractive bool
 	flags.BoolVar(&skipInteractive, "skip-interactive", false, "Skip interactive mode")
 	flags.BoolVar(&ic.includeUserDomains, "includeUserDomains", false, "Include domain portion in `databricks_user` resource name")
+	flags.BoolVar(&ic.importAllUsers, "importAllUsers", false,
+		"Import all users and service principals, even if they aren't referenced in any resource")
 	flags.StringVar(&ic.Directory, "directory", cwd,
 		"Directory to generate sources in. Defaults to current directory.")
 	flags.Int64Var(&ic.lastActiveDays, "last-active-days", 3650,

--- a/exporter/context.go
+++ b/exporter/context.go
@@ -68,6 +68,7 @@ type importContext struct {
 	workspaceConfKeys map[string]any
 
 	includeUserDomains  bool
+	importAllUsers      bool
 	debug               bool
 	mounts              bool
 	services            string

--- a/exporter/importables.go
+++ b/exporter/importables.go
@@ -577,8 +577,7 @@ var resourcesMap map[string]importable = map[string]importable{
 						ID:       fmt.Sprintf("%s|%s", g.ID, instanceProfile.Value),
 					})
 				}
-				if g.DisplayName == "users" {
-					// TODO: make flag
+				if g.DisplayName == "users" && !ic.importAllUsers {
 					log.Printf("[INFO] Skipping import of entire user directory ...")
 					continue
 				}


### PR DESCRIPTION
New flag allows to export all users and service principals even if they are only part of the `users` group

This fixes #1827