### PR TITLE
Clarify how single IP addresses should be specified

### DIFF
--- a/docs/resources/ip_access_list.md
+++ b/docs/resources/ip_access_list.md
@@ -20,6 +20,7 @@ resource "databricks_ip_access_list" "allowed-list" {
   label     = "allow_in"
   list_type = "ALLOW"
   ip_addresses = [
+    "1.1.1.1",
     "1.2.3.0/24",
     "1.2.5.0/24"
   ]
@@ -30,8 +31,8 @@ resource "databricks_ip_access_list" "allowed-list" {
 
 The following arguments are supported:
 
-* `list_type` -  Can only be "ALLOW" or "BLOCK"
-* `ip_addresses` -  This is a field to allow the group to have instance pool create privileges.
+* `list_type` -  Can only be "ALLOW" or "BLOCK".
+* `ip_addresses` - A string list of IP addresses and CIDR ranges.
 * `label` -  This is the display name for the given IP ACL List.
 * `enabled` - (Optional) Boolean `true` or `false` indicating whether this list should be active.  Defaults to `true`
 


### PR DESCRIPTION
The previous description is a copy paste error? It doesn't seem to describe the same thing?

> ip_addresses` -  This is a field to allow the group to have instance pool create privileges.

New description was taken from the [official documentation](https://docs.databricks.com/security/network/ip-access-list.html#add-an-ip-access-list). 

Someone informed me that it otherwise depends on how the whitelist is implemented if you should specify "1.1.1.1/32" or "1.1.1.1". For example that some implementations will use the default mask if not implemented or that certain AWS won't be able to handle them without CIDR. 