### PR TITLE
fix `databricks_service_principals` data source issue with empty filter

### DIFF
--- a/internal/acceptance/data_service_principals_test.go
+++ b/internal/acceptance/data_service_principals_test.go
@@ -1,0 +1,14 @@
+package acceptance
+
+import (
+	"testing"
+)
+
+func TestAccDataSourceSPNs(t *testing.T) {
+	workspaceLevel(t, step{
+		Template: `
+		data databricks_service_principals "this" {
+			display_name_contains = ""
+		}`,
+	})
+}

--- a/internal/acceptance/data_service_principals_test.go
+++ b/internal/acceptance/data_service_principals_test.go
@@ -4,11 +4,45 @@ import (
 	"testing"
 )
 
-func TestAccDataSourceSPNs(t *testing.T) {
+const spns = `
+resource "databricks_service_principal" "this" {
+	display_name = "SPN {var.RANDOM}"
+}
+
+data databricks_service_principals "this" {
+	display_name_contains = ""
+	depends_on = [databricks_service_principal.this]
+}`
+
+const azureSpns = `
+resource "databricks_service_principal" "this" {
+	application_id = "{var.RANDOM_UUID}"
+	display_name = "SPN {var.RANDOM}"
+	force = true
+}
+
+data databricks_service_principals "this" {
+	display_name_contains = ""
+	depends_on = [databricks_service_principal.this]
+}`
+
+func TestAccDataSourceSPNsOnAWS(t *testing.T) {
+	GetEnvOrSkipTest(t, "TEST_EC2_INSTANCE_PROFILE")
 	workspaceLevel(t, step{
-		Template: `
-		data databricks_service_principals "this" {
-			display_name_contains = ""
-		}`,
+		Template: spns,
+	})
+}
+
+func TestAccDataSourceSPNsOnGCP(t *testing.T) {
+	GetEnvOrSkipTest(t, "GOOGLE_CREDENTIALS")
+	workspaceLevel(t, step{
+		Template: spns,
+	})
+}
+
+func TestAccDataSourceSPNsOnAzure(t *testing.T) {
+	GetEnvOrSkipTest(t, "ARM_CLIENT_ID")
+	workspaceLevel(t, step{
+		Template: azureSpns,
 	})
 }

--- a/scim/data_service_principals.go
+++ b/scim/data_service_principals.go
@@ -19,7 +19,12 @@ func DataSourceServicePrincipals() *schema.Resource {
 		response := e.(*spnsData)
 		spnAPI := NewServicePrincipalsAPI(ctx, c)
 
-		spList, err := spnAPI.Filter(fmt.Sprintf("displayName co '%s'", response.DisplayNameContains))
+		var filter string
+
+		if response.DisplayNameContains != "" {
+			filter = fmt.Sprintf("displayName co '%s'", response.DisplayNameContains)
+		}
+		spList, err := spnAPI.Filter(filter)
 		if err != nil {
 			return err
 		}

--- a/scim/data_service_principals_test.go
+++ b/scim/data_service_principals_test.go
@@ -64,7 +64,7 @@ func TestDataServicePrincipalsReadNoFilter(t *testing.T) {
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   "GET",
-				Resource: "/api/2.0/preview/scim/v2/ServicePrincipals?filter=displayName%20co%20%27%27",
+				Resource: "/api/2.0/preview/scim/v2/ServicePrincipals?",
 				Response: UserList{
 					Resources: []User{
 						{


### PR DESCRIPTION
## Changes

- Avoid passing `displayName` filter to SCIM API when no filter string is provided.
- Add acceptance test

Closes #2178

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [x] covered with integration tests in `internal/acceptance`
- [x] relevant acceptance tests are passing
- [x] using Go SDK

