### PR TITLE
Migrate `databricks_cluster_policy` to Go SDK

### DIFF
--- a/docs/resources/cluster_policy.md
+++ b/docs/resources/cluster_policy.md
@@ -98,8 +98,11 @@ module "engineering_compute_policy" {
 The following arguments are required:
 
 * `name` - (Required) Cluster policy name. This must be unique. Length must be between 1 and 100 characters.
-* `definition` - (Required) Policy definition: JSON document expressed in [Databricks Policy Definition Language](https://docs.databricks.com/administration-guide/clusters/policies.html#cluster-policy-definition).
+* `description` - Additional human-readable description of the cluster policy.
+* `definition` - (Required) Policy definition: JSON document expressed in [Databricks Policy Definition Language](https://docs.databricks.com/administration-guide/clusters/policies.html#cluster-policy-definition). Cannot be used with `policy_family_id`
 * `max_clusters_per_user` - (Optional, integer) Maximum number of clusters allowed per user. When omitted, there is no limit. If specified, value must be greater than zero.
+* `policy_family_definition_overrides`(Optional) Policy definition JSON document expressed in Databricks Policy Definition Language. The JSON document must be passed as a string and cannot be embedded in the requests. You can use this to customize the policy definition inherited from the policy family. Policy rules specified here are merged into the inherited policy definition.
+* `policy_family_id` (Optional) ID of the policy family. The cluster policy's policy definition inherits the policy family's policy definition. Cannot be used with definition. Use `policy_family_definition_overrides` instead to customize the policy definition.
 
 ## Attribute Reference
 
@@ -113,7 +116,7 @@ In addition to all arguments above, the following attributes are exported:
 The resource cluster policy can be imported using the policy id:
 
 ```bash
-$ terraform import databricks_cluster_policy.this <cluster-policy-id>
+terraform import databricks_cluster_policy.this <cluster-policy-id>
 ```
 
 ## Related Resources

--- a/docs/resources/cluster_policy.md
+++ b/docs/resources/cluster_policy.md
@@ -98,11 +98,11 @@ module "engineering_compute_policy" {
 The following arguments are required:
 
 * `name` - (Required) Cluster policy name. This must be unique. Length must be between 1 and 100 characters.
-* `description` - Additional human-readable description of the cluster policy.
-* `definition` - (Required) Policy definition: JSON document expressed in [Databricks Policy Definition Language](https://docs.databricks.com/administration-guide/clusters/policies.html#cluster-policy-definition). Cannot be used with `policy_family_id`
+* `description` - (Optional) Additional human-readable description of the cluster policy.
+* `definition` - Policy definition: JSON document expressed in [Databricks Policy Definition Language](https://docs.databricks.com/administration-guide/clusters/policies.html#cluster-policy-definition). Cannot be used with `policy_family_id`
 * `max_clusters_per_user` - (Optional, integer) Maximum number of clusters allowed per user. When omitted, there is no limit. If specified, value must be greater than zero.
 * `policy_family_definition_overrides`(Optional) Policy definition JSON document expressed in Databricks Policy Definition Language. The JSON document must be passed as a string and cannot be embedded in the requests. You can use this to customize the policy definition inherited from the policy family. Policy rules specified here are merged into the inherited policy definition.
-* `policy_family_id` (Optional) ID of the policy family. The cluster policy's policy definition inherits the policy family's policy definition. Cannot be used with definition. Use `policy_family_definition_overrides` instead to customize the policy definition.
+* `policy_family_id` (Optional) ID of the policy family. The cluster policy's policy definition inherits the policy family's policy definition. Cannot be used with `definition`. Use `policy_family_definition_overrides` instead to customize the policy definition.
 
 ## Attribute Reference
 

--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/databricks/databricks-sdk-go/service/clusterpolicies"
 	clustersApi "github.com/databricks/databricks-sdk-go/service/clusters"
 	"github.com/databricks/databricks-sdk-go/service/gitcredentials"
 	"github.com/databricks/terraform-provider-databricks/access"
@@ -22,7 +23,6 @@ import (
 	"github.com/databricks/terraform-provider-databricks/jobs"
 	"github.com/databricks/terraform-provider-databricks/libraries"
 	"github.com/databricks/terraform-provider-databricks/pipelines"
-	"github.com/databricks/terraform-provider-databricks/policies"
 	"github.com/databricks/terraform-provider-databricks/qa"
 	"github.com/databricks/terraform-provider-databricks/repos"
 	"github.com/databricks/terraform-provider-databricks/scim"
@@ -831,8 +831,8 @@ func TestImportingJobs_JobList(t *testing.T) {
 			{
 				Method:   "GET",
 				Resource: "/api/2.0/policies/clusters/get?policy_id=123",
-				Response: policies.ClusterPolicy{
-					PolicyID: "123",
+				Response: clusterpolicies.Policy{
+					PolicyId: "123",
 					Name:     "dummy",
 					Definition: `{
 						"aws_attributes.instance_profile_arn": {
@@ -1077,8 +1077,8 @@ func TestImportingJobs_JobListMultiTask(t *testing.T) {
 			{
 				Method:   "GET",
 				Resource: "/api/2.0/policies/clusters/get?policy_id=123",
-				Response: policies.ClusterPolicy{
-					PolicyID: "123",
+				Response: clusterpolicies.Policy{
+					PolicyId: "123",
 					Name:     "dummy",
 					Definition: `{
 						"aws_attributes.instance_profile_arn": {

--- a/policies/data_cluster_policy_test.go
+++ b/policies/data_cluster_policy_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/databricks/databricks-sdk-go/apierr"
+	clusterpolicies "github.com/databricks/databricks-sdk-go/service/clusterpolicies"
 	"github.com/databricks/terraform-provider-databricks/qa"
 )
 
@@ -13,10 +14,10 @@ func TestDataSourceClusterPolicy(t *testing.T) {
 			{
 				Method:   "GET",
 				Resource: "/api/2.0/policies/clusters/list?",
-				Response: ClusterPolicyList{
-					Policies: []ClusterPolicy{
+				Response: clusterpolicies.ListPoliciesResponse{
+					Policies: []clusterpolicies.Policy{
 						{
-							PolicyID:   "abc",
+							PolicyId:   "abc",
 							Name:       "policy",
 							Definition: `{"abc":"123"}`,
 						},
@@ -61,7 +62,7 @@ func TestDataSourceClusterPolicyNotFound(t *testing.T) {
 			{
 				Method:   "GET",
 				Resource: "/api/2.0/policies/clusters/list?",
-				Response: ClusterPolicyList{},
+				Response: clusterpolicies.ListPoliciesResponse{},
 			},
 		},
 		Read:        true,

--- a/policies/resource_cluster_policy.go
+++ b/policies/resource_cluster_policy.go
@@ -21,7 +21,7 @@ func ResourceClusterPolicy() *schema.Resource {
 			m["definition"].ConflictsWith = []string{"policy_family_definition_overrides", "policy_family_id"}
 			m["policy_family_definition_overrides"].ConflictsWith = []string{"definition"}
 			m["policy_family_id"].ConflictsWith = []string{"definition"}
-			m["policy_family_id"].RequiredWith = []string{"policy_family_definition_overrides"}
+			m["policy_family_definition_overrides"].RequiredWith = []string{"policy_family_id"}
 
 			return m
 		})
@@ -55,8 +55,7 @@ func ResourceClusterPolicy() *schema.Resource {
 			if err != nil {
 				return err
 			}
-			common.StructToData(resp, s, d)
-			return nil
+			return common.StructToData(resp, s, d)
 		},
 		Update: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
 			w, err := c.WorkspaceClient()

--- a/policies/resource_cluster_policy.go
+++ b/policies/resource_cluster_policy.go
@@ -3,165 +3,73 @@ package policies
 import (
 	"context"
 
+	"github.com/databricks/databricks-sdk-go/service/clusterpolicies"
 	"github.com/databricks/terraform-provider-databricks/common"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
-
-// ClusterPolicy defines cluster policy
-type ClusterPolicy struct {
-	PolicyID           string `json:"policy_id,omitempty"`
-	Name               string `json:"name"`
-	Definition         string `json:"definition"`
-	CreatedAtTimeStamp int64  `json:"created_at_timestamp"`
-	MaxClustersPerUser int64  `json:"max_clusters_per_user,omitempty"`
-}
-
-// ClusterPolicyCreate is the entity used for request
-type ClusterPolicyCreate struct {
-	Name               string `json:"name"`
-	Definition         string `json:"definition"`
-	MaxClustersPerUser int64  `json:"max_clusters_per_user,omitempty"`
-}
-
-type ClusterPolicyList struct {
-	Policies []ClusterPolicy `json:"policies"`
-}
-
-// NewClusterPoliciesAPI creates ClusterPoliciesAPI instance from provider meta
-// Creation and editing is available to admins only.
-func NewClusterPoliciesAPI(ctx context.Context, m any) ClusterPoliciesAPI {
-	return ClusterPoliciesAPI{m.(*common.DatabricksClient), ctx}
-}
-
-// ClusterPoliciesAPI struct for cluster policies API
-type ClusterPoliciesAPI struct {
-	client  *common.DatabricksClient
-	context context.Context
-}
-
-type policyIDWrapper struct {
-	PolicyID string `json:"policy_id,omitempty" url:"policy_id,omitempty"`
-}
-
-// Create creates new cluster policy and sets PolicyID
-func (a ClusterPoliciesAPI) Create(clusterPolicy *ClusterPolicy) error {
-	var policyIDResponse = policyIDWrapper{}
-	err := a.client.Post(a.context, "/policies/clusters/create", clusterPolicy, &policyIDResponse)
-	if err != nil {
-		return err
-	}
-	clusterPolicy.PolicyID = policyIDResponse.PolicyID
-	return nil
-}
-
-// Edit will update an existing policy.
-// This may make some clusters governed by this policy invalid.
-// For such clusters the next cluster edit must provide a confirming configuration,
-// but otherwise they can continue to run.
-func (a ClusterPoliciesAPI) Edit(clusterPolicy *ClusterPolicy) error {
-	return a.client.Post(a.context, "/policies/clusters/edit", clusterPolicy, nil)
-}
-
-// Get returns cluster policy
-func (a ClusterPoliciesAPI) Get(policyID string) (policy ClusterPolicy, err error) {
-	err = a.client.Get(a.context, "/policies/clusters/get", policyIDWrapper{policyID}, &policy)
-	return
-}
-
-// Delete removes cluster policy
-func (a ClusterPoliciesAPI) Delete(policyID string) error {
-	return a.client.Post(a.context, "/policies/clusters/delete", policyIDWrapper{policyID}, nil)
-}
-
-// Get returns cluster policy
-func (a ClusterPoliciesAPI) List() ([]ClusterPolicy, error) {
-	var lst ClusterPolicyList
-	err := a.client.Get(a.context, "/policies/clusters/list", nil, &lst)
-	if err != nil {
-		return []ClusterPolicy{}, err
-	}
-	return lst.Policies, nil
-}
-
-func parsePolicyFromData(d *schema.ResourceData) (*ClusterPolicy, error) {
-	clusterPolicy := new(ClusterPolicy)
-	clusterPolicy.PolicyID = d.Id()
-	if name, ok := d.GetOk("name"); ok {
-		clusterPolicy.Name = name.(string)
-	}
-	if data, ok := d.GetOk("definition"); ok {
-		clusterPolicy.Definition = data.(string)
-	}
-	if max_clusters, ok := d.GetOk("max_clusters_per_user"); ok {
-		clusterPolicy.MaxClustersPerUser = int64(max_clusters.(int))
-	}
-	return clusterPolicy, nil
-}
 
 // ResourceClusterPolicy ...
 func ResourceClusterPolicy() *schema.Resource {
+	s := common.StructToSchema(
+		clusterpolicies.CreatePolicy{},
+		func(m map[string]*schema.Schema) map[string]*schema.Schema {
+			m["definition"].ConflictsWith = []string{"policy_family_definition_overrides", "policy_family_id"}
+			m["policy_family_definition_overrides"].ConflictsWith = []string{"definition"}
+			m["policy_family_id"].ConflictsWith = []string{"definition"}
+			return m
+		})
+
 	return common.Resource{
-		Schema: map[string]*schema.Schema{
-			"policy_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-				Description: "Cluster policy name. This must be unique.\n" +
-					"Length must be between 1 and 100 characters.",
-				ValidateFunc: validation.StringLenBetween(1, 100),
-			},
-			"definition": {
-				Type:     schema.TypeString,
-				Required: true,
-				Description: "Policy definition JSON document expressed in\n" +
-					"Databricks Policy Definition Language.",
-				ValidateFunc: validation.StringIsJSON,
-			},
-			"max_clusters_per_user": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				Description: "Max number of clusters per user that can be active\n" +
-					"using this policy. If not present, there is no max limit.",
-				ValidateFunc: validation.IntAtLeast(1),
-			},
-		},
+		Schema: s,
 		Create: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
-			clusterPolicy, err := parsePolicyFromData(d)
+			w, err := c.WorkspaceClient()
 			if err != nil {
 				return err
 			}
-			if err = NewClusterPoliciesAPI(ctx, c).Create(clusterPolicy); err != nil {
+
+			var request clusterpolicies.CreatePolicy
+			common.DataToStructPointer(d, s, &request)
+
+			clusterPolicy, err := w.ClusterPolicies.Create(ctx, request)
+			if err != nil {
 				return err
 			}
-			d.SetId(clusterPolicy.PolicyID)
+
+			d.SetId(clusterPolicy.PolicyId)
 			return nil
 		},
 		Read: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
-			clusterPolicy, err := NewClusterPoliciesAPI(ctx, c).Get(d.Id())
+			w, err := c.WorkspaceClient()
 			if err != nil {
 				return err
 			}
-			d.Set("name", clusterPolicy.Name)
-			d.Set("definition", clusterPolicy.Definition)
-			d.Set("policy_id", clusterPolicy.PolicyID)
-			d.SetId(clusterPolicy.PolicyID)
-			d.Set("max_clusters_per_user", clusterPolicy.MaxClustersPerUser)
+
+			resp, err := w.ClusterPolicies.GetByPolicyId(ctx, d.Id())
+			if err != nil {
+				return err
+			}
+			common.StructToData(resp, s, d)
 			return nil
 		},
 		Update: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
-			clusterPolicy, err := parsePolicyFromData(d)
+			w, err := c.WorkspaceClient()
 			if err != nil {
 				return err
 			}
-			return NewClusterPoliciesAPI(ctx, c).Edit(clusterPolicy)
+
+			var request clusterpolicies.EditPolicy
+			common.DataToStructPointer(d, s, &request)
+			request.PolicyId = d.Id()
+
+			return w.ClusterPolicies.Edit(ctx, request)
 		},
 		Delete: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
-			return NewClusterPoliciesAPI(ctx, c).Delete(d.Id())
+			w, err := c.WorkspaceClient()
+			if err != nil {
+				return err
+			}
+			return w.ClusterPolicies.DeleteByPolicyId(ctx, d.Id())
 		},
 	}.ToResource()
 }

--- a/policies/resource_cluster_policy.go
+++ b/policies/resource_cluster_policy.go
@@ -14,9 +14,15 @@ func ResourceClusterPolicy() *schema.Resource {
 	s := common.StructToSchema(
 		clusterpolicies.CreatePolicy{},
 		func(m map[string]*schema.Schema) map[string]*schema.Schema {
+			m["policy_id"] = &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			}
 			m["definition"].ConflictsWith = []string{"policy_family_definition_overrides", "policy_family_id"}
 			m["policy_family_definition_overrides"].ConflictsWith = []string{"definition"}
 			m["policy_family_id"].ConflictsWith = []string{"definition"}
+			m["policy_family_id"].RequiredWith = []string{"policy_family_definition_overrides"}
+
 			return m
 		})
 

--- a/policies/resource_cluster_policy_test.go
+++ b/policies/resource_cluster_policy_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/databricks/databricks-sdk-go/apierr"
+	clusterpolicies "github.com/databricks/databricks-sdk-go/service/clusterpolicies"
 	"github.com/databricks/terraform-provider-databricks/qa"
 	"github.com/stretchr/testify/assert"
 )
@@ -14,17 +15,18 @@ func TestResourceClusterPolicyRead(t *testing.T) {
 			{
 				Method:   "GET",
 				Resource: "/api/2.0/policies/clusters/get?policy_id=abc",
-				Response: ClusterPolicy{
-					PolicyID:           "abc",
+				Response: clusterpolicies.Policy{
+					PolicyId:           "abc",
 					Name:               "Dummy",
 					Definition:         "{\"spark_conf.foo\": {\"type\": \"fixed\", \"value\": \"bar\"}}",
-					CreatedAtTimeStamp: 0,
+					CreatedAtTimestamp: 0,
 					MaxClustersPerUser: 5,
 				},
 			},
 		},
 		Resource: ResourceClusterPolicy(),
 		Read:     true,
+		New:      true,
 		ID:       "abc",
 	}.Apply(t)
 	assert.NoError(t, err)
@@ -82,24 +84,23 @@ func TestResourceClusterPolicyCreate(t *testing.T) {
 			{
 				Method:   "POST",
 				Resource: "/api/2.0/policies/clusters/create",
-				ExpectedRequest: ClusterPolicy{
+				ExpectedRequest: clusterpolicies.CreatePolicy{
 					Name:               "Dummy",
 					Definition:         "{\"spark_conf.foo\": {\"type\": \"fixed\", \"value\": \"bar\"}}",
-					CreatedAtTimeStamp: 0,
 					MaxClustersPerUser: 3,
 				},
-				Response: ClusterPolicy{
-					PolicyID: "abc",
+				Response: clusterpolicies.CreatePolicyResponse{
+					PolicyId: "abc",
 				},
 			},
 			{
 				Method:   "GET",
 				Resource: "/api/2.0/policies/clusters/get?policy_id=abc",
-				Response: ClusterPolicy{
-					PolicyID:           "abc",
+				Response: clusterpolicies.Policy{
+					PolicyId:           "abc",
 					Name:               "Dummy",
 					Definition:         "{\"spark_conf.foo\": {\"type\": \"fixed\", \"value\": \"bar\"}}",
-					CreatedAtTimeStamp: 0,
+					CreatedAtTimestamp: 0,
 					MaxClustersPerUser: 3,
 				},
 			},
@@ -115,6 +116,45 @@ func TestResourceClusterPolicyCreate(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "abc", d.Id())
 	assert.Equal(t, 3, d.Get("max_clusters_per_user"))
+}
+
+func TestResourceClusterPolicyCreateConflict(t *testing.T) {
+	qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "POST",
+				Resource: "/api/2.0/policies/clusters/create",
+				ExpectedRequest: clusterpolicies.CreatePolicy{
+					Name:               "Dummy",
+					Definition:         "{\"spark_conf.foo\": {\"type\": \"fixed\", \"value\": \"bar\"}}",
+					PolicyFamilyId:     "Test",
+					MaxClustersPerUser: 3,
+				},
+				Response: clusterpolicies.CreatePolicyResponse{
+					PolicyId: "abc",
+				},
+			},
+			{
+				Method:   "GET",
+				Resource: "/api/2.0/policies/clusters/get?policy_id=abc",
+				Response: clusterpolicies.Policy{
+					PolicyId:           "abc",
+					Name:               "Dummy",
+					Definition:         "{\"spark_conf.foo\": {\"type\": \"fixed\", \"value\": \"bar\"}}",
+					CreatedAtTimestamp: 0,
+					MaxClustersPerUser: 3,
+				},
+			},
+		},
+		Resource: ResourceClusterPolicy(),
+		HCL: `
+		name = "Dummy"
+		definition = "{\"spark_conf.foo\": {\"type\": \"fixed\", \"value\": \"bar\"}}"
+		policy_family_id = "Test"
+		max_clusters_per_user = 3
+		`,
+		Create: true,
+	}.ExpectError(t, "invalid config supplied. [definition] Conflicting configuration arguments. [policy_family_id] Conflicting configuration arguments")
 }
 
 func TestResourceClusterPolicyCreate_Error(t *testing.T) {
@@ -147,21 +187,20 @@ func TestResourceClusterPolicyUpdate(t *testing.T) {
 			{
 				Method:   "POST",
 				Resource: "/api/2.0/policies/clusters/edit",
-				ExpectedRequest: ClusterPolicy{
-					PolicyID:           "abc",
-					Name:               "Dummy Updated",
-					Definition:         "{\"spark_conf.foo\": {\"type\": \"fixed\", \"value\": \"bar\"}}",
-					CreatedAtTimeStamp: 0,
+				ExpectedRequest: clusterpolicies.EditPolicy{
+					PolicyId:   "abc",
+					Name:       "Dummy Updated",
+					Definition: "{\"spark_conf.foo\": {\"type\": \"fixed\", \"value\": \"bar\"}}",
 				},
 			},
 			{
 				Method:   "GET",
 				Resource: "/api/2.0/policies/clusters/get?policy_id=abc",
-				Response: ClusterPolicy{
-					PolicyID:           "abc",
+				Response: clusterpolicies.Policy{
+					PolicyId:           "abc",
 					Name:               "Dummy Updated",
 					Definition:         "{\"spark_conf.foo\": {\"type\": \"fixed\", \"value\": \"bar\"}}",
-					CreatedAtTimeStamp: 0,
+					CreatedAtTimestamp: 0,
 				},
 			},
 		},

--- a/policies/resource_cluster_policy_test.go
+++ b/policies/resource_cluster_policy_test.go
@@ -134,27 +134,17 @@ func TestResourceClusterPolicyCreateConflict(t *testing.T) {
 					PolicyId: "abc",
 				},
 			},
-			{
-				Method:   "GET",
-				Resource: "/api/2.0/policies/clusters/get?policy_id=abc",
-				Response: clusterpolicies.Policy{
-					PolicyId:           "abc",
-					Name:               "Dummy",
-					Definition:         "{\"spark_conf.foo\": {\"type\": \"fixed\", \"value\": \"bar\"}}",
-					CreatedAtTimestamp: 0,
-					MaxClustersPerUser: 3,
-				},
-			},
 		},
 		Resource: ResourceClusterPolicy(),
 		HCL: `
 		name = "Dummy"
 		definition = "{\"spark_conf.foo\": {\"type\": \"fixed\", \"value\": \"bar\"}}"
 		policy_family_id = "Test"
+		policy_family_definition_overrides = "{\"spark_conf.foo\": {\"type\": \"fixed\", \"value\": \"bar\"}}"
 		max_clusters_per_user = 3
 		`,
 		Create: true,
-	}.ExpectError(t, "invalid config supplied. [definition] Conflicting configuration arguments. [policy_family_id] Conflicting configuration arguments")
+	}.ExpectError(t, "invalid config supplied. [definition] Conflicting configuration arguments. [policy_family_definition_overrides] Conflicting configuration arguments. [policy_family_id] Conflicting configuration arguments")
 }
 
 func TestResourceClusterPolicyCreate_Error(t *testing.T) {

--- a/policies/resource_cluster_policy_test.go
+++ b/policies/resource_cluster_policy_test.go
@@ -120,21 +120,6 @@ func TestResourceClusterPolicyCreate(t *testing.T) {
 
 func TestResourceClusterPolicyCreateConflict(t *testing.T) {
 	qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:   "POST",
-				Resource: "/api/2.0/policies/clusters/create",
-				ExpectedRequest: clusterpolicies.CreatePolicy{
-					Name:               "Dummy",
-					Definition:         "{\"spark_conf.foo\": {\"type\": \"fixed\", \"value\": \"bar\"}}",
-					PolicyFamilyId:     "Test",
-					MaxClustersPerUser: 3,
-				},
-				Response: clusterpolicies.CreatePolicyResponse{
-					PolicyId: "abc",
-				},
-			},
-		},
 		Resource: ResourceClusterPolicy(),
 		HCL: `
 		name = "Dummy"


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
Migrate the cluster policy service to go SDK.
Closes #2247

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [x] covered with integration tests in `internal/acceptance`
- [x] relevant acceptance tests are passing
- [x] using Go SDK

