### PR TITLE
Feature/add metastore datasource

### DIFF
--- a/catalog/data_metastores.go
+++ b/catalog/data_metastores.go
@@ -1,0 +1,37 @@
+package catalog
+
+import (
+	"context"
+
+	"github.com/databricks/terraform-provider-databricks/common"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func DataSourceMetastores() *schema.Resource {
+	return common.DataResource(MetastoreInfo{}, func(ctx context.Context, e any, c *common.DatabricksClient) error {
+		data := e.(*MetastoreInfo)
+		metastoresAPI := NewMetastoresAPI(ctx, c)
+		metastores, err := metastoresAPI.listMetastores()
+		if err != nil {
+			return err
+		}
+		for _, v := range metastores.Metastores {
+			data.Name = append(data.Name, v.name)
+			data.StorageRoot = append(data.StorageRoot, v.storage_root)
+			data.DefaultDacID = append(data.DefaultDacID, v.default_data_access_config_id)
+			data.Owner = append(data.Owner, v.owner)
+			data.MetastoreID = append(data.MetastoreID, v.metastore_id)
+			data.Region = append(data.Region, v.region)
+			data.Cloud = append(data.Cloud, v.cloud)
+			data.GlobalMetastoreId = append(data.GlobalMetastoreId, v.global_metastore_id)
+			data.CreatedAt = append(data.CreatedAt, v.created_at)
+			data.CreatedBy = append(data.CreatedBy, v.created_by)
+			data.UpdatedAt = append(data.UpdatedAt, v.updated_at)
+			data.UpdatedBy = append(data.UpdatedBy, v.updated_by)
+			data.DeltaSharingScope = append(data.DeltaSharingScope, v.delta_sharing_scope)
+			data.DeltaSharingRecipientTokenLifetimeInSeconds = append(data.DeltaSharingRecipientTokenLifetimeInSeconds, v.delta_sharing_recipient_token_lifetime_in_seconds)
+			data.DeltaSharingOrganizationName = (data.DeltaSharingOrganizationName, v.delta_sharing_organization_name)
+		}
+		return nil
+	})
+}

--- a/catalog/data_metastores_test.go
+++ b/catalog/data_metastores_test.go
@@ -1,0 +1,53 @@
+package catalog
+
+import (
+	"testing"
+
+	"github.com/databricks/terraform-provider-databricks/qa"
+)
+
+func TestMetastoresData(t *testing.T) {
+	qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "GET",
+				Resource: "/api/2.1/unity-catalog/metastores",
+				Response: Metastores{
+					Metastores: []MetastoreInfo{
+						{
+							Name: "a",
+							StorageRoot: "",
+							DefaultDacID: "",
+							Owner: "",
+							MetastoreID: "",
+							Region: "",
+							Cloud: "",
+							GlobalMetastoreId: "",
+							CreatedAt: 0,
+							CreatedBy: "",
+							UpdatedAt: 0,
+							UpdatedBy: "",
+							DeltaSharingScope: "",
+							DeltaSharingRecipientTokenLifetimeInSeconds: 0,
+							DeltaSharingOrganizationName: "",
+						},
+					},
+				},
+			},
+		},
+		Resource:    DataSourceMetastores(),
+		Read:        true,
+		NonWritable: true,
+		ID:          "_",
+	}.ApplyNoError(t)
+}
+
+func TestMetastoresData_Error(t *testing.T) {
+	qa.ResourceFixture{
+		Fixtures:    qa.HTTPFailures,
+		Resource:    DataSourceMetastores(),
+		Read:        true,
+		NonWritable: true,
+		ID:          "_",
+	}.ExpectError(t, "I'm a teapot")
+}

--- a/catalog/resource_metastore.go
+++ b/catalog/resource_metastore.go
@@ -43,10 +43,10 @@ type CreateMetastore struct {
 	StorageRoot string `json:"storage_root"`
 }
 
-// func (a MetastoresAPI) listMetastores() (mis []MetastoreInfo, err error) {
-// 	err = a.client.Get(a.context, "/unity-catalog/metastores", nil, &mis)
-// 	return
-// }
+func (a MetastoresAPI) listMetastores() (mis []MetastoreInfo, err error) {
+	err = a.client.Get(a.context, "/unity-catalog/metastores", nil, &mis)
+	return
+}
 
 func (a MetastoresAPI) createMetastore(cm CreateMetastore) (mi MetastoreInfo, err error) {
 	err = a.client.Post(a.context, "/unity-catalog/metastores", cm, &mi)

--- a/docs/data-sources/metastores.md
+++ b/docs/data-sources/metastores.md
@@ -1,0 +1,33 @@
+---
+subcategory: "Unity Catalog"
+---
+# databricks_metastores Data Source
+
+-> **Note** If you have a fully automated setup with workspaces created by [databricks_mws_workspaces](../resources/mws_workspaces.md) or [azurerm_databricks_workspace](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/databricks_workspace), please make sure to add [depends_on attribute](../index.md#data-resources-and-authentication-is-not-configured-errors) in order to prevent _authentication is not configured for provider_ errors.
+
+Retrieves a list of [databricks_metastore](../resources/metastore.md) objects, that were created by Terraform or manually, so that special handling could be applied.
+
+## Example Usage
+
+Listing all catalogs:
+
+```hcl
+data "databricks_metastores" "all" {}
+
+output "all_metastores" {
+  value = data.databricks_metastores.all
+}
+```
+
+## Attribute Reference
+
+This data source exports the following attributes:
+
+* `metastores` - list of [databricks_metastore](../resources/share.md)
+
+## Related Resources
+
+The following resources are used in the same context:
+
+* [databricks_metastore](../resources/metastore.md) to manage Metastores within Unity Catalog.
+* [databricks_catalog](../resources/catalog.md) to manage catalogs within Unity Catalog.


### PR DESCRIPTION
Addresses #1651

This PR would enable users to retrieve existing metastores, which will allow them to get the needed ID of a Metastore by name. This ID can then be used to assign a metastore to a workspace, without the need of hardcoding an ID for different workspace deployments.