### PR TITLE
Update documentation for `databricks_secret_scope` resource

### DIFF
--- a/docs/guides/azure-private-link-workspace-standard.md
+++ b/docs/guides/azure-private-link-workspace-standard.md
@@ -80,23 +80,23 @@ Define the required variables
 
 ```hcl
 variable "cidr_transit" {
-  type    = string
+  type = string
 }
 
 variable "cidr_dp" {
-  type    = string
+  type = string
 }
 
 variable "rg_transit" {
-  type    = string
+  type = string
 }
 
 variable "rg_dp" {
-  type    = string
+  type = string
 }
 
 variable "location" {
-  type    = string
+  type = string
 }
 
 data "azurerm_client_config" "current" {
@@ -113,7 +113,7 @@ resource "random_string" "naming" {
 }
 
 locals {
-  prefix = "adb-pl"
+  prefix   = "adb-pl"
   dbfsname = join("", ["dbfs", "${random_string.naming.result}"])
   tags = {
     Environment = "Demo"
@@ -271,7 +271,7 @@ resource "azurerm_private_endpoint" "transit_auth" {
   name                = "aadauthpvtendpoint-transit"
   location            = var.location
   resource_group_name = var.rg_transit
-  subnet_id           = azurerm_subnet.transit_plsubnet.id 
+  subnet_id           = azurerm_subnet.transit_plsubnet.id
 
   private_service_connection {
     name                           = "ple-${var.prefix}-auth"
@@ -318,7 +318,7 @@ resource "azurerm_private_endpoint" "front_pe" {
   name                = "frontprivatendpoint"
   location            = var.location
   resource_group_name = var.rg_transit
-  subnet_id           = azurerm_subnet.transit_plsubnet.id 
+  subnet_id           = azurerm_subnet.transit_plsubnet.id
 
   private_service_connection {
     name                           = "ple-${var.prefix}-uiapi"
@@ -395,7 +395,7 @@ resource "azurerm_private_dns_zone_virtual_network_link" "uiapidnszonevnetlink" 
   name                  = "dpcpvnetconnection"
   resource_group_name   = var.rg_dp
   private_dns_zone_name = azurerm_private_dns_zone.dnsdpcp.name
-  virtual_network_id    = azurerm_virtual_network.app_vnet.id 
+  virtual_network_id    = azurerm_virtual_network.app_vnet.id
 }
 ```
 
