### PR TITLE
Adding less permissive principal for self assuming UC role

### DIFF
--- a/docs/guides/unity-catalog.md
+++ b/docs/guides/unity-catalog.md
@@ -176,7 +176,7 @@ data "aws_iam_policy_document" "passrole_for_uc" {
     actions = ["sts:AssumeRole"]
     principals {
       type        = "AWS"
-      identifiers = ["*"]
+      identifiers = ["arn:aws:iam::${var.aws_account_id}:root"]
     }
     condition {
       test     = "ArnLike"


### PR DESCRIPTION
Changes:
- Replaced `*` per `arn:aws:iam::${var.aws_account_id}:root` for the self assuming part of the UC policy document role

## Changes
<!-- Summary of your changes that are easy to understand -->

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

