### PR TITLE
Document & export `databricks_workspace_conf` parameters for legacy init scripts

### DIFF
--- a/docs/resources/workspace_conf.md
+++ b/docs/resources/workspace_conf.md
@@ -14,6 +14,8 @@ Allows specification of custom configuration properties for expert usage:
  * `enableIpAccessLists` - enables the use of [databricks_ip_access_list](ip_access_list.md) resources
  * `maxTokenLifetimeDays` - (string) Maximum token lifetime of new tokens in days, as an integer. If zero, new tokens are permitted to have no lifetime limit. Negative numbers are unsupported. **WARNING:** This limit only applies to new tokens, so there may be tokens with lifetimes longer than this value, including unlimited lifetime. Such tokens may have been created before the current maximum token lifetime was set. 
  * `enableTokensConfig` - (boolean) Enable or disable personal access tokens for this workspace.
+ * `enableDeprecatedClusterNamedInitScripts` - (boolean) Enable or disable [legacy cluster-named init scripts](https://docs.databricks.com/clusters/init-scripts.html#disable-legacy-cluster-named-init-scripts-for-a-workspace) for this workspace.
+ * `enableDeprecatedGlobalInitScripts` - (boolean) Enable or disable [legacy global init scripts](https://docs.databricks.com/clusters/init-scripts.html#migrate-legacy-scripts) for this workspace.
 
 ```hcl
 resource "databricks_workspace_conf" "this" {

--- a/exporter/context.go
+++ b/exporter/context.go
@@ -110,6 +110,8 @@ var workspaceConfKeys = map[string]any{
 	"maxTokenLifetimeDays":                             0,
 	"maxUserInactiveDays":                              0,
 	"storeInteractiveNotebookResultsInCustomerAccount": false,
+	"enableDeprecatedClusterNamedInitScripts":          false,
+	"enableDeprecatedGlobalInitScripts":                false,
 }
 
 func newImportContext(c *common.DatabricksClient) *importContext {


### PR DESCRIPTION
## Changes

given the recent advisory, there are asks for disabling the legacy global & named cluster init scripts via Terraform.  This PR documents them, and also add to the exporter

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

