### PR TITLE
Add attributes to `databricks_cluster_policy` data source

### DIFF
--- a/docs/data-sources/cluster_policy.md
+++ b/docs/data-sources/cluster_policy.md
@@ -35,4 +35,8 @@ Data source exposes the following attributes:
 
 - `id` - The id of the cluster policy.
 - `definition` - Policy definition: JSON document expressed in [Databricks Policy Definition Language](https://docs.databricks.com/administration-guide/clusters/policies.html#cluster-policy-definition).
-- `max_clusters_per_user` - Max number of clusters per user that can be active using this policy
+- `description` - Additional human-readable description of the cluster policy.
+- `family_id` - ID of the policy family.
+- `family_definition_overrides` - Policy definition JSON document expressed in Databricks [Policy Definition Language](https://docs.databricks.com/administration-guide/clusters/policies.html#cluster-policy-definitions).
+- `is_default` - If true, policy is a default policy created and managed by Databricks.
+- `max_clusters_per_user` - Max number of clusters per user that can be active using this policy.

--- a/docs/data-sources/cluster_policy.md
+++ b/docs/data-sources/cluster_policy.md
@@ -36,7 +36,7 @@ Data source exposes the following attributes:
 - `id` - The id of the cluster policy.
 - `definition` - Policy definition: JSON document expressed in [Databricks Policy Definition Language](https://docs.databricks.com/administration-guide/clusters/policies.html#cluster-policy-definition).
 - `description` - Additional human-readable description of the cluster policy.
-- `family_id` - ID of the policy family.
-- `family_definition_overrides` - Policy definition JSON document expressed in Databricks [Policy Definition Language](https://docs.databricks.com/administration-guide/clusters/policies.html#cluster-policy-definitions).
+- `policy_family_id` - ID of the policy family.
+- `policy_family_definition_overrides` - Policy definition JSON document expressed in Databricks [Policy Definition Language](https://docs.databricks.com/administration-guide/clusters/policies.html#cluster-policy-definitions).
 - `is_default` - If true, policy is a default policy created and managed by Databricks.
 - `max_clusters_per_user` - Max number of clusters per user that can be active using this policy.

--- a/policies/data_cluster_policy.go
+++ b/policies/data_cluster_policy.go
@@ -11,10 +11,14 @@ import (
 // DataSourceClusterPolicy returns information about cluster policy specified by name
 func DataSourceClusterPolicy() *schema.Resource {
 	return common.WorkspaceData(func(ctx context.Context, data *struct {
-		Id                 string `json:"id,omitempty" tf:"computed"`
-		Name               string `json:"name,omitempty" tf:"computed"`
-		Definition         string `json:"definition,omitempty" tf:"computed"`
-		MaxClustersPerUser int    `json:"max_clusters_per_user,omitempty" tf:"computed"`
+		Id                        string `json:"id,omitempty" tf:"computed"`
+		Name                      string `json:"name,omitempty" tf:"computed"`
+		Definition                string `json:"definition,omitempty" tf:"computed"`
+		Description               string `json:"description,omitempty" tf:"computed"`
+		FamilyId                  string `json:"family_id,omitempty" tf:"computed"`
+		FamilyDefinitionOverrides string `json:"family_definition_overrides,omitempty" tf:"computed"`
+		IsDefault                 bool   `json:"is_default,omitempty" tf:"computed"`
+		MaxClustersPerUser        int    `json:"max_clusters_per_user,omitempty" tf:"computed"`
 	}, w *databricks.WorkspaceClient) error {
 		policy, err := w.ClusterPolicies.GetByName(ctx, data.Name)
 		if err != nil {
@@ -22,6 +26,10 @@ func DataSourceClusterPolicy() *schema.Resource {
 		}
 		data.Id = policy.PolicyId
 		data.Definition = policy.Definition
+		data.Description = policy.Description
+		data.FamilyId = policy.PolicyFamilyId
+		data.FamilyDefinitionOverrides = policy.PolicyFamilyDefinitionOverrides
+		data.IsDefault = policy.IsDefault
 		data.MaxClustersPerUser = int(policy.MaxClustersPerUser)
 		return nil
 	})

--- a/policies/data_cluster_policy.go
+++ b/policies/data_cluster_policy.go
@@ -11,14 +11,14 @@ import (
 // DataSourceClusterPolicy returns information about cluster policy specified by name
 func DataSourceClusterPolicy() *schema.Resource {
 	return common.WorkspaceData(func(ctx context.Context, data *struct {
-		Id                        string `json:"id,omitempty" tf:"computed"`
-		Name                      string `json:"name,omitempty" tf:"computed"`
-		Definition                string `json:"definition,omitempty" tf:"computed"`
-		Description               string `json:"description,omitempty" tf:"computed"`
-		FamilyId                  string `json:"family_id,omitempty" tf:"computed"`
-		FamilyDefinitionOverrides string `json:"family_definition_overrides,omitempty" tf:"computed"`
-		IsDefault                 bool   `json:"is_default,omitempty" tf:"computed"`
-		MaxClustersPerUser        int    `json:"max_clusters_per_user,omitempty" tf:"computed"`
+		Id                              string `json:"id,omitempty" tf:"computed"`
+		Name                            string `json:"name,omitempty" tf:"computed"`
+		Definition                      string `json:"definition,omitempty" tf:"computed"`
+		Description                     string `json:"description,omitempty" tf:"computed"`
+		PolicyFamilyId                  string `json:"policy_family_id,omitempty" tf:"computed"`
+		PolicyFamilyDefinitionOverrides string `json:"policy_family_definition_overrides,omitempty" tf:"computed"`
+		IsDefault                       bool   `json:"is_default,omitempty" tf:"computed"`
+		MaxClustersPerUser              int    `json:"max_clusters_per_user,omitempty" tf:"computed"`
 	}, w *databricks.WorkspaceClient) error {
 		policy, err := w.ClusterPolicies.GetByName(ctx, data.Name)
 		if err != nil {
@@ -27,8 +27,8 @@ func DataSourceClusterPolicy() *schema.Resource {
 		data.Id = policy.PolicyId
 		data.Definition = policy.Definition
 		data.Description = policy.Description
-		data.FamilyId = policy.PolicyFamilyId
-		data.FamilyDefinitionOverrides = policy.PolicyFamilyDefinitionOverrides
+		data.PolicyFamilyId = policy.PolicyFamilyId
+		data.PolicyFamilyDefinitionOverrides = policy.PolicyFamilyDefinitionOverrides
 		data.IsDefault = policy.IsDefault
 		data.MaxClustersPerUser = int(policy.MaxClustersPerUser)
 		return nil

--- a/policies/data_cluster_policy_test.go
+++ b/policies/data_cluster_policy_test.go
@@ -17,9 +17,14 @@ func TestDataSourceClusterPolicy(t *testing.T) {
 				Response: compute.ListPoliciesResponse{
 					Policies: []compute.Policy{
 						{
-							PolicyId:   "abc",
-							Name:       "policy",
-							Definition: `{"abc":"123"}`,
+							PolicyId:                        "abc",
+							Name:                            "policy",
+							Definition:                      `{"abc":"123"}`,
+							Description:                     "A description",
+							PolicyFamilyId:                  "def",
+							PolicyFamilyDefinitionOverrides: `{"def":"456"}`,
+							IsDefault:                       true,
+							MaxClustersPerUser:              42,
 						},
 					},
 				},
@@ -31,8 +36,13 @@ func TestDataSourceClusterPolicy(t *testing.T) {
 		ID:          ".",
 		HCL:         `name = "policy"`,
 	}.ApplyAndExpectData(t, map[string]any{
-		"id":         "abc",
-		"definition": `{"abc":"123"}`,
+		"id":                                 "abc",
+		"definition":                         `{"abc":"123"}`,
+		"description":                        "A description",
+		"policy_family_id":                   "def",
+		"policy_family_definition_overrides": `{"def":"456"}`,
+		"is_default":                         true,
+		"max_clusters_per_user":              42,
 	})
 }
 


### PR DESCRIPTION
## Changes
Adds the following attributes to the data source cluster policy:
- description
- policy_family_id
- policy_family_definition_overrides
- is_default

Closes #1947 

## Tests
I have modified the TestDataSourceClusterPolicy to test the cluster policy data structure using the new attributes.

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [x] relevant acceptance tests are passing
- [ ] using Go SDK

