### PR TITLE
Migrated `databricks_ip_access_list` resource to Go SDK

### DIFF
--- a/access/resource_ip_access_list.go
+++ b/access/resource_ip_access_list.go
@@ -10,14 +10,16 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
+type ipAccessListUpdateRequest struct {
+	Label       string            `json:"label"`
+	ListType    settings.ListType `json:"list_type"`
+	IpAddresses []string          `json:"ip_addresses"`
+	Enabled     bool              `json:"enabled,omitempty" tf:"default:true"`
+}
+
 // ResourceIPAccessList manages IP access lists
 func ResourceIPAccessList() *schema.Resource {
-	s := common.StructToSchema(struct {
-		Label       string   `json:"label"`
-		ListType    string   `json:"list_type"`
-		IPAddresses []string `json:"ip_addresses"`
-		Enabled     bool     `json:"enabled,omitempty" tf:"default:true"`
-	}{}, func(s map[string]*schema.Schema) map[string]*schema.Schema {
+	s := common.StructToSchema(ipAccessListUpdateRequest{}, func(s map[string]*schema.Schema) map[string]*schema.Schema {
 		// nolint
 		s["list_type"].ValidateFunc = validation.StringInSlice([]string{"ALLOW", "BLOCK"}, false)
 		s["ip_addresses"].Elem = &schema.Schema{
@@ -61,6 +63,7 @@ func ResourceIPAccessList() *schema.Resource {
 			}
 			var iacl settings.UpdateIpAccessList
 			common.DataToStructPointer(d, s, &iacl)
+			iacl.IpAccessListId = d.Id()
 			return w.IpAccessLists.Update(ctx, iacl)
 		},
 		Delete: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {

--- a/access/resource_ip_access_list.go
+++ b/access/resource_ip_access_list.go
@@ -10,43 +10,14 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
-type ListIPAccessListsResponse struct {
-	ListIPAccessListsResponse []IpAccessListStatus `json:"ip_access_lists,omitempty"`
-}
-
-type createIPAccessListRequest struct {
-	Label       string   `json:"label"`
-	ListType    string   `json:"list_type"`
-	IPAddresses []string `json:"ip_addresses"`
-}
-
-type IpAccessListStatus struct {
-	ListID        string   `json:"list_id"`
-	Label         string   `json:"label"`
-	ListType      string   `json:"list_type"`
-	IPAddresses   []string `json:"ip_addresses"`
-	AddressCount  int      `json:"address_count,omitempty"`
-	CreatedAt     int64    `json:"created_at,omitempty"`
-	CreatorUserID int64    `json:"creator_user_id,omitempty"`
-	UpdatedAt     int64    `json:"updated_at,omitempty"`
-	UpdatorUserID int64    `json:"updator_user_id,omitempty"`
-	Enabled       bool     `json:"enabled,omitempty"`
-}
-
-type IpAccessListStatusWrapper struct {
-	IPAccessList IpAccessListStatus `json:"ip_access_list,omitempty"`
-}
-
-type ipAccessListUpdateRequest struct {
-	Label       string   `json:"label"`
-	ListType    string   `json:"list_type"`
-	IPAddresses []string `json:"ip_addresses"`
-	Enabled     bool     `json:"enabled,omitempty" tf:"default:true"`
-}
-
 // ResourceIPAccessList manages IP access lists
 func ResourceIPAccessList() *schema.Resource {
-	s := common.StructToSchema(ipAccessListUpdateRequest{}, func(s map[string]*schema.Schema) map[string]*schema.Schema {
+	s := common.StructToSchema(struct {
+		Label       string   `json:"label"`
+		ListType    string   `json:"list_type"`
+		IPAddresses []string `json:"ip_addresses"`
+		Enabled     bool     `json:"enabled,omitempty" tf:"default:true"`
+	}{}, func(s map[string]*schema.Schema) map[string]*schema.Schema {
 		// nolint
 		s["list_type"].ValidateFunc = validation.StringInSlice([]string{"ALLOW", "BLOCK"}, false)
 		s["ip_addresses"].Elem = &schema.Schema{

--- a/access/resource_ip_access_list_test.go
+++ b/access/resource_ip_access_list_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/databricks/databricks-sdk-go"
 	"github.com/databricks/databricks-sdk-go/apierr"
 	"github.com/databricks/terraform-provider-databricks/qa"
 
@@ -303,7 +304,9 @@ func TestIPACLDelete_Error(t *testing.T) {
 }
 
 func TestListIpAccessLists(t *testing.T) {
-	client, server, err := qa.HttpFixtureClient(t, []qa.HTTPFixture{
+	w, err := databricks.NewWorkspaceClient()
+	require.NoError(t, err)
+	_, server, err := qa.HttpFixtureClient(t, []qa.HTTPFixture{
 		{
 			Method:   "GET",
 			Resource: "/api/2.0/ip-access-lists",
@@ -314,7 +317,8 @@ func TestListIpAccessLists(t *testing.T) {
 	require.NoError(t, err)
 
 	ctx := context.Background()
-	ipLists, err := NewIPAccessListsAPI(ctx, client).List()
+	ipLists, err := w.IpAccessLists.Impl().List(ctx)
+
 	require.NoError(t, err)
-	assert.Equal(t, len(ipLists.ListIPAccessListsResponse), 0)
+	assert.Equal(t, 0, len(ipLists.IpAccessLists))
 }

--- a/access/resource_ip_access_list_test.go
+++ b/access/resource_ip_access_list_test.go
@@ -170,7 +170,6 @@ func TestIPACLUpdate(t *testing.T) {
 	assert.Equal(t, 2, d.Get("ip_addresses.#"))
 }
 
-// tanmaytodo
 func TestIPACLUpdate_Error(t *testing.T) {
 	_, err := qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
@@ -191,7 +190,6 @@ func TestIPACLUpdate_Error(t *testing.T) {
 	qa.AssertErrorStartsWith(t, err, "Something unexpected")
 }
 
-// tanmaytodo
 func TestIPACLRead(t *testing.T) {
 	d, err := qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{

--- a/access/resource_ip_access_list_test.go
+++ b/access/resource_ip_access_list_test.go
@@ -8,8 +8,8 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/databricks/databricks-sdk-go"
 	"github.com/databricks/databricks-sdk-go/apierr"
+	"github.com/databricks/databricks-sdk-go/service/settings"
 	"github.com/databricks/terraform-provider-databricks/qa"
 
 	"github.com/stretchr/testify/assert"
@@ -20,7 +20,7 @@ var (
 	TestingID               = "234567"
 	TestingLabel            = "Naughty"
 	TestingListTypeString   = "BLOCK"
-	TestingListType         = "BLOCK"
+	TestingListType         = settings.ListType("BLOCK")
 	TestingEnabled          = true
 	TestingIPAddresses      = []string{"1.2.3.4", "1.2.4.0/24"}
 	TestingIPAddressesState = []any{"1.2.3.4", "1.2.4.0/24"}
@@ -32,41 +32,41 @@ func TestIPACLCreate(t *testing.T) {
 			{
 				Method:   http.MethodPost,
 				Resource: "/api/2.0/ip-access-lists",
-				ExpectedRequest: createIPAccessListRequest{
+				ExpectedRequest: settings.CreateIpAccessList{
 					Label:       TestingLabel,
 					ListType:    TestingListType,
-					IPAddresses: TestingIPAddresses,
+					IpAddresses: TestingIPAddresses,
 				},
-				Response: IpAccessListStatusWrapper{
-					IPAccessList: IpAccessListStatus{
-						ListID:        TestingID,
-						Label:         TestingLabel,
-						ListType:      TestingListType,
-						IPAddresses:   TestingIPAddresses,
-						AddressCount:  2,
-						CreatedAt:     87939234,
-						CreatorUserID: 1234556,
-						UpdatedAt:     87939234,
-						UpdatorUserID: 1234556,
-						Enabled:       TestingEnabled,
+				Response: settings.CreateIpAccessListResponse{
+					IpAccessList: &settings.IpAccessListInfo{
+						ListId:       TestingID,
+						Label:        TestingLabel,
+						ListType:     TestingListType,
+						IpAddresses:  TestingIPAddresses,
+						AddressCount: 2,
+						CreatedAt:    87939234,
+						CreatedBy:    1234556,
+						UpdatedAt:    87939234,
+						UpdatedBy:    1234556,
+						Enabled:      TestingEnabled,
 					},
 				},
 			},
 			{
 				Method:   http.MethodGet,
-				Resource: "/api/2.0/ip-access-lists/" + TestingID,
-				Response: IpAccessListStatusWrapper{
-					IPAccessList: IpAccessListStatus{
-						ListID:        TestingID,
-						Label:         TestingLabel,
-						ListType:      TestingListType,
-						IPAddresses:   TestingIPAddresses,
-						AddressCount:  2,
-						CreatedAt:     87939234,
-						CreatorUserID: 1234556,
-						UpdatedAt:     87939234,
-						UpdatorUserID: 1234556,
-						Enabled:       TestingEnabled,
+				Resource: "/api/2.0/ip-access-lists/" + TestingID + "?",
+				Response: settings.CreateIpAccessListResponse{
+					IpAccessList: &settings.IpAccessListInfo{
+						ListId:       TestingID,
+						Label:        TestingLabel,
+						ListType:     TestingListType,
+						IpAddresses:  TestingIPAddresses,
+						AddressCount: 2,
+						CreatedAt:    87939234,
+						CreatedBy:    1234556,
+						UpdatedAt:    87939234,
+						UpdatedBy:    1234556,
+						Enabled:      TestingEnabled,
 					},
 				},
 			},
@@ -118,37 +118,37 @@ func TestIPACLUpdate(t *testing.T) {
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   http.MethodGet,
-				Resource: "/api/2.0/ip-access-lists/" + TestingID,
-				Response: IpAccessListStatusWrapper{
-					IPAccessList: IpAccessListStatus{
-						ListID:        TestingID,
-						Label:         TestingLabel,
-						ListType:      TestingListType,
-						IPAddresses:   TestingIPAddresses,
-						AddressCount:  2,
-						CreatedAt:     87939234,
-						CreatorUserID: 1234556,
-						UpdatedAt:     87939234,
-						UpdatorUserID: 1234556,
-						Enabled:       TestingEnabled,
+				Resource: "/api/2.0/ip-access-lists/" + TestingID + "?",
+				Response: settings.CreateIpAccessListResponse{
+					IpAccessList: &settings.IpAccessListInfo{
+						ListId:       TestingID,
+						Label:        TestingLabel,
+						ListType:     TestingListType,
+						IpAddresses:  TestingIPAddresses,
+						AddressCount: 2,
+						CreatedAt:    87939234,
+						CreatedBy:    1234556,
+						UpdatedAt:    87939234,
+						UpdatedBy:    1234556,
+						Enabled:      TestingEnabled,
 					},
 				},
 			},
 			{
 				Method:   http.MethodPut,
-				Resource: "/api/2.0/ip-access-lists/" + TestingID,
-				Response: IpAccessListStatusWrapper{
-					IPAccessList: IpAccessListStatus{
-						ListID:        TestingID,
-						Label:         TestingLabel,
-						ListType:      TestingListType,
-						IPAddresses:   TestingIPAddresses,
-						AddressCount:  2,
-						CreatedAt:     87939234,
-						CreatorUserID: 1234556,
-						UpdatedAt:     87939234,
-						UpdatorUserID: 1234556,
-						Enabled:       TestingEnabled,
+				Resource: "/api/2.0/ip-access-lists/" + TestingID + "?",
+				Response: settings.CreateIpAccessListResponse{
+					IpAccessList: &settings.IpAccessListInfo{
+						ListId:       TestingID,
+						Label:        TestingLabel,
+						ListType:     TestingListType,
+						IpAddresses:  TestingIPAddresses,
+						AddressCount: 2,
+						CreatedAt:    87939234,
+						CreatedBy:    1234556,
+						UpdatedAt:    87939234,
+						UpdatedBy:    1234556,
+						Enabled:      TestingEnabled,
 					},
 				},
 			},
@@ -170,6 +170,7 @@ func TestIPACLUpdate(t *testing.T) {
 	assert.Equal(t, 2, d.Get("ip_addresses.#"))
 }
 
+// tanmaytodo
 func TestIPACLUpdate_Error(t *testing.T) {
 	_, err := qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
@@ -190,24 +191,25 @@ func TestIPACLUpdate_Error(t *testing.T) {
 	qa.AssertErrorStartsWith(t, err, "Something unexpected")
 }
 
+// tanmaytodo
 func TestIPACLRead(t *testing.T) {
 	d, err := qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   http.MethodGet,
-				Resource: "/api/2.0/ip-access-lists/" + TestingID,
-				Response: IpAccessListStatusWrapper{
-					IPAccessList: IpAccessListStatus{
-						ListID:        TestingID,
-						Label:         TestingLabel,
-						ListType:      TestingListType,
-						IPAddresses:   TestingIPAddresses,
-						AddressCount:  2,
-						CreatedAt:     87939234,
-						CreatorUserID: 1234556,
-						UpdatedAt:     87939234,
-						UpdatorUserID: 1234556,
-						Enabled:       TestingEnabled,
+				Resource: "/api/2.0/ip-access-lists/" + TestingID + "?",
+				Response: settings.CreateIpAccessListResponse{
+					IpAccessList: &settings.IpAccessListInfo{
+						ListId:       TestingID,
+						Label:        TestingLabel,
+						ListType:     TestingListType,
+						IpAddresses:  TestingIPAddresses,
+						AddressCount: 2,
+						CreatedAt:    87939234,
+						CreatedBy:    1234556,
+						UpdatedAt:    87939234,
+						UpdatedBy:    1234556,
+						Enabled:      TestingEnabled,
 					},
 				},
 			},
@@ -230,7 +232,7 @@ func TestIPACLRead_NotFound(t *testing.T) {
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   http.MethodGet,
-				Resource: "/api/2.0/ip-access-lists/" + TestingID,
+				Resource: "/api/2.0/ip-access-lists/" + TestingID + "?",
 				Response: apierr.APIErrorBody{
 					ErrorCode: "RESOURCE_DOES_NOT_EXIST",
 					Message:   "Can't find an IP access list with id: " + TestingID + ".",
@@ -250,7 +252,7 @@ func TestIPACLRead_Error(t *testing.T) {
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   http.MethodGet,
-				Resource: "/api/2.0/ip-access-lists/" + TestingID,
+				Resource: "/api/2.0/ip-access-lists/" + TestingID + "?",
 				Response: apierr.APIErrorBody{
 					ErrorCode: "SERVER_ERROR",
 					Message:   "Something unexpected happened",
@@ -304,15 +306,18 @@ func TestIPACLDelete_Error(t *testing.T) {
 }
 
 func TestListIpAccessLists(t *testing.T) {
-	w, err := databricks.NewWorkspaceClient()
-	require.NoError(t, err)
-	_, server, err := qa.HttpFixtureClient(t, []qa.HTTPFixture{
+	client, server, err := qa.HttpFixtureClient(t, []qa.HTTPFixture{
 		{
 			Method:   "GET",
 			Resource: "/api/2.0/ip-access-lists",
 			Response: map[string]any{},
 		},
 	})
+	require.NoError(t, err)
+
+	w, err := client.WorkspaceClient()
+	require.NoError(t, err)
+
 	defer server.Close()
 	require.NoError(t, err)
 

--- a/access/resource_ip_access_list_test.go
+++ b/access/resource_ip_access_list_test.go
@@ -17,13 +17,13 @@ import (
 )
 
 var (
-	TestingID               = "234567"
+	TestingId               = "234567"
 	TestingLabel            = "Naughty"
 	TestingListTypeString   = "BLOCK"
 	TestingListType         = settings.ListType("BLOCK")
 	TestingEnabled          = true
-	TestingIPAddresses      = []string{"1.2.3.4", "1.2.4.0/24"}
-	TestingIPAddressesState = []any{"1.2.3.4", "1.2.4.0/24"}
+	TestingIpAddresses      = []string{"1.2.3.4", "1.2.4.0/24"}
+	TestingIpAddressesState = []any{"1.2.3.4", "1.2.4.0/24"}
 )
 
 func TestIPACLCreate(t *testing.T) {
@@ -35,14 +35,14 @@ func TestIPACLCreate(t *testing.T) {
 				ExpectedRequest: settings.CreateIpAccessList{
 					Label:       TestingLabel,
 					ListType:    TestingListType,
-					IpAddresses: TestingIPAddresses,
+					IpAddresses: TestingIpAddresses,
 				},
 				Response: settings.CreateIpAccessListResponse{
 					IpAccessList: &settings.IpAccessListInfo{
-						ListId:       TestingID,
+						ListId:       TestingId,
 						Label:        TestingLabel,
 						ListType:     TestingListType,
-						IpAddresses:  TestingIPAddresses,
+						IpAddresses:  TestingIpAddresses,
 						AddressCount: 2,
 						CreatedAt:    87939234,
 						CreatedBy:    1234556,
@@ -54,13 +54,13 @@ func TestIPACLCreate(t *testing.T) {
 			},
 			{
 				Method:   http.MethodGet,
-				Resource: "/api/2.0/ip-access-lists/" + TestingID + "?",
+				Resource: "/api/2.0/ip-access-lists/" + TestingId + "?",
 				Response: settings.CreateIpAccessListResponse{
 					IpAccessList: &settings.IpAccessListInfo{
-						ListId:       TestingID,
+						ListId:       TestingId,
 						Label:        TestingLabel,
 						ListType:     TestingListType,
-						IpAddresses:  TestingIPAddresses,
+						IpAddresses:  TestingIpAddresses,
 						AddressCount: 2,
 						CreatedAt:    87939234,
 						CreatedBy:    1234556,
@@ -75,12 +75,12 @@ func TestIPACLCreate(t *testing.T) {
 		State: map[string]any{
 			"label":        TestingLabel,
 			"list_type":    TestingListTypeString,
-			"ip_addresses": TestingIPAddressesState,
+			"ip_addresses": TestingIpAddressesState,
 		},
 		Create: true,
 	}.Apply(t)
 	assert.NoError(t, err)
-	assert.Equal(t, TestingID, d.Id())
+	assert.Equal(t, TestingId, d.Id())
 	assert.Equal(t, TestingLabel, d.Get("label"))
 	assert.Equal(t, TestingListTypeString, d.Get("list_type"))
 	assert.Equal(t, TestingEnabled, d.Get("enabled"))
@@ -104,7 +104,7 @@ func TestAPIACLCreate_Error(t *testing.T) {
 		State: map[string]any{
 			"label":        TestingLabel,
 			"list_type":    TestingListTypeString,
-			"ip_addresses": TestingIPAddressesState,
+			"ip_addresses": TestingIpAddressesState,
 		},
 		Create: true,
 	}.Apply(t)
@@ -113,18 +113,19 @@ func TestAPIACLCreate_Error(t *testing.T) {
 	assert.Equal(t, "", d.Id(), "Id should be empty for error creates")
 }
 
+// tanmaytodo
 func TestIPACLUpdate(t *testing.T) {
 	d, err := qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   http.MethodGet,
-				Resource: "/api/2.0/ip-access-lists/" + TestingID + "?",
+				Resource: "/api/2.0/ip-access-lists/" + TestingId + "?",
 				Response: settings.CreateIpAccessListResponse{
 					IpAccessList: &settings.IpAccessListInfo{
-						ListId:       TestingID,
+						ListId:       TestingId,
 						Label:        TestingLabel,
 						ListType:     TestingListType,
-						IpAddresses:  TestingIPAddresses,
+						IpAddresses:  TestingIpAddresses,
 						AddressCount: 2,
 						CreatedAt:    87939234,
 						CreatedBy:    1234556,
@@ -135,14 +136,20 @@ func TestIPACLUpdate(t *testing.T) {
 				},
 			},
 			{
-				Method:   http.MethodPut,
-				Resource: "/api/2.0/ip-access-lists/" + TestingID + "?",
+				Method:   http.MethodPatch,
+				Resource: "/api/2.0/ip-access-lists/" + TestingId,
+				ExpectedRequest: ipAccessListUpdateRequest{
+					Label:       TestingLabel,
+					ListType:    TestingListType,
+					IpAddresses: TestingIpAddresses,
+					Enabled:     TestingEnabled,
+				},
 				Response: settings.CreateIpAccessListResponse{
 					IpAccessList: &settings.IpAccessListInfo{
-						ListId:       TestingID,
+						ListId:       TestingId,
 						Label:        TestingLabel,
 						ListType:     TestingListType,
-						IpAddresses:  TestingIPAddresses,
+						IpAddresses:  TestingIpAddresses,
 						AddressCount: 2,
 						CreatedAt:    87939234,
 						CreatedBy:    1234556,
@@ -157,13 +164,13 @@ func TestIPACLUpdate(t *testing.T) {
 		State: map[string]any{
 			"label":        TestingLabel,
 			"list_type":    TestingListTypeString,
-			"ip_addresses": TestingIPAddressesState,
+			"ip_addresses": TestingIpAddressesState,
 		},
 		Update: true,
-		ID:     TestingID,
+		ID:     TestingId,
 	}.Apply(t)
 	assert.NoError(t, err)
-	assert.Equal(t, TestingID, d.Id())
+	assert.Equal(t, TestingId, d.Id())
 	assert.Equal(t, TestingLabel, d.Get("label"))
 	assert.Equal(t, TestingListTypeString, d.Get("list_type"))
 	assert.Equal(t, TestingEnabled, d.Get("enabled"))
@@ -174,8 +181,11 @@ func TestIPACLUpdate_Error(t *testing.T) {
 	_, err := qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
 			{
-				Method:   http.MethodPut,
-				Resource: "/api/2.0/ip-access-lists/" + TestingID,
+				Method:   http.MethodPatch,
+				Resource: "/api/2.0/ip-access-lists/" + TestingId,
+				ExpectedRequest: ipAccessListUpdateRequest{
+					Enabled: TestingEnabled,
+				},
 				Response: apierr.APIErrorBody{
 					ErrorCode: "SERVER_ERROR",
 					Message:   "Something unexpected happened",
@@ -185,7 +195,7 @@ func TestIPACLUpdate_Error(t *testing.T) {
 		},
 		Resource: ResourceIPAccessList(),
 		Update:   true,
-		ID:       TestingID,
+		ID:       TestingId,
 	}.Apply(t)
 	qa.AssertErrorStartsWith(t, err, "Something unexpected")
 }
@@ -195,13 +205,13 @@ func TestIPACLRead(t *testing.T) {
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   http.MethodGet,
-				Resource: "/api/2.0/ip-access-lists/" + TestingID + "?",
+				Resource: "/api/2.0/ip-access-lists/" + TestingId + "?",
 				Response: settings.CreateIpAccessListResponse{
 					IpAccessList: &settings.IpAccessListInfo{
-						ListId:       TestingID,
+						ListId:       TestingId,
 						Label:        TestingLabel,
 						ListType:     TestingListType,
-						IpAddresses:  TestingIPAddresses,
+						IpAddresses:  TestingIpAddresses,
 						AddressCount: 2,
 						CreatedAt:    87939234,
 						CreatedBy:    1234556,
@@ -215,10 +225,10 @@ func TestIPACLRead(t *testing.T) {
 		Resource: ResourceIPAccessList(),
 		Read:     true,
 		New:      true,
-		ID:       TestingID,
+		ID:       TestingId,
 	}.Apply(t)
 	assert.NoError(t, err)
-	assert.Equal(t, TestingID, d.Id())
+	assert.Equal(t, TestingId, d.Id())
 	assert.Equal(t, TestingLabel, d.Get("label"))
 	assert.Equal(t, TestingListTypeString, d.Get("list_type"))
 	assert.Equal(t, TestingEnabled, d.Get("enabled"))
@@ -230,10 +240,10 @@ func TestIPACLRead_NotFound(t *testing.T) {
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   http.MethodGet,
-				Resource: "/api/2.0/ip-access-lists/" + TestingID + "?",
+				Resource: "/api/2.0/ip-access-lists/" + TestingId + "?",
 				Response: apierr.APIErrorBody{
 					ErrorCode: "RESOURCE_DOES_NOT_EXIST",
-					Message:   "Can't find an IP access list with id: " + TestingID + ".",
+					Message:   "Can't find an IP access list with id: " + TestingId + ".",
 				},
 				Status: 404,
 			},
@@ -241,7 +251,7 @@ func TestIPACLRead_NotFound(t *testing.T) {
 		Resource: ResourceIPAccessList(),
 		Read:     true,
 		Removed:  true,
-		ID:       TestingID,
+		ID:       TestingId,
 	}.ApplyNoError(t)
 }
 
@@ -250,7 +260,7 @@ func TestIPACLRead_Error(t *testing.T) {
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   http.MethodGet,
-				Resource: "/api/2.0/ip-access-lists/" + TestingID + "?",
+				Resource: "/api/2.0/ip-access-lists/" + TestingId + "?",
 				Response: apierr.APIErrorBody{
 					ErrorCode: "SERVER_ERROR",
 					Message:   "Something unexpected happened",
@@ -260,11 +270,11 @@ func TestIPACLRead_Error(t *testing.T) {
 		},
 		Resource: ResourceIPAccessList(),
 		Read:     true,
-		ID:       TestingID,
+		ID:       TestingId,
 	}.Apply(t)
 	assert.Error(t, err)
 	qa.AssertErrorStartsWith(t, err, "Something unexpected happened")
-	assert.Equal(t, TestingID, d.Id(), "Id should not be empty for error reads")
+	assert.Equal(t, TestingId, d.Id(), "Id should not be empty for error reads")
 }
 
 func TestIPACLDelete(t *testing.T) {
@@ -272,15 +282,15 @@ func TestIPACLDelete(t *testing.T) {
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   http.MethodDelete,
-				Resource: fmt.Sprintf("/api/2.0/ip-access-lists/%s?", TestingID),
+				Resource: fmt.Sprintf("/api/2.0/ip-access-lists/%s?", TestingId),
 			},
 		},
 		Resource: ResourceIPAccessList(),
 		Delete:   true,
-		ID:       TestingID,
+		ID:       TestingId,
 	}.Apply(t)
 	assert.NoError(t, err)
-	assert.Equal(t, TestingID, d.Id())
+	assert.Equal(t, TestingId, d.Id())
 }
 
 func TestIPACLDelete_Error(t *testing.T) {
@@ -288,7 +298,7 @@ func TestIPACLDelete_Error(t *testing.T) {
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   http.MethodDelete,
-				Resource: fmt.Sprintf("/api/2.0/ip-access-lists/%s?", TestingID),
+				Resource: fmt.Sprintf("/api/2.0/ip-access-lists/%s?", TestingId),
 				Response: apierr.APIErrorBody{
 					ErrorCode: "INVALID_STATE",
 					Message:   "Something went wrong",
@@ -299,7 +309,7 @@ func TestIPACLDelete_Error(t *testing.T) {
 		Resource: ResourceIPAccessList(),
 		Delete:   true,
 		Removed:  true,
-		ID:       TestingID,
+		ID:       TestingId,
 	}.ExpectError(t, "Something went wrong")
 }
 

--- a/access/resource_ip_access_list_test.go
+++ b/access/resource_ip_access_list_test.go
@@ -113,7 +113,6 @@ func TestAPIACLCreate_Error(t *testing.T) {
 	assert.Equal(t, "", d.Id(), "Id should be empty for error creates")
 }
 
-// tanmaytodo
 func TestIPACLUpdate(t *testing.T) {
 	d, err := qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
@@ -221,6 +220,11 @@ func TestIPACLRead(t *testing.T) {
 					},
 				},
 			},
+		},
+		State: map[string]any{
+			"label":        TestingLabel,
+			"list_type":    TestingListTypeString,
+			"ip_addresses": TestingIpAddressesState,
 		},
 		Resource: ResourceIPAccessList(),
 		Read:     true,

--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -1436,14 +1436,14 @@ func TestImportingIPAccessLists(t *testing.T) {
 			},
 			{
 				Method:   "GET",
-				Resource: "/api/2.0/ip-access-lists/123",
+				Resource: "/api/2.0/ip-access-lists/123?",
 				Response: settings.GetIpAccessListResponse{
 					IpAccessLists: []settings.IpAccessListInfo{resp},
 				},
 			},
 			{
 				Method:   "GET",
-				Resource: "/api/2.0/ip-access-lists/124",
+				Resource: "/api/2.0/ip-access-lists/124?",
 				Response: settings.GetIpAccessListResponse{
 					IpAccessLists: []settings.IpAccessListInfo{resp2},
 				},

--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -13,8 +13,8 @@ import (
 	"time"
 
 	"github.com/databricks/databricks-sdk-go/service/compute"
+	"github.com/databricks/databricks-sdk-go/service/settings"
 	workspaceApi "github.com/databricks/databricks-sdk-go/service/workspace"
-	"github.com/databricks/terraform-provider-databricks/access"
 	"github.com/databricks/terraform-provider-databricks/aws"
 	"github.com/databricks/terraform-provider-databricks/clusters"
 	"github.com/databricks/terraform-provider-databricks/commands"
@@ -1404,17 +1404,17 @@ func TestImportingRepos(t *testing.T) {
 }
 
 func TestImportingIPAccessLists(t *testing.T) {
-	resp := access.IpAccessListStatus{
-		ListID:       "123",
+	resp := settings.IpAccessListInfo{
+		ListId:       "123",
 		Label:        "block_list",
 		ListType:     "BLOCK",
-		IPAddresses:  []string{"1.2.3.4"},
+		IpAddresses:  []string{"1.2.3.4"},
 		AddressCount: 2,
 		Enabled:      true,
 	}
 	resp2 := resp
-	resp2.IPAddresses = []string{}
-	resp2.ListID = "124"
+	resp2.IpAddresses = []string{}
+	resp2.ListId = "124"
 	qa.HTTPFixturesApply(t,
 		[]qa.HTTPFixture{
 			meAdminFixture,
@@ -1430,22 +1430,22 @@ func TestImportingIPAccessLists(t *testing.T) {
 			{
 				Method:   "GET",
 				Resource: "/api/2.0/ip-access-lists",
-				Response: access.ListIPAccessListsResponse{
-					ListIPAccessListsResponse: []access.IpAccessListStatus{resp, resp2},
+				Response: settings.GetIpAccessListsResponse{
+					IpAccessLists: []settings.IpAccessListInfo{resp, resp2},
 				},
 			},
 			{
 				Method:   "GET",
 				Resource: "/api/2.0/ip-access-lists/123",
-				Response: access.IpAccessListStatusWrapper{
-					IPAccessList: resp,
+				Response: settings.GetIpAccessListResponse{
+					IpAccessLists: []settings.IpAccessListInfo{resp},
 				},
 			},
 			{
 				Method:   "GET",
 				Resource: "/api/2.0/ip-access-lists/124",
-				Response: access.IpAccessListStatusWrapper{
-					IPAccessList: resp2,
+				Response: settings.GetIpAccessListResponse{
+					IpAccessLists: []settings.IpAccessListInfo{resp2},
 				},
 			},
 			{
@@ -1840,6 +1840,3 @@ func TestImportingGlobalSqlConfig(t *testing.T) {
 			assert.NoError(t, err)
 		})
 }
-
-// 			emptyRepos,
-// emptyIpAccessLIst,

--- a/internal/acceptance/ip_access_list_test.go
+++ b/internal/acceptance/ip_access_list_test.go
@@ -15,5 +15,15 @@ func TestAccIPACLListsResourceFullLifecycle(t *testing.T) {
 				"10.0.10.0/24"
 			]
 		}`,
+	}, step{
+		Template: `
+	resource "databricks_ip_access_list" "this" {
+		label = "tf-{var.RANDOM}"
+		list_type = "BLOCK"
+		ip_addresses = [
+			"10.0.11.25",
+			"10.0.11.0/24"
+		]
+	}`,
 	})
 }

--- a/internal/acceptance/ip_access_list_test.go
+++ b/internal/acceptance/ip_access_list_test.go
@@ -17,13 +17,13 @@ func TestAccIPACLListsResourceFullLifecycle(t *testing.T) {
 		}`,
 	}, step{
 		Template: `
-	resource "databricks_ip_access_list" "this" {
-		label = "tf-{var.RANDOM}"
-		list_type = "BLOCK"
-		ip_addresses = [
-			"10.0.11.25",
-			"10.0.11.0/24"
-		]
-	}`,
+		resource "databricks_ip_access_list" "this" {
+			label = "tf-{var.RANDOM}"
+			list_type = "BLOCK"
+			ip_addresses = [
+				"10.0.11.25",
+				"10.0.11.0/24"
+			]
+		}`,
 	})
 }

--- a/internal/acceptance/ip_access_list_test.go
+++ b/internal/acceptance/ip_access_list_test.go
@@ -4,13 +4,9 @@ import (
 	"testing"
 )
 
-func TestIPACLListsResourceFullLifecycle(t *testing.T) {
+func TestAccIPACLListsResourceFullLifecycle(t *testing.T) {
 	workspaceLevel(t, step{
 		Template: `
-		resource "databricks_workspace_conf" "features" {
-			enable_ip_access_lists = "true"
-		}
-		  
 		resource "databricks_ip_access_list" "this" {
 			label = "tf-{var.RANDOM}"
 			list_type = "BLOCK"
@@ -18,7 +14,6 @@ func TestIPACLListsResourceFullLifecycle(t *testing.T) {
 				"10.0.10.25",
 				"10.0.10.0/24"
 			]
-			depends_on = [databricks_workspace_conf.features]
 		}`,
 	})
 }


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
- Migrate IP ACL to Go SDK 
- Update and enable integration tests
- Fix tests to use body for updates
- No relevant change is needed to be updated in docs since argument references are the same.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder 
- [ ] covered with integration tests in `internal/acceptance`
- [x] relevant acceptance tests are passing
- [x] using Go SDK

Integration test: internal/acceptance/ip_access_list_test.go. Full integration test suite is also running successfully. 

