### PR TITLE
Added support for running `databricks_cluster` init scripts from workspace files

### DIFF
--- a/clusters/clusters_api.go
+++ b/clusters/clusters_api.go
@@ -205,6 +205,11 @@ type LocalFileInfo struct {
 	Destination string `json:"destination,omitempty"`
 }
 
+// WorkspaceFileInfo represents a file in the Databricks workspace.
+type WorkspaceFileInfo struct {
+	Destination string `json:"destination,omitempty"`
+}
+
 // StorageInfo contains the struct for either DBFS or S3 storage depending on which one is relevant.
 type StorageInfo struct {
 	Dbfs *DbfsStorageInfo `json:"dbfs,omitempty" tf:"group:storage"`
@@ -213,11 +218,12 @@ type StorageInfo struct {
 
 // InitScriptStorageInfo captures the allowed sources of init scripts.
 type InitScriptStorageInfo struct {
-	Dbfs  *DbfsStorageInfo  `json:"dbfs,omitempty" tf:"group:storage"`
-	Gcs   *GcsStorageInfo   `json:"gcs,omitempty" tf:"group:storage"`
-	S3    *S3StorageInfo    `json:"s3,omitempty" tf:"group:storage"`
-	Abfss *AbfssStorageInfo `json:"abfss,omitempty" tf:"group:storage"`
-	File  *LocalFileInfo    `json:"file,omitempty"`
+	Dbfs      *DbfsStorageInfo   `json:"dbfs,omitempty" tf:"group:storage"`
+	Gcs       *GcsStorageInfo    `json:"gcs,omitempty" tf:"group:storage"`
+	S3        *S3StorageInfo     `json:"s3,omitempty" tf:"group:storage"`
+	Abfss     *AbfssStorageInfo  `json:"abfss,omitempty" tf:"group:storage"`
+	File      *LocalFileInfo     `json:"file,omitempty"`
+	Workspace *WorkspaceFileInfo `json:"workspace,omitempty"`
 }
 
 // SparkNodeAwsAttributes is the struct that determines if the node is a spot instance or not

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -256,7 +256,17 @@ There are a few more advanced attributes for S3 log delivery:
 
 To run a particular init script on all clusters within the same workspace, both automated/job and interactive/all-purpose cluster types, please consider the [databricks_global_init_script](global_init_script.md) resource.
 
-It is possible to specify up to 10 different cluster-scoped init scripts per cluster.  Like the `cluster_log_conf` configuration block, init scripts support DBFS and cloud storage locations.
+It is possible to specify up to 10 different cluster-scoped init scripts per cluster.  Init scripts support DBFS, cloud storage locations, and workspace files.
+
+Example of using a Databricks workspace file as init script:
+
+```hcl
+init_scripts {
+  workspace {
+    destination = "/Users/user@domain/install-elk.sh"
+  }
+}
+```
 
 Example of taking init script from DBFS:
 


### PR DESCRIPTION
## Changes

This PR adds support for using workspace files as init scripts:

```hcl
init_scripts {
  workspace {
    destination = "/Users/user@domain/install-elk.sh"
  }
}
```

## Tests

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [x] tested manually 
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

