### PR TITLE
Added `source` parameter for `spark_python_task` in `databricks_job`

### DIFF
--- a/docs/resources/job.md
+++ b/docs/resources/job.md
@@ -143,6 +143,7 @@ Each entry in `webhook_notification` block takes a list `webhook` blocks. The fi
 Note that the `id` is not to be confused with the name of the alert destination. The `id` can be retrieved through the API or the URL of Databricks UI `https://<workspace host>/sql/destinations/<notification id>?o=<workspace id>`
 
 Example
+
 ```hcl
 webhook_notifications {
   on_failure {
@@ -170,13 +171,14 @@ You can invoke Spark submit tasks only on new clusters. **In the `new_cluster` s
 
 ### spark_python_task Configuration Block
 
-* `python_file` - (Required) The URI of the Python file to be executed. [databricks_dbfs_file](dbfs_file.md#path), cloud file URIs (e.g. `s3:/`, `abfss:/`, `gs:/`) and workspace paths are supported. For python files stored in the Databricks workspace, the path must be absolute and begin with `/Repos`. This field is required.
+* `python_file` - (Required) The URI of the Python file to be executed. [databricks_dbfs_file](dbfs_file.md#path), cloud file URIs (e.g. `s3:/`, `abfss:/`, `gs:/`), workspace paths and remote repository are supported. For Python files stored in the Databricks workspace, the path must be absolute and begin with `/Repos`. For files stored in a remote repository, the path must be relative. This field is required.
+* `source` - (Optional) Location type of the Python file, can only be `GIT`. When set to `GIT`, the Python file will be retrieved from a Git repository defined in `git_source`.
 * `parameters` - (Optional) (List) Command line parameters passed to the Python file.
 
 ### notebook_task Configuration Block
 
 * `notebook_path` - (Required) The path of the [databricks_notebook](notebook.md#path) to be run in the Databricks workspace or remote repository. For notebooks stored in the Databricks workspace, the path must be absolute and begin with a slash. For notebooks stored in a remote repository, the path must be relative. This field is required.
-* `source` - (Optional) Location type of the notebook, can only be `WORKSPACE` or `GIT`. When set to `WORKSPACE`, the notebook will be retrieved from the local Databricks workspace. When set to `GIT`, the notebook will be retrieved from a Git repository defined in git_source. If the value is empty, the task will use `GIT` if `git_source` is defined and `WORKSPACE` otherwise.
+* `source` - (Optional) Location type of the notebook, can only be `WORKSPACE` or `GIT`. When set to `WORKSPACE`, the notebook will be retrieved from the local Databricks workspace. When set to `GIT`, the notebook will be retrieved from a Git repository defined in `git_source`. If the value is empty, the task will use `GIT` if `git_source` is defined and `WORKSPACE` otherwise.
 * `base_parameters` - (Optional) (Map) Base parameters to be used for each run of this job. If the run is initiated by a call to run-now with parameters specified, the two parameters maps will be merged. If the same key is specified in base_parameters and in run-now, the value from run-now will be used. If the notebook takes a parameter that is not specified in the job’s base_parameters or the run-now override parameters, the default value from the notebook will be used. Retrieve these parameters in a notebook using `dbutils.widgets.get`.
 
 ### pipeline_task Configuration Block
@@ -214,6 +216,7 @@ One of the `query`, `dashboard` or `alert` needs to be provided.
 * `alert` - (Optional) block consisting of single string field: `alert_id` - identifier of the Databricks SQL Alert.
 
 Example
+
 ```hcl
 resource "databricks_job" "sql_aggregation_job" {
   name = "Example SQL Job"

--- a/jobs/resource_job.go
+++ b/jobs/resource_job.go
@@ -31,6 +31,7 @@ type NotebookTask struct {
 // SparkPythonTask contains the information for python jobs
 type SparkPythonTask struct {
 	PythonFile string   `json:"python_file"`
+	Source     string   `json:"source,omitempty" tf:"suppress_diff"`
 	Parameters []string `json:"parameters,omitempty"`
 }
 


### PR DESCRIPTION
## Changes
Add support for using `spark_python_task` with a `git_source` by adding the `source` parameter, same as `notebook_task`

Closes #2138 
## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [x] covered with integration tests in `internal/acceptance`
- [x] relevant acceptance tests are passing
- [ ] using Go SDK

