### PR TITLE
Add support for notifications in `databricks_pipeline` resource

### DIFF
--- a/common/reflect_resource.go
+++ b/common/reflect_resource.go
@@ -216,6 +216,12 @@ func typeToSchema(v reflect.Value, t reflect.Type, path []string) map[string]*sc
 						continue
 					}
 					scm[fieldName].MaxItems = maxItems
+				case "min_items":
+					minItems, err := strconv.Atoi(tfValue)
+					if err != nil {
+						continue
+					}
+					scm[fieldName].MinItems = minItems
 				}
 			}
 		}

--- a/common/reflect_resource_test.go
+++ b/common/reflect_resource_test.go
@@ -51,7 +51,7 @@ type testPtr struct {
 }
 
 type testStruct struct {
-	Integer        int               `json:"integer,omitempty" tf:"default:10,max_items:invalid"`
+	Integer        int               `json:"integer,omitempty" tf:"default:10,min_items:invalid,max_items:invalid"`
 	Float          float64           `json:"float,omitempty"`
 	Bool           bool              `json:"bool,omitempty"`
 	NonOptional    string            `json:"non_optional"`
@@ -201,7 +201,7 @@ type Dummy struct {
 	Enabled     bool              `json:"enabled" tf:"conflicts:workers"`
 	Workers     int               `json:"workers,omitempty" tf:"suppress_diff"`
 	Description string            `json:"description,omitempty"`
-	Addresses   []Address         `json:"addresses,omitempty" tf:"max_items:10"`
+	Addresses   []Address         `json:"addresses,omitempty" tf:"min_items:1,max_items:10"`
 	Unique      []Address         `json:"unique,omitempty" tf:"slice_set"`
 	Things      []string          `json:"things,omitempty" tf:"slice_set"`
 	Tags        map[string]string `json:"tags,omitempty" tf:"max_items:5"`

--- a/docs/resources/pipeline.md
+++ b/docs/resources/pipeline.md
@@ -53,6 +53,16 @@ resource "databricks_pipeline" "this" {
   }
 
   continuous = false
+
+  notification {
+    email_recipients = ["user@domain.com", "user1@domain.com"]
+    alerts = [
+      "on-update-failure",
+      "on-update-fatal-failure",
+      "on-update-success",
+      "on-flow-failure"
+    ]
+  }
 }
 ```
 
@@ -71,6 +81,18 @@ The following arguments are supported:
 * `target` - The name of a database for persisting pipeline output data. Configuring the target setting allows you to view and query the pipeline output data from the Databricks UI.
 * `edition` - optional name of the [product edition](https://docs.databricks.com/data-engineering/delta-live-tables/delta-live-tables-concepts.html#editions). Supported values are: `core`, `pro`, `advanced` (default).
 * `channel` - optional name of the release channel for Spark version used by DLT pipeline.  Supported values are: `current` (default) and `preview`.
+
+### notification block
+
+DLT allows to specify one or more notification blocks to get notifications about pipeline's execution.  This block consists of following attributes:
+
+* `email_recipients` (Required) non-empty list of emails to notify.
+* `alerts` (Required) non-empty list of alert types. Right now following alert types are supported, consult documentation for actual list
+  * `on-update-success` - a pipeline update completes successfully.
+  * `on-update-failure` - a pipeline update fails with a retryable error.
+  * `on-update-fatal-failure` - a pipeline update fails with a non-retryable (fatal) error.
+  * `on-flow-failure` - a single data flow fails.
+
 
 ## Import
 

--- a/pipelines/resource_pipeline.go
+++ b/pipelines/resource_pipeline.go
@@ -102,7 +102,7 @@ type PipelineSpec struct {
 	Photon              bool              `json:"photon,omitempty"`
 	Edition             string            `json:"edition,omitempty" tf:"suppress_diff,default:ADVANCED"`
 	Channel             string            `json:"channel,omitempty" tf:"suppress_diff,default:CURRENT"`
-	Notifications       []Notification    `json:"notifications,omitempty" tf:",alias:notification"`
+	Notifications       []Notification    `json:"notifications,omitempty" tf:"alias:notification"`
 }
 
 type createPipelineResponse struct {

--- a/pipelines/resource_pipeline.go
+++ b/pipelines/resource_pipeline.go
@@ -81,6 +81,11 @@ type filters struct {
 	Exclude []string `json:"exclude,omitempty"`
 }
 
+type Notification struct {
+	EmailRecipients []string `json:"email_recipients" tf:"min_items:1"`
+	Alerts          []string `json:"alerts" tf:"min_items:1"`
+}
+
 type PipelineSpec struct {
 	ID                  string            `json:"id,omitempty" tf:"computed"`
 	Name                string            `json:"name,omitempty"`
@@ -97,6 +102,7 @@ type PipelineSpec struct {
 	Photon              bool              `json:"photon,omitempty"`
 	Edition             string            `json:"edition,omitempty" tf:"suppress_diff,default:ADVANCED"`
 	Channel             string            `json:"channel,omitempty" tf:"suppress_diff,default:CURRENT"`
+	Notifications       []Notification    `json:"notifications,omitempty" tf:",alias:notification"`
 }
 
 type createPipelineResponse struct {


### PR DESCRIPTION
## Changes

Add support for email notifications in `databricks_pipeline` resource

Also added support for `min_items` terraform annotation to simplify specificaiton of non-empty lists.


<!-- Summary of your changes that are easy to understand -->

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [x] tested manually
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

