### PR TITLE
Fixed `databricks_entitlements` resource edge behaviour

### DIFF
--- a/internal/acceptance/entitlements_test.go
+++ b/internal/acceptance/entitlements_test.go
@@ -20,6 +20,10 @@ func TestAccEntitlementResource(t *testing.T) {
 		allow_cluster_create       = true
 		allow_instance_pool_create = true		
 	}
+
+	resource "databricks_group" "third" {
+		display_name = "{var.RANDOM} group 2"
+	}	
 	
 	resource "databricks_entitlements" "first_entitlements" {
 		user_id                    = databricks_user.first.id
@@ -31,6 +35,14 @@ func TestAccEntitlementResource(t *testing.T) {
 		group_id                   = databricks_group.second.id
 		allow_cluster_create       = true
 		allow_instance_pool_create = true
+	}
+	
+	resource "databricks_entitlements" "third_entitlements" {
+		group_id                   = databricks_group.third.id
+		allow_cluster_create       = false
+		allow_instance_pool_create = false
+		databricks_sql_access      = false
+		workspace_access           = false
 	}`
 	workspaceLevel(t, step{
 		Template: conf,

--- a/scim/resource_entitlement.go
+++ b/scim/resource_entitlement.go
@@ -28,7 +28,7 @@ func ResourceEntitlements() *schema.Resource {
 	addEntitlementsToSchema(&entitlementSchema)
 	return common.Resource{
 		Create: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
-			return patchEntitlements(ctx, d, c, "add")
+			return patchEntitlements(ctx, d, c, "replace")
 		},
 		Read: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
 			split := strings.SplitN(d.Id(), "/", 2)

--- a/scim/resource_entitlement.go
+++ b/scim/resource_entitlement.go
@@ -41,18 +41,21 @@ func ResourceEntitlements() *schema.Resource {
 				if err != nil {
 					return err
 				}
+				group.Entitlements.generateEmpty(d)
 				return group.Entitlements.readIntoData(d)
 			case "user":
 				user, err := NewUsersAPI(ctx, c).Read(split[1], "entitlements")
 				if err != nil {
 					return err
 				}
+				user.Entitlements.generateEmpty(d)
 				return user.Entitlements.readIntoData(d)
 			case "spn":
 				spn, err := NewServicePrincipalsAPI(ctx, c).Read(split[1])
 				if err != nil {
 					return err
 				}
+				spn.Entitlements.generateEmpty(d)
 				return spn.Entitlements.readIntoData(d)
 			}
 			return nil

--- a/scim/resource_entitlement.go
+++ b/scim/resource_entitlement.go
@@ -74,6 +74,7 @@ func patchEntitlements(ctx context.Context, d *schema.ResourceData, c *common.Da
 	groupId := d.Get("group_id").(string)
 	userId := d.Get("user_id").(string)
 	spnId := d.Get("service_principal_id").(string)
+	noEntitlementMessage := "invalidPath No such attribute with the name : entitlements in the current resource"
 	request := PatchRequestComplexValue([]patchOperation{
 		{
 			op,
@@ -84,7 +85,7 @@ func patchEntitlements(ctx context.Context, d *schema.ResourceData, c *common.Da
 	if groupId != "" {
 		groupsAPI := NewGroupsAPI(ctx, c)
 		err := groupsAPI.UpdateEntitlements(groupId, request)
-		if err != nil {
+		if err != nil && !strings.Contains(err.Error(), noEntitlementMessage) {
 			return err
 		}
 		d.SetId("group/" + groupId)
@@ -92,7 +93,7 @@ func patchEntitlements(ctx context.Context, d *schema.ResourceData, c *common.Da
 	if userId != "" {
 		usersAPI := NewUsersAPI(ctx, c)
 		err := usersAPI.UpdateEntitlements(userId, request)
-		if err != nil {
+		if err != nil && !strings.Contains(err.Error(), noEntitlementMessage) {
 			return err
 		}
 		d.SetId("user/" + userId)
@@ -100,7 +101,7 @@ func patchEntitlements(ctx context.Context, d *schema.ResourceData, c *common.Da
 	if spnId != "" {
 		spnAPI := NewServicePrincipalsAPI(ctx, c)
 		err := spnAPI.UpdateEntitlements(spnId, request)
-		if err != nil {
+		if err != nil && !strings.Contains(err.Error(), noEntitlementMessage) {
 			return err
 		}
 		d.SetId("spn/" + spnId)

--- a/scim/resource_entitlement_test.go
+++ b/scim/resource_entitlement_test.go
@@ -37,9 +37,15 @@ var newGroup = Group{
 	},
 }
 
+var emptyGroup = Group{
+	Schemas:     []URN{"urn:ietf:params:scim:schemas:core:2.0:Group"},
+	DisplayName: "Data Scientists",
+	ID:          "abc",
+}
+
 var addRequest = PatchRequestComplexValue([]patchOperation{
 	{
-		"add", "entitlements", []ComplexValue{
+		"replace", "entitlements", []ComplexValue{
 			{
 				Value: "allow-cluster-create",
 			},
@@ -48,6 +54,16 @@ var addRequest = PatchRequestComplexValue([]patchOperation{
 			},
 			{
 				Value: "databricks-sql-access",
+			},
+		},
+	},
+})
+
+var emptyAddRequest = PatchRequestComplexValue([]patchOperation{
+	{
+		"replace", "entitlements", []ComplexValue{
+			{
+				Value: "",
 			},
 		},
 	},
@@ -85,20 +101,19 @@ var updateRequest = PatchRequestComplexValue([]patchOperation{
 	},
 })
 
-var deleteRequest = PatchRequestComplexValue([]patchOperation{{"remove", "entitlements", []ComplexValue{
+var deleteRequest = PatchRequestComplexValue([]patchOperation{
 	{
-		Value: "allow-cluster-create",
+		"remove", "entitlements", []ComplexValue{
+			{
+				Value: "allow-cluster-create",
+			},
+		},
 	},
-}}})
+})
 
 func TestResourceEntitlementsGroupCreate(t *testing.T) {
 	d, err := qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
-			{
-				Method:   "GET",
-				Resource: "/api/2.0/preview/scim/v2/Groups/abc?attributes=entitlements",
-				Response: oldGroup,
-			},
 			{
 				Method:          "PATCH",
 				Resource:        "/api/2.0/preview/scim/v2/Groups/abc",
@@ -149,6 +164,29 @@ func TestResourceEntitlementsGroupRead(t *testing.T) {
 	})
 }
 
+func TestResourceEntitlementsGroupReadEmpty(t *testing.T) {
+	qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "GET",
+				Resource: "/api/2.0/preview/scim/v2/Groups/abc?attributes=entitlements",
+				Response: emptyGroup,
+			},
+		},
+		Resource: ResourceEntitlements(),
+		HCL:      `group_id = "abc"`,
+		New:      true,
+		Read:     true,
+		ID:       "group/abc",
+	}.ApplyAndExpectData(t, map[string]any{
+		"group_id":                   "abc",
+		"allow_cluster_create":       false,
+		"workspace_access":           false,
+		"allow_instance_pool_create": false,
+		"databricks_sql_access":      false,
+	})
+}
+
 func TestResourceEntitlementsGroupRead_Error(t *testing.T) {
 	qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
@@ -173,11 +211,6 @@ func TestResourceEntitlementsGroupRead_Error(t *testing.T) {
 func TestResourceEntitlementsGroupUpdate(t *testing.T) {
 	d, err := qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
-			{
-				Method:   "GET",
-				Resource: "/api/2.0/preview/scim/v2/Groups/abc?attributes=entitlements",
-				Response: oldGroup,
-			},
 			{
 				Method:          "PATCH",
 				Resource:        "/api/2.0/preview/scim/v2/Groups/abc",
@@ -314,11 +347,6 @@ func TestResourceEntitlementsUserCreate(t *testing.T) {
 	d, err := qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
 			{
-				Method:   "GET",
-				Resource: "/api/2.0/preview/scim/v2/Users/abc?attributes=entitlements",
-				Response: oldUser,
-			},
-			{
 				Method:          "PATCH",
 				Resource:        "/api/2.0/preview/scim/v2/Users/abc",
 				ExpectedRequest: addRequest,
@@ -432,11 +460,6 @@ func TestResourceEntitlementsUserUpdate(t *testing.T) {
 	d, err := qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
 			{
-				Method:   "GET",
-				Resource: "/api/2.0/preview/scim/v2/Users/abc?attributes=entitlements",
-				Response: oldUser,
-			},
-			{
 				Method:          "PATCH",
 				Resource:        "/api/2.0/preview/scim/v2/Users/abc",
 				ExpectedRequest: updateRequest,
@@ -505,11 +528,6 @@ func TestResourceEntitlementsUserDelete(t *testing.T) {
 func TestResourceEntitlementsSPNCreate(t *testing.T) {
 	d, err := qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
-			{
-				Method:   "GET",
-				Resource: "/api/2.0/preview/scim/v2/ServicePrincipals/abc",
-				Response: oldUser,
-			},
 			{
 				Method:          "PATCH",
 				Resource:        "/api/2.0/preview/scim/v2/ServicePrincipals/abc",
@@ -613,11 +631,6 @@ func TestResourceEntitlementsSPNUpdate(t *testing.T) {
 	d, err := qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
 			{
-				Method:   "GET",
-				Resource: "/api/2.0/preview/scim/v2/ServicePrincipals/abc",
-				Response: oldUser,
-			},
-			{
 				Method:          "PATCH",
 				Resource:        "/api/2.0/preview/scim/v2/ServicePrincipals/abc",
 				ExpectedRequest: updateRequest,
@@ -681,4 +694,39 @@ func TestResourceEntitlementsSPNDelete(t *testing.T) {
 		allow_cluster_create = true
 		`,
 	}.ApplyNoError(t)
