### PR TITLE
Add `databricks_workspace_file` resource

### DIFF
--- a/docs/resources/notebook.md
+++ b/docs/resources/notebook.md
@@ -63,7 +63,7 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Access Control
 
-* [databricks_permissions](permissions.md#Notebook-usage) can control which groups or individual users can access notebooks or folders.
+* [databricks_permissions](permissions.md#notebook-usage) can control which groups or individual users can access notebooks or folders.
 
 ## Import
 

--- a/docs/resources/permissions.md
+++ b/docs/resources/permissions.md
@@ -320,6 +320,45 @@ resource "databricks_permissions" "notebook_usage" {
 }
 ```
 
+## Workspace file usage
+
+Valid permission levels for [databricks_workspace_file](workspace_file.md) are: `CAN_READ`, `CAN_RUN`, `CAN_EDIT`, and `CAN_MANAGE`.
+
+```hcl
+resource "databricks_group" "auto" {
+  display_name = "Automation"
+}
+
+resource "databricks_group" "eng" {
+  display_name = "Engineering"
+}
+
+resource "databricks_workspace_file" "this" {
+  content_base64 = base64encode("print('Hello World')")
+  path           = "/Production/ETL/Features.py"
+}
+
+resource "databricks_permissions" "workspace_file_usage" {
+  workspace_file_path = databricks_workspace_file.this.path
+
+  access_control {
+    group_name       = "users"
+    permission_level = "CAN_READ"
+  }
+
+  access_control {
+    group_name       = databricks_group.auto.display_name
+    permission_level = "CAN_RUN"
+  }
+
+  access_control {
+    group_name       = databricks_group.eng.display_name
+    permission_level = "CAN_EDIT"
+  }
+}
+```
+
+
 ## Folder usage
 
 Valid [permission levels](https://docs.databricks.com/security/access-control/workspace-acl.html#folder-permissions) for folders of [databricks_directory](directory.md) are: `CAN_READ`, `CAN_RUN`, `CAN_EDIT`, and `CAN_MANAGE`. Notebooks and experiments in a folder inherit all permissions settings of that folder. For example, a user (or service principal) that has `CAN_RUN` permission on a folder has `CAN_RUN` permission on the notebooks in that folder.

--- a/docs/resources/workspace_file.md
+++ b/docs/resources/workspace_file.md
@@ -19,15 +19,16 @@ resource "databricks_workspace_file" "module" {
 }
 ```
 
-You can also create a managed notebook with inline sources through `content_base64`  attribute.
+You can also create a managed workspace file with inline sources through `content_base64`  attribute.
 
 ```hcl
 resource "databricks_workspace_file" "init_script" {
   content_base64 = base64encode(<<-EOT
     #!/bin/bash
     echo "Hello World"
+    EOT
   )
-  path     = "/Shared/init-script.sh"
+  path = "/Shared/init-script.sh"
 }
 ```
 
@@ -39,26 +40,26 @@ The size of a workspace file source code must not exceed a few megabytes. The fo
 
 * `path` -  (Required) The absolute path of the workspace file, beginning with "/", e.g. "/Demo".
 * `source` - Path to file on local filesystem. Conflicts with `content_base64`.
-* `content_base64` - The base64-encoded file content. Conflicts with `source`. Use of `content_base64` is discouraged, as it's increasing memory footprint of Terraform state and should only be used in exceptional circumstances, like creating a notebook with configuration properties for a data pipeline.
+* `content_base64` - The base64-encoded file content. Conflicts with `source`. Use of `content_base64` is discouraged, as it's increasing memory footprint of Terraform state and should only be used in exceptional circumstances, like creating a workspace file with configuration properties for a data pipeline.
 
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` -  Path of notebook on workspace
-* `url` - Routable URL of the notebook
-* `object_id` -  Unique identifier for a NOTEBOOK
+* `id` -  Path of workspace file
+* `url` - Routable URL of the workspace file
+* `object_id` -  Unique identifier for a workspace file
 
 ## Access Control
 
-* [databricks_permissions](permissions.md#workspace-file-usage) can control which groups or individual users can access notebooks or folders.
+* [databricks_permissions](permissions.md#workspace-file-usage) can control which groups or individual users can access workspace file.
 
 ## Import
 
-The resource notebook can be imported using notebook path
+The workspace file resource can be imported using workspace file path
 
 ```bash
-$ terraform import databricks_workspace_file.this /path/to/notebook
+$ terraform import databricks_workspace_file.this /path/to/file
 ```
 
 ## Related Resources

--- a/docs/resources/workspace_file.md
+++ b/docs/resources/workspace_file.md
@@ -1,0 +1,78 @@
+---
+subcategory: "Workspace"
+---
+# databricks_workspace_file Resource
+
+This resource allows you to manage [Databricks Workspace Files](https://docs.databricks.com/files/workspace.html).
+
+## Example Usage
+
+You can declare Terraform-managed workspace file by specifying `source` attribute of corresponding local file.
+
+```hcl
+data "databricks_current_user" "me" {
+}
+
+resource "databricks_workspace_file" "module" {
+  source = "${path.module}/module.py"
+  path   = "${data.databricks_current_user.me.home}/AA/BB/CC"
+}
+```
+
+You can also create a managed notebook with inline sources through `content_base64`  attribute.
+
+```hcl
+resource "databricks_workspace_file" "init_script" {
+  content_base64 = base64encode(<<-EOT
+    #!/bin/bash
+    echo "Hello World"
+  )
+  path     = "/Shared/init-script.sh"
+}
+```
+
+## Argument Reference
+
+-> **Note** Files in Databricks workspace would only be changed, if Terraform stage did change. This means that any manual changes to managed workspace files won't be overwritten by Terraform, if there's no local change to file sources. Workspace files are identified by their path, so changing file's name manually on the workspace and then applying Terraform state would result in creation of workspace file from Terraform state.
+
+The size of a workspace file source code must not exceed a few megabytes. The following arguments are supported:
+
+* `path` -  (Required) The absolute path of the workspace file, beginning with "/", e.g. "/Demo".
+* `source` - Path to file on local filesystem. Conflicts with `content_base64`.
+* `content_base64` - The base64-encoded file content. Conflicts with `source`. Use of `content_base64` is discouraged, as it's increasing memory footprint of Terraform state and should only be used in exceptional circumstances, like creating a notebook with configuration properties for a data pipeline.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` -  Path of notebook on workspace
+* `url` - Routable URL of the notebook
+* `object_id` -  Unique identifier for a NOTEBOOK
+
+## Access Control
+
+* [databricks_permissions](permissions.md#workspace-file-usage) can control which groups or individual users can access notebooks or folders.
+
+## Import
+
+The resource notebook can be imported using notebook path
+
+```bash
+$ terraform import databricks_workspace_file.this /path/to/notebook
+```
+
+## Related Resources
+
+The following resources are often used in the same context:
+
+* [End to end workspace management](../guides/workspace-management.md) guide.
+* [databricks_cluster](cluster.md) to create [Databricks Clusters](https://docs.databricks.com/clusters/index.html).
+* [databricks_directory](directory.md) to manage directories in [Databricks Workpace](https://docs.databricks.com/workspace/workspace-objects.html).
+* [databricks_job](job.md) to manage [Databricks Jobs](https://docs.databricks.com/jobs.html) to run non-interactive code in a [databricks_cluster](cluster.md).
+* [databricks_pipeline](pipeline.md) to deploy [Delta Live Tables](https://docs.databricks.com/data-engineering/delta-live-tables/index.html).
+* [databricks_repo](repo.md) to manage [Databricks Repos](https://docs.databricks.com/repos.html).
+* [databricks_secret](secret.md) to manage [secrets](https://docs.databricks.com/security/secrets/index.html#secrets-user-guide) in Databricks workspace.
+* [databricks_secret_acl](secret_acl.md) to manage access to [secrets](https://docs.databricks.com/security/secrets/index.html#secrets-user-guide) in Databricks workspace.
+* [databricks_secret_scope](secret_scope.md) to create [secret scopes](https://docs.databricks.com/security/secrets/index.html#secrets-user-guide) in Databricks workspace.
+* [databricks_user](user.md) to [manage users](https://docs.databricks.com/administration-guide/users-groups/users.html), that could be added to [databricks_group](group.md) within the workspace.
+* [databricks_user](../data-sources/user.md) data to retrieve information about [databricks_user](user.md).

--- a/internal/acceptance/workspace_file_test.go
+++ b/internal/acceptance/workspace_file_test.go
@@ -17,3 +17,17 @@ func TestAccWorkspaceFile(t *testing.T) {
 		}`,
 	})
 }
+
+func TestAccWorkspaceFileBase64(t *testing.T) {
+	workspaceLevel(t, step{
+		Template: `resource "databricks_workspace_file" "this2" {
+			"content_base64": "YWJjCg==",
+			path = "/Shared/provider-test/xx2_{var.RANDOM}"
+		}`,
+	}, step{
+		Template: `resource "databricks_workspace_file" "this2" {
+			"content_base64": "YWJjCg==",
+			path = "/Shared/provider-test/xx2_{var.RANDOM}_renamed"
+		}`,
+	})
+}

--- a/internal/acceptance/workspace_file_test.go
+++ b/internal/acceptance/workspace_file_test.go
@@ -1,0 +1,19 @@
+package acceptance
+
+import (
+	"testing"
+)
+
+func TestAccWorkspaceFile(t *testing.T) {
+	workspaceLevel(t, step{
+		Template: `resource "databricks_workspace_file" "this" {
+			source = "{var.CWD}/../../storage/testdata/tf-test-python.py"
+			path = "/Shared/provider-test/xx_{var.RANDOM}"
+		}`,
+	}, step{
+		Template: `resource "databricks_workspace_file" "this" {
+			source = "{var.CWD}/../../storage/testdata/tf-test-python.py"
+			path = "/Shared/provider-test/xx_{var.RANDOM}_renamed"
+		}`,
+	})
+}

--- a/permissions/resource_permissions.go
+++ b/permissions/resource_permissions.go
@@ -296,6 +296,8 @@ func permissionsResourceIDFields() []permissionsIDFieldMapping {
 		{"notebook_path", "notebook", "notebooks", []string{"CAN_READ", "CAN_RUN", "CAN_EDIT", "CAN_MANAGE"}, PATH},
 		{"directory_id", "directory", "directories", []string{"CAN_READ", "CAN_RUN", "CAN_EDIT", "CAN_MANAGE"}, SIMPLE},
 		{"directory_path", "directory", "directories", []string{"CAN_READ", "CAN_RUN", "CAN_EDIT", "CAN_MANAGE"}, PATH},
+		{"workspace_file_id", "file", "files", []string{"CAN_READ", "CAN_RUN", "CAN_EDIT", "CAN_MANAGE"}, SIMPLE},
+		{"workspace_file_path", "file", "files", []string{"CAN_READ", "CAN_RUN", "CAN_EDIT", "CAN_MANAGE"}, PATH},
 		{"repo_id", "repo", "repos", []string{"CAN_READ", "CAN_RUN", "CAN_EDIT", "CAN_MANAGE"}, SIMPLE},
 		{"repo_path", "repo", "repos", []string{"CAN_READ", "CAN_RUN", "CAN_EDIT", "CAN_MANAGE"}, PATH},
 		{"authorization", "tokens", "authorization", []string{"CAN_USE"}, SIMPLE},
@@ -336,7 +338,12 @@ func (oa *ObjectACL) ToPermissionsEntity(d *schema.ResourceData, me string) (Per
 			continue
 		}
 		entity.ObjectType = mapping.objectType
-		pathVariant := d.Get(mapping.objectType + "_path")
+		var pathVariant any
+		if mapping.objectType == "file" {
+			pathVariant = d.Get("workspace_file_path")
+		} else {
+			pathVariant = d.Get(mapping.objectType + "_path")
+		}
 		if pathVariant != nil && pathVariant.(string) != "" {
 			// we're not importing and it's a path... it's set, so let's not re-set it
 			return entity, nil

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -154,6 +154,7 @@ func DatabricksProvider() *schema.Provider {
 			"databricks_user_instance_profile":       aws.ResourceUserInstanceProfile(),
 			"databricks_user_role":                   aws.ResourceUserRole(),
 			"databricks_workspace_conf":              workspace.ResourceWorkspaceConf(),
+			"databricks_workspace_file":              workspace.ResourceWorkspaceFile(),
 		},
 		Schema: providerSchema(),
 	}

--- a/workspace/data_notebook_paths.go
+++ b/workspace/data_notebook_paths.go
@@ -20,10 +20,12 @@ func DataSourceNotebookPaths() *schema.Resource {
 			d.SetId(path)
 			var notebookPathList []map[string]string
 			for _, v := range notebookList {
-				notebookPathMap := map[string]string{}
-				notebookPathMap["path"] = v.Path
-				notebookPathMap["language"] = string(v.Language)
-				notebookPathList = append(notebookPathList, notebookPathMap)
+				if v.ObjectType == Notebook {
+					notebookPathMap := map[string]string{}
+					notebookPathMap["path"] = v.Path
+					notebookPathMap["language"] = string(v.Language)
+					notebookPathList = append(notebookPathList, notebookPathMap)
+				}
 			}
 			// nolint
 			d.Set("notebook_path_list", notebookPathList)

--- a/workspace/resource_notebook.go
+++ b/workspace/resource_notebook.go
@@ -16,12 +16,14 @@ import (
 // ...
 const (
 	Notebook  string = "NOTEBOOK"
+	File      string = "FILE"
 	Directory string = "DIRECTORY"
 	Scala     string = "SCALA"
 	Python    string = "PYTHON"
 	SQL       string = "SQL"
 	R         string = "R"
 	Jupyter   string = "JUPYTER"
+	Auto      string = "AUTO"
 )
 
 type notebookLanguageFormat struct {
@@ -149,7 +151,7 @@ func (a NotebooksAPI) recursiveAddPaths(path string, pathList *[]ObjectStatus) e
 		return err
 	}
 	for _, v := range notebookInfoList {
-		if v.ObjectType == Notebook {
+		if v.ObjectType == Notebook || v.ObjectType == File {
 			*pathList = append(*pathList, v)
 		} else if v.ObjectType == Directory {
 			err := a.recursiveAddPaths(v.Path, pathList)
@@ -254,10 +256,9 @@ func ResourceNotebook() *schema.Resource {
 			Deprecated: "Always is a notebook",
 		},
 		"object_id": {
-			Type:       schema.TypeInt,
-			Optional:   true,
-			Computed:   true,
-			Deprecated: "Use id argument to retrieve object id",
+			Type:     schema.TypeInt,
+			Optional: true,
+			Computed: true,
 		},
 	})
 	s["content_base64"].RequiredWith = []string{"language"}

--- a/workspace/resource_workspace_file.go
+++ b/workspace/resource_workspace_file.go
@@ -36,22 +36,20 @@ func ResourceWorkspaceFile() *schema.Resource {
 			if err != nil {
 				return err
 			}
-			notebooksAPI := client.Workspace
 			path := d.Get("path").(string)
 			parent := filepath.ToSlash(filepath.Dir(path))
 			if parent != "/" {
-				err = notebooksAPI.MkdirsByPath(ctx, parent)
+				err = client.Workspace.MkdirsByPath(ctx, parent)
 				if err != nil {
 					return err
 				}
 			}
-			createNotebook := ws_api.Import{
+			err = client.Workspace.Import(ctx, ws_api.Import{
 				Content:   base64.StdEncoding.EncodeToString(content),
 				Format:    ws_api.ExportFormatAuto,
 				Path:      path,
 				Overwrite: true,
-			}
-			err = notebooksAPI.Import(ctx, createNotebook)
+			})
 			if err != nil {
 				return err
 			}

--- a/workspace/resource_workspace_file.go
+++ b/workspace/resource_workspace_file.go
@@ -1,0 +1,82 @@
+package workspace
+
+import (
+	"context"
+	"encoding/base64"
+	"path/filepath"
+
+	"github.com/databricks/terraform-provider-databricks/common"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// ResourceWorkspaceFile manages files in workspace
+func ResourceWorkspaceFile() *schema.Resource {
+	s := FileContentSchema(map[string]*schema.Schema{
+		"url": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"object_id": {
+			Type:     schema.TypeInt,
+			Optional: true,
+			Computed: true,
+		},
+	})
+	return common.Resource{
+		Schema:        s,
+		SchemaVersion: 1,
+		Create: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
+			content, err := ReadContent(d)
+			if err != nil {
+				return err
+			}
+			notebooksAPI := NewNotebooksAPI(ctx, c)
+			path := d.Get("path").(string)
+			parent := filepath.ToSlash(filepath.Dir(path))
+			if parent != "/" {
+				err = notebooksAPI.Mkdirs(parent)
+				if err != nil {
+					return err
+				}
+			}
+			createNotebook := ImportPath{
+				Content:   base64.StdEncoding.EncodeToString(content),
+				Format:    Auto,
+				Path:      path,
+				Overwrite: true,
+			}
+			err = notebooksAPI.Create(createNotebook)
+			if err != nil {
+				return err
+			}
+			d.SetId(path)
+			return nil
+		},
+		Read: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
+			notebooksAPI := NewNotebooksAPI(ctx, c)
+			objectStatus, err := notebooksAPI.Read(d.Id())
+			if err != nil {
+				return err
+			}
+			d.Set("url", c.FormatURL("#workspace", d.Id()))
+			return common.StructToData(objectStatus, s, d)
+		},
+		Update: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
+			notebooksAPI := NewNotebooksAPI(ctx, c)
+			content, err := ReadContent(d)
+			if err != nil {
+				return err
+			}
+			return notebooksAPI.Create(ImportPath{
+				Content:   base64.StdEncoding.EncodeToString(content),
+				Format:    Auto,
+				Overwrite: true,
+				Path:      d.Id(),
+			})
+		},
+		Delete: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
+			return NewNotebooksAPI(ctx, c).Delete(d.Id(), true)
+		},
+	}.ToResource()
+}

--- a/workspace/resource_workspace_file_test.go
+++ b/workspace/resource_workspace_file_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/databricks/databricks-sdk-go/apierr"
+	ws_api "github.com/databricks/databricks-sdk-go/service/workspace"
 	"github.com/databricks/terraform-provider-databricks/qa"
 
 	"github.com/stretchr/testify/assert"
@@ -109,7 +110,7 @@ func TestResourceWorkspaceFileCreate(t *testing.T) {
 			{
 				Method:   http.MethodPost,
 				Resource: "/api/2.0/workspace/import",
-				ExpectedRequest: ImportPath{
+				ExpectedRequest: ws_api.Import{
 					Content:   "YWJjCg==",
 					Path:      "/foo/path.py",
 					Overwrite: true,
@@ -150,7 +151,7 @@ func TestResourceWorkspaceFileCreateSource(t *testing.T) {
 			{
 				Method:   http.MethodPost,
 				Resource: "/api/2.0/workspace/import",
-				ExpectedRequest: ImportPath{
+				ExpectedRequest: ws_api.Import{
 					Content: "LS0gRGF0YWJyaWNrcyBub3RlYm9vayBzb3VyY2UKU0VMRUNUIDEwKjIwC" +
 						"gotLSBDT01NQU5EIC0tLS0tLS0tLS0KClNFTEVDVCAyMCoxMDAKCi0tIE" +
 						"NPTU1BTkQgLS0tLS0tLS0tLQoKCg==",
@@ -231,7 +232,7 @@ func TestResourceWorkspaceFileUpdate(t *testing.T) {
 			{
 				Method:   "POST",
 				Resource: "/api/2.0/workspace/import",
-				ExpectedRequest: ImportPath{
+				ExpectedRequest: ws_api.Import{
 					Format:    "AUTO",
 					Overwrite: true,
 					Content:   "YWJjCg==",

--- a/workspace/resource_workspace_file_test.go
+++ b/workspace/resource_workspace_file_test.go
@@ -1,0 +1,260 @@
+package workspace
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/databricks/databricks-sdk-go/apierr"
+	"github.com/databricks/terraform-provider-databricks/qa"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResourceWorkspaceFileRead(t *testing.T) {
+	path := "/test/path.py"
+	objectID := 12345
+	d, err := qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   http.MethodGet,
+				Resource: "/api/2.0/workspace/get-status?path=%2Ftest%2Fpath.py",
+				Response: ObjectStatus{
+					ObjectID:   int64(objectID),
+					ObjectType: File,
+					Path:       path,
+				},
+			},
+		},
+		Resource: ResourceWorkspaceFile(),
+		Read:     true,
+		New:      true,
+		ID:       path,
+	}.Apply(t)
+	assert.NoError(t, err)
+	assert.Equal(t, path, d.Id())
+	assert.Equal(t, path, d.Get("path"))
+	assert.Equal(t, objectID, d.Get("object_id"))
+}
+
+func TestResourceWorkspaceFileDelete(t *testing.T) {
+	path := "/test/path.py"
+	d, err := qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:          http.MethodPost,
+				Resource:        "/api/2.0/workspace/delete",
+				Status:          http.StatusOK,
+				ExpectedRequest: DeletePath{Path: path, Recursive: true},
+			},
+		},
+		Resource: ResourceWorkspaceFile(),
+		Delete:   true,
+		ID:       path,
+	}.Apply(t)
+	assert.NoError(t, err)
+	assert.Equal(t, path, d.Id())
+}
+
+func TestResourceWorkspaceFileRead_NotFound(t *testing.T) {
+	qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{ // read log output for correct url...
+				Method:   "GET",
+				Resource: "/api/2.0/workspace/get-status?path=%2Ftest%2Fpath",
+				Response: apierr.APIErrorBody{
+					ErrorCode: "NOT_FOUND",
+					Message:   "Item not found",
+				},
+				Status: 404,
+			},
+		},
+		Resource: ResourceWorkspaceFile(),
+		Read:     true,
+		Removed:  true,
+		ID:       "/test/path",
+	}.ApplyNoError(t)
+}
+
+func TestResourceWorkspaceFileRead_Error(t *testing.T) {
+	d, err := qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "GET",
+				Resource: "/api/2.0/workspace/get-status?path=%2Ftest%2Fpath",
+				Response: apierr.APIErrorBody{
+					ErrorCode: "INVALID_REQUEST",
+					Message:   "Internal error happened",
+				},
+				Status: 400,
+			},
+		},
+		Resource: ResourceWorkspaceFile(),
+		Read:     true,
+		ID:       "/test/path",
+	}.Apply(t)
+	qa.AssertErrorStartsWith(t, err, "Internal error happened")
+	assert.Equal(t, "/test/path", d.Id(), "Id should not be empty for error reads")
+}
+
+func TestResourceWorkspaceFileCreate(t *testing.T) {
+	d, err := qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "POST",
+				Resource: "/api/2.0/workspace/mkdirs",
+				ExpectedRequest: map[string]string{
+					"path": "/foo",
+				},
+			},
+			{
+				Method:   http.MethodPost,
+				Resource: "/api/2.0/workspace/import",
+				ExpectedRequest: ImportPath{
+					Content:   "YWJjCg==",
+					Path:      "/foo/path.py",
+					Overwrite: true,
+					Format:    "AUTO",
+				},
+			},
+			{
+				Method:   http.MethodGet,
+				Resource: "/api/2.0/workspace/export?format=SOURCE&path=%2Ffoo%2Fpath.py",
+				Response: ExportPath{
+					Content: "YWJjCg==",
+				},
+			},
+			{
+				Method:   http.MethodGet,
+				Resource: "/api/2.0/workspace/get-status?path=%2Ffoo%2Fpath.py",
+				Response: ObjectStatus{
+					ObjectID:   4567,
+					ObjectType: File,
+					Path:       "/foo/path.py",
+				},
+			},
+		},
+		Resource: ResourceWorkspaceFile(),
+		State: map[string]any{
+			"content_base64": "YWJjCg==",
+			"path":           "/foo/path.py",
+		},
+		Create: true,
+	}.Apply(t)
+	assert.NoError(t, err)
+	assert.Equal(t, "/foo/path.py", d.Id())
+}
+
+func TestResourceWorkspaceFileCreateSource(t *testing.T) {
+	d, err := qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   http.MethodPost,
+				Resource: "/api/2.0/workspace/import",
+				ExpectedRequest: ImportPath{
+					Content: "LS0gRGF0YWJyaWNrcyBub3RlYm9vayBzb3VyY2UKU0VMRUNUIDEwKjIwC" +
+						"gotLSBDT01NQU5EIC0tLS0tLS0tLS0KClNFTEVDVCAyMCoxMDAKCi0tIE" +
+						"NPTU1BTkQgLS0tLS0tLS0tLQoKCg==",
+					Path:      "/Dashboard",
+					Overwrite: true,
+					Format:    "AUTO",
+				},
+			},
+			{
+				Method:   http.MethodGet,
+				Resource: "/api/2.0/workspace/get-status?path=%2FDashboard",
+				Response: ObjectStatus{
+					ObjectID:   4567,
+					ObjectType: File,
+					Path:       "/Dashboard",
+				},
+			},
+		},
+		Resource: ResourceWorkspaceFile(),
+		State: map[string]any{
+			"source": "acceptance/testdata/tf-test-sql.sql",
+			"path":   "/Dashboard",
+		},
+		Create: true,
+	}.Apply(t)
+	assert.NoError(t, err)
+	assert.Equal(t, "/Dashboard", d.Id())
+}
+
+func TestResourceWorkspaceFileCreate_Error(t *testing.T) {
+	d, err := qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   http.MethodPost,
+				Resource: "/api/2.0/workspace/import",
+				Response: apierr.APIErrorBody{
+					ErrorCode: "INVALID_REQUEST",
+					Message:   "Internal error happened",
+				},
+				Status: 400,
+			},
+		},
+		Resource: ResourceWorkspaceFile(),
+		State: map[string]any{
+			"content_base64": "YWJjCg==",
+			"path":           "/path.py",
+		},
+		Create: true,
+	}.Apply(t)
+	qa.AssertErrorStartsWith(t, err, "Internal error happened")
+	assert.Equal(t, "", d.Id(), "Id should be empty for error creates")
+}
+
+func TestResourceWorkspaceFileDelete_Error(t *testing.T) {
+	d, err := qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "POST",
+				Resource: "/api/2.0/workspace/delete",
+				Response: apierr.APIErrorBody{
+					ErrorCode: "INVALID_REQUEST",
+					Message:   "Internal error happened",
+				},
+				Status: 400,
+			},
+		},
+		Resource: ResourceWorkspaceFile(),
+		Delete:   true,
+		ID:       "abc",
+	}.Apply(t)
+	qa.AssertErrorStartsWith(t, err, "Internal error happened")
+	assert.Equal(t, "abc", d.Id())
+}
+
+func TestResourceWorkspaceFileUpdate(t *testing.T) {
+	qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "POST",
+				Resource: "/api/2.0/workspace/import",
+				ExpectedRequest: ImportPath{
+					Format:    "AUTO",
+					Overwrite: true,
+					Content:   "YWJjCg==",
+					Path:      "abc",
+				},
+			},
+			{
+				Method:   http.MethodGet,
+				Resource: "/api/2.0/workspace/get-status?path=abc",
+				Response: ObjectStatus{
+					ObjectID:   4567,
+					ObjectType: File,
+					Path:       "abc",
+				},
+			},
+		},
+		Resource: ResourceWorkspaceFile(),
+		State: map[string]any{
+			"content_base64": "YWJjCg==",
+			"path":           "/path.py",
+		},
+		ID:          "abc",
+		RequiresNew: true,
+		Update:      true,
+	}.ApplyNoError(t)
+}


### PR DESCRIPTION
## Changes

With recent release of the workspace file support it's now possible to store arbitrary files in the workspace, not only notebooks.  It's also recommended way to store init scripts to avoid security problems associated with storing init scripts on DBFS.

I deliberately didn't use the Go SDK as all code was already available. Migration to Go SDK will follow after discussions on the change required for supporting list command (see #2258)

This fixes #2206

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] tested manually
- [x] relevant change in `docs/` folder
- [x] covered with integration tests in `internal/acceptance`
- [x] relevant acceptance tests are passing
- [ ] using Go SDK