@@ -465,7 +465,7 @@ resource "azurerm_subnet" "app_plsubnet" {
   resource_group_name                            = var.rg_dp
   virtual_network_name                           = azurerm_virtual_network.app_vnet.name
   address_prefixes                               = [cidrsubnet(local.cidr_dp, 6, 2)]
-  enforce_private_link_endpoint_network_policies = true 
+  enforce_private_link_endpoint_network_policies = true
 }
 
 resource "azurerm_databricks_workspace" "app_workspace" {
@@ -486,7 +486,7 @@ resource "azurerm_databricks_workspace" "app_workspace" {
     private_subnet_network_security_group_association_id = azurerm_subnet_network_security_group_association.app_private.id
     storage_account_name                                 = "dbfsapp723k4b3"
   }
-  
+
   depends_on = [
     azurerm_subnet_network_security_group_association.app_public,
     azurerm_subnet_network_security_group_association.app_private
@@ -499,7 +499,7 @@ resource "azurerm_databricks_workspace" "app_workspace" {
 ```hcl
 resource "azurerm_private_endpoint" "app_dpcp" {
   name                = "dpcppvtendpoint"
-  resource_group_name  = var.rg_dp
+  resource_group_name = var.rg_dp
   location            = var.location
   subnet_id           = azurerm_subnet.app_plsubnet.id
 

--- a/docs/resources/job.md
+++ b/docs/resources/job.md
@@ -95,10 +95,13 @@ The resource supports the following arguments:
 Example
 
 ```hcl
+resource "databricks_job" "this" {
+  # ...
   tags = {
     environment = "dev"
     owner       = "dream-team"
   }
+}
 ```
 
 ### job_cluster Configuration Block

--- a/docs/resources/secret_scope.md
+++ b/docs/resources/secret_scope.md
@@ -22,7 +22,7 @@ The following arguments are supported:
 
 ## keyvault_metadata
 
-On Azure it's possible to create and manage secrets in Azure Key Vault and use Azure Databricks secret redaction & access control functionality for reading them. There has to be a single Key Vault per single secret scope. 
+On Azure, it is possible to create Azure Databricks secret scopes backed by Azure Key Vault. Secrets are stored in Azure Key Vault and can be accessed through the Azure Databricks secrets utilities, making use of Azure Databricks access control and secret redaction. A secret scope may be configured with at most one Key Vault. 
 
 -> **Warning** To create a secret scope from Azure Key Vault you need to use one of the [Azure-specific authentication methods](../index.md#special-configurations-for-azure). You can't create such secret scope using personal access token (PAT).
 

--- a/docs/resources/secret_scope.md
+++ b/docs/resources/secret_scope.md
@@ -22,7 +22,11 @@ The following arguments are supported:
 
 ## keyvault_metadata
 
-On Azure it's possible to create and manage secrets in Azure Key Vault and have use Azure Databricks secret redaction & access control functionality for reading them. There has to be a single Key Vault per single secret scope. To define AKV access policies, you must use [azurerm_key_vault_access_policy](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) instead of [access_policy](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault#access_policy) blocks on `azurerm_key_vault`, otherwise Terraform will remove access policies needed to access the Key Vault and the secret scope won't be in a usable state anymore.
+On Azure it's possible to create and manage secrets in Azure Key Vault and use Azure Databricks secret redaction & access control functionality for reading them. There has to be a single Key Vault per single secret scope. 
+
+-> **Warning** To create a secret scope from Azure Key Vault you need to use one of the [Azure-specific authentication methods](../index.md#special-configurations-for-azure). You can't create such secret scope using personal access token (PAT).
+
+To define AKV access policies, you must use [azurerm_key_vault_access_policy](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) instead of [access_policy](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault#access_policy) blocks on `azurerm_key_vault`, otherwise Terraform will remove access policies needed to access the Key Vault and the secret scope won't be in a usable state anymore.
 
 
 ```hcl
@@ -44,7 +48,7 @@ resource "azurerm_key_vault_access_policy" "this" {
   key_vault_id       = azurerm_key_vault.this.id
   tenant_id          = data.azurerm_client_config.current.tenant_id
   object_id          = data.azurerm_client_config.current.object_id
-  secret_permissions = ["delete", "get", "list", "set"]
+  secret_permissions = ["Delete", "Get", "List", "Set"]
 }
 
 resource "databricks_secret_scope" "kv" {

--- a/docs/resources/secret_scope.md
+++ b/docs/resources/secret_scope.md
@@ -24,7 +24,7 @@ The following arguments are supported:
 
 On Azure, it is possible to create Azure Databricks secret scopes backed by Azure Key Vault. Secrets are stored in Azure Key Vault and can be accessed through the Azure Databricks secrets utilities, making use of Azure Databricks access control and secret redaction. A secret scope may be configured with at most one Key Vault. 
 
--> **Warning** To create a secret scope from Azure Key Vault you need to use one of the [Azure-specific authentication methods](../index.md#special-configurations-for-azure). You can't create such secret scope using personal access token (PAT).
+-> **Warning** To create a secret scope from Azure Key Vault, you must use one of the [Azure-specific authentication methods](../index.md#special-configurations-for-azure). Secret scopes backed by Azure Key Vault cannot be created using personal access tokens (PAT).
 
 To define AKV access policies, you must use [azurerm_key_vault_access_policy](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) instead of [access_policy](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault#access_policy) blocks on `azurerm_key_vault`, otherwise Terraform will remove access policies needed to access the Key Vault and the secret scope won't be in a usable state anymore.
 

--- a/docs/resources/sql_table.md
+++ b/docs/resources/sql_table.md
@@ -40,26 +40,26 @@ resource "databricks_sql_table" "thing" {
   storage_location   = ""
 
   column {
-    name      = "id"
-    type      = "int"
+    name = "id"
+    type = "int"
   }
   column {
-    name      = "name"
-    type      = "string"
-    comment   = "name of thing"
+    name    = "name"
+    type    = "string"
+    comment = "name of thing"
   }
   comment = "this table is managed by terraform"
 }
 
 resource "databricks_sql_table" "thing_view" {
-  provider           = databricks.workspace
-  name               = "quickstart_table_view"
-  catalog_name       = databricks_catalog.sandbox.name
-  schema_name        = databricks_schema.things.name
-  table_type         = "VIEW"
-  cluster_id         = "0423-201305-xsrt82qn"
+  provider     = databricks.workspace
+  name         = "quickstart_table_view"
+  catalog_name = databricks_catalog.sandbox.name
+  schema_name  = databricks_schema.things.name
+  table_type   = "VIEW"
+  cluster_id   = "0423-201305-xsrt82qn"
 
-  view_definition    = format("SELECT name FROM %s WHERE id == 1", databricks_sql_table.thing.id)
+  view_definition = format("SELECT name FROM %s WHERE id == 1", databricks_sql_table.thing.id)
 
   comment = "this view is managed by terraform"
 }


### PR DESCRIPTION
## Changes

This includes following changes:

* Fix Azure Key Vault access policy example - this fixes #2293
* Add a warning that for AKV-baked secret scopes the Azure authentication should be used
* reformat docs
## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

