### PR TITLE
Fix TestUcAccMetastoreDataAccessOnAws

### DIFF
--- a/internal/acceptance/metastore_data_access_test.go
+++ b/internal/acceptance/metastore_data_access_test.go
@@ -8,7 +8,7 @@ func TestUcAccMetastoreDataAccessOnAws(t *testing.T) {
 	unityWorkspaceLevel(t, step{
 		Template: `
 		resource "databricks_metastore" "this" {
-			name          = "primary"
+			name          = "primary-{var.RANDOM}"
 			storage_root  = "s3://{env.TEST_BUCKET}/test{var.RANDOM}"
 			force_destroy = true
 		}


### PR DESCRIPTION
## Changes
TestUcAccMetastoreDataAccessOnAws does not pass on master due to the "metastore" catalog being defined. This PR changes this integration test to use a new, randomly-generated metastore each time it runs.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] ~~relevant change in `docs/` folder~~
- [ ] ~~covered with integration tests in `internal/acceptance`~~
- [x] relevant acceptance tests are passing
- [ ] ~~using Go SDK~~

