### PR TITLE
Document `workload_type` block in `databricks_cluster` resource

### DIFF
--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -491,6 +491,24 @@ resource "databricks_cluster" "with_nfs" {
 }
 ```
 
+## workload_type block
+
+It's possible to restrict which workloads may run on the given cluster - notebooks and/or jobs. It's done by defining a `workload_type` block that consists of a single block `clients` with following attributes:
+
+* `notebooks` - (Optional) boolean flag defining if it's possible to run notebooks on this cluster. Default: `true`.
+* `jobs` - (Optional) boolean flag defining if it's possible to run Databricks Jobs on this cluster. Default: `true`.
+
+```hcl
+resource "databricks_cluster" "with_nfs" {
+  # ...
+  workload_type {
+    clients {
+      jobs      = false
+      notebooks = true
+    }
+  }
+}
+```
 
 ## Attribute Reference
 


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

It's possible to restrict a workload type for a given `databricks_cluster` instance.  For example, it's possible to disable execution of jobs on a cluster.

Related to #2369

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

