### PR TITLE
Added missing `serverless` option to PipelineSpec

### DIFF
--- a/docs/resources/pipeline.md
+++ b/docs/resources/pipeline.md
@@ -82,7 +82,6 @@ The following arguments are supported:
 * `target` - The name of a database (in either the Hive metastore or in a UC catalog) for persisting pipeline output data. Configuring the target setting allows you to view and query the pipeline output data from the Databricks UI.
 * `edition` - optional name of the [product edition](https://docs.databricks.com/data-engineering/delta-live-tables/delta-live-tables-concepts.html#editions). Supported values are: `core`, `pro`, `advanced` (default).
 * `channel` - optional name of the release channel for Spark version used by DLT pipeline.  Supported values are: `current` (default) and `preview`.
-* `serverless` - A flag to indicate whether serverless compute is enabled for this pipeline. The default value is `false`.
 
 ### notification block
 

--- a/docs/resources/pipeline.md
+++ b/docs/resources/pipeline.md
@@ -82,6 +82,7 @@ The following arguments are supported:
 * `target` - The name of a database (in either the Hive metastore or in a UC catalog) for persisting pipeline output data. Configuring the target setting allows you to view and query the pipeline output data from the Databricks UI.
 * `edition` - optional name of the [product edition](https://docs.databricks.com/data-engineering/delta-live-tables/delta-live-tables-concepts.html#editions). Supported values are: `core`, `pro`, `advanced` (default).
 * `channel` - optional name of the release channel for Spark version used by DLT pipeline.  Supported values are: `current` (default) and `preview`.
+* `serverless` - A flag to indicate whether serverless compute is enabled for this pipeline. The default value is `false`.
 
 ### notification block
 

--- a/pipelines/resource_pipeline.go
+++ b/pipelines/resource_pipeline.go
@@ -102,6 +102,7 @@ type PipelineSpec struct {
 	Edition             string            `json:"edition,omitempty" tf:"suppress_diff,default:ADVANCED"`
 	Channel             string            `json:"channel,omitempty" tf:"suppress_diff,default:CURRENT"`
 	Notifications       []Notification    `json:"notifications,omitempty" tf:"alias:notification"`
+	Serverless          bool              `json:"serverless,omitempty"`
 }
 
 type createPipelineResponse struct {

--- a/pipelines/resource_pipeline.go
+++ b/pipelines/resource_pipeline.go
@@ -102,7 +102,7 @@ type PipelineSpec struct {
 	Edition             string            `json:"edition,omitempty" tf:"suppress_diff,default:ADVANCED"`
 	Channel             string            `json:"channel,omitempty" tf:"suppress_diff,default:CURRENT"`
 	Notifications       []Notification    `json:"notifications,omitempty" tf:"alias:notification"`
-	Serverless          bool              `json:"serverless,omitempty"`
+	Serverless          bool              `json:"serverless" tf:"optional"`
 }
 
 type createPipelineResponse struct {

--- a/pipelines/resource_pipeline_test.go
+++ b/pipelines/resource_pipeline_test.go
@@ -598,3 +598,103 @@ func TestStorageSuppressDiff(t *testing.T) {
 	require.False(t, suppressStorageDiff(k, generated, "/tmp/abc", nil))
 	require.False(t, suppressStorageDiff(k, "/tmp/abc", "", nil))
 }
+
+func TestResourcePipelineCreateServerless(t *testing.T) {
+	var serverlessPipelineSpec = PipelineSpec{
+		Name:    "test-pipeline-serverless",
+		Storage: "/test/storage",
+		Configuration: map[string]string{
+			"key1": "value1",
+			"key2": "value2",
+		},
+		Clusters: []pipelineCluster{
+			{
+				Label: "default",
+				CustomTags: map[string]string{
+					"cluster_tag1": "cluster_value1",
+				},
+			},
+		},
+		Libraries: []PipelineLibrary{
+			{
+				Notebook: &NotebookLibrary{
+					Path: "/TestServerless",
+				},
+			},
+		},
+		Filters: &filters{
+			Include: []string{"com.databricks.include"},
+			Exclude: []string{"com.databricks.exclude"},
+		},
+		Serverless: true,
+	}
+	d, err := qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "POST",
+				Resource: "/api/2.0/pipelines",
+				Response: createPipelineResponse{
+					PipelineID: "serverless",
+				},
+			},
+			{
+				Method:   "GET",
+				Resource: "/api/2.0/pipelines/serverless",
+				Response: map[string]any{
+					"id":    "serverless",
+					"name":  "test-pipeline-serverless",
+					"state": "DEPLOYING",
+					"spec":  serverlessPipelineSpec,
+				},
+			},
+			{
+				Method:   "GET",
+				Resource: "/api/2.0/pipelines/serverless",
+				Response: map[string]any{
+					"id":    "serverless",
+					"name":  "test-pipeline-serverless",
+					"state": "RUNNING",
+					"spec":  serverlessPipelineSpec,
+				},
+			},
+			{
+				Method:   "GET",
+				Resource: "/api/2.0/pipelines/serverless",
+				Response: map[string]any{
+					"id":    "serverless",
+					"name":  "test-pipeline-serverless",
+					"state": "RUNNING",
+					"spec":  serverlessPipelineSpec,
+				},
+			},
+		},
+		Create:   true,
+		Resource: ResourcePipeline(),
+		HCL: `name = "test-pipeline-serverless"
+		storage = "/test/storage"
+		configuration = {
+		  key1 = "value1"
+		  key2 = "value2"
+		}
+		cluster {
+		  label = "default"
+		  custom_tags = {
+			"cluster_tag1" = "cluster_value1"
+		  }
+		}
+		library {
+		  notebook {
+			path = "/TestServerless"
+		  }
+		}
+		filters {
+		  include = ["com.databricks.include"]
+		  exclude = ["com.databricks.exclude"]
+		}
+		continuous = false
+		serverless = true
+		`,
+	}.Apply(t)
+	assert.NoError(t, err)
+	assert.Equal(t, "serverless", d.Id())
+}


### PR DESCRIPTION
## Changes
Added missing `serverless` option to PipelineSpec

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] ~covered with integration tests in `internal/acceptance`~
- [ ] ~relevant acceptance tests are passing~
- [ ] ~using Go SDK~

