### PR TITLE
Remove support for releasing 32-bit binaries

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,12 +14,7 @@ builds:
     - darwin
   goarch:
     - amd64
-    - '386'
-    - arm
     - arm64
-  ignore:
-    - goos: darwin
-      goarch: '386'
 archives:
 - format: zip
   name_template: '{{ .ProjectName }}_{{ replace .Version "v" "" }}_{{ .Os }}_{{ .Arch }}'


### PR DESCRIPTION
## Changes

Removes 32-bit builds from .goreleaser.yml

Closes #2304
