### PR TITLE
Exporter: add support for SQL Alerts

### DIFF
--- a/docs/guides/experimental-exporter.md
+++ b/docs/guides/experimental-exporter.md
@@ -98,6 +98,7 @@ Exporter aims to generate HCL code for the most of resources within the Databric
 | [databricks_secret_acl](../resources/secret_acl.md) | Yes |
 | [databricks_secret_scope](../resources/secret_scope.md) | Yes |
 | [databricks_service_principal](../resources/service_principal.md) | Yes |
+| [databricks_sql_alert](../resources/sql_alert.md) | Yes |
 | [databricks_sql_dashboard](../resources/sql_dashboard.md) | Yes |
 | [databricks_sql_endpoint](../resources/sql_endpoint.md) | Yes |
 | [databricks_sql_global_config](../resources/sql_global_config.md) | Yes |

--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -45,6 +45,18 @@ func getJSONObject(filename string) any {
 	}
 	return obj
 }
+
+func getJSONArray(filename string) any {
+	data, _ := ioutil.ReadFile(filename)
+	var obj []any
+	err := json.Unmarshal(data, &obj)
+	if err != nil {
+		fmt.Printf("[ERROR] error! err=%v\n", err)
+		fmt.Printf("[ERROR] data=%s\n", string(data))
+	}
+	return obj
+}
+
 func workspaceConfKeysToURL() string {
 	keys := make([]string, 0, len(workspaceConfKeys))
 	for k := range workspaceConfKeys {
@@ -268,6 +280,13 @@ var emptySqlQueries = qa.HTTPFixture{
 	ReuseRequest: true,
 }
 
+var emptySqlAlerts = qa.HTTPFixture{
+	Method:       "GET",
+	Resource:     "/api/2.0/preview/sql/alerts",
+	Response:     map[string]any{},
+	ReuseRequest: true,
+}
+
 var emptyWorkspaceConf = qa.HTTPFixture{
 	Method:       "GET",
 	Resource:     "/api/2.0/workspace-conf?",
@@ -306,6 +325,7 @@ func TestImportingUsersGroupsSecretScopes(t *testing.T) {
 			emptySqlDashboards,
 			emptySqlEndpoints,
 			emptySqlQueries,
+			emptySqlAlerts,
 			emptyPipelines,
 			emptyWorkspaceConf,
 			allKnownWorkspaceConfs,
@@ -517,6 +537,7 @@ func TestImportingNoResourcesError(t *testing.T) {
 			emptySqlEndpoints,
 			emptySqlQueries,
 			emptySqlDashboards,
+			emptySqlAlerts,
 			emptyPipelines,
 			{
 				Method:       "GET",
@@ -1025,6 +1046,14 @@ func TestImportingJobs_JobListMultiTask(t *testing.T) {
 								SqlTask: &jobs.SqlTask{
 									Query: &jobs.SqlQueryTask{
 										QueryID: "123",
+									},
+								},
+							},
+							{
+								TaskKey: "dummy3",
+								SqlTask: &jobs.SqlTask{
+									Alert: &jobs.SqlAlertTask{
+										AlertID: "123",
 									},
 								},
 							},
@@ -1549,6 +1578,22 @@ func TestImportingSqlObjects(t *testing.T) {
 				Resource: "/api/2.0/preview/sql/permissions/dashboards/9cb0c8f5-6262-4a1f-a741-2181de76028f",
 				Response: getJSONObject("test-data/get-sql-dashboard-permissions.json"),
 			},
+			{
+				Method:       "GET",
+				Resource:     "/api/2.0/preview/sql/alerts",
+				Response:     getJSONArray("test-data/get-sql-alerts.json"),
+				ReuseRequest: true,
+			},
+			{
+				Method:   "GET",
+				Resource: "/api/2.0/preview/sql/alerts/3cf91a42-6217-4f3c-a6f0-345d489051b9?",
+				Response: getJSONObject("test-data/get-sql-alert.json"),
+			},
+			{
+				Method:   "GET",
+				Resource: "/api/2.0/preview/sql/permissions/alerts/3cf91a42-6217-4f3c-a6f0-345d489051b9",
+				Response: getJSONObject("test-data/get-sql-alert-permissions.json"),
+			},
 		},
 		func(ctx context.Context, client *common.DatabricksClient) {
 			tmpDir := fmt.Sprintf("/tmp/tf-%s", qa.RandomName())
@@ -1556,8 +1601,8 @@ func TestImportingSqlObjects(t *testing.T) {
 
 			ic := newImportContext(client)
 			ic.Directory = tmpDir
-			ic.listing = "sql-dashboards,sql-queries,sql-endpoints"
-			ic.services = "sql-dashboards,sql-queries,sql-endpoints,access,notebooks"
+			ic.listing = "sql-dashboards,sql-queries,sql-endpoints,sql-alerts"
+			ic.services = "sql-dashboards,sql-queries,sql-alerts,sql-endpoints,access,notebooks"
 
 			err := ic.Run()
 			assert.NoError(t, err)

--- a/exporter/test-data/get-sql-alert-permissions.json
+++ b/exporter/test-data/get-sql-alert-permissions.json
@@ -1,0 +1,14 @@
+{
+  "access_control_list": [
+    {
+      "permission_level": "CAN_MANAGE",
+      "user_name": "test@domain.com"
+    },
+    {
+      "group_name": "users",
+      "permission_level": "CAN_RUN"
+    }
+  ],
+  "object_id": "alerts/3cf91a42-6217-4f3c-a6f0-345d489051b9",
+  "object_type": "alert"
+}

--- a/exporter/test-data/get-sql-alert.json
+++ b/exporter/test-data/get-sql-alert.json
@@ -1,0 +1,83 @@
+{
+  "conditions": {
+    "alert": {
+      "column": {
+        "aggregation": null,
+        "display": "threshold",
+        "name": "threshold"
+      }
+    },
+    "op": "\u003e",
+    "query_plan": null,
+    "threshold": {
+      "value": "50"
+    }
+  },
+  "created_at": "2023-04-10T08:14:47Z",
+  "id": "3cf91a42-6217-4f3c-a6f0-345d489051b9",
+  "last_triggered_at": "2023-04-10T08:15:56Z",
+  "name": "Test Alert",
+  "parent": "folders/4451965692354143",
+  "options": {
+    "aggregation": null,
+    "column": "threshold",
+    "display_column": "threshold",
+    "folder_node_internal_name": "tree/3467386930489745",
+    "folder_node_status": "ACTIVE",
+    "muted": false,
+    "op": "\u003e",
+    "parent": "folders/4451965692354143",
+    "query_plan": null,
+    "value": "50"
+  },
+  "query": {
+    "created_at": "2023-04-10T08:13:33Z",
+    "data_source_id": "78520023-ab69-44a4-84d0-4fda0c69ea91",
+    "description": null,
+    "id": "16c4f969-eea0-4aad-8f82-03d79b078dcc",
+    "is_archived": false,
+    "is_draft": false,
+    "is_safe": true,
+    "name": "Alert Query",
+    "options": {
+      "apply_auto_limit": true,
+      "folder_node_internal_name": "tree/3467386930489744",
+      "folder_node_status": "ACTIVE",
+      "parameters": null,
+      "parent": "folders/4451965692354143",
+      "visualization_control_order": null
+    },
+    "query": "select 42 as threshold",
+    "run_as_role": null,
+    "run_as_service_principal_id": null,
+    "schedule": null,
+    "tags": null,
+    "updated_at": "2023-04-10T08:14:13Z",
+    "user_id": 661448457191611,
+    "version": 1
+  },
+  "rearm": null,
+  "refresh_schedules": [
+    {
+      "cron": "1 15 8 * * ?",
+      "data_source_id": "78520023-ab69-44a4-84d0-4fda0c69ea91",
+      "id": "71cebca8-3684-4b60-95f1-5d9b3786b9f8",
+      "job_id": "91aeb0a4644e0d357a36f61824a8c71436b61506"
+    }
+  ],
+  "state": "ok",
+  "subscriptions": [
+    {
+      "user_id": 661448457191611
+    }
+  ],
+  "updated_at": "2023-04-10T08:17:21Z",
+  "user": {
+    "email": "user@domain.com",
+    "id": 661448457191611,
+    "is_db_admin": false,
+    "name": "user@domain.com",
+    "profile_image_url": "https://www.gravatar.com/avatar/1111?s=40\u0026d=identicon"
+  },
+  "user_id": 661448457191611
+}

--- a/exporter/test-data/get-sql-alerts.json
+++ b/exporter/test-data/get-sql-alerts.json
@@ -1,0 +1,84 @@
+[
+  {
+    "conditions": {
+      "alert": {
+        "column": {
+          "aggregation": null,
+          "display": "threshold",
+          "name": "threshold"
+        }
+      },
+      "op": "\u003e",
+      "query_plan": null,
+      "threshold": {
+        "value": "50"
+      }
+    },
+    "created_at": "2023-04-10T08:14:47Z",
+    "id": "3cf91a42-6217-4f3c-a6f0-345d489051b9",
+    "last_triggered_at": "2023-04-10T08:15:56Z",
+    "name": "Test Alert",
+    "options": {
+      "aggregation": null,
+      "column": "threshold",
+      "display_column": "threshold",
+      "folder_node_internal_name": "tree/3467386930489745",
+      "folder_node_status": "ACTIVE",
+      "muted": false,
+      "op": "\u003e",
+      "parent": "folders/4451965692354143",
+      "query_plan": null,
+      "value": "50"
+    },
+    "query": {
+      "created_at": "2023-04-10T08:13:33Z",
+      "data_source_id": "78520023-ab69-44a4-84d0-4fda0c69ea91",
+      "description": null,
+      "id": "16c4f969-eea0-4aad-8f82-03d79b078dcc",
+      "is_archived": false,
+      "is_draft": false,
+      "is_safe": true,
+      "name": "Alert Query",
+      "options": {
+        "apply_auto_limit": true,
+        "folder_node_internal_name": "tree/3467386930489744",
+        "folder_node_status": "ACTIVE",
+        "parameters": null,
+        "parent": "folders/4451965692354143",
+        "visualization_control_order": null
+      },
+      "query": "select 42 as threshold",
+      "run_as_role": null,
+      "run_as_service_principal_id": null,
+      "schedule": null,
+      "tags": null,
+      "updated_at": "2023-04-10T08:14:13Z",
+      "user_id": 661448457191611,
+      "version": 1
+    },
+    "rearm": null,
+    "refresh_schedules": [
+      {
+        "cron": "1 15 8 * * ?",
+        "data_source_id": "78520023-ab69-44a4-84d0-4fda0c69ea91",
+        "id": "71cebca8-3684-4b60-95f1-5d9b3786b9f8",
+        "job_id": "91aeb0a4644e0d357a36f61824a8c71436b61506"
+      }
+    ],
+    "state": "ok",
+    "subscriptions": [
+      {
+        "user_id": 661448457191611
+      }
+    ],
+    "updated_at": "2023-04-10T08:17:21Z",
+    "user": {
+      "email": "user@domain.com",
+      "id": 661448457191611,
+      "is_db_admin": false,
+      "name": "user@domain.com",
+      "profile_image_url": "https://www.gravatar.com/avatar/1111?s=40\u0026d=identicon"
+    },
+    "user_id": 661448457191611
+  }
+]


### PR DESCRIPTION
## Changes

Add support for exporting SQL alerts


## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [x] manual test
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [x] using Go SDK

