### PR TITLE
Add run_as and run_as_user_name field to job definition 

### DIFF
--- a/docs/resources/job.md
+++ b/docs/resources/job.md
@@ -88,6 +88,7 @@ The resource supports the following arguments:
 * `email_notifications` - (Optional) (List) An optional set of email addresses notified when runs of this job begins, completes and fails. The default behavior is to not send any emails. This field is a block and is documented below.
 * `webhook_notifications` - (Optional) (List) An optional set of system destinations (for example, webhook destinations or Slack) to be notified when runs of this job begins, completes and fails. The default behavior is to not send any notifications. This field is a block and is documented below.
 * `schedule` - (Optional) (List) An optional periodic schedule for this job. The default behavior is that the job runs when triggered by clicking Run Now in the Jobs UI or sending an API request to runNow. This field is a block and is documented below.
+* `run_as` - (Optional) job's identity
 
 ### tags Configuration Map
 `tags` - (Optional) (Map) An optional map of the tags associated with the job. Specified tags will be used as cluster tags for job clusters.
@@ -103,6 +104,12 @@ resource "databricks_job" "this" {
   }
 }
 ```
+
+### run_as Configuration Block
+
+* `user_name` - (Optional) a.
+* `service_principal_name` - b.
+
 
 ### job_cluster Configuration Block
 

--- a/docs/resources/job.md
+++ b/docs/resources/job.md
@@ -88,7 +88,6 @@ The resource supports the following arguments:
 * `email_notifications` - (Optional) (List) An optional set of email addresses notified when runs of this job begins, completes and fails. The default behavior is to not send any emails. This field is a block and is documented below.
 * `webhook_notifications` - (Optional) (List) An optional set of system destinations (for example, webhook destinations or Slack) to be notified when runs of this job begins, completes and fails. The default behavior is to not send any notifications. This field is a block and is documented below.
 * `schedule` - (Optional) (List) An optional periodic schedule for this job. The default behavior is that the job runs when triggered by clicking Run Now in the Jobs UI or sending an API request to runNow. This field is a block and is documented below.
-* `run_as` - (Optional) An optional identifier of the user or the service principal that the job runs as. If not specified, the job runs as the user who created the job. This field is a block and is documented below.
 
 ### tags Configuration Map
 `tags` - (Optional) (Map) An optional map of the tags associated with the job. Specified tags will be used as cluster tags for job clusters.
@@ -106,6 +105,9 @@ resource "databricks_job" "this" {
 ```
 
 ### run_as Configuration Block
+
+The `run_as` block allows specifying the user or the service principal that the job runs as. If not specified, the job runs as the user or service
+principal that created the job.
 
 * `user_name` - (Optional) The email of an active workspace user. Non-admin users can only set this field to their own email.
 * `service_principal_name` - (Optional) The application ID of an active service principal. Setting this field requires the `servicePrincipal/user` role.

--- a/docs/resources/job.md
+++ b/docs/resources/job.md
@@ -88,7 +88,7 @@ The resource supports the following arguments:
 * `email_notifications` - (Optional) (List) An optional set of email addresses notified when runs of this job begins, completes and fails. The default behavior is to not send any emails. This field is a block and is documented below.
 * `webhook_notifications` - (Optional) (List) An optional set of system destinations (for example, webhook destinations or Slack) to be notified when runs of this job begins, completes and fails. The default behavior is to not send any notifications. This field is a block and is documented below.
 * `schedule` - (Optional) (List) An optional periodic schedule for this job. The default behavior is that the job runs when triggered by clicking Run Now in the Jobs UI or sending an API request to runNow. This field is a block and is documented below.
-* `run_as` - (Optional) Optional identifier of the user or service principal that the job runs as. If not specified, the job runs as the user who created the job. This field is a block and is documented below.
+* `run_as` - (Optional) An optional identifier of the user or the service principal that the job runs as. If not specified, the job runs as the user who created the job. This field is a block and is documented below.
 
 ### tags Configuration Map
 `tags` - (Optional) (Map) An optional map of the tags associated with the job. Specified tags will be used as cluster tags for job clusters.
