### PR TITLE
Exporter: improve export of users/groups on account level

### DIFF
--- a/exporter/context.go
+++ b/exporter/context.go
@@ -221,15 +221,20 @@ func (ic *importContext) Run() error {
 			`terraform {
 				required_providers {
 			  		databricks = {
-						source = "databricks/databricks"
+						source  = "databricks/databricks"
 						version = "` + common.Version() + `"
 				  	}
 				}
 		  	}
 
 		  	provider "databricks" {
-		  	}
 		  	`)
+		if ic.accountLevel {
+			dcfile.WriteString(fmt.Sprintf(`	host       = "%s"
+				account_id = "%s"
+			`, ic.Client.Config.Host, ic.Client.Config.AccountID))
+		}
+		dcfile.WriteString(`}`)
 		dcfile.Close()
 	}
 	ic.generateHclForResources(sh)

--- a/exporter/importables.go
+++ b/exporter/importables.go
@@ -556,7 +556,6 @@ var resourcesMap map[string]importable = map[string]importable{
 			if err := ic.cacheGroups(); err != nil {
 				return err
 			}
-			// TODO: don't export users and admins group
 			for offset, g := range ic.allGroups {
 				if !ic.MatchesName(g.DisplayName) {
 					log.Printf("[INFO] Group %s doesn't match %s filter", g.DisplayName, ic.match)
@@ -584,8 +583,9 @@ var resourcesMap map[string]importable = map[string]importable{
 		},
 		Import: func(ic *importContext, r *resource) error {
 			groupName := r.Data.Get("display_name").(string)
-			if groupName == "admins" || groupName == "users" {
-				// admins & users are to be imported through "data block"
+			if (!ic.accountLevel && (groupName == "admins" || groupName == "users")) ||
+				(ic.accountLevel && groupName == "account users") {
+				// Workspace admins & users or Account users are to be imported through "data block"
 				r.Mode = "data"
 				r.Data.Set("workspace_access", false)
 				r.Data.Set("databricks_sql_access", false)
@@ -608,7 +608,8 @@ var resourcesMap map[string]importable = map[string]importable{
 					continue
 				}
 				ic.emitRoles("group", g.ID, g.Roles)
-				if g.DisplayName == "users" && !ic.importAllUsers {
+				builtInUserGroup := (ic.accountLevel && g.DisplayName == "account users") || (!ic.accountLevel && g.DisplayName == "users")
+				if builtInUserGroup && !ic.importAllUsers {
 					log.Printf("[INFO] Skipping import of entire user directory ...")
 					continue
 				}
@@ -630,32 +631,47 @@ var resourcesMap map[string]importable = map[string]importable{
 					}
 				}
 				for i, x := range g.Members {
-					if strings.Contains(x.Ref, "Users/") {
+					if strings.HasPrefix(x.Ref, "Users/") {
 						ic.Emit(&resource{
 							Resource: "databricks_user",
 							ID:       x.Value,
 						})
+						if !builtInUserGroup {
+							ic.Emit(&resource{
+								Resource: "databricks_group_member",
+								ID:       fmt.Sprintf("%s|%s", g.ID, x.Value),
+								Name:     fmt.Sprintf("%s_%s_%s", g.DisplayName, g.ID, x.Display),
+							})
+						}
 					}
-					if strings.Contains(x.Ref, "ServicePrincipals/") {
+					if strings.HasPrefix(x.Ref, "ServicePrincipals/") {
 						ic.Emit(&resource{
 							Resource: "databricks_service_principal",
 							ID:       x.Value,
 						})
+						if !builtInUserGroup {
+							ic.Emit(&resource{
+								Resource: "databricks_group_member",
+								ID:       fmt.Sprintf("%s|%s", g.ID, x.Value),
+								Name:     fmt.Sprintf("%s_%s_%s", g.DisplayName, g.ID, x.Display),
+							})
+						}
 					}
-					if strings.Contains(x.Ref, "Groups/") {
+					if strings.HasPrefix(x.Ref, "Groups/") {
 						ic.Emit(&resource{
 							Resource: "databricks_group",
 							ID:       x.Value,
 						})
-						ic.Emit(&resource{
-							Resource: "databricks_group_member",
-							ID:       fmt.Sprintf("%s|%s", g.ID, x.Value),
-							Name:     fmt.Sprintf("%s_%s_%s", g.DisplayName, g.ID, x.Display),
-						})
+						if !builtInUserGroup {
+							ic.Emit(&resource{
+								Resource: "databricks_group_member",
+								ID:       fmt.Sprintf("%s|%s", g.ID, x.Value),
+								Name:     fmt.Sprintf("%s_%s_%s", g.DisplayName, g.ID, x.Display),
+							})
+						}
 					}
 					if len(g.Members) > 10 {
-						log.Printf("[INFO] Imported %d of %d members of %s",
-							i, len(g.Members), g.DisplayName)
+						log.Printf("[INFO] Imported %d of %d members of %s", i+1, len(g.Members), g.DisplayName)
 					}
 				}
 			}


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

This includes following changes:

- fix exporting of groups membership as Account Users SCIM API doesn't return a list of groups in contrast to workspace SCIM API
- align exporting of all users with workspace level - you need to pass the `importAllUsers` to force it
- generate host/account ID parameters in the provider declaration


## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] tested manually
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

