### PR TITLE
Added support for `iam_role_arn` in `databricks_instance_profile`

### DIFF
--- a/aws/resource_group_instance_profile.go
+++ b/aws/resource_group_instance_profile.go
@@ -14,7 +14,7 @@ import (
 func ResourceGroupInstanceProfile() *schema.Resource {
 	r := common.NewPairID("group_id", "instance_profile_id").Schema(func(
 		m map[string]*schema.Schema) map[string]*schema.Schema {
-		m["instance_profile_id"].ValidateDiagFunc = ValidInstanceProfile
+		m["instance_profile_id"].ValidateDiagFunc = ValidArn
 		return m
 	}).BindResource(common.BindResource{
 		ReadContext: func(ctx context.Context, groupID, roleARN string, c *common.DatabricksClient) error {

--- a/aws/resource_instance_profile.go
+++ b/aws/resource_instance_profile.go
@@ -18,7 +18,7 @@ import (
 
 // InstanceProfileInfo contains the ARN for aws instance profiles
 type InstanceProfileInfo struct {
-	InstanceProfileArn    string `json:"instance_profile_arn,omitempty"`
+	InstanceProfileArn    string `json:"instance_profile_arn"`
 	IamRoleArn            string `json:"iam_role_arn,omitempty"`
 	IsMetaInstanceProfile bool   `json:"is_meta_instance_profile,omitempty"`
 	SkipValidation        bool   `json:"skip_validation,omitempty" tf:"computed"`

--- a/aws/resource_instance_profile.go
+++ b/aws/resource_instance_profile.go
@@ -87,7 +87,7 @@ func (a InstanceProfilesAPI) Delete(instanceProfileARN string) error {
 // Update updates the IAM role ARN of an existing instance profile
 func (a InstanceProfilesAPI) Update(ipi InstanceProfileInfo) error {
 	data := map[string]any{
-		"inatance_profile_arn": ipi.InstanceProfileArn,
+		"instance_profile_arn": ipi.InstanceProfileArn,
 		"iam_role_arn":         ipi.InstanceProfileArn,
 	}
 	if ipi.IamRoleArn != "" {

--- a/aws/resource_instance_profile.go
+++ b/aws/resource_instance_profile.go
@@ -203,12 +203,18 @@ func ValidArn(v any, c cty.Path) diag.Diagnostics {
 	}
 	var arnType string
 	switch c[0].(cty.GetAttrStep).Name {
-	case "instance_profile_arn":
-		arnType = "instance-profile"
-	case "instance_profile_id":
+	case "instance_profile_arn", "instance_profile_id":
 		arnType = "instance-profile"
 	case "iam_role_arn":
 		arnType = "role"
+	default:
+		return diag.Diagnostics{
+			diag.Diagnostic{
+				AttributePath: c,
+				Summary:       "Unknown attribute",
+				Detail:        "ARN type associated with attribute is not known",
+			},
+		}
 	}
 	if s == "" && arnType == "role" {
 		return nil

--- a/aws/resource_instance_profile.go
+++ b/aws/resource_instance_profile.go
@@ -210,7 +210,7 @@ func ValidArn(v any, c cty.Path) diag.Diagnostics {
 	case "iam_role_arn":
 		arnType = "role"
 	}
-	if s == "" {
+	if s == "" && arnType == "role" {
 		return nil
 	}
 	if !strings.HasPrefix(s, "arn:") {

--- a/aws/resource_instance_profile_test.go
+++ b/aws/resource_instance_profile_test.go
@@ -132,7 +132,7 @@ func TestResourceInstanceProfileCreate_Error(t *testing.T) {
 	assert.Equal(t, "", d.Id(), "Id should be empty for error creates")
 }
 
-func TestResourceInstanceProfileCreate_Error_InvalidARN(t *testing.T) {
+func TestResourceInstanceProfileCreate_Error_InvalidInstanceProfileARN(t *testing.T) {
 	_, err := qa.ResourceFixture{
 		Resource: ResourceInstanceProfile(),
 		State: map[string]any{
@@ -149,6 +149,40 @@ func TestResourceInstanceProfileCreate_Error_InvalidRoleARN(t *testing.T) {
 		State: map[string]any{
 			"instance_profile_arn": "arn:aws:iam::999999999999:instance-profile/my-fake-instance-profile",
 			"iam_role_arn":         "abc",
+		},
+		Create: true,
+	}.Apply(t)
+	assert.EqualError(t, err, "invalid config supplied. [iam_role_arn] Invalid ARN")
+}
+
+func TestResourceInstanceProfileCreate_Error_MalformedARN(t *testing.T) {
+	_, err := qa.ResourceFixture{
+		Resource: ResourceInstanceProfile(),
+		State: map[string]any{
+			"instance_profile_arn": "arn:aws:iam::instance-profile/my-fake-instance-profile",
+		},
+		Create: true,
+	}.Apply(t)
+	assert.EqualError(t, err, "invalid config supplied. [instance_profile_arn] Invalid ARN")
+}
+
+func TestResourceInstanceProfileCreate_Error_WrongTypeProfileARN(t *testing.T) {
+	_, err := qa.ResourceFixture{
+		Resource: ResourceInstanceProfile(),
+		State: map[string]any{
+			"instance_profile_arn": "arn:aws:iam::999999999999:failure/my-fake-instance-profile",
+		},
+		Create: true,
+	}.Apply(t)
+	assert.EqualError(t, err, "invalid config supplied. [instance_profile_arn] Invalid ARN")
+}
+
+func TestResourceInstanceProfileCreate_Error_WrongTypeRoleARN(t *testing.T) {
+	_, err := qa.ResourceFixture{
+		Resource: ResourceInstanceProfile(),
+		State: map[string]any{
+			"instance_profile_arn": "arn:aws:iam::999999999999:instance-profile/my-fake-instance-profile",
+			"iam_role_arn":         "arn:aws:iam::999999999999:failure/my-fake-instance-profile-role",
 		},
 		Create: true,
 	}.Apply(t)

--- a/aws/resource_instance_profile_test.go
+++ b/aws/resource_instance_profile_test.go
@@ -132,7 +132,7 @@ func TestResourceInstanceProfileCreate_Error(t *testing.T) {
 	assert.Equal(t, "", d.Id(), "Id should be empty for error creates")
 }
 
-func TestResourceInstanceProfileCreate_Error_InvalidInstanceProfileARN(t *testing.T) {
+func TestResourceInstanceProfileValidate_Error_InvalidInstanceProfileARN(t *testing.T) {
 	_, err := qa.ResourceFixture{
 		Resource: ResourceInstanceProfile(),
 		State: map[string]any{
@@ -143,7 +143,7 @@ func TestResourceInstanceProfileCreate_Error_InvalidInstanceProfileARN(t *testin
 	assert.EqualError(t, err, "invalid config supplied. [instance_profile_arn] Invalid ARN")
 }
 
-func TestResourceInstanceProfileCreate_Error_InvalidRoleARN(t *testing.T) {
+func TestResourceInstanceProfileValidate_Error_InvalidRoleARN(t *testing.T) {
 	_, err := qa.ResourceFixture{
 		Resource: ResourceInstanceProfile(),
 		State: map[string]any{
@@ -155,7 +155,7 @@ func TestResourceInstanceProfileCreate_Error_InvalidRoleARN(t *testing.T) {
 	assert.EqualError(t, err, "invalid config supplied. [iam_role_arn] Invalid ARN")
 }
 
-func TestResourceInstanceProfileCreate_Error_MalformedARN(t *testing.T) {
+func TestResourceInstanceProfileValidate_Error_MalformedARN(t *testing.T) {
 	_, err := qa.ResourceFixture{
 		Resource: ResourceInstanceProfile(),
 		State: map[string]any{
@@ -166,7 +166,7 @@ func TestResourceInstanceProfileCreate_Error_MalformedARN(t *testing.T) {
 	assert.EqualError(t, err, "invalid config supplied. [instance_profile_arn] Invalid ARN")
 }
 
-func TestResourceInstanceProfileCreate_Error_WrongTypeProfileARN(t *testing.T) {
+func TestResourceInstanceProfileValidate_Error_WrongTypeProfileARN(t *testing.T) {
 	_, err := qa.ResourceFixture{
 		Resource: ResourceInstanceProfile(),
 		State: map[string]any{
@@ -177,7 +177,7 @@ func TestResourceInstanceProfileCreate_Error_WrongTypeProfileARN(t *testing.T) {
 	assert.EqualError(t, err, "invalid config supplied. [instance_profile_arn] Invalid ARN")
 }
 
-func TestResourceInstanceProfileCreate_Error_WrongTypeRoleARN(t *testing.T) {
+func TestResourceInstanceProfileValidate_Error_WrongTypeRoleARN(t *testing.T) {
 	_, err := qa.ResourceFixture{
 		Resource: ResourceInstanceProfile(),
 		State: map[string]any{

--- a/aws/resource_instance_profile_test.go
+++ b/aws/resource_instance_profile_test.go
@@ -189,6 +189,18 @@ func TestResourceInstanceProfileValidate_Error_WrongTypeRoleARN(t *testing.T) {
 	assert.EqualError(t, err, "invalid config supplied. [iam_role_arn] Invalid ARN")
 }
 
+func TestResourceInstanceProfileValidate_Error_EmptyInstanceProfileARN(t *testing.T) {
+	_, err := qa.ResourceFixture{
+		Resource: ResourceInstanceProfile(),
+		State: map[string]any{
+			"instance_profile_arn": "",
+			"iam_role_arn":         "arn:aws:iam::999999999999:role/my-fake-instance-profile-role",
+		},
+		Create: true,
+	}.Apply(t)
+	assert.EqualError(t, err, "invalid config supplied. [instance_profile_arn] Invalid ARN")
+}
+
 func TestResourceInstanceProfileRead(t *testing.T) {
 	d, err := qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{

--- a/aws/resource_user_instance_profile.go
+++ b/aws/resource_user_instance_profile.go
@@ -14,7 +14,7 @@ import (
 func ResourceUserInstanceProfile() *schema.Resource {
 	r := common.NewPairID("user_id", "instance_profile_id").Schema(func(
 		m map[string]*schema.Schema) map[string]*schema.Schema {
-		m["instance_profile_id"].ValidateDiagFunc = ValidInstanceProfile
+		m["instance_profile_id"].ValidateDiagFunc = ValidArn
 		return m
 	}).BindResource(common.BindResource{
 		CreateContext: func(ctx context.Context, userID, roleARN string, c *common.DatabricksClient) error {

--- a/docs/resources/instance_profile.md
+++ b/docs/resources/instance_profile.md
@@ -108,12 +108,50 @@ resource "databricks_group_instance_profile" "all" {
   instance_profile_id = databricks_instance_profile.this.id
 }
 ```
+## Usage with Databricks SQL serverless
+When the instance profile ARN and its associated IAM role ARN don't match and the instance profile is intended for use with Databricks SQL serverless, the `iam_role_arn` parameter can be specified
+
+```hcl
+data "aws_iam_policy_document" "sql_serverless_assume_role" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::790110701330:role/serverless-customer-resource-role"]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "sts:ExternalID"
+      values = [
+        "databricks-serverless-<YOUR_WORKSPACE_ID1>",
+        "databricks-serverless-<YOUR_WORKSPACE_ID2>"
+      ]
+    }
+  }
+}
+
+resource "aws_iam_role" "this" {
+  name               = "my-databricks-sql-serverless-role"
+  assume_role_policy = data.aws_iam_policy_document.sql_serverless_assume_role.json
+}
+
+resource "aws_iam_instance_profile" "this" {
+  name = "my-databricks-sql-serverless-instance-profile"
+  role = aws_iam_role.this.name
+}
+
+resource "databricks_instance_profile" "this" {
+  instance_profile_arn = aws_iam_instance_profile.this.arn
+  iam_role_arn         = aws_iam_role.this.arn
+}
+```
 
 ## Argument Reference
 
 The following arguments are supported:
 
 * `instance_profile_arn` - (Required) `ARN` attribute of `aws_iam_instance_profile` output, the EC2 instance profile association to AWS IAM role. This ARN would be validated upon resource creation.
+* `iam_role_arn` - (Optional) The AWS IAM role ARN of the role associated with the instance profile. It must have the form `arn:aws:iam::<account-id>:role/<name>`. This field is required if your role name and instance profile name do not match and you want to use the instance profile with Databricks SQL Serverless.
 * `is_meta_instance_profile` - (Optional) Whether the instance profile is a meta instance profile. Used only in [IAM credential passthrough](https://docs.databricks.com/security/credential-passthrough/iam-passthrough.html).
 * `skip_validation` - (Optional) **For advanced usage only.** If validation fails with an error message that does not indicate an IAM related permission issue, (e.g. “Your requested instance type is not supported in your requested availability zone”), you can pass this flag to skip the validation and forcibly add the instance profile.
 


### PR DESCRIPTION
This PR adds support to manage an instance profile's IAM role ARN when it does not match the instance profile name. This feature is needed when managing instance profiles for use with Databricks SQL serverless.

See [Databricks REST API documentation for instance profiles](https://docs.databricks.com/dev-tools/api/latest/instance-profiles.html#add)

Fixes #1911 
Fixes #1710 