### PR TITLE
Automatically add `CAN_MANAGE` permission on `databricks_instance_pool` to calling user

### DIFF
--- a/permissions/resource_permissions.go
+++ b/permissions/resource_permissions.go
@@ -124,7 +124,7 @@ func urlPathForObjectID(objectID string) string {
 // permissions when POSTing permissions changes through the REST API, to avoid accidentally
 // revoking the calling user's ability to manage the current object.
 func (a PermissionsAPI) shouldExplicitlyGrantCallingUserManagePermissions(objectID string) bool {
-	for _, prefix := range [...]string{"/registered-models/", "/clusters/", "/queries/", "/sql/warehouses"} {
+	for _, prefix := range [...]string{"/registered-models/", "/clusters/", "/instance-pools/", "/queries/", "/sql/warehouses"} {
 		if strings.HasPrefix(objectID, prefix) {
 			return true
 		}


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
Closes #2238

## Tests

Tests locally
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] ~~relevant change in `docs/` folder~~
- [ ] ~~covered with integration tests in `internal/acceptance`~~
- [x] relevant acceptance tests are passing
- [ ] ~~using Go SDK~~

