### PR TITLE
Skip `TestAccClusterResource_CreateClusterWithLibraries` integration test

### DIFF
--- a/internal/acceptance/cluster_test.go
+++ b/internal/acceptance/cluster_test.go
@@ -5,6 +5,7 @@ import (
 )
 
 func TestAccClusterResource_CreateClusterWithLibraries(t *testing.T) {
+	t.Skip("Waiting for maintenance release for fix")
 	workspaceLevel(t, step{
 		Template: `data "databricks_spark_version" "latest" {
 		}


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
Release is scheduled in release after next 2 weeks. Skipping this for now. 

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

