### PR TITLE
Add `notification_settings` block to `databricks_job` resource

### DIFF
--- a/docs/resources/job.md
+++ b/docs/resources/job.md
@@ -141,7 +141,7 @@ This block is used to specify Git repository information & branch/tag/commit tha
 * `on_start` - (Optional) (List) list of emails to notify when the run starts.
 * `on_success` - (Optional) (List) list of emails to notify when the run completes successfully.
 * `on_failure` - (Optional) (List) list of emails to notify when the run fails.
-* `no_alert_for_skipped_runs` - (Optional) (Bool) don't send alert for skipped runs.
+* `no_alert_for_skipped_runs` - (Optional) (Bool) don't send alert for skipped runs. (It's recommended to use the corresponding setting in the `notification_settings` configuration block).
 
 ### webhook_notifications Configuration Block
 
@@ -168,6 +168,13 @@ webhook_notifications {
 * `id` - ID of the system notification that is notified when an event defined in `webhook_notifications` is triggered.
 
 -> **Note** The following configuration blocks can be standalone or nested inside a `task` block
+
+###  notification_settings Configuration Block
+
+This block controls notification settings for both email & webhook notifications:
+
+* `no_alert_for_skipped_runs` - (Optional) (Bool) don't send alert for skipped runs.
+* `no_alert_for_canceled_runs` - (Optional) (Bool) don't send alert for cancelled runs.
 
 ### spark_jar_task Configuration Block
 

--- a/jobs/resource_job.go
+++ b/jobs/resource_job.go
@@ -114,6 +114,12 @@ type WebhookNotifications struct {
 	OnFailure []Webhook `json:"on_failure,omitempty"`
 }
 
+// NotificationSettings control the notification settings for a job
+type NotificationSettings struct {
+	NoAlertForSkippedRuns  bool `json:"no_alert_for_skipped_runs,omitempty"`
+	NoAlertForCanceledRuns bool `json:"no_alert_for_canceled_runs,omitempty"`
+}
+
 func (wn *WebhookNotifications) Sort() {
 	if wn == nil {
 		return
@@ -242,6 +248,7 @@ type JobSettings struct {
 	MaxConcurrentRuns    int32                 `json:"max_concurrent_runs,omitempty"`
 	EmailNotifications   *EmailNotifications   `json:"email_notifications,omitempty" tf:"suppress_diff"`
 	WebhookNotifications *WebhookNotifications `json:"webhook_notifications,omitempty" tf:"suppress_diff"`
+	NotificationSettings *NotificationSettings `json:"notification_settings,omitempty"`
 	Tags                 map[string]string     `json:"tags,omitempty"`
 	Queue                *Queue                `json:"queue,omitempty"`
 }

--- a/jobs/resource_job_test.go
+++ b/jobs/resource_job_test.go
@@ -570,6 +570,10 @@ func TestResourceJobCreateWithWebhooks(t *testing.T) {
 						OnSuccess: []Webhook{{ID: "id2"}},
 						OnFailure: []Webhook{{ID: "id3"}},
 					},
+					NotificationSettings: &NotificationSettings{
+						NoAlertForSkippedRuns:  true,
+						NoAlertForCanceledRuns: true,
+					},
 				},
 				Response: Job{
 					JobID: 789,
@@ -596,6 +600,10 @@ func TestResourceJobCreateWithWebhooks(t *testing.T) {
 							OnStart:   []Webhook{{ID: "id1"}, {ID: "id2"}, {ID: "id3"}},
 							OnSuccess: []Webhook{{ID: "id2"}},
 							OnFailure: []Webhook{{ID: "id3"}},
+						},
+						NotificationSettings: &NotificationSettings{
+							NoAlertForSkippedRuns:  true,
+							NoAlertForCanceledRuns: true,
 						},
 					},
 				},
@@ -628,7 +636,12 @@ func TestResourceJobCreateWithWebhooks(t *testing.T) {
 			on_failure {
 				id = "id3" 
 			}
-		}`,
+		}
+		notification_settings {
+			no_alert_for_skipped_runs = true
+			no_alert_for_canceled_runs = true
+		  }
+	`,
 	}.Apply(t)
 	assert.NoError(t, err)
 	assert.Equal(t, "789", d.Id())


### PR DESCRIPTION


This fixes #2270

## Changes
The new configuration block allows to control handling of notifications for skipped & canceled runs for both email & webhook notifications.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [x] tested manually
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

