### PR TITLE
Add Unity Catalog on GCP support

### DIFF
--- a/catalog/resource_metastore_data_access.go
+++ b/catalog/resource_metastore_data_access.go
@@ -37,6 +37,10 @@ type GcpServiceAccountKey struct {
 	PrivateKey   string `json:"private_key" tf:"sensitive"`
 }
 
+type DbGcpServiceAccount struct {
+	Email string `json:"email,omitempty" tf:"computed"`
+}
+
 type DataAccessConfiguration struct {
 	ID                string                 `json:"id,omitempty" tf:"computed"`
 	Name              string                 `json:"name"`
@@ -45,9 +49,10 @@ type DataAccessConfiguration struct {
 	Azure             *AzureServicePrincipal `json:"azure_service_principal,omitempty" tf:"group:access"`
 	AzMI              *AzureManagedIdentity  `json:"azure_managed_identity,omitempty" tf:"group:access"`
 	GcpSAKey          *GcpServiceAccountKey  `json:"gcp_service_account_key,omitempty" tf:"group:access"`
+	DBGcpSA           *DbGcpServiceAccount   `json:"databricks_gcp_service_account,omitempty" tf:"group:access"`
 }
 
-var alofCred = []string{"aws_iam_role", "azure_service_principal", "azure_managed_identity", "gcp_service_account_key"}
+var alofCred = []string{"aws_iam_role", "azure_service_principal", "azure_managed_identity", "gcp_service_account_key", "databricks_gcp_service_account"}
 
 func (a DataAccessConfigurationsAPI) Create(metastoreID string, dac *DataAccessConfiguration) error {
 	path := fmt.Sprintf("/unity-catalog/metastores/%s/data-access-configurations", metastoreID)
@@ -88,6 +93,7 @@ func ResourceMetastoreDataAccess() *schema.Resource {
 			m["azure_service_principal"].AtLeastOneOf = alofCred
 			m["azure_managed_identity"].AtLeastOneOf = alofCred
 			m["gcp_service_account_key"].AtLeastOneOf = alofCred
+			m["databricks_gcp_service_account"].AtLeastOneOf = alofCred
 
 			// suppress changes for private_key
 			m["gcp_service_account_key"].DiffSuppressFunc = SuppressGcpSAKeyDiff

--- a/catalog/resource_storage_credential.go
+++ b/catalog/resource_storage_credential.go
@@ -24,6 +24,7 @@ type StorageCredentialInfo struct {
 	Azure       *AzureServicePrincipal `json:"azure_service_principal,omitempty" tf:"group:access"`
 	AzMI        *AzureManagedIdentity  `json:"azure_managed_identity,omitempty" tf:"group:access"`
 	GcpSAKey    *GcpServiceAccountKey  `json:"gcp_service_account_key,omitempty" tf:"group:access"`
+	DBGcpSA     *DbGcpServiceAccount   `json:"databricks_gcp_service_account,omitempty" tf:"computed"`
 	MetastoreID string                 `json:"metastore_id,omitempty" tf:"computed"`
 }
 
@@ -47,6 +48,7 @@ func ResourceStorageCredential() *schema.Resource {
 			m["azure_service_principal"].AtLeastOneOf = alofCred
 			m["azure_managed_identity"].AtLeastOneOf = alofCred
 			m["gcp_service_account_key"].AtLeastOneOf = alofCred
+			m["databricks_gcp_service_account"].AtLeastOneOf = alofCred
 
 			// suppress changes for private_key
 			m["gcp_service_account_key"].DiffSuppressFunc = SuppressGcpSAKeyDiff

--- a/catalog/resource_storage_credential_test.go
+++ b/catalog/resource_storage_credential_test.go
@@ -272,6 +272,43 @@ func TestUpdateAzStorageCredentials(t *testing.T) {
 	}.ApplyNoError(t)
 }
 
+func TestCreateStorageCredentialWithDbGcpSA(t *testing.T) {
+	qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "POST",
+				Resource: "/api/2.1/unity-catalog/storage-credentials",
+				ExpectedRequest: StorageCredentialInfo{
+					Name:    "a",
+					DBGcpSA: &DbGcpServiceAccount{},
+					Comment: "c",
+				},
+				Response: StorageCredentialInfo{
+					Name: "a",
+				},
+			},
+			{
+				Method:   "GET",
+				Resource: "/api/2.1/unity-catalog/storage-credentials/a",
+				Response: StorageCredentialInfo{
+					Name: "a",
+					DBGcpSA: &DbGcpServiceAccount{
+						Email: "a@example.com",
+					},
+					MetastoreID: "d",
+				},
+			},
+		},
+		Resource: ResourceStorageCredential(),
+		Create:   true,
+		HCL: `
+		name = "a"
+		databricks_gcp_service_account {}
+		comment = "c"
+		`,
+	}.ApplyNoError(t)
+}
+
 func TestUpdateAzStorageCredentialMI(t *testing.T) {
 	qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{

--- a/docs/guides/unity-catalog-gcp.md
+++ b/docs/guides/unity-catalog-gcp.md
@@ -1,0 +1,346 @@
+---
+page_title: "Unity Catalog set up on Google Cloud"
+---
+
+# Deploying pre-requisite resources and enabling Unity Catalog
+
+Databricks Unity Catalog brings fine-grained governance and security to Lakehouse data using a familiar, open interface. You can use Terraform to deploy the underlying cloud resources and Unity Catalog objects automatically, using a programmatic approach.
+
+This guide uses the following variables in configurations:
+
+- `databricks_workspace_url`: Value of `workspace_url` attribute from [databricks_mws_workspaces](../resources/mws_workspaces.md#attribute-reference) resource.
+
+This guide is provided as-is and you can use this guide as the basis for your custom Terraform module.
+
+To get started with Unity Catalog, this guide takes you throw the following high-level steps:
+
+- [Deploying pre-requisite resources and enabling Unity Catalog](#deploying-pre-requisite-resources-and-enabling-unity-catalog)
+  - [Provider initialization](#provider-initialization)
+  - [Configure Google Cloud objects](#configure-google-cloud-objects)
+  - [Create a Unity Catalog metastore and link it to workspaces](#create-a-unity-catalog-metastore-and-link-it-to-workspaces)
+  - [Create Unity Catalog objects in the metastore](#create-unity-catalog-objects-in-the-metastore)
+  - [Configure external tables and credentials](#configure-external-tables-and-credentials)
+  - [Configure Unity Catalog clusters](#configure-unity-catalog-clusters)
+
+## Provider initialization
+
+Initialize the 3 providers to set up the required resources. See [Databricks provider authentication](../index.md#authenticating-with-hostname,-username,-and-password), [Azure AD provider authentication](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs#authenticating-to-azure-active-directory) and [Azure provider authentication](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs#authenticating-to-azure) for more details.
+
+Define the required variables, and calculate the local values
+
+```hcl
+variable "databricks_workspace_url" {}
+
+variable "databricks_workspace_id" {}
+
+variable "location" {}
+
+variable "project" {
+  type    = string
+  default = "<my-project-id>"
+}
+
+//generate a random string as the prefix for GCP resources, to ensure uniqueness
+resource "random_string" "naming" {
+  special = false
+  upper   = false
+  length  = 6
+}
+
+locals {
+  prefix = "unity${random_string.naming.result}"
+}
+```
+
+```hcl
+terraform {
+  required_providers {
+    databricks = {
+      source = "databricks/databricks"
+    }
+    google = {
+      source  = "hashicorp/google"
+    }
+    random = {
+      source = "hashicorp/random"
+    }    
+  }
+}
+
+provider "google" {
+  project = var.project
+}
+
+provider "databricks" {
+  host = var.databricks_workspace_url
+}
+```
+
+## Configure Google Cloud objects
+
+The first step is to create the required Google Cloud objects:
+
+- A GCS bucket which is the default storage location for managed tables in Unity Catalog. Please use a dedicated bucket for each metastore.
+- A service account that provides Unity Catalog permissions to access and manage data in the bucket and a service account key.
+
+```hcl
+resource "google_storage_bucket" "unity_metastore" {
+  name          = "${local.prefix}-metastore"
+  location      = var.location
+  force_destroy = true
+}
+
+resource "google_service_account" "unity_sa" {
+  account_id   = "unity-sa"
+  display_name = "Service Account for Unity Catalog"
+}
+
+resource "google_storage_bucket_iam_member" "unity_sa_admin" {
+  bucket = google_storage_bucket.unity_metastore.name
+  role = "roles/storage.objectAdmin"
+  member = "serviceAccount:${google_service_account.unity_sa.email}"
+}
+
+resource "google_storage_bucket_iam_member" "unity_sa_reader" {
+  bucket = google_storage_bucket.unity_metastore.name
+  role = "roles/storage.legacyBucketReader"
+  member = "serviceAccount:${google_service_account.unity_sa.email}"
+}
+
+resource "google_service_account_key" "mykey" {
+  service_account_id = google_service_account.unity_sa.name
+}
+```
+
+## Create a Unity Catalog metastore and link it to workspaces
+
+A [databricks_metastore](../resources/metastore.md) is the top level container for data in Unity Catalog. You can only create a single metastore for each region in which your organization operates, and attach workspaces to the metastore. Each workspace will have the same view of the data you manage in Unity Catalog.
+
+```hcl
+resource "databricks_metastore" "this" {
+  name          = "primary"
+  storage_root  = "gs://${google_storage_bucket.unity_metastore.name}"
+  force_destroy = true
+}
+
+resource "databricks_metastore_data_access" "first" {
+  metastore_id = databricks_metastore.this.id
+  name         = "the-keys"
+  gcp_service_account_key {
+    email          = google_service_account.unity_sa.email
+    private_key_id = google_service_account_key.mykey.id
+    private_key    = google_service_account_key.mykey.private_key
+  }
+
+  is_default = true
+}
+
+resource "databricks_metastore_assignment" "this" {
+  workspace_id         = var.databricks_workspace_id
+  metastore_id         = databricks_metastore.this.id
+  default_catalog_name = "hive_metastore"
+}
+```
+
+## Create Unity Catalog objects in the metastore
+
+Each metastore exposes a 3-level namespace (catalog-schema-table) by which data can be organized.
+
+```hcl
+resource "databricks_catalog" "sandbox" {
+  metastore_id = databricks_metastore.this.id
+  name         = "sandbox"
+  comment      = "this catalog is managed by terraform"
+  properties = {
+    purpose = "testing"
+  }
+  depends_on = [databricks_metastore_assignment.default_metastore]
+}
+
+resource "databricks_grants" "sandbox" {
+  catalog = databricks_catalog.sandbox.name
+  grant {
+    principal  = "Data Scientists"
+    privileges = ["USAGE", "CREATE"]
+  }
+  grant {
+    principal  = "Data Engineers"
+    privileges = ["USAGE"]
+  }
+}
+
+resource "databricks_schema" "things" {
+  catalog_name = databricks_catalog.sandbox.id
+  name         = "things"
+  comment      = "this database is managed by terraform"
+  properties = {
+    kind = "various"
+  }
+}
+
+resource "databricks_grants" "things" {
+  schema = databricks_schema.things.id
+  grant {
+    principal  = "Data Engineers"
+    privileges = ["USAGE"]
+  }
+}
+```
+
+## Configure external tables and credentials
+
+To work with external tables, Unity Catalog introduces two new objects to access and work with external cloud storage:
+
+- [databricks_storage_credential](../resources/storage_credential.md) represent authentication methods to access cloud storage. Storage credentials are access-controlled to determine which users can use the credential.
+- [databricks_external_location](../resources/external_location.md) are objects that combine a cloud storage path with a Storage Credential that can be used to access the location.
+
+First, create the required objects in GCP.
+
+```hcl
+resource "google_storage_bucket" "ext_bucket" {
+  name          = "${local.prefix}-ext-bucket"
+  location      = var.location
+  force_destroy = true
+}
+
+resource "google_service_account" "unity_credential" {
+  account_id   = "unity-credential"
+  display_name = "Service Account for Unity Catalog"
+}
+
+resource "google_storage_bucket_iam_member" "unity_cred_admin" {
+  bucket = google_storage_bucket.unity_metastore.name
+  role = "roles/storage.objectAdmin"
+  member = "serviceAccount:${google_service_account.unity_credential.email}"
+}
+
+resource "google_storage_bucket_iam_member" "unity_cred_reader" {
+  bucket = google_storage_bucket.unity_metastore.name
+  role = "roles/storage.legacyBucketReader"
+  member = "serviceAccount:${google_service_account.unity_credential.email}"
+}
+
+resource "google_service_account_key" "my_cred_key" {
+  service_account_id = google_service_account.unity_credential.name
+}
+```
+
+Then create the [databricks_storage_credential](../resources/storage_credential.md) and [databricks_external_location](../resources/external_location.md) in Unity Catalog.
+
+```hcl
+resource "databricks_storage_credential" "external" {
+  name = google_service_account.unity_credential.name
+
+  gcp_service_account_key {
+    email          = google_service_account.unity_credential.email
+    private_key_id = google_service_account_key.my_cred_key.id
+    private_key    = google_service_account_key.my_cred_key.private_key
+  }
+  comment = "Managed by TF"
+  depends_on = [
+    databricks_metastore_assignment.this
+  ]
+}
+
+resource "databricks_grants" "external_creds" {
+  storage_credential = databricks_storage_credential.external.id
+  grant {
+    principal  = "Data Engineers"
+    privileges = ["CREATE_TABLE"]
+  }
+}
+
+resource "databricks_external_location" "some" {
+  name = "external"
+  url = "gs://${google_storage_bucket.ext_bucket.name}"
+
+  credential_name = databricks_storage_credential.external.id
+  comment         = "Managed by TF"
+  depends_on = [
+    databricks_metastore_assignment.this
+  ]
+}
+
+resource "databricks_grants" "some" {
+  external_location = databricks_external_location.some.id
+  grant {
+    principal  = "Data Engineers"
+    privileges = ["CREATE_TABLE", "READ_FILES"]
+  }
+}
+```
+
+## Configure Unity Catalog clusters
+
+To ensure the integrity of ACLs, Unity Catalog data can be accessed only through compute resources configured with strong isolation guarantees and other security features. A Unity Catalog [databricks_cluster](../resources/cluster.md) has a  ‘Security Mode’ set to either **User Isolation** or **Single User**.
+
+- **User Isolation** clusters can be shared by multiple users, but only Python (using DBR>=11.1) and SQL languages are allowed. Some advanced cluster features such as library installation, init scripts and the DBFS Fuse mount are also disabled in this mode to ensure security isolation among cluster users.
+
+```hcl
+data "databricks_spark_version" "latest" {
+}
+data "databricks_node_type" "smallest" {
+  local_disk = true
+}
+
+resource "databricks_cluster" "unity_sql" {
+  cluster_name            = "Unity SQL"
+  spark_version           = data.databricks_spark_version.latest.id
+  node_type_id            = data.databricks_node_type.smallest.id
+  autotermination_minutes = 60
+  enable_elastic_disk     = false
+  num_workers             = 2
+  azure_attributes {
+    availability = "SPOT"
+  }
+  data_security_mode = "USER_ISOLATION"
+  # need to wait until the metastore is assigned
+  depends_on = [
+    databricks_metastore_assignment.this
+  ]
+}
+```
+
+- To use those advanced cluster features or languages like Machine Learning Runtime, Streaming, Scala and R with Unity Catalog, one must choose **Single User** mode when launching the cluster. The cluster can only be used exclusively by a single user (by default the owner of the cluster); other users are not allowed to attach to the cluster.
+The below example will create a collection of single-user [databricks_cluster](../resources/cluster.md) for each user in a group managed through SCIM provisioning. Individual user will be able to restart their cluster, but not anyone else. Terraform's `for_each` meta-attribute will help us achieve this.
+
+First we use [databricks_group](../data-sources/group.md) and [databricks_user](../data-sources/user.md) data resources to get the list of user names that belong to a group.
+
+```hcl
+data "databricks_group" "dev" {
+  display_name = "dev-clusters"
+}
+
+data "databricks_user" "dev" {
+  for_each = data.databricks_group.dev.members
+  user_id  = each.key
+}
+```
+
+Once we have a specific list of user resources, we could proceed creating single-user clusters and provide permissions with `for_each = data.databricks_user.dev` to ensure it's done for each user:
+
+```hcl
+resource "databricks_cluster" "dev" {
+  for_each                = data.databricks_user.dev
+  cluster_name            = "${each.value.display_name} unity cluster"
+  spark_version           = data.databricks_spark_version.latest.id
+  node_type_id            = data.databricks_node_type.smallest.id
+  autotermination_minutes = 10
+  num_workers             = 2
+  data_security_mode = "SINGLE_USER"
+  single_user_name   = each.value.user_name
+  # need to wait until the metastore is assigned
+  depends_on = [
+    databricks_metastore_assignment.this
+  ]
+}
+
+resource "databricks_permissions" "dev_restart" {
+  for_each   = data.databricks_user.dev
+  cluster_id = databricks_cluster.dev[each.key].cluster_id
+  access_control {
+    user_name        = each.value.user_name
+    permission_level = "CAN_RESTART"
+  }
+}
+```

--- a/docs/resources/external_location.md
+++ b/docs/resources/external_location.md
@@ -74,12 +74,29 @@ resource "databricks_grants" "some" {
 }
 ```
 
+For GCP
+
+```hcl
+resource "databricks_storage_credential" "ext" {
+  name = "the-creds"
+  databricks_gcp_service_account {}
+}
+
+resource "databricks_external_location" "some" {
+  name = "the-ext-location"
+  url  = "gs://${google_storage_bucket.ext_bucket.name}"
+
+  credential_name = databricks_storage_credential.ext.id
+  comment         = "Managed by TF"
+}
+```
+
 ## Argument Reference
 
 The following arguments are required:
 
 - `name` - Name of External Location, which must be unique within the [databricks_metastore](metastore.md). Change forces creation of a new resource.
-- `url` - Path URL in cloud storage, of the form: `s3://[bucket-host]/[bucket-dir]` (AWS), `abfss://[user]@[host]/[path]` (Azure).
+- `url` - Path URL in cloud storage, of the form: `s3://[bucket-host]/[bucket-dir]` (AWS), `abfss://[user]@[host]/[path]` (Azure), `gs://[bucket-host]/[bucket-dir]` (GCP).
 - `credential_name` - Name of the [databricks_storage_credential](storage_credential.md) to use with this External Location.
 - `owner` - (Optional) Username/groupname/sp application_id of the external Location owner.
 - `comment` - (Optional) User-supplied free-form text.

--- a/docs/resources/metastore_data_access.md
+++ b/docs/resources/metastore_data_access.md
@@ -94,6 +94,10 @@ The following arguments are required:
 
 * `access_connector_id` - The Resource ID of the Azure Databricks Access Connector resource, of the form `/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-name/providers/Microsoft.Databricks/accessConnectors/connector-name`
 
+`databricks_gcp_service_account` optional configuration block for creating a Databricks-managed GCP Service Account:
+
+* `email` (output only) - The email of the GCP service account created, to be granted access to relevant buckets.
+
 ## Import
 
 -> **Note** Importing this resource is not currently supported.

--- a/docs/resources/storage_credential.md
+++ b/docs/resources/storage_credential.md
@@ -33,28 +33,29 @@ resource "databricks_grants" "external_creds" {
 For Azure
 
 ```hcl
-data "azurerm_resource_group" "this" {
-  name = "example-rg"
-}
-
-resource "azurerm_databricks_access_connector" "example" {
-  name                = "databrickstest"
-  resource_group_name = azurerm_resource_group.this.name
-  location            = azurerm_resource_group.this.location
-  identity {
-    type = "SystemAssigned"
-  }
-  tags = {
-    Environment = "Production"
-  }
-}
-
 resource "databricks_storage_credential" "external_mi" {
   name = "mi_credential"
   azure_managed_identity {
     access_connector_id = azurerm_databricks_access_connector.example.id
   }
   comment = "Managed identity credential managed by TF"
+}
+
+resource "databricks_grants" "external_creds" {
+  storage_credential = databricks_storage_credential.external.id
+  grant {
+    principal  = "Data Engineers"
+    privileges = ["CREATE_TABLE"]
+  }
+}
+```
+
+For GCP
+
+```hcl
+resource "databricks_storage_credential" "external" {
+  name = "the-creds"
+  databricks_gcp_service_account {}
 }
 
 resource "databricks_grants" "external_creds" {
@@ -73,7 +74,6 @@ The following arguments are required:
 - `name` - Name of Storage Credentials, which must be unique within the [databricks_metastore](metastore.md). Change forces creation of a new resource.
 - `owner` - (Optional) Username/groupname/sp application_id of the storage credential owner.
 
-
 `aws_iam_role` optional configuration block for credential details for AWS:
 
 - `role_arn` - The Amazon Resource Name (ARN) of the AWS IAM role for S3 data access, of the form `arn:aws:iam::1234567890:role/MyRole-AJJHDSKSDF`
@@ -87,6 +87,10 @@ The following arguments are required:
 - `directory_id` - The directory ID corresponding to the Azure Active Directory (AAD) tenant of the application
 - `application_id` - The application ID of the application registration within the referenced AAD tenant
 - `client_secret` - The client secret generated for the above app ID in AAD. **This field is redacted on output**
+
+`databricks_gcp_service_account` optional configuration block for creating a Databricks-managed GCP Service Account:
+
+- `email` (output only) - The email of the GCP service account created, to be granted access to relevant buckets.
 
 ## Import
 


### PR DESCRIPTION
- Add support for `databricks_gcp_service_account` attribute for `databricks_storage_credential` and `databricks_metastore_data_access` resources
- Update docs for UC resources to highlight GCP-equivalent syntax
- Adds a user guide for Unity Catalog on GCP