+}
+
+func TestResourceEntitlementsGroupCreateEmpty(t *testing.T) {
+	d, err := qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:          "PATCH",
+				Resource:        "/api/2.0/preview/scim/v2/Groups/abc",
+				ExpectedRequest: emptyAddRequest,
+				Response: Group{
+					ID: "abc",
+				},
+			},
+			{
+				Method:   "GET",
+				Resource: "/api/2.0/preview/scim/v2/Groups/abc?attributes=entitlements",
+				Response: emptyGroup,
+			},
+		},
+		Resource: ResourceEntitlements(),
+		HCL: `
+		group_id = "abc"
+		allow_instance_pool_create = false
+		allow_cluster_create = false
+		databricks_sql_access = false
+		workspace_access = false
+		`,
+		Create: true,
+	}.Apply(t)
+	assert.NoError(t, err)
+	assert.Equal(t, "group/abc", d.Id())
+	assert.Equal(t, false, d.Get("allow_cluster_create"))
+	assert.Equal(t, false, d.Get("allow_instance_pool_create"))
+	assert.Equal(t, false, d.Get("databricks_sql_access"))
+	assert.Equal(t, false, d.Get("workspace_access"))
 }

--- a/scim/resource_entitlement_test.go
+++ b/scim/resource_entitlement_test.go
@@ -277,6 +277,39 @@ func TestResourceEntitlementsGroupDelete(t *testing.T) {
 	}.Apply(t)
 }
 
