### PR TITLE
Add suppress diff for `path` argument of `databricks_directory` resource when it ends with `/`

### DIFF
--- a/workspace/resource_directory.go
+++ b/workspace/resource_directory.go
@@ -9,13 +9,18 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
+func directoryPathSuppressDiff(k, old, new string, d *schema.ResourceData) bool {
+	return new == (old + "/")
+}
+
 // ResourceDirectory manages directories
 func ResourceDirectory() *schema.Resource {
 	s := map[string]*schema.Schema{
 		"path": {
-			Type:     schema.TypeString,
-			Required: true,
-			ForceNew: true,
+			Type:             schema.TypeString,
+			Required:         true,
+			ForceNew:         true,
+			DiffSuppressFunc: directoryPathSuppressDiff,
 		},
 		"object_id": {
 			Type:     schema.TypeInt,

--- a/workspace/resource_directory_test.go
+++ b/workspace/resource_directory_test.go
@@ -258,3 +258,8 @@ func TestResourceDirectoryReadNotDirectory(t *testing.T) {
 	qa.AssertErrorStartsWith(t, err, "different object type")
 	assert.Equal(t, "", d.Id(), "Id should be empty for different object type read")
 }
+
+func TestDirectoryPathSuppressDiff(t *testing.T) {
+	assert.True(t, directoryPathSuppressDiff("", "/TF_DIR_WITH_SLASH", "/TF_DIR_WITH_SLASH/", nil))
+	assert.False(t, directoryPathSuppressDiff("", "/new_dir", "/TF_DIR_WITH_SLASH/", nil))
+}


### PR DESCRIPTION
## Changes

Right now if we have directory declared as follows:

```hcl
resource "databricks_directory" "test" {
  path = "/Users/user@domain/TF_DIR_WITH_SLASH/"
}
```

on update it's trying to recreate resource because REST API returns normalized path, without ending `/`, and this leads to following:

```
  # databricks_directory.test must be replaced
-/+ resource "databricks_directory" "test" {
      ~ id               = "/Users/user@domain/TF_DIR_WITH_SLASH/" -> (known after apply)
      ~ object_id        = 696671922817959 -> (known after apply)
      ~ path             = "/Users/user@domain/TF_DIR_WITH_SLASH" -> "/Users/user@domain/TF_DIR_WITH_SLASH/" # forces replacement
        # (1 unchanged attribute hidden)
    }
```

this patch fixes this behavior

<!-- Summary of your changes that are easy to understand -->

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] separate test was added to check behaviour
- [x] tested manually 
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

