### PR TITLE
Migrate `databricks_mlflow_expiment` and `databricks_mlflow_model` to go SDK

### DIFF
--- a/mlflow/resource_mlflow_experiment.go
+++ b/mlflow/resource_mlflow_experiment.go
@@ -3,102 +3,64 @@ package mlflow
 import (
 	"context"
 
+	"github.com/databricks/databricks-sdk-go/service/mlflow"
 	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-// Experiment defines the response object from the API
-type Experiment struct {
-	Name             string `json:"name"`
-	Description      string `json:"description,omitempty"`
-	ExperimentId     string `json:"experiment_id,omitempty" tf:"computed"`
-	ArtifactLocation string `json:"artifact_location,omitempty" tf:"force_new,suppress_diff"`
-	LifecycleStage   string `json:"lifecycle_stage,omitempty" tf:"computed"`
-	LastUpdateTime   int64  `json:"last_update_time,omitempty" tf:"computed"`
-	CreationTime     int64  `json:"creation_time,omitempty" tf:"computed"`
-}
-
-type experimentUpdate struct {
-	ExperimentId string `json:"experiment_id"`
-	NewName      string `json:"new_name"`
-}
-
-type experimentWrapper struct {
-	Experiment Experiment `json:"experiment"`
-}
-
-// ExperimentsAPI ...
-type ExperimentsAPI struct {
-	client  *common.DatabricksClient
-	context context.Context
-}
-
-// NewExperimentsAPI ...
-func NewExperimentsAPI(ctx context.Context, m any) ExperimentsAPI {
-	return ExperimentsAPI{m.(*common.DatabricksClient), ctx}
-}
-
-// Create ...
-func (a ExperimentsAPI) Create(d *Experiment) error {
-	return a.client.Post(a.context, "/mlflow/experiments/create", d, &d)
-}
-
-// Read ...
-func (a ExperimentsAPI) Read(experimentId string) (*Experiment, error) {
-	var d experimentWrapper
-	err := a.client.Get(a.context, "/mlflow/experiments/get", map[string]string{
-		"experiment_id": experimentId,
-	}, &d)
-	if err != nil {
-		return nil, err
-	}
-	return &d.Experiment, nil
-}
-
-// Update ...
-func (a ExperimentsAPI) Update(e *experimentUpdate) error {
-	return a.client.Post(a.context, "/mlflow/experiments/update", e, &e)
-}
-
-// Delete ...
-func (a ExperimentsAPI) Delete(id string) error {
-	return a.client.Post(a.context, "/mlflow/experiments/delete", map[string]string{
-		"experiment_id": id,
-	}, nil)
-}
-
 func ResourceMlflowExperiment() *schema.Resource {
 	s := common.StructToSchema(
-		Experiment{},
+		mlflow.Experiment{},
 		func(m map[string]*schema.Schema) map[string]*schema.Schema {
 			return m
 		})
 
 	return common.Resource{
 		Create: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
-			var e Experiment
-			common.DataToStructPointer(d, s, &e)
-			if err := NewExperimentsAPI(ctx, c).Create(&e); err != nil {
-				return err
-			}
-			d.SetId(e.ExperimentId)
-			return nil
-		},
-		Read: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
-			e, err := NewExperimentsAPI(ctx, c).Read(d.Id())
+			w, err := c.WorkspaceClient()
 			if err != nil {
 				return err
 			}
-			return common.StructToData(*e, s, d)
+			exp, err := w.Experiments.Create(ctx, mlflow.CreateExperiment{
+				ArtifactLocation: d.Get("artifact_location").(string),
+				Name:             d.Get("name").(string),
+			})
+			if err != nil {
+				return err
+			}
+			d.SetId(exp.ExperimentId)
+			return nil
+		},
+		Read: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
+			w, err := c.WorkspaceClient()
+			if err != nil {
+				return err
+			}
+			exp, err := w.Experiments.GetByExperimentId(ctx, d.Id())
+			if err != nil {
+				return err
+			}
+			return common.StructToData(exp, s, d)
 		},
 		Update: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
