### PR TITLE
Update ip_access_list.md

### DIFF
--- a/docs/resources/ip_access_list.md
+++ b/docs/resources/ip_access_list.md
@@ -12,7 +12,7 @@ Security-conscious enterprises that use cloud SaaS applications need to restrict
 ```hcl
 resource "databricks_workspace_conf" "this" {
   custom_config = {
-    "enableIpAccessLists" : true
+    "enableIpAccessLists" = true
   }
 }
 


### PR DESCRIPTION
This example is wrong, it is also wrong on the https://registry.terraform.io/providers/databricks/databricks/latest/docs/resources/workspace_conf page. Terraform v1.3.7 will attempt to apply the resource and then error out.