### PR TITLE
[DOC] Fix job datasource docs

### DIFF
--- a/docs/data-sources/job.md
+++ b/docs/data-sources/job.md
@@ -27,7 +27,7 @@ output "job_num_workers" {
 This data source exports the following attributes:
 
 
-* `id` - the id of [databricks_job](../resources/job.md) if the resource was matched by name.
+* `job_id` - the id of [databricks_job](../resources/job.md) if the resource was matched by name.
 * `name` - the job name of [databricks_job](../resources/job.md) if the resource was matched by id.
 * `job_settings` - the same fields as in [databricks_job](../resources/job.md).
 

--- a/docs/data-sources/job.md
+++ b/docs/data-sources/job.md
@@ -27,7 +27,7 @@ output "job_num_workers" {
 This data source exports the following attributes:
 
 
-* `job_id` - the id of [databricks_job](../resources/job.md) if the resource was matched by name.
+* `id` - the id of [databricks_job](../resources/job.md) if the resource was matched by name.
 * `name` - the job name of [databricks_job](../resources/job.md) if the resource was matched by id.
 * `job_settings` - the same fields as in [databricks_job](../resources/job.md).
 

--- a/docs/resources/job.md
+++ b/docs/resources/job.md
@@ -221,6 +221,7 @@ resource "databricks_job" "sql_aggregation_job" {
 
 In addition to all arguments above, the following attributes are exported:
 
+* `id` - ID of the job
 * `url` - URL of the job on the given workspace
 
 ## Access Control


### PR DESCRIPTION
Addresses #1986

- As explained in the issue, in the output of the data source `databricks_job`, the attribute containing the job ID is `job_id` and not `id`. This PR fixes that.
- Additionally, I saw that in the Databricks resource `databricks_job`, in the list of "additionally" exported values, only `url` is listed. Since the job ID is the most important exported attribute (it is needed for any permission that you may want to apply later) I also added `id` to the list of exported attributes. 

**Note:** There is an inconsistency in the job ID naming, since in the data source response the ID is under the attribute `job_id` and in the resource it is under `id`. This is quite confusing.