### PR TITLE
Updated `TestAccClusterResource_CreateClusterWithLibraries` test to use `databricks-sdk` library instead of `Faker` 

### DIFF
--- a/internal/acceptance/cluster_test.go
+++ b/internal/acceptance/cluster_test.go
@@ -31,7 +31,7 @@ func TestAccClusterResource_CreateClusterWithLibraries(t *testing.T) {
 			library {
 				pypi {
 					repo = "https://pypi.org/simple"
-					package = "Faker"
+					package = "databricks-sdk"
 				}
 			}
 			library {


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
Replace since Faker library isn't being installed correctly.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

