### PR TITLE
Add `config_reference` attribute to `databricks_secret` for easier reference from Spark configuration

### DIFF
--- a/docs/resources/secret.md
+++ b/docs/resources/secret.md
@@ -33,6 +33,7 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - Canonical unique identifier for the secret.
 * `last_updated_timestamp` - (Integer) time secret was updated
+* `config_reference` - (String) value to use as a secret reference in [Spark configuration and environment variables](https://docs.databricks.com/security/secrets/secrets.html#use-a-secret-in-a-spark-configuration-property-or-environment-variable): `{{secrets/scope/key}}`.
 
 
 ## Import

--- a/secrets/resource_secret.go
+++ b/secrets/resource_secret.go
@@ -145,6 +145,10 @@ func ResourceSecret() *schema.Resource {
 				Type:     schema.TypeInt,
 				Computed: true,
 			},
+			"config_reference": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 		Create: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
 			if err := NewSecretsAPI(ctx, c).Create(d.Get("string_value").(string), d.Get("scope").(string),
@@ -163,6 +167,7 @@ func ResourceSecret() *schema.Resource {
 			if err != nil {
 				return err
 			}
+			d.Set("config_reference", fmt.Sprintf("{{secrets/%s/%s}}", scope, key))
 			return d.Set("last_updated_timestamp", m.LastUpdatedTimestamp)
 		},
 		Delete: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {

--- a/secrets/resource_secret_test.go
+++ b/secrets/resource_secret_test.go
@@ -35,6 +35,7 @@ func TestResourceSecretRead(t *testing.T) {
 	assert.Equal(t, 12345678, d.Get("last_updated_timestamp"))
 	assert.Equal(t, "foo", d.Get("scope"))
 	assert.Equal(t, "", d.Get("string_value"))
+	assert.Equal(t, "{{secrets/foo/bar}}", d.Get("config_reference"))
 }
 
 func TestResourceSecretRead_NotFound(t *testing.T) {


### PR DESCRIPTION
The `config_reference` attribute exposes string value in form of `{{secrets/scope/key}}` for easier reference from Spark configuration or environment variables.

It will be also used later in exporter for handling dependencies