### PR TITLE
Add suppress diff for `storage_location` in `databricks_sql_table` and `databricks_volume` resources

### DIFF
--- a/catalog/resource_sql_table.go
+++ b/catalog/resource_sql_table.go
@@ -311,6 +311,7 @@ func ResourceSqlTable() *schema.Resource {
 				}
 				return strings.EqualFold(strings.ToLower(old), strings.ToLower(new))
 			}
+			s["storage_location"].DiffSuppressFunc = ucDirectoryPathSuppressDiff
 			return s
 		})
 	return common.Resource{

--- a/catalog/resource_volume.go
+++ b/catalog/resource_volume.go
@@ -31,6 +31,7 @@ type VolumeInfo struct {
 func ResourceVolume() *schema.Resource {
 	s := common.StructToSchema(VolumeInfo{},
 		func(m map[string]*schema.Schema) map[string]*schema.Schema {
+			m["storage_location"].DiffSuppressFunc = ucDirectoryPathSuppressDiff
 			return m
 		})
 	return common.Resource{


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

Similar to changes in #2336 we need to suppress diff detection when storage URL is normalized by the backend, leading to creation of plans like this:

```
  # databricks_volume.this will be updated in-place
  ~ resource "databricks_volume" "this" {
        id               = "main.tmp.tftest"
        name             = "tftest"
      ~ storage_location = "s3://xxxx/catalog_test/vtest" -> "s3://xxxx/catalog_test/vtest/"
        # (5 unchanged attributes hidden)
    }
```

this fixes #2316

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] tested manually
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

