### PR TITLE
add search by name for `databricks_cluster` data source

### DIFF
--- a/clusters/data_cluster.go
+++ b/clusters/data_cluster.go
@@ -2,6 +2,7 @@ package clusters
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -9,18 +10,40 @@ import (
 
 func DataSourceCluster() *schema.Resource {
 	type clusterData struct {
-		ClusterId   string       `json:"cluster_id"`
+		Id          string       `json:"id,omitempty" tf:"computed"`
+		ClusterId   string       `json:"cluster_id,omitempty" tf:"computed"`
+		Name        string       `json:"name,omitempty" tf:"computed"`
 		ClusterInfo *ClusterInfo `json:"cluster_info,omitempty" tf:"computed"`
 	}
 	return common.DataResource(clusterData{}, func(ctx context.Context, e interface{}, c *common.DatabricksClient) error {
 		data := e.(*clusterData)
 		clusterAPI := NewClustersAPI(ctx, c)
-		clusterInfo, err := clusterAPI.Get(data.ClusterId)
-
-		data.ClusterInfo = &clusterInfo
-		if err != nil {
-			return err
+		if data.Name != "" {
+			clusters, err := clusterAPI.List()
+			if err != nil {
+				return err
+			}
+			for _, clst := range clusters {
+				cluster := clst
+				if cluster.ClusterName == data.Name {
+					data.ClusterInfo = &cluster
+					break
+				}
+			}
+			if data.ClusterInfo == nil {
+				return fmt.Errorf("there is no cluster with name '%s'", data.Name)
+			}
+		} else if data.ClusterId != "" {
+			cls, err := clusterAPI.Get(data.ClusterId)
+			if err != nil {
+				return err
+			}
+			data.ClusterInfo = &cls
+		} else {
+			return fmt.Errorf("you need to specify either `name` or `cluster_id`")
 		}
+		data.Id = data.ClusterInfo.ClusterID
+		data.ClusterId = data.ClusterInfo.ClusterID
 
 		return nil
 	})

--- a/clusters/data_cluster_test.go
+++ b/clusters/data_cluster_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestClusterData(t *testing.T) {
+func TestClusterDataByID(t *testing.T) {
 	d, err := qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
 			{
@@ -47,6 +47,78 @@ func TestClusterData(t *testing.T) {
 	}
 }
 
+func TestClusterDataByName(t *testing.T) {
+	d, err := qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "GET",
+				Resource: "/api/2.0/clusters/list",
+
+				Response: ClusterList{
+					Clusters: []ClusterInfo{{
+						ClusterID:              "abc",
+						NumWorkers:             100,
+						ClusterName:            "Shared Autoscaling",
+						SparkVersion:           "7.1-scala12",
+						NodeTypeID:             "i3.xlarge",
+						AutoterminationMinutes: 15,
+						State:                  ClusterStateRunning,
+						AutoScale: &AutoScale{
+							MaxWorkers: 4,
+						},
+					}},
+				},
+			},
+		},
+		Resource:    DataSourceCluster(),
+		HCL:         `name = "Shared Autoscaling"`,
+		Read:        true,
+		NonWritable: true,
+		ID:          "_",
+	}.Apply(t)
+	require.NoError(t, err, err)
+	assert.Equal(t, 15, d.Get("cluster_info.0.autotermination_minutes"))
+	assert.Equal(t, "Shared Autoscaling", d.Get("cluster_info.0.cluster_name"))
+	assert.Equal(t, "i3.xlarge", d.Get("cluster_info.0.node_type_id"))
+	assert.Equal(t, 4, d.Get("cluster_info.0.autoscale.0.max_workers"))
+	assert.Equal(t, "RUNNING", d.Get("cluster_info.0.state"))
+
+	for k, v := range d.State().Attributes {
+		fmt.Printf("assert.Equal(t, %#v, d.Get(%#v))\n", v, k)
+	}
+}
+
+func TestClusterDataByName_NotFound(t *testing.T) {
+	qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "GET",
+				Resource: "/api/2.0/clusters/list",
+
+				Response: ClusterList{
+					Clusters: []ClusterInfo{},
+				},
+			},
+		},
+		Resource:    DataSourceCluster(),
+		HCL:         `name = "Unknown"`,
+		Read:        true,
+		NonWritable: true,
+		ID:          "_",
+	}.ExpectError(t, "there is no cluster with name 'Unknown'")
+}
+
+func TestClusterDataByName_ListError(t *testing.T) {
+	qa.ResourceFixture{
+		Fixtures:    qa.HTTPFailures,
+		Resource:    DataSourceCluster(),
+		HCL:         `name = "Unknown"`,
+		Read:        true,
+		NonWritable: true,
+		ID:          "_",
+	}.ExpectError(t, "I'm a teapot")
+}
+
 func TestClusterData_Error(t *testing.T) {
 	qa.ResourceFixture{
 		Fixtures:    qa.HTTPFailures,
@@ -56,4 +128,14 @@ func TestClusterData_Error(t *testing.T) {
 		HCL:         `cluster_id = "abc"`,
 		ID:          "_",
 	}.ExpectError(t, "I'm a teapot")
+}
+
+func TestClusterData_ErrorNoParams(t *testing.T) {
+	qa.ResourceFixture{
+		Resource:    DataSourceCluster(),
+		Read:        true,
+		NonWritable: true,
+		HCL:         "",
+		ID:          "_",
+	}.ExpectError(t, "you need to specify either `name` or `cluster_id`")
 }

--- a/docs/data-sources/cluster.md
+++ b/docs/data-sources/cluster.md
@@ -24,8 +24,8 @@ data "databricks_cluster" "all" {
 
 ## Argument Reference
 
-* `cluster_id` - (Required if `name` isn't specified) The id of the cluster
-* `name` - (Required if `cluster_id` isn't specified) The exact name of the cluster to search
+* `cluster_id` - (Required if `cluster_name` isn't specified) The id of the cluster
+* `cluster_name` - (Required if `cluster_id` isn't specified) The exact name of the cluster to search
 
 ## Attribute Reference
 

--- a/docs/data-sources/cluster.md
+++ b/docs/data-sources/cluster.md
@@ -24,12 +24,14 @@ data "databricks_cluster" "all" {
 
 ## Argument Reference
 
-* `cluster_id` - (Required) The id of the cluster
+* `cluster_id` - (Required if `name` isn't specified) The id of the cluster
+* `name` - (Required if `cluster_id` isn't specified) The exact name of the cluster to search
 
 ## Attribute Reference
 
 This data source exports the following attributes:
 
+* `id` - cluster ID
 * `cluster_info` block, consisting of following fields:
   * `cluster_name` - Cluster name, which doesn’t have to be unique.
   * `spark_version` - [Runtime version](https://docs.databricks.com/runtime/index.html) of the cluster.

--- a/docs/data-sources/job.md
+++ b/docs/data-sources/job.md
@@ -16,7 +16,7 @@ data "databricks_job" "this" {
   job_name = "My job"
 }
 
-output "cluster_id" {
+output "job_num_workers" {
   value     = data.databricks_job.this.job_settings[0].settings[0].new_cluster[0].num_workers
   sensitive = false
 }
@@ -26,8 +26,9 @@ output "cluster_id" {
 
 This data source exports the following attributes:
 
-* `job_id` - the id of [databricks_job](../resources/job.md) if the resource was matched by name.
-* `job_name` - the job name of [databricks_job](../resources/job.md) if the resource was matched by id.
+
+* `id` - the id of [databricks_job](../resources/job.md) if the resource was matched by name.
+* `name` - the job name of [databricks_job](../resources/job.md) if the resource was matched by id.
 * `job_settings` - the same fields as in [databricks_job](../resources/job.md).
 
 ## Related Resources

--- a/jobs/data_job.go
+++ b/jobs/data_job.go
@@ -10,15 +10,23 @@ import (
 
 func DataSourceJob() *schema.Resource {
 	type queryableJobData struct {
-		Id   string `json:"job_id,omitempty" tf:"computed"`
-		Name string `json:"job_name,omitempty" tf:"computed"`
-		Job  *Job   `json:"job_settings,omitempty" tf:"computed"`
+		Id      string `json:"id,omitempty" tf:"computed"`
+		JobId   string `json:"job_id,omitempty" tf:"computed"`
+		Name    string `json:"name,omitempty" tf:"computed"`
+		JobName string `json:"job_name,omitempty" tf:"computed"`
+		Job     *Job   `json:"job_settings,omitempty" tf:"computed"`
 	}
 	return common.DataResource(queryableJobData{}, func(ctx context.Context, e any, c *common.DatabricksClient) error {
 		data := e.(*queryableJobData)
 		jobsAPI := NewJobsAPI(ctx, c)
 		var list []Job
 		var err error
+		if data.Id == "" {
+			data.Id = data.JobId
+		}
+		if data.Name == "" {
+			data.Name = data.JobName
+		}
 		if data.Name != "" {
 			// if name is provided, need to list all jobs ny name
 			list, err = jobsAPI.ListByName(data.Name, true)
@@ -43,6 +51,7 @@ func DataSourceJob() *schema.Resource {
 				data.Job = &currentJob
 				data.Name = currentJobName
 				data.Id = currentJobId
+				data.JobId = currentJobId
 				return nil // break the loop after we found the job
 			}
 		}

--- a/jobs/data_job_test.go
+++ b/jobs/data_job_test.go
@@ -76,9 +76,10 @@ func TestDataSourceQueryableJobMatchesId(t *testing.T) {
 		New:         true,
 		NonWritable: true,
 		HCL:         `job_id = "234"`,
-		ID:          "_",
+		ID:          "234",
 	}.ApplyAndExpectData(t, map[string]any{
 		"job_id":                         "234",
+		"id":                             "234",
 		"job_settings.0.settings.0.name": "Second",
 	})
 }
@@ -90,9 +91,10 @@ func TestDataSourceQueryableJobMatchesName(t *testing.T) {
 		Read:        true,
 		NonWritable: true,
 		HCL:         `job_name = "First"`,
-		ID:          "_",
+		ID:          "123",
 	}.ApplyAndExpectData(t, map[string]any{
 		"job_id":                         "123",
+		"id":                             "123",
 		"job_settings.0.settings.0.name": "First",
 	})
 }
@@ -132,7 +134,7 @@ func TestDataSourceQueryableJobNoMatchId(t *testing.T) {
 		Resource:    DataSourceJob(),
 		Read:        true,
 		NonWritable: true,
-		HCL:         `job_id= "567"`,
+		HCL:         `id= "567"`,
 		ID:          "_",
 	}.ExpectError(t, "Job 567 does not exist.")
 }


### PR DESCRIPTION
Also expose `id` for `databricks_cluster` & `databricks_job` data sources so it's easier to use results.

This is a follow up for #1885