@@ -108,7 +108,7 @@ resource "databricks_job" "this" {
 ### run_as Configuration Block
 
 * `user_name` - (Optional) The email of an active workspace user. Non-admin users can only set this field to their own email.
-* `service_principal_name` - (Optional) Application ID of an active service principal. Setting this field requires the `servicePrincipal/user` role.
+* `service_principal_name` - (Optional) The application ID of an active service principal. Setting this field requires the `servicePrincipal/user` role.
 
 Example
 

--- a/docs/resources/job.md
+++ b/docs/resources/job.md
@@ -88,7 +88,7 @@ The resource supports the following arguments:
 * `email_notifications` - (Optional) (List) An optional set of email addresses notified when runs of this job begins, completes and fails. The default behavior is to not send any emails. This field is a block and is documented below.
 * `webhook_notifications` - (Optional) (List) An optional set of system destinations (for example, webhook destinations or Slack) to be notified when runs of this job begins, completes and fails. The default behavior is to not send any notifications. This field is a block and is documented below.
 * `schedule` - (Optional) (List) An optional periodic schedule for this job. The default behavior is that the job runs when triggered by clicking Run Now in the Jobs UI or sending an API request to runNow. This field is a block and is documented below.
-* `run_as` - (Optional) job's identity
+* `run_as` - (Optional) Optional identifier of the user or service principal that the job runs as. If not specified, the job runs as the user who created the job. This field is a block and is documented below.
 
 ### tags Configuration Map
 `tags` - (Optional) (Map) An optional map of the tags associated with the job. Specified tags will be used as cluster tags for job clusters.
@@ -107,8 +107,20 @@ resource "databricks_job" "this" {
 
 ### run_as Configuration Block
 
-* `user_name` - (Optional) a.
-* `service_principal_name` - b.
+* `user_name` - (Optional) The email of an active workspace user. Non-admin users can only set this field to their own email.
+* `service_principal_name` - (Optional) Application ID of an active service principal. Setting this field requires the `servicePrincipal/user` role.
+
+Example
+
+```hcl
+resource "databricks_job" "this" {
+    # ...
+    run_as {
+      service_principal_name =  "8d23ae77-912e-4a19-81e4-b9c3f5cc9349"
+    }
+}
+```
+
 
 
 ### job_cluster Configuration Block

--- a/jobs/resource_job.go
+++ b/jobs/resource_job.go
@@ -201,8 +201,8 @@ type Queue struct {
 }
 
 type JobRunAs struct {
-	userName             string `json:"user_name,omitempty"`
-	servicePrincipalName string `json:"service_principal_name,omitempty"`
+	UserName             string `json:"user_name,omitempty"`
+	ServicePrincipalName string `json:"service_principal_name,omitempty"`
 }
 
 type FileArrival struct {

--- a/jobs/resource_job.go
+++ b/jobs/resource_job.go
@@ -200,6 +200,11 @@ type ContinuousConf struct {
 type Queue struct {
 }
 
+type JobRunAs struct {
+	userName             string `json:"user_name,omitempty"`
+	servicePrincipalName string `json:"service_principal_name,omitempty"`
+}
+
 type FileArrival struct {
 	URL                           string `json:"url"`
 	MinTimeBetweenTriggersSeconds int32  `json:"min_time_between_trigger_seconds,omitempty"`
@@ -251,6 +256,7 @@ type JobSettings struct {
 	NotificationSettings *NotificationSettings `json:"notification_settings,omitempty"`
 	Tags                 map[string]string     `json:"tags,omitempty"`
 	Queue                *Queue                `json:"queue,omitempty"`
+	RunAs                *JobRunAs             `json:"run_as,omitempty"`
 }
 
 func (js *JobSettings) isMultiTask() bool {
@@ -277,6 +283,7 @@ type JobListResponse struct {
 type Job struct {
 	JobID           int64        `json:"job_id,omitempty"`
 	CreatorUserName string       `json:"creator_user_name,omitempty"`
+	RunAsUserName   string       `json:"run_as_user_name,omitempty" tf:"computed"`
 	Settings        *JobSettings `json:"settings,omitempty"`
 	CreatedTime     int64        `json:"created_time,omitempty"`
 }

--- a/jobs/resource_job_test.go
+++ b/jobs/resource_job_test.go
@@ -47,7 +47,7 @@ func TestResourceJobCreate(t *testing.T) {
 					MaxConcurrentRuns:      1,
 					Queue:                  &Queue{},
 					RunAs: &JobRunAs{
-						userName: "user@mail.com",
+						UserName: "user@mail.com",
 					},
 				},
 				Response: Job{

--- a/jobs/resource_job_test.go
+++ b/jobs/resource_job_test.go
@@ -112,7 +112,7 @@ func TestResourceJobCreate(t *testing.T) {
 		}
 		queue {}
 		run_as {
-			user_name: "user@mail.com"
+			user_name = "user@mail.com"
 		}`,
 	}.Apply(t)
 	assert.NoError(t, err)

--- a/jobs/resource_job_test.go
+++ b/jobs/resource_job_test.go
@@ -46,6 +46,9 @@ func TestResourceJobCreate(t *testing.T) {
 					RetryOnTimeout:         true,
 					MaxConcurrentRuns:      1,
 					Queue:                  &Queue{},
+					RunAs: &JobRunAs{
+						userName: "user@mail.com",
+					},
 				},
 				Response: Job{
 					JobID: 789,
@@ -55,7 +58,8 @@ func TestResourceJobCreate(t *testing.T) {
 				Method:   "GET",
 				Resource: "/api/2.0/jobs/get?job_id=789",
 				Response: Job{
-					JobID: 789,
+					JobID:         789,
+					RunAsUserName: "user@mail.com",
 					Settings: &JobSettings{
 						ExistingClusterID: "abc",
 						SparkJarTask: &SparkJarTask{
@@ -106,7 +110,10 @@ func TestResourceJobCreate(t *testing.T) {
 		library {
 			jar = "dbfs://ff/gg/hh.jar"
 		}
-		queue {}`,
+		queue {}
+		run_as {
+			user_name: "user@mail.com"
+		}`,
 	}.Apply(t)
 	assert.NoError(t, err)
 	assert.Equal(t, "789", d.Id())


### PR DESCRIPTION
## Changes

Added read-only runAsUserName field to job definition and write-only runAs field to job settings definition.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

