### PR TITLE
Exporter: don't export `storage` when `databricks_pipeline` was created with default value

### DIFF
--- a/exporter/importables.go
+++ b/exporter/importables.go
@@ -47,6 +47,7 @@ var (
 	predefinedClusterPolicies = []string{"Personal Compute", "Job Compute", "Power User Compute", "Shared Compute"}
 	secretPathRegex           = regexp.MustCompile(`^\{\{secrets\/([^\/]+)\/([^}]+)\}\}$`)
 	sqlParentRegexp           = regexp.MustCompile(`^folders/(\d+)$`)
+	dltDefaultStorageRegex    = regexp.MustCompile(`^dbfs:/pipelines/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
 )
 
 func generateMountBody(ic *importContext, body *hclwrite.Body, r *resource) error {
@@ -1549,6 +1550,9 @@ var resourcesMap map[string]importable = map[string]importable{
 		ShouldOmitField: func(ic *importContext, pathString string, as *schema.Schema, d *schema.ResourceData) bool {
 			if res := dltClusterRegex.FindStringSubmatch(pathString); res != nil { // analyze DLT clusters
 				return makeShouldOmitFieldForCluster(dltClusterRegex)(ic, pathString, as, d)
+			}
+			if pathString == "storage" {
+				return dltDefaultStorageRegex.FindStringSubmatch(d.Get("storage").(string)) != nil
 			}
 			return pathString == "creator_user_name" || defaultShouldOmitFieldFunc(ic, pathString, as, d)
 		},

--- a/exporter/test-data/get-dlt-pipeline.json
+++ b/exporter/test-data/get-dlt-pipeline.json
@@ -49,7 +49,7 @@
     ],
     "name": "Test DLT",
     "photon": false,
-    "storage": "/tmp/test",
+    "storage": "dbfs:/pipelines/9ab12322-ccef-4539-8bf1-a43a95667dac",
     "target": "test"
   },
   "state": "IDLE"


### PR DESCRIPTION

## Changes
When `storage` isn't specified in DLT pipeline, then DLT service generates a unique location on DBFS, but it's not portable, and should be ignored...

## Tests

- [X] `make test` run locally
- [X] tested manually
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

