### PR TITLE
fix databricks_share Read

### DIFF
--- a/catalog/resource_share.go
+++ b/catalog/resource_share.go
@@ -207,7 +207,7 @@ func ResourceShare() *schema.Resource {
 			if err != nil {
 				return err
 			}
-			return common.StructToData(si, shareSchema, d)
+			return common.StructToDataNoSkipEmpty(si, shareSchema, d, []string{"object"})
 		},
 		Update: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
 			beforeSi, err := NewSharesAPI(ctx, c).get(d.Id())

--- a/common/reflect_resource_test.go
+++ b/common/reflect_resource_test.go
@@ -434,7 +434,7 @@ func TestStructToDataNoSkipEmpty(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, schema.TypeString, sp.Type)
 
-	dummy := Dummy{
+	dummyOrig := Dummy{
 		Enabled:     false,
 		Workers:     1004,
 		Description: "something",
@@ -466,10 +466,10 @@ func TestStructToDataNoSkipEmpty(t *testing.T) {
 
 	d := schema.TestResourceDataRaw(t, s, map[string]any{})
 	d.MarkNewResource()
-	err = StructToData(dummy, s, d)
+	err = StructToData(dummyOrig, s, d)
 	assert.NoError(t, err)
 
-	dummy1 := Dummy{
+	dummyUpdate := Dummy{
 		Enabled:     false,
 		Workers:     1004,
 		Description: "something",
@@ -483,10 +483,13 @@ func TestStructToDataNoSkipEmpty(t *testing.T) {
 		},
 	}
 
-	err = StructToDataNoSkipEmpty(dummy1, s, d, []string{"addresses"})
+	err = StructToDataNoSkipEmpty(dummyUpdate, s, d, []string{"addresses"})
 	assert.NoError(t, err)
 
+	// This was overwritten with empty list from dummtUpdate
 	assert.Equal(t, 0, d.Get("addresses.#"))
+	// This is not overwritten, so it retains the list from dummyOrig
+	assert.Equal(t, 1, d.Get("unique.#"))
 }
 
 func TestDiffSuppressor(t *testing.T) {


### PR DESCRIPTION
## Changes
If the API call returns 0 `object`s in `si` and there are `object`s in `d` (in existing tfstate), they are not deleted from `d` by `common.StructToData` so TF thinks there is no diff.

This causes an issue that there is no diff detected when the share returned by the API is empty.

This makes sure `object` is overwritten even when empty.

## Tests
Not sure how to fully reproduce it in resource_share tests.


- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

