### PR TITLE
Removed reference to deprecated `databricks_group_instance_profile` from `databricks_group_role` docs

### DIFF
--- a/docs/resources/group_role.md
+++ b/docs/resources/group_role.md
@@ -18,9 +18,9 @@ resource "databricks_group" "my_group" {
   display_name = "my_group_name"
 }
 
-resource "databricks_group_instance_profile" "my_group_instance_profile" {
-  group_id            = databricks_group.my_group.id
-  instance_profile_id = databricks_instance_profile.instance_profile.id
+resource "databricks_group_role" "my_group_instance_profile" {
+  group_id = databricks_group.my_group.id
+  role     = databricks_instance_profile.instance_profile.id
 }
 ```
 


### PR DESCRIPTION
Connects to https://github.com/databricks/terraform-provider-databricks/issues/1870
Connects to https://github.com/databricks/terraform-provider-databricks/pull/1881

Documentation for `databricks_group_role` gives an example using the deprecated `databricks_group_instance_profile`. Based on the rest of the documentation 
https://github.com/databricks/terraform-provider-databricks/blob/28cbf483fbd94a04f62821549d3f6678c1c3cc37/docs/resources/group_role.md?plain=1#L52
seems like `role` should be pointing to the same `databricks_instance_profile`. 

Is this the intended way forward with `databricks_group_role` and instance profiles?
