### PR TITLE
resource_workspace_conf Delete: only reset enable and enforce properties

### DIFF
--- a/workspace/resource_workspace_conf.go
+++ b/workspace/resource_workspace_conf.go
@@ -106,6 +106,7 @@ func ResourceWorkspaceConf() *schema.Resource {
 			for k, v := range config {
 				if !strings.HasPrefix(k, "enable") && !strings.HasPrefix(k, "enforce") {
 					log.Printf("[DEBUG] Skip erasing configuration of %s", k)
+					delete(config, k)
 					continue
 				}
 				switch r := v.(type) {

--- a/workspace/resource_workspace_conf.go
+++ b/workspace/resource_workspace_conf.go
@@ -104,6 +104,10 @@ func ResourceWorkspaceConf() *schema.Resource {
 		Delete: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
 			config := d.Get("custom_config").(map[string]any)
 			for k, v := range config {
+				if !strings.HasPrefix(k, "enable") && !strings.HasPrefix(k, "enforce") {
+					log.Printf("[DEBUG] Skip erasing configuration of %s", k)
+					continue
+				}
 				switch r := v.(type) {
 				default:
 					config[k] = ""

--- a/workspace/resource_workspace_conf_test.go
+++ b/workspace/resource_workspace_conf_test.go
@@ -184,7 +184,6 @@ func TestWorkspaceConfDelete(t *testing.T) {
 					"enableFancyThing":     "false",
 					"enableSomething":      "false",
 					"enforceSomethingElse": "false",
-					"someProperty":         "",
 				},
 			},
 		},
@@ -192,7 +191,7 @@ func TestWorkspaceConfDelete(t *testing.T) {
 			enableSomething = true
 			enforceSomethingElse = "true"
 			enableFancyThing = "false"
-			someProperty = "thing"
+			someProperty = "does-not-start-with-enable-or-enforce"
 		}`,
 		Resource: ResourceWorkspaceConf(),
 		Delete:   true,


### PR DESCRIPTION
Make the code aligned with the documentation: https://registry.terraform.io/providers/databricks/databricks/latest/docs/resources/workspace_conf#argument-reference

PR for Issue: #1802 (remove a workspace with a non-enable/enforce setting)