### PR TITLE
use generics in contains function

### DIFF
--- a/catalog/update.go
+++ b/catalog/update.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func contains(s []string, e string) bool {
+func contains[T comparable](s []T, e T) bool {
 	for _, a := range s {
 		if a == e {
 			return true


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
Converting the `contains` function to use generics rather than just strings. This is needed for #2364 to be used for an int64 comparison.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

