### PR TITLE
Deprecate `enable_serverless_compute` on `databricks_sql_global_config` resource

### DIFF
--- a/sql/resource_sql_endpoint.go
+++ b/sql/resource_sql_endpoint.go
@@ -194,6 +194,8 @@ func (a SQLEndpointsAPI) Delete(endpointID string) error {
 func ResourceSqlEndpoint() *schema.Resource {
 	s := common.StructToSchema(SQLEndpoint{}, func(
 		m map[string]*schema.Schema) map[string]*schema.Schema {
+		m["enable_serverless_compute"].Deprecated = "This field is intended as an internal API " +
+			"and may be removed from the Databricks Terraform provider in the future"
 		m["cluster_size"].ValidateDiagFunc = validation.ToDiagFunc(
 			validation.StringInSlice(ClusterSizes, false))
 		m["max_num_clusters"].ValidateDiagFunc = validation.ToDiagFunc(

--- a/sql/resource_sql_endpoint.go
+++ b/sql/resource_sql_endpoint.go
@@ -194,8 +194,6 @@ func (a SQLEndpointsAPI) Delete(endpointID string) error {
 func ResourceSqlEndpoint() *schema.Resource {
 	s := common.StructToSchema(SQLEndpoint{}, func(
 		m map[string]*schema.Schema) map[string]*schema.Schema {
-		m["enable_serverless_compute"].Deprecated = "This field is intended as an internal API " +
-			"and may be removed from the Databricks Terraform provider in the future"
 		m["cluster_size"].ValidateDiagFunc = validation.ToDiagFunc(
 			validation.StringInSlice(ClusterSizes, false))
 		m["max_num_clusters"].ValidateDiagFunc = validation.ToDiagFunc(

--- a/sql/resource_sql_global_config.go
+++ b/sql/resource_sql_global_config.go
@@ -104,6 +104,8 @@ func (a globalConfigAPI) Get() (GlobalConfig, error) {
 func ResourceSqlGlobalConfig() *schema.Resource {
 	s := common.StructToSchema(GlobalConfig{}, func(
 		m map[string]*schema.Schema) map[string]*schema.Schema {
+		m["enable_serverless_compute"].Deprecated = "This field is intended as an internal API " +
+			"and may be removed from the Databricks Terraform provider in the future"
 		return m
 	})
 	setGlobalConfig := func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {


### PR DESCRIPTION
cc @jxbell 