### PR TITLE
databricks_mount S3: Use zone_id:"auto"

### DIFF
--- a/storage/aws_s3_mount.go
+++ b/storage/aws_s3_mount.go
@@ -135,6 +135,7 @@ func GetOrCreateMountingClusterWithInstanceProfile(
 	cluster.AwsAttributes = &clusters.AwsAttributes{
 		InstanceProfileArn: instanceProfile,
 		Availability:       "SPOT",
+		ZoneID:             "auto",
 	}
 	return clustersAPI.GetOrCreateRunningCluster(clusterName, cluster)
 }

--- a/storage/resource_mount_test.go
+++ b/storage/resource_mount_test.go
@@ -186,6 +186,7 @@ func TestResourceAwsS3MountGenericCreate_WithInstanceProfile(t *testing.T) {
 							AwsAttributes: &clusters.AwsAttributes{
 								InstanceProfileArn: instance_profile,
 								Availability:       "SPOT",
+								ZoneID:             "auto",
 							},
 							AutoterminationMinutes: 10,
 							SparkConf: map[string]string{"spark.databricks.cluster.profile": "singleNode",
@@ -219,6 +220,7 @@ func TestResourceAwsS3MountGenericCreate_WithInstanceProfile(t *testing.T) {
 					AwsAttributes: &clusters.AwsAttributes{
 						InstanceProfileArn: instance_profile,
 						Availability:       "SPOT",
+						ZoneID:             "auto",
 					},
 					AutoterminationMinutes: 10,
 					SparkConf: map[string]string{"spark.databricks.cluster.profile": "singleNode",

--- a/storage/s3_test.go
+++ b/storage/s3_test.go
@@ -67,6 +67,7 @@ func TestPreprocessS3MountOnDeletedClusterWorks(t *testing.T) {
 				AwsAttributes: &clusters.AwsAttributes{
 					Availability:       "SPOT",
 					InstanceProfileArn: "arn:aws:iam::1234567:instance-profile/s3-access",
+					ZoneID:             "auto",
 				},
 				AutoterminationMinutes: 10,
 				SparkConf: map[string]string{


### PR DESCRIPTION
Resolves #1756.