### PR TITLE
1. Add support for gcp cmk

### DIFF
--- a/docs/guides/gcp-workspace.md
+++ b/docs/guides/gcp-workspace.md
@@ -90,7 +90,7 @@ After you’ve added Service Account to Databricks Accounts Console, please copy
 
 Databricks account-level APIs can only be called by account owners and account admins, and can only be authenticated using Google-issued OIDC tokens. The simplest way to do this would be via [Google Cloud CLI](https://cloud.google.com/sdk/gcloud). The `gcloud` command is available after installing the SDK. Then run the following commands
 
-* `gcloud auth application-default login` to authorise your user with Google Cloud Platform.
+* `gcloud auth application-default login` to authorise your user with Google Cloud Platform. (If you want to use your [service account's credentials instead](https://cloud.google.com/docs/authentication/provide-credentials-adc#local-key), set the environment variable `GOOGLE_APPLICATION_CREDENTIALS` to the path of the JSON file that contains your service account key)
 * `terraform init` to load Google and Databricks Terraform providers.
 * `terraform apply` to apply the configuration changes. Terraform will use your credential to impersonate the service account specified in `databricks_google_service_account` to call the Databricks account-level API.
 

--- a/internal/acceptance/mws_customer_managed_keys_test.go
+++ b/internal/acceptance/mws_customer_managed_keys_test.go
@@ -17,7 +17,7 @@ func TestMwsAccAwsCustomerManagedKeys(t *testing.T) {
 	})
 }
 
-func TestGcpaAccCustomerManagedKeysForStorage(t *testing.T) {
+func TestMwsAccGcpCustomerManagedKeysForStorage(t *testing.T) {
 	accountLevel(t, step{
 		Template: `provider "databricks" {
 				host     = "{env.DATABRICKS_HOST}"

--- a/internal/acceptance/mws_customer_managed_keys_test.go
+++ b/internal/acceptance/mws_customer_managed_keys_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 )
 
-func TestMwsAccCustomerManagedKeys(t *testing.T) {
+func TestMwsAccAwsCustomerManagedKeys(t *testing.T) {
 	accountLevel(t, step{
 		Template: `resource "databricks_mws_customer_managed_keys" "this" {
 			account_id   = "{env.DATABRICKS_ACCOUNT_ID}"
@@ -14,5 +14,20 @@ func TestMwsAccCustomerManagedKeys(t *testing.T) {
 			}
 			use_cases = ["MANAGED_SERVICES"]
 		}`,
+	})
+}
+
+func TestGcpaAccCustomerManagedKeysForStorage(t *testing.T) {
+	accountLevel(t, step{
+		Template: `provider "databricks" {
+				host     = "{env.DATABRICKS_HOST}"
+			}
+			resource "databricks_mws_customer_managed_keys" "this" {
+				account_id   = "{env.DATABRICKS_ACCOUNT_ID}"
+				gcp_key_info {
+					kms_key_id   = "{env.TEST_GCP_KMS_KEY_ID}"
+				}
+				use_cases = ["STORAGE"]
+			}`,
 	})
 }

--- a/internal/acceptance/mws_customer_managed_keys_test.go
+++ b/internal/acceptance/mws_customer_managed_keys_test.go
@@ -19,10 +19,7 @@ func TestMwsAccAwsCustomerManagedKeys(t *testing.T) {
 
 func TestMwsAccGcpCustomerManagedKeysForStorage(t *testing.T) {
 	accountLevel(t, step{
-		Template: `provider "databricks" {
-				host     = "{env.DATABRICKS_HOST}"
-			}
-			resource "databricks_mws_customer_managed_keys" "this" {
+		Template: `resource "databricks_mws_customer_managed_keys" "this" {
 				account_id   = "{env.DATABRICKS_ACCOUNT_ID}"
 				gcp_key_info {
 					kms_key_id   = "{env.TEST_GCP_KMS_KEY_ID}"

--- a/mws/resource_mws_customer_managed_keys.go
+++ b/mws/resource_mws_customer_managed_keys.go
@@ -17,10 +17,17 @@ type AwsKeyInfo struct {
 	KeyRegion string `json:"key_region,omitempty" tf:"computed"`
 }
 
+// GcpKeyInfo has information about the KMS key for BYOK
+type GcpKeyInfo struct {
+	KmsKeyId string `json:"kms_key_id"`
+}
+
 // CustomerManagedKey contains key information and metadata for BYOK for E2
+// You must specify either AwsKeyInfo for AWS or GcpKeyInfo for GCP, but not both
 type CustomerManagedKey struct {
 	CustomerManagedKeyID string      `json:"customer_managed_key_id,omitempty" tf:"computed"`
-	AwsKeyInfo           *AwsKeyInfo `json:"aws_key_info" tf:"force_new"`
+	AwsKeyInfo           *AwsKeyInfo `json:"aws_key_info,omitempty" tf:"force_new,conflicts:gcp_key_info"`
+	GcpKeyInfo           *GcpKeyInfo `json:"gcp_key_info,omitempty" tf:"force_new,conflicts:aws_key_info"`
 	AccountID            string      `json:"account_id" tf:"force_new"`
 	CreationTime         int64       `json:"creation_time,omitempty" tf:"computed"`
 	UseCases             []string    `json:"use_cases"`


### PR DESCRIPTION
Tested acceptance test by running `bash-3.2$ scripts/run.sh gcp-accounts 'TestGcpaAccCustomerManagedKeysForStorage' --debug --tee` -
```


3 tf_rpc=ApplyResourceChange
2023-02-16T17:10:32.183-0800 [TRACE] sdk.helper_schema: Calling downstream: tf_resource_type=databricks_mws_customer_managed_keys tf_req_id=d4d9dd50-0291-96e6-a6b4-32e2ae934e85 tf_provider_addr=registry.terraform.io/hashicorp/databricks tf_rpc=ApplyResourceChange
2023/02/16 17:10:32 [INFO] Configured google-accounts auth: host=https://accounts.staging.gcp.databricks.com, account_id=9fcbb245-7c44-4522-9870-e38324104cf8, google_service_account=rohansa2-staging@databricks-staging-customer.iam.gserviceaccount.com
2023/02/16 17:10:33 [DEBUG] POST /api/2.0/accounts/9fcbb245-7c44-4522-9870-e38324104cf8/customer-managed-keys {
  "account_id": "9fcbb245-7c44-4522-9870-e38324104cf8",
  "gcp_key_info": {
    "kms_key_id": "projects/databricks-staging-customer/locations/us-central1/keyRings/cmk-qa/cryptoKeys/cmk-qa-key"
  },
  "use_cases": [
    "STORAGE"
  ]
}
2023/02/16 17:10:34 [DEBUG] 201 Created  {
  "account_id": "9fcbb245-7c44-4522-9870-e38324104cf8",
  "creation_time": 1676596234145,
  "customer_managed_key_id": "77b97eae-24eb-422e-90ed-f36f1540acc5",
  "gcp_key_info": {
    "kms_key_id": "projects/databricks-staging-customer/locations/us-central1/keyRings/cmk-qa/cryptoKeys/cmk-qa-key"
  },
  "updated_time": 1676596234145,
  "use_cases": [
    "STORAGE"
  ]
} <- POST /api/2.0/accounts/9fcbb245-7c44-4522-9870-e38324104cf8/customer-managed-keys
2023/02/16 17:10:34 [DEBUG] GET /api/2.0/accounts/9fcbb245-7c44-4522-9870-e38324104cf8/customer-managed-keys/77b97eae-24eb-422e-90ed-f36f1540acc5
2023/02/16 17:10:34 [DEBUG] 200 OK  {
  "account_id": "9fcbb245-7c44-4522-9870-e38324104cf8",
  "creation_time": 1676596234145,
  "customer_managed_key_id": "77b97eae-24eb-422e-90ed-f36f1540acc5",
  "gcp_key_info": {
    "kms_key_id": "projects/databricks-staging-customer/locations/us-central1/keyRings/cmk-qa/cryptoKeys/cmk-qa-key"
  },
  "updated_time": 1676596234145,
  "use_cases": [
    "STORAGE"
  ]
} <- GET /api/2.0/accounts/9fcbb245-7c44-4522-9870-e38324104cf8/customer-managed-keys/77b97eae-24eb-422e-90ed-f36f1540acc5
2023-02-16T17:10:34.609-0800 [TRACE] sdk.helper_schema: Called downstream: tf_provider_addr=registry.terraform.io/hashicorp/databricks tf_rpc=ApplyResourceChange tf_resource_type=databricks_mws_customer_managed_keys tf_req_id=d4d9dd50-0291-96e6-a6b4-32e2ae934e85
```