+func TestResourceEntitlementsGroupDeleteEmptyEntitlement(t *testing.T) {
+	qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "GET",
+				Resource: "/api/2.0/preview/scim/v2/Groups/abc?attributes=entitlements",
+				Response: emptyGroup,
+			},
+			{
+				Method:          "PATCH",
+				Resource:        "/api/2.0/preview/scim/v2/Groups/abc",
+				ExpectedRequest: deleteRequest,
+				Response: apierr.APIErrorBody{
+					ErrorCode: "INVALID_PATH",
+					Message:   "invalidPath No such attribute with the name : entitlements in the current resource",
+				},
+				Status: 400,
+			},
+		},
+		Resource: ResourceEntitlements(),
+		Delete:   true,
+		ID:       "group/abc",
+		InstanceState: map[string]string{
+			"group_id":             "abc",
+			"allow_cluster_create": "true",
+		},
+		HCL: `
+		group_id    = "abc"
+		allow_cluster_create = true
+		`,
+	}.Apply(t)
+}
+
 var oldUser = User{
 	DisplayName: "Example user",
 	Active:      true,

--- a/scim/scim.go
+++ b/scim/scim.go
@@ -56,6 +56,9 @@ var possibleEntitlements = []string{
 type entitlements []ComplexValue
 
 func (e entitlements) readIntoData(d *schema.ResourceData) error {
+	for _, entitlement := range possibleEntitlements {
+		d.Set(entitlementMapping[entitlement], false)
+	}
 	for _, ent := range e {
 		field_name := entitlementMapping[ent.Value]
 		if err := d.Set(field_name, true); err != nil {
@@ -84,6 +87,12 @@ func readEntitlementsFromData(d *schema.ResourceData) entitlements {
 				Value: entitlement,
 			})
 		}
+	}
+	// if there is no nil value
+	if e == nil {
+		e = append(e, ComplexValue{
+			Value: "",
+		})
 	}
 	return e
 }

--- a/scim/scim.go
+++ b/scim/scim.go
@@ -55,10 +55,14 @@ var possibleEntitlements = []string{
 
 type entitlements []ComplexValue
 
-func (e entitlements) readIntoData(d *schema.ResourceData) error {
+func (e entitlements) generateEmpty(d *schema.ResourceData) error {
 	for _, entitlement := range possibleEntitlements {
 		d.Set(entitlementMapping[entitlement], false)
 	}
+	return nil
+}
+
+func (e entitlements) readIntoData(d *schema.ResourceData) error {
 	for _, ent := range e {
 		field_name := entitlementMapping[ent.Value]
 		if err := d.Set(field_name, true); err != nil {


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
Fix edge cases behaviour for `databricks_entitlements`
- [x] Resource creation failed when all entitlements set to `false`
- [x] Resource did not enforce entitlements that were removed out of bound
- [x] Cannot delete resource if identity has no entitlement: `Error: cannot delete entitlements: invalidPath No such attribute with the name : entitlements in the current resource`

Close #2382

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [x] covered with integration tests in `internal/acceptance`
- [x] relevant acceptance tests are passing
- [x] ~using Go SDK~

