### PR TITLE
Release v1.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Version changelog
 
+### 1.11.0
+
+ * Added `force_delete_home_dir` and `force_delete_repos` attributes to [databricks_user](https://registry.terraform.io/providers/databricks/databricks/latest/docs/resources/user) and [databricks_service_principal](https://registry.terraform.io/providers/databricks/databricks/latest/docs/resources/service_principal) resources ([#2032](https://github.com/databricks/terraform-provider-databricks/pull/2032)).
+ * Added docs for `continuous` block in the [databricks_job](https://registry.terraform.io/providers/databricks/databricks/latest/docs/resources/job) resource ([#2048](https://github.com/databricks/terraform-provider-databricks/pull/2048)).
+ * Exporter: `databricks_permissions` for [databricks_notebook](https://registry.terraform.io/providers/databricks/databricks/latest/docs/resources/notebook) & [databricks_directory](https://registry.terraform.io/providers/databricks/databricks/latest/docs/resources/directory) ([#1908](https://github.com/databricks/terraform-provider-databricks/pull/1908)).
+ * Improve error messages for [databricks_permissions](https://registry.terraform.io/providers/databricks/databricks/latest/docs/resources/permissions) ([#2055](https://github.com/databricks/terraform-provider-databricks/pull/2055)).
+ * Make reflect resource utility friendly with Go SDK ([#2051](https://github.com/databricks/terraform-provider-databricks/pull/2051)).
+
+Updated dependency versions:
+
+ * Bump github.com/stretchr/testify from 1.8.1 to 1.8.2 ([#2049](https://github.com/databricks/terraform-provider-databricks/pull/2049)).
+
 ### 1.10.1
 
  * Migrated [databricks_catalogs](https://registry.terraform.io/providers/databricks/databricks/latest/docs/data-sources/catalogs) data to Go SDK ([#2038](https://github.com/databricks/terraform-provider-databricks/pull/2038)).

--- a/common/version.go
+++ b/common/version.go
@@ -3,7 +3,7 @@ package common
 import "context"
 
 var (
-	version = "1.10.1"
+	version = "1.11.0"
 	// ResourceName is resource name without databricks_ prefix
 	ResourceName contextKey = 1
 	// Provider is the current instance of provider

--- a/internal/acceptance/user_test.go
+++ b/internal/acceptance/user_test.go
@@ -46,6 +46,22 @@ func TestAccForceUserImport(t *testing.T) {
 	})
 }
 
+func TestAccUserHomeDeleteHasNoEffectInAccount(t *testing.T) {
+	username := qa.RandomEmail()
+	accountLevel(t, step{
+		Template: `
+		resource "databricks_user" "first" {
+			user_name = "` + username + `"
+			force_delete_home_dir = true
+		}`,
+	}, step{
+		Template: `
+		resource "databricks_user" "second" {
+			user_name = "{var.RANDOM}@example.com"
+		}`,
+	})
+}
+
 func TestAccUserHomeDelete(t *testing.T) {
 	username := qa.RandomEmail()
 	workspaceLevel(t, step{
@@ -54,9 +70,6 @@ func TestAccUserHomeDelete(t *testing.T) {
 			user_name = "` + username + `"
 			force_delete_home_dir = true
 		}`,
-		Check: func(s *terraform.State) error {
-			return nil
-		},
 	}, step{
 		Template: `
 		resource "databricks_user" "second" {
@@ -80,6 +93,7 @@ func TestAccUserHomeDelete(t *testing.T) {
 		},
 	})
 }
+
 func TestAccUserHomeDeleteNotDeleted(t *testing.T) {
 	username := qa.RandomEmail()
 	workspaceLevel(t, step{
@@ -106,6 +120,7 @@ func TestAccUserHomeDeleteNotDeleted(t *testing.T) {
 		},
 	})
 }
+
 func TestAccUserResource(t *testing.T) {
 	differentUsers := `
 	resource "databricks_user" "first" {


### PR DESCRIPTION
# Version changelog

### 1.11.0

 * Added `force_delete_home_dir` and `force_delete_repos` attributes to [databricks_user](https://registry.terraform.io/providers/databricks/databricks/latest/docs/resources/user) and [databricks_service_principal](https://registry.terraform.io/providers/databricks/databricks/latest/docs/resources/service_principal) resources ([#2032](https://github.com/databricks/terraform-provider-databricks/pull/2032)).
 * Added docs for `continuous` block in the [databricks_job](https://registry.terraform.io/providers/databricks/databricks/latest/docs/resources/job) resource ([#2048](https://github.com/databricks/terraform-provider-databricks/pull/2048)).
 * Exporter: `databricks_permissions` for [databricks_notebook](https://registry.terraform.io/providers/databricks/databricks/latest/docs/resources/notebook) & [databricks_directory](https://registry.terraform.io/providers/databricks/databricks/latest/docs/resources/directory) ([#1908](https://github.com/databricks/terraform-provider-databricks/pull/1908)).
 * Improve error messages for [databricks_permissions](https://registry.terraform.io/providers/databricks/databricks/latest/docs/resources/permissions) ([#2055](https://github.com/databricks/terraform-provider-databricks/pull/2055)).
 * Make reflect resource utility friendly with Go SDK ([#2051](https://github.com/databricks/terraform-provider-databricks/pull/2051)).

Updated dependency versions:

 * Bump github.com/stretchr/testify from 1.8.1 to 1.8.2 ([#2049](https://github.com/databricks/terraform-provider-databricks/pull/2049)).