### PR TITLE
Automatically add `CAN_MANAGE` permission on `databricks_sql_endpoint` for calling user

### DIFF
--- a/permissions/resource_permissions.go
+++ b/permissions/resource_permissions.go
@@ -126,7 +126,7 @@ func urlPathForObjectID(objectID string) string {
 // permissions when POSTing permissions changes through the REST API, to avoid accidentally
 // revoking the calling user's ability to manage the current object.
 func (a PermissionsAPI) shouldExplicitlyGrantCallingUserManagePermissions(objectID string) bool {
-	for _, prefix := range [...]string{"/registered-models/", "/clusters/", "/queries/"} {
+	for _, prefix := range [...]string{"/registered-models/", "/clusters/", "/queries/", "/sql/warehouses"} {
 		if strings.HasPrefix(objectID, prefix) {
 			return true
 		}
@@ -174,21 +174,6 @@ func (a PermissionsAPI) Update(objectID string, objectACL AccessControlChangeLis
 		// Prevent "Cannot change permissions for group 'admins' to None."
 		objectACL.AccessControlList = append(objectACL.AccessControlList, AccessControlChange{
 			GroupName:       "admins",
-			PermissionLevel: "CAN_MANAGE",
-		})
-	}
-	w, err := a.client.WorkspaceClient()
-	if err != nil {
-		return err
-	}
-	if strings.HasPrefix(objectID, "/sql/warehouses") {
-		warehouse, err := w.Warehouses.GetById(a.context, strings.ReplaceAll(objectID, "/sql/warehouses/", ""))
-		if err != nil {
-			return err
-		}
-		// add CAN_MANAGE permission for creator
-		objectACL.AccessControlList = append(objectACL.AccessControlList, AccessControlChange{
-			UserName:        warehouse.CreatorName,
 			PermissionLevel: "CAN_MANAGE",
 		})
 	}

--- a/permissions/resource_permissions_test.go
+++ b/permissions/resource_permissions_test.go
@@ -9,8 +9,9 @@ import (
 	"github.com/databricks/databricks-sdk-go"
 	"github.com/databricks/databricks-sdk-go/apierr"
 	"github.com/databricks/databricks-sdk-go/config"
+	"github.com/databricks/databricks-sdk-go/service/jobs"
+	"github.com/databricks/databricks-sdk-go/service/sql"
 	"github.com/databricks/terraform-provider-databricks/common"
-	"github.com/databricks/terraform-provider-databricks/jobs"
 	"github.com/databricks/terraform-provider-databricks/scim"
 
 	"github.com/databricks/terraform-provider-databricks/qa"
@@ -816,6 +817,19 @@ func TestResourcePermissionsCreate_SQLA_Endpoint(t *testing.T) {
 		Fixtures: []qa.HTTPFixture{
 			me,
 			{
+				Method:   http.MethodGet,
+				Resource: "/api/2.0/sql/warehouses/abc?",
+				Response: sql.GetWarehouseResponse{
+					Name:           "foo",
+					ClusterSize:    "Small",
+					Id:             "abc",
+					State:          "RUNNING",
+					CreatorName:    TestingAdminUser,
+					MaxNumClusters: 1,
+					NumClusters:    1,
+				},
+			},
+			{
 				Method:   "PUT",
 				Resource: "/api/2.0/permissions/sql/warehouses/abc",
 				ExpectedRequest: AccessControlChangeList{
@@ -823,6 +837,10 @@ func TestResourcePermissionsCreate_SQLA_Endpoint(t *testing.T) {
 						{
 							UserName:        TestingUser,
 							PermissionLevel: "CAN_USE",
+						},
+						{
+							UserName:        TestingAdminUser,
+							PermissionLevel: "CAN_MANAGE",
 						},
 					},
 				},
@@ -837,6 +855,10 @@ func TestResourcePermissionsCreate_SQLA_Endpoint(t *testing.T) {
 						{
 							UserName:        TestingUser,
 							PermissionLevel: "CAN_USE",
+						},
+						{
+							UserName:        TestingAdminUser,
+							PermissionLevel: "CAN_MANAGE",
 						},
 					},
 				},
@@ -1160,7 +1182,7 @@ func TestShouldKeepAdminsOnAnythingExceptPasswordsAndAssignsOwnerForJob(t *testi
 		},
 		{
 			Method:   "GET",
-			Resource: "/api/2.0/jobs/get?job_id=123",
+			Resource: "/api/2.1/jobs/get?job_id=123",
 			Response: jobs.Job{
 				CreatorUserName: "creator@example.com",
 			},
@@ -1215,7 +1237,7 @@ func TestShouldKeepAdminsOnAnythingExceptPasswordsAndAssignsOwnerForPipeline(t *
 		},
 		{
 			Method:   "GET",
-			Resource: "/api/2.0/pipelines/123",
+			Resource: "/api/2.0/pipelines/123?",
 			Response: jobs.Job{
 				CreatorUserName: "creator@example.com",
 			},

--- a/permissions/resource_permissions_test.go
+++ b/permissions/resource_permissions_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/databricks/databricks-sdk-go/apierr"
 	"github.com/databricks/databricks-sdk-go/config"
 	"github.com/databricks/databricks-sdk-go/service/jobs"
-	"github.com/databricks/databricks-sdk-go/service/sql"
 	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/databricks/terraform-provider-databricks/scim"
 
@@ -816,19 +815,6 @@ func TestResourcePermissionsCreate_SQLA_Endpoint(t *testing.T) {
 	d, err := qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
 			me,
-			{
-				Method:   http.MethodGet,
-				Resource: "/api/2.0/sql/warehouses/abc?",
-				Response: sql.GetWarehouseResponse{
-					Name:           "foo",
-					ClusterSize:    "Small",
-					Id:             "abc",
-					State:          "RUNNING",
-					CreatorName:    TestingAdminUser,
-					MaxNumClusters: 1,
-					NumClusters:    1,
-				},
-			},
 			{
 				Method:   "PUT",
 				Resource: "/api/2.0/permissions/sql/warehouses/abc",


### PR DESCRIPTION
## Changes
- Automatically add `CAN_MANAGE` permission for calling user to `databricks_sql_endpoint` closes #2165
- Refactor some API calls in `databricks_permissions` to use Go SDK

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

