### PR TITLE
Fix TestAccWorkspaceFileBase64

### DIFF
--- a/internal/acceptance/workspace_file_test.go
+++ b/internal/acceptance/workspace_file_test.go
@@ -21,12 +21,12 @@ func TestAccWorkspaceFile(t *testing.T) {
 func TestAccWorkspaceFileBase64(t *testing.T) {
 	workspaceLevel(t, step{
 		Template: `resource "databricks_workspace_file" "this2" {
-			"content_base64": "YWJjCg==",
+			content_base64 = "YWJjCg=="
 			path = "/Shared/provider-test/xx2_{var.RANDOM}"
 		}`,
 	}, step{
 		Template: `resource "databricks_workspace_file" "this2" {
-			"content_base64": "YWJjCg==",
+			content_base64 = "YWJjCg=="
 			path = "/Shared/provider-test/xx2_{var.RANDOM}_renamed"
 		}`,
 	})


### PR DESCRIPTION
## Changes
The test HCL template for TestAccWorkspaceFileBase64 was incorrect. With this change, the integration test passes.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [ ] ~~relevant change in `docs/` folder~~
- [ ] ~~covered with integration tests in `internal/acceptance`~~
- [x] relevant acceptance tests are passing
- [ ] ~~using Go SDK~~

