### PR TITLE
Add suppress diff for URL change that only change `/` (remove or add) in UC resources

### DIFF
--- a/catalog/resource_catalog.go
+++ b/catalog/resource_catalog.go
@@ -3,10 +3,19 @@ package catalog
 import (
 	"context"
 	"fmt"
+	"log"
 
 	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
+
+func ucDirectoryPathSuppressDiff(k, old, new string, d *schema.ResourceData) bool {
+	if (new == (old + "/")) || (old == (new + "/")) {
+		log.Printf("[DEBUG] Ignoring configuration drift from %s to %s", old, new)
+		return true
+	}
+	return false
+}
 
 type CatalogsAPI struct {
 	client  *common.DatabricksClient
@@ -68,6 +77,7 @@ func ResourceCatalog() *schema.Resource {
 				Optional: true,
 				Default:  false,
 			}
+			m["storage_root"].DiffSuppressFunc = ucDirectoryPathSuppressDiff
 			return m
 		})
 	update := updateFunctionFactory("/unity-catalog/catalogs", []string{"owner", "comment", "properties"})

--- a/catalog/resource_catalog_test.go
+++ b/catalog/resource_catalog_test.go
@@ -303,3 +303,12 @@ func TestCatalogCreateDeltaSharing(t *testing.T) {
 		`,
 	}.ApplyNoError(t)
 }
+
+func TestUcDirectoryPathSuppressDiff(t *testing.T) {
+	assert.True(t, ucDirectoryPathSuppressDiff("", "abfss://test@test.dfs.core.windows.net/TF_DIR_WITH_SLASH",
+		"abfss://test@test.dfs.core.windows.net/TF_DIR_WITH_SLASH/", nil))
+	assert.True(t, ucDirectoryPathSuppressDiff("", "abfss://test@test.dfs.core.windows.net/TF_DIR_WITH_SLASH/",
+		"abfss://test@test.dfs.core.windows.net/TF_DIR_WITH_SLASH", nil))
+	assert.False(t, ucDirectoryPathSuppressDiff("", "abfss://test@test.dfs.core.windows.net/new_dir",
+		"abfss://test@test.dfs.core.windows.net/TF_DIR_WITH_SLASH/", nil))
+}

--- a/catalog/resource_external_location.go
+++ b/catalog/resource_external_location.go
@@ -46,6 +46,7 @@ func ResourceExternalLocation() *schema.Resource {
 			m["skip_validation"].DiffSuppressFunc = func(k, old, new string, d *schema.ResourceData) bool {
 				return old == "false" && new == "true"
 			}
+			m["url"].DiffSuppressFunc = ucDirectoryPathSuppressDiff
 			return m
 		})
 	update := updateFunctionFactory("/unity-catalog/external-locations", []string{"owner", "comment", "url", "credential_name"})

--- a/catalog/resource_schema.go
+++ b/catalog/resource_schema.go
@@ -73,6 +73,7 @@ func ResourceSchema() *schema.Resource {
 				Optional: true,
 				Default:  false,
 			}
+			m["storage_root"].DiffSuppressFunc = ucDirectoryPathSuppressDiff
 			return m
 		})
 	update := updateFunctionFactory("/unity-catalog/schemas", []string{"owner", "comment", "properties"})


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

UC Engineering team changed a way how the storage URLs are normalized, and this caused an issue with existing UC resources (catalogs, schemas, ...) that used URLs like `s3://bucket` instead of `s3://bucket/`

This fixes #2335

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] tested manually
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [x] relevant acceptance tests are passing - tested with `aws-prod-ucws`
- [ ] using Go SDK

