### PR TITLE
Allow assigning GCP SA in `databricks_sql_global_config` resource

### DIFF
--- a/docs/resources/sql_global_config.md
+++ b/docs/resources/sql_global_config.md
@@ -47,6 +47,7 @@ The following arguments are supported (see [documentation](https://docs.databric
 * `security_policy` (Optional, String) - The policy for controlling access to datasets. Default value: `DATA_ACCESS_CONTROL`, consult documentation for list of possible values
 * `data_access_config` (Optional, Map) - Data access configuration for [databricks_sql_endpoint](sql_endpoint.md), such as configuration for an external Hive metastore, Hadoop Filesystem configuration, etc.  Please note that the list of supported configuration properties is limited, so refer to the [documentation](https://docs.databricks.com/sql/admin/data-access-configuration.html#supported-properties) for a full list.  Apply will fail if you're specifying not permitted configuration.
 * `instance_profile_arn` (Optional, String) - [databricks_instance_profile](instance_profile.md) used to access storage from [databricks_sql_endpoint](sql_endpoint.md). Please note that this parameter is only for AWS, and will generate an error if used on other clouds. 
+* `google_service_account` (Optional, String) - used to access GCP services, such as Cloud Storage, from [databricks_sql_endpoint](sql_endpoint.md). Please note that this parameter is only for GCP, and will generate an error if used on other clouds. 
 * `sql_config_params` (Optional, Map) - SQL Configuration Parameters let you override the default behavior for all sessions with all endpoints.
 
 ## Import

--- a/sql/resource_sql_global_config_test.go
+++ b/sql/resource_sql_global_config_test.go
@@ -84,6 +84,7 @@ func TestResourceSQLGlobalConfigCreateWithData(t *testing.T) {
 					EnableServerlessCompute:    false,
 					SecurityPolicy:             "PASSTHROUGH",
 					InstanceProfileARN:         "arn:...",
+					GoogleServiceAccount:       "poc@databricks-test-poc.iam.gserviceaccount.com",
 				},
 			},
 			{
@@ -96,6 +97,7 @@ func TestResourceSQLGlobalConfigCreateWithData(t *testing.T) {
 						{Key: "spark.sql.session.timeZone", Value: "UTC"},
 					},
 					InstanceProfileARN: "arn:...",
+					GoogleServiceAccount: "poc@databricks-test-poc.iam.gserviceaccount.com",
 					SqlConfigurationParameters: &repeatedEndpointConfPairs{
 						ConfigPairs: []confPair{
 							{Key: "ANSI_MODE", Value: "true"},
@@ -109,6 +111,7 @@ func TestResourceSQLGlobalConfigCreateWithData(t *testing.T) {
 		State: map[string]any{
 			"security_policy":      "PASSTHROUGH",
 			"instance_profile_arn": "arn:...",
+			"google_service_account": "poc@databricks-test-poc.iam.gserviceaccount.com",
 			"data_access_config": map[string]any{
 				"spark.sql.session.timeZone": "UTC",
 			},
@@ -130,6 +133,7 @@ func TestResourceSQLGlobalConfigCreateError(t *testing.T) {
 		State: map[string]any{
 			"security_policy":      "PASSTHROUGH",
 			"instance_profile_arn": "arn:...",
+			"google_service_account": "poc@databricks-test-poc.iam.gserviceaccount.com",
 			"data_access_config": map[string]any{
 				"spark.sql.session.timeZone": "UTC",
 			},

--- a/sql/resource_sql_global_config_test.go
+++ b/sql/resource_sql_global_config_test.go
@@ -137,3 +137,54 @@ func TestResourceSQLGlobalConfigCreateError(t *testing.T) {
 	}.Apply(t)
 	qa.AssertErrorStartsWith(t, err, "can't use instance_profile_arn outside of AWS")
 }
+
+func TestResourceSQLGlobalConfigCreateWithDataGCP(t *testing.T) {
+	d, err := qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "PUT",
+				Resource: "/api/2.0/sql/config/warehouses",
+				ExpectedRequest: GlobalConfigForRead{
+					DataAccessConfig:           []confPair{{Key: "spark.sql.session.timeZone", Value: "UTC"}},
+					SqlConfigurationParameters: &repeatedEndpointConfPairs{ConfigPairs: []confPair{{Key: "ANSI_MODE", Value: "true"}}},
+					EnableServerlessCompute:    false,
+					SecurityPolicy:             "DATA_ACCESS_CONTROL",
+					GoogleServiceAccount:       "poc@databricks.iam.gserviceaccount.com",
+				},
+			},
+			{
+				Method:       "GET",
+				Resource:     "/api/2.0/sql/config/warehouses",
+				ReuseRequest: true,
+				Response: GlobalConfigForRead{
+					SecurityPolicy: "DATA_ACCESS_CONTROL",
+					DataAccessConfig: []confPair{
+						{Key: "spark.sql.session.timeZone", Value: "UTC"},
+					},
+					GoogleServiceAccount: "poc@databricks.iam.gserviceaccount.com",
+					SqlConfigurationParameters: &repeatedEndpointConfPairs{
+						ConfigPairs: []confPair{
+							{Key: "ANSI_MODE", Value: "true"},
+						},
+					},
+				},
+			},
+		},
+		Resource: ResourceSqlGlobalConfig(),
+		Create:   true,
+		Gcp:      true,
+		State: map[string]any{
+			"security_policy":        "DATA_ACCESS_CONTROL",
+			"google_service_account": "poc@databricks.iam.gserviceaccount.com",
+			"data_access_config": map[string]any{
+				"spark.sql.session.timeZone": "UTC",
+			},
+			"sql_config_params": map[string]any{
+				"ANSI_MODE": "true",
+			},
+		},
+	}.Apply(t)
+	require.NoError(t, err)
+	assert.Equal(t, "global", d.Id(), "Id should not be empty")
+	assert.Equal(t, "DATA_ACCESS_CONTROL", d.Get("security_policy"))
+}

--- a/sql/resource_sql_global_config_test.go
+++ b/sql/resource_sql_global_config_test.go
@@ -84,7 +84,6 @@ func TestResourceSQLGlobalConfigCreateWithData(t *testing.T) {
 					EnableServerlessCompute:    false,
 					SecurityPolicy:             "PASSTHROUGH",
 					InstanceProfileARN:         "arn:...",
-					GoogleServiceAccount:       "poc@databricks-test-poc.iam.gserviceaccount.com",
 				},
 			},
 			{
@@ -97,7 +96,6 @@ func TestResourceSQLGlobalConfigCreateWithData(t *testing.T) {
 						{Key: "spark.sql.session.timeZone", Value: "UTC"},
 					},
 					InstanceProfileARN: "arn:...",
-					GoogleServiceAccount: "poc@databricks-test-poc.iam.gserviceaccount.com",
 					SqlConfigurationParameters: &repeatedEndpointConfPairs{
 						ConfigPairs: []confPair{
 							{Key: "ANSI_MODE", Value: "true"},
@@ -111,7 +109,6 @@ func TestResourceSQLGlobalConfigCreateWithData(t *testing.T) {
 		State: map[string]any{
 			"security_policy":      "PASSTHROUGH",
 			"instance_profile_arn": "arn:...",
-			"google_service_account": "poc@databricks-test-poc.iam.gserviceaccount.com",
 			"data_access_config": map[string]any{
 				"spark.sql.session.timeZone": "UTC",
 			},
@@ -133,7 +130,6 @@ func TestResourceSQLGlobalConfigCreateError(t *testing.T) {
 		State: map[string]any{
 			"security_policy":      "PASSTHROUGH",
 			"instance_profile_arn": "arn:...",
-			"google_service_account": "poc@databricks-test-poc.iam.gserviceaccount.com",
 			"data_access_config": map[string]any{
 				"spark.sql.session.timeZone": "UTC",
 			},


### PR DESCRIPTION
## Changes
Allow google_service_account to be assigned to SQL warehouse global settings. 
This change impacts GCP Databricks workspace only. Corresponding [REST API endpoint](https://docs.databricks.com/api/gcp/workspace/warehouses/setworkspacewarehouseconfig)

## Tests

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [x] using Go SDK

