### PR TITLE
Rework Graviton selection logic in `databricks_node_type` data source

### DIFF
--- a/clusters/data_node_type.go
+++ b/clusters/data_node_type.go
@@ -178,19 +178,19 @@ func (a ClustersAPI) GetSmallestNodeType(r NodeTypeRequest) string {
 		if r.Category != "" && !strings.EqualFold(nt.Category, r.Category) {
 			continue
 		}
-		if r.IsIOCacheEnabled && nt.IsIOCacheEnabled != r.IsIOCacheEnabled {
+		if r.IsIOCacheEnabled && !nt.IsIOCacheEnabled {
 			continue
 		}
-		if r.SupportPortForwarding && nt.SupportPortForwarding != r.SupportPortForwarding {
+		if r.SupportPortForwarding && !nt.SupportPortForwarding {
 			continue
 		}
-		if r.PhotonDriverCapable && nt.PhotonDriverCapable != r.PhotonDriverCapable {
+		if r.PhotonDriverCapable && !nt.PhotonDriverCapable {
 			continue
 		}
-		if r.PhotonWorkerCapable && nt.PhotonWorkerCapable != r.PhotonWorkerCapable {
+		if r.PhotonWorkerCapable && !nt.PhotonWorkerCapable {
 			continue
 		}
-		if r.Graviton && nt.Graviton != r.Graviton {
+		if nt.Graviton != r.Graviton {
 			continue
 		}
 		return nt.NodeTypeID


### PR DESCRIPTION
The issue is that Graviton nodes were selected even in case when Graviton selector wasn't specified.

This fixes #1973