### PR TITLE
Remove deprecated params from bucket

### DIFF
--- a/scripts/awsmt-integration/data-security.tf
+++ b/scripts/awsmt-integration/data-security.tf
@@ -1,14 +1,22 @@
 // create bucket for mounting
 resource "aws_s3_bucket" "ds" {
   bucket = "${local.prefix}-ds"
-  acl    = "private"
-  versioning {
-    enabled = false
-  }
   force_destroy = true
   tags = merge(local.tags, {
     Name = "${local.prefix}-ds"
   })
+}
+
+resource "aws_s3_bucket_acl" "ds" {
+  bucket = aws_s3_bucket.ds.id
+  acl    = "private"
+}
+
+resource "aws_s3_bucket_versioning" "ds" {
+  bucket = aws_s3_bucket.ds.id
+  versioning_configuration {
+    status = "Disabled"
+  }
 }
 
 data "aws_iam_policy_document" "assume_role_for_ec2" {


### PR DESCRIPTION
The `acl` and `versioning` parameters are deprecated on the `aws_s3_bucket` resource. The docs recommend using `aws_s3_bucket_acl` and `aws_s3_bucket_versioning` resources instead. From what I can gather, this helps with drift detection in Terraform.