-			var e Experiment
-			common.DataToStructPointer(d, s, &e)
-			updateDoc := experimentUpdate{ExperimentId: d.Id(), NewName: e.Name}
-			return NewExperimentsAPI(ctx, c).Update(&updateDoc)
+			w, err := c.WorkspaceClient()
+			if err != nil {
+				return err
+			}
+			err = w.Experiments.Update(ctx, mlflow.UpdateExperiment{
+				ExperimentId: d.Id(),
+				NewName:      d.Get("name").(string), // TODO:check this
+			})
+			return err
 		},
 		Delete: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
-			return NewExperimentsAPI(ctx, c).Delete(d.Id())
+			w, err := c.WorkspaceClient()
+			if err != nil {
+				return err
+			}
+			err = w.Experiments.DeleteByExperimentId(ctx, d.Id())
+			return err
+
 		},
 		StateUpgraders: []schema.StateUpgrader{},
 		Schema:         s,

--- a/mlflow/resource_mlflow_model.go
+++ b/mlflow/resource_mlflow_model.go
@@ -8,38 +8,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-type Tag struct {
-	Key   string `json:"key"`
-	Value string `json:"value"`
-}
-
-// ModelVersion defines a MLFlow model version as returned by the API
-type ModelVersion struct {
-	Name                 string `json:"name"`
-	Version              string `json:"version"`
-	CreationTimestamp    int64  `json:"creation_timestamp,omitempty"`
-	LastUpdatedTimestamp int64  `json:"last_updated_timestamp,omitempty"`
-	UserID               string `json:"user_id,omitempty"`
-	CurrentStage         string `json:"current_stage,omitempty"`
-	Source               string `json:"source,omitempty"`
-	Status               string `json:"status,omitempty"`
-}
-
-// Model defines the response object from the API
-type Model struct {
-	Name                 string         `json:"name" tf:"force_new"`
-	CreationTimestamp    int64          `json:"creation_timestamp,omitempty" tf:"computed"`
-	LastUpdatedTimestamp int64          `json:"last_updated_timestamp,omitempty" tf:"computed"`
-	UserID               string         `json:"user_id,omitempty" tf:"computed"`
-	LatestVersions       []ModelVersion `json:"latest_versions,omitempty" tf:"computed"`
-	Description          string         `json:"description,omitempty"`
-	Tags                 []Tag          `json:"tags,omitempty"`
-	RegisteredModelID    string         `json:"id,omitempty" tf:"computed,alias:registered_model_id"`
-}
-
 func ResourceMlflowModel() *schema.Resource {
 	s := common.StructToSchema(
-		Model{},
+		mlflow.RegisteredModel{},
 		func(m map[string]*schema.Schema) map[string]*schema.Schema {
 			delete(m, "latest_versions")
 			return m

--- a/mlflow/resource_mlflow_model.go
+++ b/mlflow/resource_mlflow_model.go
@@ -37,16 +37,6 @@ type Model struct {
 	RegisteredModelID    string         `json:"id,omitempty" tf:"computed,alias:registered_model_id"`
 }
 
-// registeredModel defines response from GET API op
-type registeredModel struct {
-	RegisteredModelDatabricks Model `json:"registered_model_databricks"`
-}
-
-type ModelsAPI struct {
-	client  *common.DatabricksClient
-	context context.Context
-}
-
 func ResourceMlflowModel() *schema.Resource {
 	s := common.StructToSchema(
 		Model{},

--- a/mlflow/resource_mlflow_model_test.go
+++ b/mlflow/resource_mlflow_model_test.go
@@ -19,7 +19,6 @@ func m() mlflow.RegisteredModel {
 }
 
 func TestModelCreateNoTags(t *testing.T) {
-	//TODO: getting error: panic: interface conversion: interface {} is []interface {}, not []mlflow.RegisteredModelTag
 	_, err := qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
 			{
@@ -27,6 +26,16 @@ func TestModelCreateNoTags(t *testing.T) {
 				Resource: "/api/2.0/mlflow/registered-models/create",
 				ExpectedRequest: mlflow.CreateRegisteredModelRequest{
 					Name: "xyz",
+				},
+			},
+			{
+				Method:   "GET",
+				Resource: "/api/2.0/mlflow/registered-models/get?name=xyz",
+
+				Response: mlflow.CreateRegisteredModelResponse{
+					RegisteredModel: &mlflow.RegisteredModel{
+						Name: "xyz",
+					},
 				},
 			},
 		},
@@ -42,7 +51,6 @@ func TestModelCreateNoTags(t *testing.T) {
 
 func TestModelCreateWithTags(t *testing.T) {
 	model := m()
-	//TODO: getting error: panic: interface conversion: interface {} is []interface {}, not []mlflow.RegisteredModelTag
 	d, err := qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
 			{

--- a/mlflow/resource_mlflow_model_test.go
+++ b/mlflow/resource_mlflow_model_test.go
@@ -19,7 +19,6 @@ func m() mlflow.RegisteredModel {
 }
 
 func TestModelCreateNoTags(t *testing.T) {
-	//model := m()
 	//TODO: getting error: panic: interface conversion: interface {} is []interface {}, not []mlflow.RegisteredModelTag
 	_, err := qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{

--- a/mlflow/resource_mlflow_model_test.go
+++ b/mlflow/resource_mlflow_model_test.go
@@ -3,34 +3,68 @@ package mlflow
 import (
 	"testing"
 
+	"github.com/databricks/databricks-sdk-go/service/mlflow"
 	"github.com/databricks/terraform-provider-databricks/qa"
 	"github.com/stretchr/testify/assert"
 )
 
-func m() Model {
-	return Model{
+func m() mlflow.RegisteredModel {
+	return mlflow.RegisteredModel{
 		Name: "xyz",
-		Tags: []Tag{
+		Tags: []mlflow.RegisteredModelTag{
 			{Key: "key1", Value: "value1"},
 			{Key: "key2", Value: "value2"},
 		},
 	}
 }
 
-func TestModelCreate(t *testing.T) {
+func TestModelCreateNoTags(t *testing.T) {
+	//model := m()
+	//TODO: getting error: panic: interface conversion: interface {} is []interface {}, not []mlflow.RegisteredModelTag
+	_, err := qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "POST",
+				Resource: "/api/2.0/mlflow/registered-models/create",
+				ExpectedRequest: mlflow.CreateRegisteredModelRequest{
+					Name: "xyz",
+				},
+			},
+		},
+		Resource: ResourceMlflowModel(),
+		Create:   true,
+		HCL: `
+		name = "xyz"
+		`,
+	}.Apply(t)
+
+	assert.NoError(t, err)
+}
+
+func TestModelCreateWithTags(t *testing.T) {
+	model := m()
+	//TODO: getting error: panic: interface conversion: interface {} is []interface {}, not []mlflow.RegisteredModelTag
 	d, err := qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
 			{
-				Method:          "POST",
-				Resource:        "/api/2.0/mlflow/registered-models/create",
-				ExpectedRequest: m(),
-				Response:        m(),
+				Method:   "POST",
+				Resource: "/api/2.0/mlflow/registered-models/create",
+				ExpectedRequest: mlflow.CreateRegisteredModelRequest{
+					Name: "xyz",
+					Tags: []mlflow.RegisteredModelTag{
+						{Key: "key1", Value: "value1"},
+						{Key: "key2", Value: "value2"},
+					},
+				},
+				Response: mlflow.CreateRegisteredModelResponse{
+					RegisteredModel: &model,
+				},
 			},
 			{
 				Method:   "GET",
-				Resource: "/api/2.0/mlflow/databricks/registered-models/get?name=xyz",
-				Response: registeredModel{
-					RegisteredModelDatabricks: m(),
+				Resource: "/api/2.0/mlflow/registered-models/get?name=xyz",
+				Response: mlflow.GetRegisteredModelResponse{
+					RegisteredModel: &model,
 				},
 			},
 		},
@@ -56,14 +90,23 @@ func TestModelCreate(t *testing.T) {
 }
 
 func TestModelCreatePostError(t *testing.T) {
+	model := m()
 	_, err := qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
 			{
-				Method:          "POST",
-				Resource:        "/api/2.0/mlflow/registered-models/create",
-				ExpectedRequest: m(),
-				Response:        m(),
-				Status:          400,
+				Method:   "POST",
+				Resource: "/api/2.0/mlflow/registered-models/create",
+				ExpectedRequest: mlflow.CreateRegisteredModelRequest{
+					Name: "xyz",
+					Tags: []mlflow.RegisteredModelTag{
+						{Key: "key1", Value: "value1"},
+						{Key: "key2", Value: "value2"},
+					},
+				},
+				Response: mlflow.CreateRegisteredModelResponse{
+					RegisteredModel: &model,
+				},
+				Status: 400,
 			},
 		},
 		Resource: ResourceMlflowModel(),
@@ -85,13 +128,14 @@ func TestModelCreatePostError(t *testing.T) {
 }
 
 func TestModelRead(t *testing.T) {
+	model := m()
 	d, err := qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   "GET",
-				Resource: "/api/2.0/mlflow/databricks/registered-models/get?name=xyz",
-				Response: registeredModel{
-					RegisteredModelDatabricks: m(),
+				Resource: "/api/2.0/mlflow/registered-models/get?name=xyz",
+				Response: mlflow.GetRegisteredModelResponse{
+					RegisteredModel: &model,
 				},
 			},
 		},
@@ -105,13 +149,14 @@ func TestModelRead(t *testing.T) {
 }
 
 func TestModelReadGetError(t *testing.T) {
+	model := m()
 	_, err := qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   "GET",
-				Resource: "/api/2.0/mlflow/databricks/registered-models/get?name=xyz",
-				Response: registeredModel{
-					RegisteredModelDatabricks: m(),
+				Resource: "/api/2.0/mlflow/registered-models/get?name=xyz",
+				Response: mlflow.GetRegisteredModelResponse{
+					RegisteredModel: &model,
 				},
 				Status: 400,
 			},
@@ -138,9 +183,9 @@ func TestModelUpdate(t *testing.T) {
 			},
 			{
 				Method:   "GET",
-				Resource: "/api/2.0/mlflow/databricks/registered-models/get?name=xyz",
-				Response: registeredModel{
-					RegisteredModelDatabricks: gm,
+				Resource: "/api/2.0/mlflow/registered-models/get?name=xyz",
+				Response: mlflow.GetRegisteredModelResponse{
+					RegisteredModel: &gm,
 				},
 			},
 		},
@@ -152,9 +197,9 @@ func TestModelUpdate(t *testing.T) {
 			"name": "xyz",
 		},
 		HCL: `
-		name = "xyz"
-		description = "updateddescription"
-		`,
+			name = "xyz"
+			description = "updateddescription"
+			`,
 	}.Apply(t)
 
 	assert.NoError(t, err)
@@ -184,21 +229,20 @@ func TestModelUpdatePatchError(t *testing.T) {
 			"name": "xyz",
 		},
 		HCL: `
-		name = "xyz"
-		description = "updateddescription"
-		`,
+			name = "xyz"
+			description = "updateddescription"
+			`,
 	}.Apply(t)
 
 	assert.Error(t, err)
 }
-
 func TestModelDelete(t *testing.T) {
 	d, err := qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   "DELETE",
 				Resource: "/api/2.0/mlflow/registered-models/delete",
-				ExpectedRequest: Model{
+				ExpectedRequest: mlflow.DeleteRegisteredModelRequest{
 					Name: "xyz",
 				},
 			},
@@ -221,7 +265,7 @@ func TestModelDeleteError(t *testing.T) {
 			{
 				Method:   "DELETE",
 				Resource: "/api/2.0/mlflow/registered-models/delete",
-				ExpectedRequest: Model{
+				ExpectedRequest: mlflow.DeleteRegisteredModelRequest{
 					Name: "xyz",
 				},
 				Status: 400,


### PR DESCRIPTION
## Changes
Migrate the mlflow service to go SDK.

## Tests

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

