### PR TITLE
Use separate suppress diff function for `databricks_sql_table` and `databricks_volume`

### DIFF
--- a/catalog/resource_catalog.go
+++ b/catalog/resource_catalog.go
@@ -10,8 +10,16 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func ucDirectoryPathSuppressDiff(k, old, new string, d *schema.ResourceData) bool {
+func ucDirectoryPathSlashOnlySuppressDiff(k, old, new string, d *schema.ResourceData) bool {
 	if (new == (old + "/")) || (old == (new + "/")) {
+		log.Printf("[DEBUG] Ignoring configuration drift from %s to %s", old, new)
+		return true
+	}
+	return false
+}
+
+func ucDirectoryPathSlashAndEmptySuppressDiff(k, old, new string, d *schema.ResourceData) bool {
+	if (new == (old + "/")) || (old == (new + "/")) || (new == "" && old != "") {
 		log.Printf("[DEBUG] Ignoring configuration drift from %s to %s", old, new)
 		return true
 	}
@@ -38,7 +46,7 @@ func ResourceCatalog() *schema.Resource {
 				Optional: true,
 				Default:  false,
 			}
-			m["storage_root"].DiffSuppressFunc = ucDirectoryPathSuppressDiff
+			m["storage_root"].DiffSuppressFunc = ucDirectoryPathSlashOnlySuppressDiff
 			return m
 		})
 	return common.Resource{

--- a/catalog/resource_catalog_test.go
+++ b/catalog/resource_catalog_test.go
@@ -346,10 +346,15 @@ func TestCatalogCreateDeltaSharing(t *testing.T) {
 }
 
 func TestUcDirectoryPathSuppressDiff(t *testing.T) {
-	assert.True(t, ucDirectoryPathSuppressDiff("", "abfss://test@test.dfs.core.windows.net/TF_DIR_WITH_SLASH",
+	assert.True(t, ucDirectoryPathSlashOnlySuppressDiff("", "abfss://test@test.dfs.core.windows.net/TF_DIR_WITH_SLASH",
 		"abfss://test@test.dfs.core.windows.net/TF_DIR_WITH_SLASH/", nil))
-	assert.True(t, ucDirectoryPathSuppressDiff("", "abfss://test@test.dfs.core.windows.net/TF_DIR_WITH_SLASH/",
+	assert.True(t, ucDirectoryPathSlashOnlySuppressDiff("", "abfss://test@test.dfs.core.windows.net/TF_DIR_WITH_SLASH/",
 		"abfss://test@test.dfs.core.windows.net/TF_DIR_WITH_SLASH", nil))
-	assert.False(t, ucDirectoryPathSuppressDiff("", "abfss://test@test.dfs.core.windows.net/new_dir",
+	assert.False(t, ucDirectoryPathSlashOnlySuppressDiff("", "abfss://test@test.dfs.core.windows.net/new_dir",
 		"abfss://test@test.dfs.core.windows.net/TF_DIR_WITH_SLASH/", nil))
+	//
+	assert.True(t, ucDirectoryPathSlashAndEmptySuppressDiff("", "abfss://test@test.dfs.core.windows.net/TF_DIR_WITH_SLASH/",
+		"", nil))
+	assert.False(t, ucDirectoryPathSlashOnlySuppressDiff("", "abfss://test@test.dfs.core.windows.net/new_dir",
+		"abfss://test@test.dfs.core.windows.net/OTHER/", nil))
 }

--- a/catalog/resource_external_location.go
+++ b/catalog/resource_external_location.go
@@ -53,7 +53,7 @@ func ResourceExternalLocation() *schema.Resource {
 			m["skip_validation"].DiffSuppressFunc = func(k, old, new string, d *schema.ResourceData) bool {
 				return old == "false" && new == "true"
 			}
-			m["url"].DiffSuppressFunc = ucDirectoryPathSuppressDiff
+			m["url"].DiffSuppressFunc = ucDirectoryPathSlashOnlySuppressDiff
 			return m
 		})
 	update := updateFunctionFactory("/unity-catalog/external-locations", []string{"owner", "comment", "url", "credential_name"})

--- a/catalog/resource_schema.go
+++ b/catalog/resource_schema.go
@@ -66,7 +66,7 @@ func ResourceSchema() *schema.Resource {
 				Optional: true,
 				Default:  false,
 			}
-			m["storage_root"].DiffSuppressFunc = ucDirectoryPathSuppressDiff
+			m["storage_root"].DiffSuppressFunc = ucDirectoryPathSlashOnlySuppressDiff
 			return m
 		})
 	update := updateFunctionFactory("/unity-catalog/schemas", []string{"owner", "comment", "properties"})

--- a/catalog/resource_sql_table.go
+++ b/catalog/resource_sql_table.go
@@ -311,7 +311,7 @@ func ResourceSqlTable() *schema.Resource {
 				}
 				return strings.EqualFold(strings.ToLower(old), strings.ToLower(new))
 			}
-			s["storage_location"].DiffSuppressFunc = ucDirectoryPathSuppressDiff
+			s["storage_location"].DiffSuppressFunc = ucDirectoryPathSlashAndEmptySuppressDiff
 			return s
 		})
 	return common.Resource{

--- a/catalog/resource_volume.go
+++ b/catalog/resource_volume.go
@@ -31,7 +31,7 @@ type VolumeInfo struct {
 func ResourceVolume() *schema.Resource {
 	s := common.StructToSchema(VolumeInfo{},
 		func(m map[string]*schema.Schema) map[string]*schema.Schema {
-			m["storage_location"].DiffSuppressFunc = ucDirectoryPathSuppressDiff
+			m["storage_location"].DiffSuppressFunc = ucDirectoryPathSlashAndEmptySuppressDiff
 			return m
 		})
 	return common.Resource{


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

This is a follow up fix for #2408. It's needed because tables & volumes could be managed, and in this case API populate the `storage_location` with generated value and terraform was removing it because it's empty in the terraform code.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] tested manually
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [x] relevant acceptance tests are passing
- [ ] using Go SDK

