### PR TITLE
Fixed regression in `databricks_group` data not to require workspace admin privileges

### DIFF
--- a/exporter/util.go
+++ b/exporter/util.go
@@ -200,7 +200,7 @@ func (ic *importContext) cacheGroups() error {
 	if len(ic.allGroups) == 0 {
 		log.Printf("[INFO] Caching groups in memory ...")
 		groupsAPI := scim.NewGroupsAPI(ic.Context, ic.Client)
-		g, err := groupsAPI.Filter("", true)
+		g, err := groupsAPI.Filter("")
 		if err != nil {
 			return err
 		}

--- a/scim/data_group_test.go
+++ b/scim/data_group_test.go
@@ -18,7 +18,7 @@ func TestDataSourceGroup(t *testing.T) {
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   "GET",
-				Resource: "/api/2.0/preview/scim/v2/Groups?excludedAttributes=roles&filter=displayName%20eq%20%27ds%27",
+				Resource: "/api/2.0/preview/scim/v2/Groups?filter=displayName%20eq%20%27ds%27",
 				Response: GroupList{
 					Resources: []Group{
 						{
@@ -48,43 +48,11 @@ func TestDataSourceGroup(t *testing.T) {
 									Value: "abc",
 								},
 							},
-						},
-					},
-				},
-			},
-			{
-				Method:   "GET",
-				Resource: "/api/2.0/preview/scim/v2/Groups/eerste?attributes=members,roles,entitlements,externalId",
-				Response: Group{
-					DisplayName: "ds",
-					ID:          "eerste",
-					Entitlements: []ComplexValue{
-						{
-							Value: "allow-cluster-create",
-						},
-					},
-					Roles: []ComplexValue{
-						{
-							Value: "a",
-						},
-					},
-					Members: []ComplexValue{
-						{
-							Ref:   "Users/1112",
-							Value: "1112",
-						},
-						{
-							Ref:   "ServicePrincipals/1113",
-							Value: "1113",
-						},
-						{
-							Ref:   "Groups/1114",
-							Value: "1114",
-						},
-					},
-					Groups: []ComplexValue{
-						{
-							Value: "abc",
+							Roles: []ComplexValue{
+								{
+									Value: "a",
+								},
+							},
 						},
 					},
 				},

--- a/scim/resource_group_test.go
+++ b/scim/resource_group_test.go
@@ -354,7 +354,7 @@ func TestCreateForceOverwriteCannotListGroups(t *testing.T) {
 	qa.HTTPFixturesApply(t, []qa.HTTPFixture{
 		{
 			Method:   "GET",
-			Resource: "/api/2.0/preview/scim/v2/Groups?excludedAttributes=roles&filter=displayName%20eq%20%27abc%27",
+			Resource: "/api/2.0/preview/scim/v2/Groups?filter=displayName%20eq%20%27abc%27",
 			Status:   417,
 			Response: apierr.APIError{
 				Message: "cannot find group",
@@ -376,7 +376,7 @@ func TestCreateForceOverwriteFindsAndSetsGroupID(t *testing.T) {
 	qa.HTTPFixturesApply(t, []qa.HTTPFixture{
 		{
 			Method:   "GET",
-			Resource: "/api/2.0/preview/scim/v2/Groups?excludedAttributes=roles&filter=displayName%20eq%20%27abc%27",
+			Resource: "/api/2.0/preview/scim/v2/Groups?filter=displayName%20eq%20%27abc%27",
 			Response: GroupList{
 				Resources: []Group{
 					{
@@ -388,13 +388,6 @@ func TestCreateForceOverwriteFindsAndSetsGroupID(t *testing.T) {
 		{
 			Method:   "GET",
 			Resource: "/api/2.0/preview/scim/v2/Groups/123?attributes=displayName,entitlements,groups,members,externalId",
-			Response: Group{
-				ID: "123",
-			},
-		},
-		{
-			Method:   "GET",
-			Resource: "/api/2.0/preview/scim/v2/Groups/123?attributes=",
 			Response: Group{
 				ID: "123",
 			},


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
We had a regression as specified in https://github.com/databricks/terraform-provider-databricks/issues/2193

The fix is to revert back to using the list groups API since that is not gated to admins

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

Tested using existing unit tests and manually with a non admin account with the following hcl

```
terraform {
  required_providers {
    databricks = {
      source = "databricks/databricks"
    }
  }
}

provider "databricks" {
  profile = "aws-prod-nonadmin"
}

data databricks_group "this" {
    display_name = "users"
}
```

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

