### PR TITLE
Add Pulumi user agent support

### DIFF
--- a/provider/provider.go
+++ b/provider/provider.go
@@ -37,10 +37,16 @@ import (
 	"github.com/databricks/terraform-provider-databricks/workspace"
 )
 
+var IsPulumi string = "false"
+
 func init() {
 	// IMPORTANT: this line cannot be changed, because it's used for
 	// internal purposes at Databricks.
-	useragent.WithProduct("databricks-tf-provider", common.Version())
+	BaseUserAgent := "databricks-tf-provider"
+	if IsPulumi == "true" {
+		BaseUserAgent = "databricks-pulumi-provider"
+	}
+	useragent.WithProduct(BaseUserAgent, common.Version())
 }
 
 // DatabricksProvider returns the entire terraform provider object


### PR DESCRIPTION
## Changes

Per a request via partnership, this enables the Pulumi Databricks provider to use a distinct user agent string, via setting `IsPulumi = true` via `ldflags` or a minimal patch.

If you'd prefer, we could modify the code to this instead:

```go
// IMPORTANT: this line cannot be changed, because it's used for
// internal purposes at Databricks.
var BaseUserAgent string = "databricks-tf-provider"

func init() {
	useragent.WithProduct(BaseUserAgent, common.Version())
}
```

But this is, I think, more fragile in that your code wouldn't contain the other Pulumi UA string and it might not be obvious to future engineers why this is a variable instead of a const, why it is factored out of `init()`, and so on. 

