### PR TITLE
Add caching of scim/me API to `databricks_current_user` data source and `databricks_permissions` resource.

### DIFF
--- a/exporter/context.go
+++ b/exporter/context.go
@@ -157,8 +157,11 @@ func (ic *importContext) Run() error {
 	} else if !info.IsDir() {
 		return fmt.Errorf("the path %s is not a directory", ic.Directory)
 	}
-	usersAPI := scim.NewUsersAPI(ic.Context, ic.Client)
-	me, err := usersAPI.Me()
+	w, err := ic.Client.WorkspaceClient()
+	if err != nil {
+		return err
+	}
+	me, err := w.CurrentUser.Me(ic.Context)
 	if err != nil {
 		return err
 	}

--- a/internal/acceptance/secret_scope_test.go
+++ b/internal/acceptance/secret_scope_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/databricks/terraform-provider-databricks/qa"
-	"github.com/databricks/terraform-provider-databricks/scim"
 	"github.com/databricks/terraform-provider-databricks/secrets"
 
 	"github.com/databricks/terraform-provider-databricks/common"
@@ -33,8 +32,10 @@ func TestAccSecretScopeResource(t *testing.T) {
 					acls, err := secretACLAPI.List(id)
 					require.NoError(t, err)
 
-					usersAPI := scim.NewUsersAPI(ctx, client)
-					me, err := usersAPI.Me()
+					w, err := client.WorkspaceClient()
+					require.NoError(t, err)
+
+					me, err := w.CurrentUser.Me(ctx)
 					require.NoError(t, err)
 					assert.Equal(t, 1, len(acls))
 					assert.Equal(t, me.UserName, acls[0].Principal)

--- a/permissions/resource_permissions.go
+++ b/permissions/resource_permissions.go
@@ -13,7 +13,6 @@ import (
 	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/databricks/terraform-provider-databricks/jobs"
 	"github.com/databricks/terraform-provider-databricks/pipelines"
-	"github.com/databricks/terraform-provider-databricks/scim"
 
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -141,7 +140,11 @@ func (a PermissionsAPI) ensureCurrentUserCanManageObject(objectID string, object
 	if !a.shouldExplicitlyGrantCallingUserManagePermissions(objectID) {
 		return objectACL, nil
 	}
-	me, err := scim.NewUsersAPI(a.context, a.client).Me()
+	w, err := a.client.WorkspaceClient()
+	if err != nil {
+		return objectACL, err
+	}
+	me, err := w.CurrentUser.Me(a.context)
 	if err != nil {
 		return objectACL, err
 	}
@@ -184,7 +187,11 @@ func (a PermissionsAPI) Update(objectID string, objectACL AccessControlChangeLis
 			}
 		}
 		if owners == 0 {
-			me, err := scim.NewUsersAPI(a.context, a.client).Me()
+			w, err := a.client.WorkspaceClient()
+			if err != nil {
+				return err
+			}
+			me, err := w.CurrentUser.Me(a.context)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
## Changes
* cache scim/me API
## Tests
* manual
*  existing acceptance tests
   * gcp-prod
   * aws-prod
   * azure-prod
   * aws-prod-ucws
   * aws-prod-ucacct
   * azure-prod-acct
   * gcp-prod-acct


