### PR TITLE
Add missing permission to `databricks_aws_crossaccount_policy` data source

### DIFF
--- a/aws/data_aws_crossaccount_policy.go
+++ b/aws/data_aws_crossaccount_policy.go
@@ -69,6 +69,7 @@ func DataAwsCrossaccountPolicy() *schema.Resource {
 							"ec2:DescribeInstances",
 							"ec2:DescribeInternetGateways",
 							"ec2:DescribeLaunchTemplates",
+							"ec2:DescribeLaunchTemplateVersions",
 							"ec2:DescribeNatGateways",
 							"ec2:DescribeNetworkAcls",
 							"ec2:DescribePlacementGroups",

--- a/aws/data_aws_crossaccount_policy_test.go
+++ b/aws/data_aws_crossaccount_policy_test.go
@@ -16,7 +16,7 @@ func TestDataAwsCrossAccountPolicy(t *testing.T) {
 	}.Apply(t)
 	assert.NoError(t, err)
 	j := d.Get("json")
-	assert.Lenf(t, j, 3294, "Strange length for policy: %s", j)
+	assert.Lenf(t, j, 3340, "Strange length for policy: %s", j)
 }
 
 func TestDataAwsCrossAccountPolicy_WithPassRoles(t *testing.T) {
@@ -29,5 +29,5 @@ func TestDataAwsCrossAccountPolicy_WithPassRoles(t *testing.T) {
 	}.Apply(t)
 	assert.NoError(t, err)
 	j := d.Get("json")
-	assert.Lenf(t, j, 3430, "Strange length for policy: %s", j)
+	assert.Lenf(t, j, 3476, "Strange length for policy: %s", j)
 }


### PR DESCRIPTION
## Changes

One more permission that is necessary for fleet use was missing from the policy definition in our documentation (tracked as a separate Jira)

This is follow up fix for #2255 

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

