### PR TITLE
Deterministic diff for `databricks_permissions`

### DIFF
--- a/catalog/resource_grants.go
+++ b/catalog/resource_grants.go
@@ -281,7 +281,7 @@ func ResourceGrants() *schema.Resource {
 		})
 	return common.Resource{
 		Schema: s,
-		CustomizeDiff: func(ctx context.Context, d *schema.ResourceDiff, c any) error {
+		CustomizeDiff: func(ctx context.Context, d *schema.ResourceDiff) error {
 			if d.Id() == "" {
 				// unfortunately we cannot do validation before dependent resources exist with tfsdkv2
 				return nil

--- a/catalog/resource_table.go
+++ b/catalog/resource_table.go
@@ -85,7 +85,7 @@ func ResourceTable() *schema.Resource {
 		"view_definition", "comment", "properties"})
 	return common.Resource{
 		Schema: tableSchema,
-		CustomizeDiff: func(ctx context.Context, d *schema.ResourceDiff, c any) error {
+		CustomizeDiff: func(ctx context.Context, d *schema.ResourceDiff) error {
 			if d.Get("table_type") != "EXTERNAL" {
 				return nil
 			}

--- a/jobs/resource_job.go
+++ b/jobs/resource_job.go
@@ -595,7 +595,7 @@ func ResourceJob() *schema.Resource {
 			Create: schema.DefaultTimeout(clusters.DefaultProvisionTimeout),
 			Update: schema.DefaultTimeout(clusters.DefaultProvisionTimeout),
 		},
-		CustomizeDiff: func(ctx context.Context, d *schema.ResourceDiff, m any) error {
+		CustomizeDiff: func(ctx context.Context, d *schema.ResourceDiff) error {
 			var js JobSettings
 			common.DiffToStructPointer(d, jobSchema, &js)
 			alwaysRunning := d.Get("always_running").(bool)

--- a/mws/resource_mws_workspaces.go
+++ b/mws/resource_mws_workspaces.go
@@ -570,7 +570,7 @@ func ResourceMwsWorkspaces() *schema.Resource {
 			}
 			return NewWorkspacesAPI(ctx, c).Delete(accountID, workspaceID)
 		},
-		CustomizeDiff: func(ctx context.Context, d *schema.ResourceDiff, m any) error {
+		CustomizeDiff: func(ctx context.Context, d *schema.ResourceDiff) error {
 			old, new := d.GetChange("private_access_settings_id")
 			if old != "" && new == "" {
 				return fmt.Errorf("cannot remove private access setting from workspace")

--- a/permissions/resource_permissions_test.go
+++ b/permissions/resource_permissions_test.go
@@ -409,51 +409,32 @@ func TestResourcePermissionsRead_some_error(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func TestResourcePermissionsCustomizeDiff_ErrorOnScimMe(t *testing.T) {
+func TestResourcePermissionsCustomizeDiff_ErrorOnCreate(t *testing.T) {
+	qa.ResourceFixture{
+		Resource: ResourcePermissions(),
+		Create:   true,
+		HCL: `
+		cluster_id = "abc"
+		access_control {
+			permission_level = "WHATEVER"
+		}`,
+	}.ExpectError(t, "permission_level WHATEVER is not supported with cluster_id objects")
+}
+
+func TestResourcePermissionsCustomizeDiff_ErrorOnPermissionsDecreate(t *testing.T) {
 	qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
-			{
-				Method:   http.MethodGet,
-				Resource: "/api/2.0/permissions/clusters/abc",
-				Response: ObjectACL{
-					ObjectID:   "/clusters/abc",
-					ObjectType: "clusters",
-					AccessControlList: []AccessControl{
-						{
-							UserName: TestingUser,
-							AllPermissions: []Permission{
-								{
-									PermissionLevel: "CAN_READ",
-									Inherited:       false,
-								},
-							},
-						},
-						{
-							UserName: TestingAdminUser,
-							AllPermissions: []Permission{
-								{
-									PermissionLevel: "CAN_MANAGE",
-									Inherited:       false,
-								},
-							},
-						},
-					},
-				},
-			},
-			{
-				Method:   http.MethodGet,
-				Resource: "/api/2.0/preview/scim/v2/Me",
-				Response: apierr.APIErrorBody{
-					ErrorCode: "INVALID_REQUEST",
-					Message:   "Internal error happened",
-				},
-				Status: 400,
-			},
+			me,
 		},
 		Resource: ResourcePermissions(),
-		Read:     true,
-		ID:       "/clusters/abc",
-	}.ExpectError(t, "customize diff: me: Internal error happened")
+		Create:   true,
+		HCL: `
+		cluster_id = "abc"
+		access_control {
+			permission_level = "CAN_ATTACH_TO"
+			user_name = "admin"
+		}`,
+	}.ExpectError(t, "it is not possible to decrease administrative permissions for the current user: admin")
 }
 
 func TestResourcePermissionsRead_ErrorOnScimMe(t *testing.T) {


### PR DESCRIPTION
This PR removes SDK client as the argument to CustomizeDiff callback on the level of `common.Resource` framework. All customize diff validation must be hermetic and take only `schema.ResourceDiff` as the input. Any validation, that may require calls to the platform must be done in scope of Create or Update callbacks.

Fix #2052