### PR TITLE
Fix attributes typo in SCIM API

### DIFF
--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -420,7 +420,7 @@ func TestImportingUsersGroupsSecretScopes(t *testing.T) {
 			// TODO: add groups to the output
 			{
 				Method:   "GET",
-				Resource: "/api/2.0/preview/scim/v2/Users/123?attributes=userName,displayName,active,externalID,entitlements",
+				Resource: "/api/2.0/preview/scim/v2/Users/123?attributes=userName,displayName,active,externalId,entitlements",
 				Response: scim.User{ID: "123", DisplayName: "test@test.com", UserName: "test@test.com"},
 			},
 			{
@@ -1676,7 +1676,7 @@ func TestImportingDLTPipelines(t *testing.T) {
 			},
 			{
 				Method:   "GET",
-				Resource: "/api/2.0/preview/scim/v2/Users/123?attributes=userName,displayName,active,externalID,entitlements",
+				Resource: "/api/2.0/preview/scim/v2/Users/123?attributes=userName,displayName,active,externalId,entitlements",
 				Response: scim.User{ID: "123", DisplayName: "user@domain.com", UserName: "user@domain.com"},
 			},
 			{

--- a/scim/resource_user.go
+++ b/scim/resource_user.go
@@ -81,7 +81,7 @@ func ResourceUser() *schema.Resource {
 			return nil
 		},
 		Read: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
-			user, err := NewUsersAPI(ctx, c).Read(d.Id(), "userName,displayName,active,externalID,entitlements")
+			user, err := NewUsersAPI(ctx, c).Read(d.Id(), "userName,displayName,active,externalId,entitlements")
 			if err != nil {
 				return err
 			}
@@ -98,7 +98,7 @@ func ResourceUser() *schema.Resource {
 			if err != nil {
 				return err
 			}
-			return NewUsersAPI(ctx, c).Update(d.Id(), "userName,displayName,active,externalID,entitlements", u)
+			return NewUsersAPI(ctx, c).Update(d.Id(), "userName,displayName,active,externalId,entitlements", u)
 		},
 		Delete: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
 			user := NewUsersAPI(ctx, c)
@@ -146,5 +146,5 @@ func createForceOverridesManuallyAddedUser(err error, d *schema.ResourceData, us
 	}
 	user := userList[0]
 	d.SetId(user.ID)
-	return usersAPI.Update(d.Id(), "userName,displayName,active,externalID,entitlements", u)
+	return usersAPI.Update(d.Id(), "userName,displayName,active,externalId,entitlements", u)
 }

--- a/scim/resource_user_test.go
+++ b/scim/resource_user_test.go
@@ -19,7 +19,7 @@ func TestResourceUserRead(t *testing.T) {
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   "GET",
-				Resource: "/api/2.0/preview/scim/v2/Users/abc?attributes=userName,displayName,active,externalID,entitlements",
+				Resource: "/api/2.0/preview/scim/v2/Users/abc?attributes=userName,displayName,active,externalId,entitlements",
 				Response: User{
 					ID:          "abc",
 					DisplayName: "Example user",
@@ -56,7 +56,7 @@ func TestResourceUserRead_NotFound(t *testing.T) {
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   "GET",
-				Resource: "/api/2.0/preview/scim/v2/Users/abc?attributes=userName,displayName,active,externalID,entitlements",
+				Resource: "/api/2.0/preview/scim/v2/Users/abc?attributes=userName,displayName,active,externalId,entitlements",
 				Status:   404,
 			},
 		},
@@ -73,7 +73,7 @@ func TestResourceUserRead_Error(t *testing.T) {
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   "GET",
-				Resource: "/api/2.0/preview/scim/v2/Users/abc?attributes=userName,displayName,active,externalID,entitlements",
+				Resource: "/api/2.0/preview/scim/v2/Users/abc?attributes=userName,displayName,active,externalId,entitlements",
 				Status:   400,
 				Response: apierr.APIErrorBody{
 					ScimDetail: "Something",
@@ -113,7 +113,7 @@ func TestResourceUserCreate(t *testing.T) {
 			},
 			{
 				Method:   "GET",
-				Resource: "/api/2.0/preview/scim/v2/Users/abc?attributes=userName,displayName,active,externalID,entitlements",
+				Resource: "/api/2.0/preview/scim/v2/Users/abc?attributes=userName,displayName,active,externalId,entitlements",
 				Response: User{
 					DisplayName: "Example user",
 					Active:      true,
@@ -177,7 +177,7 @@ func TestResourceUserCreateInactive(t *testing.T) {
 			},
 			{
 				Method:   "GET",
-				Resource: "/api/2.0/preview/scim/v2/Users/abc?attributes=userName,displayName,active,externalID,entitlements",
+				Resource: "/api/2.0/preview/scim/v2/Users/abc?attributes=userName,displayName,active,externalId,entitlements",
 				Response: User{
 					DisplayName: "Example user",
 					Active:      false,
@@ -271,7 +271,7 @@ func TestResourceUserUpdate(t *testing.T) {
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   "GET",
-				Resource: "/api/2.0/preview/scim/v2/Users/abc?attributes=userName,displayName,active,externalID,entitlements",
+				Resource: "/api/2.0/preview/scim/v2/Users/abc?attributes=userName,displayName,active,externalId,entitlements",
 				Response: User{
 					DisplayName: "Example user",
 					Active:      true,
@@ -309,7 +309,7 @@ func TestResourceUserUpdate(t *testing.T) {
 			},
 			{
 				Method:   "GET",
-				Resource: "/api/2.0/preview/scim/v2/Users/abc?attributes=userName,displayName,active,externalID,entitlements",
+				Resource: "/api/2.0/preview/scim/v2/Users/abc?attributes=userName,displayName,active,externalId,entitlements",
 				Response: newUser,
 			},
 		},
@@ -340,7 +340,7 @@ func TestResourceUserUpdate_Error(t *testing.T) {
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   "GET",
-				Resource: "/api/2.0/preview/scim/v2/Users/abc?attributes=userName,displayName,active,externalID,entitlements",
+				Resource: "/api/2.0/preview/scim/v2/Users/abc?attributes=userName,displayName,active,externalId,entitlements",
 				Status:   400,
 			},
 		},
@@ -362,7 +362,7 @@ func TestResourceUserUpdate_ErrorPut(t *testing.T) {
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   "GET",
-				Resource: "/api/2.0/preview/scim/v2/Users/abc?attributes=userName,displayName,active,externalID,entitlements",
+				Resource: "/api/2.0/preview/scim/v2/Users/abc?attributes=userName,displayName,active,externalId,entitlements",
 				Response: User{
 					DisplayName: "Example user",
 					Active:      true,
@@ -658,7 +658,7 @@ func TestCreateForceOverwriteFindsAndSetsID(t *testing.T) {
 		},
 		{
 			Method:   "GET",
-			Resource: "/api/2.0/preview/scim/v2/Users/abc?attributes=userName,displayName,active,externalID,entitlements",
+			Resource: "/api/2.0/preview/scim/v2/Users/abc?attributes=userName,displayName,active,externalId,entitlements",
 			Response: User{
 				ID: "abc",
 			},
@@ -700,7 +700,7 @@ func TestCreateForceOverwriteFindsAndSetsAccID(t *testing.T) {
 		},
 		{
 			Method:   "GET",
-			Resource: "/api/2.0/preview/scim/v2/Users/abc?attributes=userName,displayName,active,externalID,entitlements",
+			Resource: "/api/2.0/preview/scim/v2/Users/abc?attributes=userName,displayName,active,externalId,entitlements",
 			Response: User{
 				ID: "abc",
 			},


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

The SCIM API attributes are case sensitive, so due to a typo in attributes (`externalId` vs. `externalID`), `externalId` was not returned and lead to permanent drifts

Closes #2209

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] ~~relevant change in `docs/` folder~~
- [ ] ~~covered with integration tests in `internal/acceptance`~~
- [x] relevant acceptance tests are passing
- [ ] ~~using Go SDK~~

