### PR TITLE
Allow creation of classic endpoints using terraform

### DIFF
--- a/sql/resource_sql_endpoint.go
+++ b/sql/resource_sql_endpoint.go
@@ -29,7 +29,7 @@ type SQLEndpoint struct {
 	MaxNumClusters          int             `json:"max_num_clusters,omitempty" tf:"default:1"`
 	NumClusters             int             `json:"num_clusters,omitempty" tf:"suppress_diff"`
 	EnablePhoton            bool            `json:"enable_photon" tf:"optional,default:true"`
-	EnableServerlessCompute bool            `json:"enable_serverless_compute,omitempty" tf:"suppress_diff"`
+	EnableServerlessCompute bool            `json:"enable_serverless_compute" tf:"suppress_diff,optional,default:true"`
 	InstanceProfileARN      string          `json:"instance_profile_arn,omitempty"`
 	State                   string          `json:"state,omitempty" tf:"computed"`
 	JdbcURL                 string          `json:"jdbc_url,omitempty" tf:"computed"`

--- a/sql/resource_sql_endpoint_test.go
+++ b/sql/resource_sql_endpoint_test.go
@@ -41,12 +41,13 @@ func TestResourceSQLEndpointCreate(t *testing.T) {
 				Method:   "POST",
 				Resource: "/api/2.0/sql/warehouses",
 				ExpectedRequest: SQLEndpoint{
-					Name:               "foo",
-					ClusterSize:        "Small",
-					MaxNumClusters:     1,
-					AutoStopMinutes:    120,
-					EnablePhoton:       true,
-					SpotInstancePolicy: "COST_OPTIMIZED",
+					Name:                    "foo",
+					ClusterSize:             "Small",
+					MaxNumClusters:          1,
+					AutoStopMinutes:         120,
+					EnablePhoton:            true,
+					EnableServerlessCompute: true,
+					SpotInstancePolicy:      "COST_OPTIMIZED",
 				},
 				Response: SQLEndpoint{
 					ID: "abc",
@@ -80,6 +81,54 @@ func TestResourceSQLEndpointCreate(t *testing.T) {
 	assert.Equal(t, "d7c9d05c-7496-4c69-b089-48823edad40c", d.Get("data_source_id"))
 }
 
+func TestResourceClassicSQLEndpointCreate(t *testing.T) {
+	d, err := qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "POST",
+				Resource: "/api/2.0/sql/warehouses",
+				ExpectedRequest: SQLEndpoint{
+					Name:                    "foo",
+					ClusterSize:             "Small",
+					MaxNumClusters:          1,
+					AutoStopMinutes:         120,
+					EnablePhoton:            true,
+					EnableServerlessCompute: false,
+					SpotInstancePolicy:      "COST_OPTIMIZED",
+				},
+				Response: SQLEndpoint{
+					ID: "abc",
+				},
+			},
+			{
+				Method:       "GET",
+				Resource:     "/api/2.0/sql/warehouses/abc",
+				ReuseRequest: true,
+				Response: SQLEndpoint{
+					Name:           "foo",
+					ClusterSize:    "Small",
+					ID:             "abc",
+					State:          "RUNNING",
+					Tags:           &Tags{},
+					MaxNumClusters: 1,
+					NumClusters:    1,
+				},
+			},
+			dataSourceListHTTPFixture,
+		},
+		Resource: ResourceSqlEndpoint(),
+		Create:   true,
+		HCL: `
+		name = "foo"
+  		cluster_size = "Small"
+		enable_serverless_compute = "false"
+		`,
+	}.Apply(t)
+	require.NoError(t, err)
+	assert.Equal(t, "abc", d.Id(), "Id should not be empty")
+	assert.Equal(t, "d7c9d05c-7496-4c69-b089-48823edad40c", d.Get("data_source_id"))
+}
+
 func TestResourceSQLEndpointCreateNoAutoTermination(t *testing.T) {
 	d, err := qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
@@ -87,12 +136,13 @@ func TestResourceSQLEndpointCreateNoAutoTermination(t *testing.T) {
 				Method:   "POST",
 				Resource: "/api/2.0/sql/warehouses",
 				ExpectedRequest: SQLEndpoint{
-					Name:               "foo",
-					ClusterSize:        "Small",
-					MaxNumClusters:     1,
-					AutoStopMinutes:    0,
-					EnablePhoton:       true,
-					SpotInstancePolicy: "COST_OPTIMIZED",
+					Name:                    "foo",
+					ClusterSize:             "Small",
+					MaxNumClusters:          1,
+					AutoStopMinutes:         0,
+					EnablePhoton:            true,
+					EnableServerlessCompute: true,
+					SpotInstancePolicy:      "COST_OPTIMIZED",
 				},
 				Response: SQLEndpoint{
 					ID: "abc",
@@ -185,13 +235,14 @@ func TestResourceSQLEndpointUpdate(t *testing.T) {
 				Method:   "POST",
 				Resource: "/api/2.0/sql/warehouses/abc/edit",
 				ExpectedRequest: SQLEndpoint{
-					ID:                 "abc",
-					Name:               "foo",
-					ClusterSize:        "Small",
-					AutoStopMinutes:    120,
-					MaxNumClusters:     1,
-					EnablePhoton:       true,
-					SpotInstancePolicy: "COST_OPTIMIZED",
+					ID:                      "abc",
+					Name:                    "foo",
+					ClusterSize:             "Small",
+					AutoStopMinutes:         120,
+					MaxNumClusters:          1,
+					EnablePhoton:            true,
+					EnableServerlessCompute: true,
+					SpotInstancePolicy:      "COST_OPTIMIZED",
 				},
 			},
 			{


### PR DESCRIPTION
This PR is a fix for issue: https://github.com/databricks/terraform-provider-databricks/pull/new/classic-endpoint

This issue was caused because the default for enable_serverless_compute on the server side is true but we had provided the "omitempty" tag on the client side.

This has been tested manually and through unit tests