### PR TITLE
Add experimental compute field to `databricks_job` resource

### DIFF
--- a/compute/compute_api.go
+++ b/compute/compute_api.go
@@ -1,5 +1,0 @@
-package compute
-
-type ComputeSpec struct {
-	Kind string `json:"kind"`
-}

--- a/compute/compute_api.go
+++ b/compute/compute_api.go
@@ -1,0 +1,6 @@
+package compute
+
+
+type ComputeSpec struct {
+    Kind string                                `json:"kind"`
+}

--- a/compute/compute_api.go
+++ b/compute/compute_api.go
@@ -1,6 +1,5 @@
 package compute
 
-
 type ComputeSpec struct {
-    Kind string                                `json:"kind"`
+	Kind string `json:"kind"`
 }

--- a/jobs/resource_job.go
+++ b/jobs/resource_job.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/databricks/databricks-sdk-go/apierr"
 	"github.com/databricks/terraform-provider-databricks/clusters"
+	"github.com/databricks/terraform-provider-databricks/compute"
 	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/databricks/terraform-provider-databricks/libraries"
 	"github.com/databricks/terraform-provider-databricks/repos"
@@ -172,6 +173,7 @@ type JobTaskSettings struct {
 	ExistingClusterID      string              `json:"existing_cluster_id,omitempty" tf:"group:cluster_type"`
 	NewCluster             *clusters.Cluster   `json:"new_cluster,omitempty" tf:"group:cluster_type"`
 	JobClusterKey          string              `json:"job_cluster_key,omitempty" tf:"group:cluster_type"`
+	ComputeKey          string              `json:"compute_key,omitempty" tf:"group:cluster_type"`
 	Libraries              []libraries.Library `json:"libraries,omitempty" tf:"slice_set,alias:library"`
 	NotebookTask           *NotebookTask       `json:"notebook_task,omitempty" tf:"group:task_type"`
 	SparkJarTask           *SparkJarTask       `json:"spark_jar_task,omitempty" tf:"group:task_type"`
@@ -191,6 +193,11 @@ type JobTaskSettings struct {
 type JobCluster struct {
 	JobClusterKey string            `json:"job_cluster_key,omitempty" tf:"group:cluster_type"`
 	NewCluster    *clusters.Cluster `json:"new_cluster,omitempty" tf:"group:cluster_type"`
+}
+
+type JobCompute struct {
+	ComputeKey string                          `json:"compute_key,omitempty" tf:"group:cluster_type"`
+	ComputeSpec    *compute.ComputeSpec        `json:"spec,omitempty" tf:"group:cluster_type"`
 }
 
 type ContinuousConf struct {
@@ -241,6 +248,7 @@ type JobSettings struct {
 	Tasks       []JobTaskSettings `json:"tasks,omitempty" tf:"alias:task"`
 	Format      string            `json:"format,omitempty" tf:"computed"`
 	JobClusters []JobCluster      `json:"job_clusters,omitempty" tf:"alias:job_cluster"`
+	Compute     []JobCompute      `json:"compute,omitempty" tf:"alias:compute"`
 	// END Jobs API 2.1
 
 	// BEGIN Jobs + Repo integration preview

--- a/jobs/resource_job.go
+++ b/jobs/resource_job.go
@@ -15,9 +15,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/databricks/databricks-sdk-go/apierr"
+	"github.com/databricks/databricks-sdk-go/service/compute"
 	"github.com/databricks/terraform-provider-databricks/clusters"
 	"github.com/databricks/terraform-provider-databricks/common"
-	"github.com/databricks/terraform-provider-databricks/compute"
 	"github.com/databricks/terraform-provider-databricks/libraries"
 	"github.com/databricks/terraform-provider-databricks/repos"
 )

--- a/jobs/resource_job.go
+++ b/jobs/resource_job.go
@@ -16,8 +16,8 @@ import (
 
 	"github.com/databricks/databricks-sdk-go/apierr"
 	"github.com/databricks/terraform-provider-databricks/clusters"
-	"github.com/databricks/terraform-provider-databricks/compute"
 	"github.com/databricks/terraform-provider-databricks/common"
+	"github.com/databricks/terraform-provider-databricks/compute"
 	"github.com/databricks/terraform-provider-databricks/libraries"
 	"github.com/databricks/terraform-provider-databricks/repos"
 )
@@ -173,7 +173,7 @@ type JobTaskSettings struct {
 	ExistingClusterID      string              `json:"existing_cluster_id,omitempty" tf:"group:cluster_type"`
 	NewCluster             *clusters.Cluster   `json:"new_cluster,omitempty" tf:"group:cluster_type"`
 	JobClusterKey          string              `json:"job_cluster_key,omitempty" tf:"group:cluster_type"`
-	ComputeKey          string              `json:"compute_key,omitempty" tf:"group:cluster_type"`
+	ComputeKey             string              `json:"compute_key,omitempty" tf:"group:cluster_type"`
 	Libraries              []libraries.Library `json:"libraries,omitempty" tf:"slice_set,alias:library"`
 	NotebookTask           *NotebookTask       `json:"notebook_task,omitempty" tf:"group:task_type"`
 	SparkJarTask           *SparkJarTask       `json:"spark_jar_task,omitempty" tf:"group:task_type"`
@@ -196,8 +196,8 @@ type JobCluster struct {
 }
 
 type JobCompute struct {
-	ComputeKey string                          `json:"compute_key,omitempty" tf:"group:cluster_type"`
-	ComputeSpec    *compute.ComputeSpec        `json:"spec,omitempty" tf:"group:cluster_type"`
+	ComputeKey  string               `json:"compute_key,omitempty" tf:"group:cluster_type"`
+	ComputeSpec *compute.ComputeSpec `json:"spec,omitempty" tf:"group:cluster_type"`
 }
 
 type ContinuousConf struct {

--- a/jobs/resource_job_test.go
+++ b/jobs/resource_job_test.go
@@ -8,9 +8,9 @@ import (
 	"time"
 
 	"github.com/databricks/databricks-sdk-go/apierr"
+	"github.com/databricks/databricks-sdk-go/service/compute"
 	"github.com/databricks/terraform-provider-databricks/clusters"
 	"github.com/databricks/terraform-provider-databricks/common"
-	"github.com/databricks/terraform-provider-databricks/compute"
 	"github.com/databricks/terraform-provider-databricks/libraries"
 	"github.com/databricks/terraform-provider-databricks/qa"
 	"github.com/stretchr/testify/assert"

--- a/jobs/resource_job_test.go
+++ b/jobs/resource_job_test.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/databricks/databricks-sdk-go/apierr"
 	"github.com/databricks/terraform-provider-databricks/clusters"
-	"github.com/databricks/terraform-provider-databricks/compute"
 	"github.com/databricks/terraform-provider-databricks/common"
+	"github.com/databricks/terraform-provider-databricks/compute"
 	"github.com/databricks/terraform-provider-databricks/libraries"
 	"github.com/databricks/terraform-provider-databricks/qa"
 	"github.com/stretchr/testify/assert"
@@ -343,7 +343,7 @@ func TestResourceJobCreate_JobCompute(t *testing.T) {
 					Name: "JobComputed",
 					Tasks: []JobTaskSettings{
 						{
-							TaskKey: "b",
+							TaskKey:    "b",
 							ComputeKey: "j",
 							NotebookTask: &NotebookTask{
 								NotebookPath: "/Stuff",


### PR DESCRIPTION
## Changes
Add support for private preview functionality `compute` and `compute_key`.

## Tests
Add test case to `resource_job_test.go`

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [x] using Go SDK

