### PR TITLE
Improve error messages for `databricks_permissions`

### DIFF
--- a/permissions/resource_permissions.go
+++ b/permissions/resource_permissions.go
@@ -383,7 +383,8 @@ func ResourcePermissions() *schema.Resource {
 		Schema: s,
 		CustomizeDiff: func(ctx context.Context, diff *schema.ResourceDiff, c any) error {
 			client := c.(*common.DatabricksClient)
-			if client.DatabricksClient.Config.Host == "" {
+			log.Printf("[DEBUG] permissions id=%s, config_present=%v", diff.Id(), client.Config != nil)
+			if client.Config.Host == "" || client.DatabricksClient.Config.Host == "" {
 				log.Printf("[WARN] cannot validate permission levels, because host is not known yet")
 				return nil
 			}
@@ -393,7 +394,7 @@ func ResourcePermissions() *schema.Resource {
 			}
 			me, err := w.CurrentUser.Me(ctx)
 			if err != nil {
-				return err
+				return fmt.Errorf("customize diff: me: %w", err)
 			}
 			// Plan time validation for object permission levels
 			for _, mapping := range permissionsResourceIDFields() {

--- a/permissions/resource_permissions_test.go
+++ b/permissions/resource_permissions_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/databricks/databricks-sdk-go"
 	"github.com/databricks/databricks-sdk-go/apierr"
-	"github.com/databricks/databricks-sdk-go/client"
 	"github.com/databricks/databricks-sdk-go/config"
 	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/databricks/terraform-provider-databricks/jobs"
@@ -454,7 +453,7 @@ func TestResourcePermissionsCustomizeDiff_ErrorOnScimMe(t *testing.T) {
 		Resource: ResourcePermissions(),
 		Read:     true,
 		ID:       "/clusters/abc",
-	}.ExpectError(t, "Internal error happened")
+	}.ExpectError(t, "customize diff: me: Internal error happened")
 }
 
 func TestResourcePermissionsRead_ErrorOnScimMe(t *testing.T) {
@@ -1261,14 +1260,6 @@ func TestShouldKeepAdminsOnAnythingExceptPasswordsAndAssignsOwnerForPipeline(t *
 		err := p.Delete("/pipelines/123")
 		assert.NoError(t, err)
 	})
-}
-
-func TestCustomizeDiffNoHostYet(t *testing.T) {
-	assert.Nil(t, ResourcePermissions().CustomizeDiff(context.TODO(), nil, &common.DatabricksClient{
-		DatabricksClient: &client.DatabricksClient{
-			Config: &config.Config{},
-		},
-	}))
 }
 
 func TestPathPermissionsResourceIDFields(t *testing.T) {


### PR DESCRIPTION
This does not fix the issue, but adds more debug information to the error output.