### PR TITLE
Added `gcp_attributes.local_ssd_count` to `databricks_cluster` resource

### DIFF
--- a/clusters/clusters_api.go
+++ b/clusters/clusters_api.go
@@ -171,6 +171,7 @@ type GcpAttributes struct {
 	Availability            Availability `json:"availability,omitempty"`
 	BootDiskSize            int32        `json:"boot_disk_size,omitempty"`
 	ZoneId                  string       `json:"zone_id,omitempty"`
+	LocalSsdCount           int32        `json:"local_ssd_count,omitempty"`
 }
 
 // DbfsStorageInfo contains the destination string for DBFS

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -424,6 +424,7 @@ The following options are available:
 * `google_service_account` - (Optional, string) Google Service Account email address that the cluster uses to authenticate with Google Identity. This field is used for authentication with the GCS and BigQuery data sources.
 * `availability` - (Optional) Availability type used for all nodes. Valid values are `PREEMPTIBLE_GCP`, `PREEMPTIBLE_WITH_FALLBACK_GCP` and `ON_DEMAND_GCP`, default: `ON_DEMAND_GCP`.
 * `boot_disk_size` (optional, int) Boot disk size in GB
+* `local_ssd_count` (optional, int) Number of local SSD disks (each is 375GB in size) that will be attached to each node of the cluster. 
 * `zone_id` (optional)  Identifier for the availability zone in which the cluster resides. This can be one of the following:
   * `HA` (default): High availability, spread nodes across availability zones for a Databricks deployment region.
   * `AUTO`: Databricks picks an availability zone to schedule the cluster on.


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

New setting allows to specify number of local SSD disks to be attached to each node

Unfortunately we need to wait until Clusters GET is fixed because right now it doesn't return that attribute 🤦 

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [x] tested manually
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

