### PR TITLE
Migrate `databricks_catalogs` data to Go SDK

### DIFF
--- a/catalog/data_catalogs.go
+++ b/catalog/data_catalogs.go
@@ -3,6 +3,7 @@ package catalog
 import (
 	"context"
 
+	"github.com/databricks/databricks-sdk-go"
 	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -11,14 +12,12 @@ func DataSourceCatalogs() *schema.Resource {
 	type catalogsData struct {
 		Ids []string `json:"ids,omitempty" tf:"computed,slice_set"`
 	}
-	return common.DataResource(catalogsData{}, func(ctx context.Context, e any, c *common.DatabricksClient) error {
-		data := e.(*catalogsData)
-		catalogsAPI := NewCatalogsAPI(ctx, c)
-		catalogs, err := catalogsAPI.list()
+	return common.WorkspaceData(func(ctx context.Context, data *catalogsData, w *databricks.WorkspaceClient) error {
+		catalogs, err := w.Catalogs.ListAll(ctx)
 		if err != nil {
 			return err
 		}
-		for _, v := range catalogs.Catalogs {
+		for _, v := range catalogs {
 			data.Ids = append(data.Ids, v.Name)
 		}
 		return nil

--- a/catalog/data_catalogs.go
+++ b/catalog/data_catalogs.go
@@ -9,10 +9,9 @@ import (
 )
 
 func DataSourceCatalogs() *schema.Resource {
-	type catalogsData struct {
+	return common.WorkspaceData(func(ctx context.Context, data *struct {
 		Ids []string `json:"ids,omitempty" tf:"computed,slice_set"`
-	}
-	return common.WorkspaceData(func(ctx context.Context, data *catalogsData, w *databricks.WorkspaceClient) error {
+	}, w *databricks.WorkspaceClient) error {
 		catalogs, err := w.Catalogs.ListAll(ctx)
 		if err != nil {
 			return err

--- a/catalog/data_catalogs_test.go
+++ b/catalog/data_catalogs_test.go
@@ -28,7 +28,9 @@ func TestCatalogsData(t *testing.T) {
 		Read:        true,
 		NonWritable: true,
 		ID:          "_",
-	}.ApplyNoError(t)
+	}.ApplyAndExpectData(t, map[string]any{
+		"ids": []string{"a", "b"},
+	})
 }
 
 func TestCatalogsData_Error(t *testing.T) {

--- a/catalog/resource_catalog.go
+++ b/catalog/resource_catalog.go
@@ -32,11 +32,6 @@ type Catalogs struct {
 	Catalogs []CatalogInfo `json:"catalogs"`
 }
 
-func (a CatalogsAPI) list() (catalogs Catalogs, err error) {
-	err = a.client.Get(a.context, "/unity-catalog/catalogs", nil, &catalogs)
-	return
-}
-
 func (a CatalogsAPI) createCatalog(ci *CatalogInfo) error {
 	return a.client.Post(a.context, "/unity-catalog/catalogs", ci, ci)
 }


### PR DESCRIPTION
This PR also introduces `common.WorkspaceData` to reduce code boilerplate. The minimal data resource is now to be defined as:

```go
return common.WorkspaceData(func(ctx context.Context, data *struct {
         // now even possible with inline structs!
	Ids []string `json:"ids,omitempty" tf:"computed,slice_set"`
}, w *databricks.WorkspaceClient) error {
	catalogs, err := w.Catalogs.ListAll(ctx)
	if err != nil {
		return err
	}
	for _, v := range catalogs {
		data.Ids = append(data.Ids, v.Name)
	}
	return nil
})
```