### PR TITLE
Exporter: logging improvements

### DIFF
--- a/exporter/importables.go
+++ b/exporter/importables.go
@@ -518,7 +518,7 @@ var resourcesMap map[string]importable = map[string]importable{
 				return err
 			}
 			// TODO: don't export users and admins group
-			for _, g := range ic.allGroups {
+			for offset, g := range ic.allGroups {
 				if !ic.MatchesName(g.DisplayName) {
 					log.Printf("[INFO] Group %s doesn't match %s filter", g.DisplayName, ic.match)
 					continue
@@ -527,6 +527,7 @@ var resourcesMap map[string]importable = map[string]importable{
 					Resource: "databricks_group",
 					ID:       g.ID,
 				})
+				log.Printf("[INFO] Scanned %d of %d groups", offset+1, len(ic.allGroups))
 			}
 			return nil
 		},
@@ -792,7 +793,7 @@ var resourcesMap map[string]importable = map[string]importable{
 						ID:       scope.Name,
 						Name:     scope.Name,
 					})
-					log.Printf("[INFO] Imported %d of %d secret scopes", i, len(scopes))
+					log.Printf("[INFO] Imported %d of %d secret scopes", i+1, len(scopes))
 				}
 			}
 			return nil

--- a/exporter/util.go
+++ b/exporter/util.go
@@ -352,7 +352,7 @@ func (ic *importContext) importJobs(l []jobs.Job) {
 	a := jobs.NewJobsAPI(ic.Context, ic.Client)
 	starterAfter := (nowSeconds - (ic.lastActiveDays * 24 * 60 * 60)) * 1000
 	i := 0
-	for _, job := range l {
+	for offset, job := range l {
 		if !ic.MatchesName(job.Settings.Name) {
 			log.Printf("[INFO] Job name %s doesn't match selection %s", job.Settings.Name, ic.match)
 			continue
@@ -383,8 +383,9 @@ func (ic *importContext) importJobs(l []jobs.Job) {
 			ID:       job.ID(),
 		})
 		i++
-		log.Printf("[INFO] Imported %d of total %d jobs", i, len(l))
+		log.Printf("[INFO] Scanned %d of total %d jobs", offset+1, len(l))
 	}
+	log.Printf("[INFO] %d of total %d jobs are going to be imported", i, len(l))
 }
 
 // returns created file name in "files" directory for the export and error if any


### PR DESCRIPTION
- Use 1-based numeration in `databricks_secret_scope` listing instead of 0-based that is confusing for users
- Improve logging when listing `databricks_job` resources