### PR TITLE
Explicit conversion of strings to int64.

### DIFF
--- a/access/resource_permission_assignment.go
+++ b/access/resource_permission_assignment.go
@@ -66,7 +66,7 @@ func (a PermissionAssignmentAPI) List() (list PermissionAssignmentList, err erro
 }
 
 func mustInt64(s string) int64 {
-	n, err := strconv.ParseInt(s, 10, 0)
+	n, err := strconv.ParseInt(s, 10, 64)
 	if err != nil {
 		panic(err)
 	}

--- a/mws/resource_mws_permission_assignment.go
+++ b/mws/resource_mws_permission_assignment.go
@@ -82,7 +82,7 @@ func (a PermissionAssignmentAPI) List(workspaceId int64) (list PermissionAssignm
 }
 
 func mustInt64(s string) int64 {
-	n, err := strconv.ParseInt(s, 10, 0)
+	n, err := strconv.ParseInt(s, 10, 64)
 	if err != nil {
 		panic(err)
 	}

--- a/permissions/resource_permissions.go
+++ b/permissions/resource_permissions.go
@@ -221,7 +221,7 @@ func (a PermissionsAPI) Delete(objectID string) error {
 		return err
 	}
 	if strings.HasPrefix(objectID, "/jobs") {
-		jobId, err := strconv.ParseInt(strings.ReplaceAll(objectID, "/jobs/", ""), 10, 0)
+		jobId, err := strconv.ParseInt(strings.ReplaceAll(objectID, "/jobs/", ""), 10, 64)
 		if err != nil {
 			return err
 		}

--- a/repos/resource_git_credential.go
+++ b/repos/resource_git_credential.go
@@ -67,7 +67,7 @@ func ResourceGitCredential() *schema.Resource {
 			if err != nil {
 				return err
 			}
-			cred_id, err := strconv.ParseInt(d.Id(), 10, 0)
+			cred_id, err := strconv.ParseInt(d.Id(), 10, 64)
 			if err != nil {
 				return err
 			}
@@ -83,7 +83,7 @@ func ResourceGitCredential() *schema.Resource {
 			var req workspace.UpdateCredentials
 
 			common.DataToStructPointer(d, s, &req)
-			cred_id, err := strconv.ParseInt(d.Id(), 10, 0)
+			cred_id, err := strconv.ParseInt(d.Id(), 10, 64)
 			if err != nil {
 				return err
 			}
@@ -99,7 +99,7 @@ func ResourceGitCredential() *schema.Resource {
 			if err != nil {
 				return err
 			}
-			cred_id, err := strconv.ParseInt(d.Id(), 10, 0)
+			cred_id, err := strconv.ParseInt(d.Id(), 10, 64)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
## Changes
Explicit conversion of strings to `int64`. Instead of machine dependent conversion when using integer type `int` (bit size 0 in `strconv.ParseInt`), that will throw "value out of range" error for platforms that infer `int` as `int32`, when larger integers than `int32` is used.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

