### PR TITLE
Added SQL example for `databricks_job` documentation

### DIFF
--- a/docs/resources/job.md
+++ b/docs/resources/job.md
@@ -190,6 +190,22 @@ One of the `query`, `dashboard` or `alert` needs to be provided.
 * `dashboard` - (Optional) block consisting of single string field: `dashboard_id` - identifier of the Databricks SQL Dashboard [databricks_sql_dashboard](sql_dashboard.md).
 * `alert` - (Optional) block consisting of single string field: `alert_id` - identifier of the Databricks SQL Alert.
 
+Example
+```hcl
+resource "databricks_job" "sql_aggregation_job" {
+  name     = "Example SQL Job"
+  task {
+    task_key = "run_agg_query"
+    sql_task {
+      warehouse_id = databricks_sql_endpoint.sql_job_warehouse.id
+      query {
+        query_id = databricks_sql_query.agg_query.id
+      }
+    }
+  }
+}
+```
+
 ### Exported attributes
 
 In addition to all arguments above, the following attributes are exported:


### PR DESCRIPTION
I found this advanced Terraform syntax a bit confusion, so I think it would be nice to give an example would it easier. 

We could alternatively also add it as a task in the main example? Is it possible to combine it with other types? I've only tried it as a stand separate thing.

Another option would be to include how to add in an job it in the [databricks_sql_query docs](https://registry.terraform.io/providers/databricks/databricks/latest/docs/resources/sql_query).

https://github.com/databricks/terraform-provider-databricks/issues/1951