### PR TITLE
Release v1.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Version changelog
 
+### 1.10.0
+
+ * Added new attribute to [databricks_job](https://registry.terraform.io/providers/databricks/databricks/latest/docs/resources/job) resource ([#1988](https://github.com/databricks/terraform-provider-databricks/pull/1988)).
+ * Added `history_data_sharing_status`, `partition` and `status` fields to [databricks_share](https://registry.terraform.io/providers/databricks/databricks/latest/docs/resources/share) ([#2013](https://github.com/databricks/terraform-provider-databricks/pull/2013)).
+ * Added `start_version` and `cdf_enabled` support for [databricks_share](https://registry.terraform.io/providers/databricks/databricks/latest/docs/resources/share) ([#2007](https://github.com/databricks/terraform-provider-databricks/pull/2007)).
+ * Fixed [databricks_share](https://registry.terraform.io/providers/databricks/databricks/latest/docs/resources/share) update logic ([#2022](https://github.com/databricks/terraform-provider-databricks/pull/2022)).
+ * Updated GCP guide with new permissions required to deploy [databricks_mws_networks](https://registry.terraform.io/providers/databricks/databricks/latest/docs/resources/mws_networks) ([#1999](https://github.com/databricks/terraform-provider-databricks/pull/1999)).
+ * Minor doc changes to address [#1916](https://github.com/databricks/terraform-provider-databricks/issues/1916), [#1937](https://github.com/databricks/terraform-provider-databricks/issues/1937), [#2010](https://github.com/databricks/terraform-provider-databricks/issues/2010) ([#2012](https://github.com/databricks/terraform-provider-databricks/pull/2012)).
+ * Various documentation improvements ([#1981](https://github.com/databricks/terraform-provider-databricks/pull/1981), [#1998](https://github.com/databricks/terraform-provider-databricks/pull/1998), [#2002](https://github.com/databricks/terraform-provider-databricks/pull/2002), [#2016](https://github.com/databricks/terraform-provider-databricks/pull/2016), [#2019](https://github.com/databricks/terraform-provider-databricks/pull/2019)).
+ * Integration testing improvements ([#1935](https://github.com/databricks/terraform-provider-databricks/pull/1935), [#2024](https://github.com/databricks/terraform-provider-databricks/pull/2024)).
+
+Updated dependency versions:
+
+ * Migrate client and configuration layer to `github.com/databricks/databricks-sdk-go` ([#1848](https://github.com/databricks/terraform-provider-databricks/pull/1848)).
+ * Removed unused `github.com/Azure/go-autorest/autorest` and `github.com/mitchellh/go-homedir` ([#2026](https://github.com/databricks/terraform-provider-databricks/pull/2026)).
+ * Bump Go from 1.18 to 1.19 ([#2029](https://github.com/databricks/terraform-provider-databricks/pull/2029)).
+ * Bump CodeQL to v2 ([#2027](https://github.com/databricks/terraform-provider-databricks/pull/2027)).
+ * Bump github.com/golang-jwt/jwt/v4 from 4.4.3 to 4.5.0 ([#2030](https://github.com/databricks/terraform-provider-databricks/pull/2030)).
+ * Bump github.com/hashicorp/hcl/v2 from 2.15.0 to 2.16.1 ([#1971](https://github.com/databricks/terraform-provider-databricks/pull/1971), [#1997](https://github.com/databricks/terraform-provider-databricks/pull/1997)).
+ * Bump github.com/hashicorp/terraform-plugin-sdk/v2 from 2.24.1 to 2.25.0 ([#2031](https://github.com/databricks/terraform-provider-databricks/pull/2031)).
+ * Bump golang.org/x/mod from 0.7.0 to 0.8.0 ([#1996](https://github.com/databricks/terraform-provider-databricks/pull/1996)).
+ * Bump golang.org/x/net from 0.6.0 to 0.7.0 ([#2028](https://github.com/databricks/terraform-provider-databricks/pull/2028)).
+ * Bump google.golang.org/api from 0.108.0 to 0.110.0 ([#1984](https://github.com/databricks/terraform-provider-databricks/pull/1984), [#1995](https://github.com/databricks/terraform-provider-databricks/pull/1995)).
+
 ### 1.9.2
 
  * Added `file` library type to [databricks_pipeline](https://registry.terraform.io/providers/databricks/databricks/latest/docs/resources/pipeline) resource ([#1975](https://github.com/databricks/terraform-provider-databricks/pull/1975)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### 1.10.0
 
+ * Migrated client and configuration layer to [`github.com/databricks/databricks-sdk-go`](http://github.com/databricks/databricks-sdk-go) ([#1848](https://github.com/databricks/terraform-provider-databricks/pull/1848)).
  * Added new attribute to [databricks_job](https://registry.terraform.io/providers/databricks/databricks/latest/docs/resources/job) resource ([#1988](https://github.com/databricks/terraform-provider-databricks/pull/1988)).
  * Added `history_data_sharing_status`, `partition` and `status` fields to [databricks_share](https://registry.terraform.io/providers/databricks/databricks/latest/docs/resources/share) ([#2013](https://github.com/databricks/terraform-provider-databricks/pull/2013)).
  * Added `start_version` and `cdf_enabled` support for [databricks_share](https://registry.terraform.io/providers/databricks/databricks/latest/docs/resources/share) ([#2007](https://github.com/databricks/terraform-provider-databricks/pull/2007)).
@@ -13,7 +14,6 @@
 
 Updated dependency versions:
 
- * Migrate client and configuration layer to `github.com/databricks/databricks-sdk-go` ([#1848](https://github.com/databricks/terraform-provider-databricks/pull/1848)).
  * Removed unused `github.com/Azure/go-autorest/autorest` and `github.com/mitchellh/go-homedir` ([#2026](https://github.com/databricks/terraform-provider-databricks/pull/2026)).
  * Bump Go from 1.18 to 1.19 ([#2029](https://github.com/databricks/terraform-provider-databricks/pull/2029)).
  * Bump CodeQL to v2 ([#2027](https://github.com/databricks/terraform-provider-databricks/pull/2027)).

--- a/common/version.go
+++ b/common/version.go
@@ -3,7 +3,7 @@ package common
 import "context"
 
 var (
-	version = "1.9.2"
+	version = "1.10.0"
 	// ResourceName is resource name without databricks_ prefix
 	ResourceName contextKey = 1
 	// Provider is the current instance of provider

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ description: Terraform provider for the Databricks Lakehouse platform
 
 # Databricks Provider
 
-Use the Databricks Terraform provider to interact with almost all of [Databricks](http://databricks.com/) resources. If you're new to Databricks, please follow guide to create a workspace on [Azure](guides/azure-workspace.md) or [AWS](guides/aws-workspace.md) and then this [workspace management](guides/workspace-management.md) tutorial. If you're migrating from version *0.3.x*, please follow [this guide](guides/migration-0.4.x.md). Changelog is available [on GitHub](https://github.com/databricks/terraform-provider-databricks/blob/master/CHANGELOG.md).
+Use the Databricks Terraform provider to interact with almost all of [Databricks](http://databricks.com/) resources. If you're new to Databricks, please follow guide to create a workspace on [Azure](guides/azure-workspace.md) or [AWS](guides/aws-workspace.md) and then this [workspace management](guides/workspace-management.md) tutorial. Changelog is available [on GitHub](https://github.com/databricks/terraform-provider-databricks/blob/master/CHANGELOG.md).
 
 ![Resources](https://github.com/databricks/terraform-provider-databricks/raw/master/docs/resources.png)
 
@@ -201,7 +201,7 @@ Alternatively, you can provide this value as an environment variable `DATABRICKS
 * `profile` - (optional) Connection profile specified within ~/.databrickscfg. Please check [connection profiles section](https://docs.databricks.com/dev-tools/cli/index.html#connection-profiles) for more details. This field defaults to
 `DEFAULT`.
 * `account_id` - (optional) Account Id that could be found in the bottom left corner of [Accounts Console](https://accounts.cloud.databricks.com/). Alternatively, you can provide this value as an environment variable `DATABRICKS_ACCOUNT_ID`. Only has effect when `host = "https://accounts.cloud.databricks.com/"`, and is currently used to provision account admins via [databricks_user](resources/user.md). In the future releases of the provider this property will also be used specify account for `databricks_mws_*` resources as well.
-* `auth_type` - (optional) enforce specific auth type to be used in very rare cases, where a single Terraform state manages Databricks workspaces on more than one cloud and `More than one authorization method configured` error is a false positive. Valid values are `pat`, `basic`, `azure-client-secret`, `azure-msi`, `azure-cli`, `google-creds`, `google-accounts`, `google-workspace` and `databricks-cli`.
+* `auth_type` - (optional) enforce specific auth type to be used in very rare cases, where a single Terraform state manages Databricks workspaces on more than one cloud and `more than one authorization method configured` error is a false positive. Valid values are `pat`, `basic`, `azure-client-secret`, `azure-msi`, `azure-cli`, `google-credentials`, and `google-id`.
 
 ## Special configurations for Azure
 
@@ -345,3 +345,5 @@ provider "databricks" {}
 8. Will check for the `~/.databrickscfg` file in the home directory, will fail otherwise.
 9. Will check for `profile` presence and try picking from that file will fail otherwise.
 10. Will check for `host` and `token` or `username`+`password` combination, and will fail if none of these exist.
+
+Please check [Default Authentication Flow](https://github.com/databricks/databricks-sdk-go#default-authentication-flow) from [Databricks SDK for Go](https://docs.databricks.com/dev-tools/sdk-go.html) in case you need more details.

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -37,7 +37,7 @@ import (
 )
 
 func init() {
-	// IMPORTANT: this line cannot be changed, because it's used for 
+	// IMPORTANT: this line cannot be changed, because it's used for
 	// internal purposes at Databricks.
 	useragent.WithProduct("databricks-tf-provider", common.Version())
 }
@@ -207,6 +207,20 @@ func configureDatabricksClient(ctx context.Context, d *schema.ResourceData) (any
 	}
 	sort.Strings(attrsUsed)
 	log.Printf("[INFO] Explicit and implicit attributes: %s", strings.Join(attrsUsed, ", "))
+	if cfg.AuthType != "" {
+		// mapping from previous Google authentication types
+		// and current authentication types from Databricks Go SDK
+		oldToNewerAuthType := map[string]string{
+			"google-creds":     "google-credentials",
+			"google-accounts":  "google-id",
+			"google-workspace": "google-id",
+		}
+		newer, ok := oldToNewerAuthType[cfg.AuthType]
+		if ok {
+			log.Printf("[INFO] Changing required auth_type from %s to %s", cfg.AuthType, newer)
+			cfg.AuthType = newer
+		}
+	}
 	client, err := client.New(cfg)
 	if err != nil {
 		return nil, diag.FromErr(err)


### PR DESCRIPTION
 * Migrated client and configuration layer to [`github.com/databricks/databricks-sdk-go`](http://github.com/databricks/databricks-sdk-go) ([#1848](https://github.com/databricks/terraform-provider-databricks/pull/1848)).
 * Added new attribute to [databricks_job](https://registry.terraform.io/providers/databricks/databricks/latest/docs/resources/job) resource ([#1988](https://github.com/databricks/terraform-provider-databricks/pull/1988)).
 * Added `history_data_sharing_status`, `partition` and `status` fields to [databricks_share](https://registry.terraform.io/providers/databricks/databricks/latest/docs/resources/share) ([#2013](https://github.com/databricks/terraform-provider-databricks/pull/2013)).
 * Added `start_version` and `cdf_enabled` support for [databricks_share](https://registry.terraform.io/providers/databricks/databricks/latest/docs/resources/share) ([#2007](https://github.com/databricks/terraform-provider-databricks/pull/2007)).
 * Fixed [databricks_share](https://registry.terraform.io/providers/databricks/databricks/latest/docs/resources/share) update logic ([#2022](https://github.com/databricks/terraform-provider-databricks/pull/2022)).
 * Updated GCP guide with new permissions required to deploy [databricks_mws_networks](https://registry.terraform.io/providers/databricks/databricks/latest/docs/resources/mws_networks) ([#1999](https://github.com/databricks/terraform-provider-databricks/pull/1999)).
 * Minor doc changes to address [#1916](https://github.com/databricks/terraform-provider-databricks/issues/1916), [#1937](https://github.com/databricks/terraform-provider-databricks/issues/1937), [#2010](https://github.com/databricks/terraform-provider-databricks/issues/2010) ([#2012](https://github.com/databricks/terraform-provider-databricks/pull/2012)).
 * Various documentation improvements ([#1981](https://github.com/databricks/terraform-provider-databricks/pull/1981), [#1998](https://github.com/databricks/terraform-provider-databricks/pull/1998), [#2002](https://github.com/databricks/terraform-provider-databricks/pull/2002), [#2016](https://github.com/databricks/terraform-provider-databricks/pull/2016), [#2019](https://github.com/databricks/terraform-provider-databricks/pull/2019)).
 * Integration testing improvements ([#1935](https://github.com/databricks/terraform-provider-databricks/pull/1935), [#2024](https://github.com/databricks/terraform-provider-databricks/pull/2024)).

Updated dependency versions:

 * Removed unused `github.com/Azure/go-autorest/autorest` and `github.com/mitchellh/go-homedir` ([#2026](https://github.com/databricks/terraform-provider-databricks/pull/2026)).
 * Bump Go from 1.18 to 1.19 ([#2029](https://github.com/databricks/terraform-provider-databricks/pull/2029)).
 * Bump CodeQL to v2 ([#2027](https://github.com/databricks/terraform-provider-databricks/pull/2027)).
 * Bump github.com/golang-jwt/jwt/v4 from 4.4.3 to 4.5.0 ([#2030](https://github.com/databricks/terraform-provider-databricks/pull/2030)).
 * Bump github.com/hashicorp/hcl/v2 from 2.15.0 to 2.16.1 ([#1971](https://github.com/databricks/terraform-provider-databricks/pull/1971), [#1997](https://github.com/databricks/terraform-provider-databricks/pull/1997)).
 * Bump github.com/hashicorp/terraform-plugin-sdk/v2 from 2.24.1 to 2.25.0 ([#2031](https://github.com/databricks/terraform-provider-databricks/pull/2031)).
 * Bump golang.org/x/mod from 0.7.0 to 0.8.0 ([#1996](https://github.com/databricks/terraform-provider-databricks/pull/1996)).
 * Bump golang.org/x/net from 0.6.0 to 0.7.0 ([#2028](https://github.com/databricks/terraform-provider-databricks/pull/2028)).
 * Bump google.golang.org/api from 0.108.0 to 0.110.0 ([#1984](https://github.com/databricks/terraform-provider-databricks/pull/1984), [#1995](https://github.com/databricks/terraform-provider-databricks/pull/1995)).