### PR TITLE
Add ability to subscribe to dashboards & alert SQL tasks in `databricks_job`

### DIFF
--- a/docs/resources/job.md
+++ b/docs/resources/job.md
@@ -254,8 +254,15 @@ One of the `query`, `dashboard` or `alert` needs to be provided.
 * `warehouse_id` - (Required) ID of the (the [databricks_sql_endpoint](sql_endpoint.md)) that will be used to execute the task.  Only Serverless & Pro warehouses are supported right now.
 * `parameters` - (Optional) (Map) parameters to be used for each run of this task. The SQL alert task does not support custom parameters.
 * `query` - (Optional) block consisting of single string field: `query_id` - identifier of the Databricks SQL Query ([databricks_sql_query](sql_query.md)).
-* `dashboard` - (Optional) block consisting of single string field: `dashboard_id` - identifier of the Databricks SQL Dashboard [databricks_sql_dashboard](sql_dashboard.md).
-* `alert` - (Optional) block consisting of single string field: `alert_id` - identifier of the Databricks SQL Alert.
+* `dashboard` - (Optional) block consisting of following fields:
+  * `dashboard_id` - (Required) (String) identifier of the Databricks SQL Dashboard [databricks_sql_dashboard](sql_dashboard.md).
+  * `subscriptions` - (Optional) a list of subscription blocks consisting out of one of the required fields: `user_name` for user emails or `destination_id` - for Alert destination's identifier.
+  * `custom_subject` - (Optional) string specifying a custom subject of email sent.
+  * `pause_subscriptions` - (Optional) flag that specifies if subscriptions are paused or not.
+* `alert` - (Optional) block consisting of following fields: 
+  * `alert_id` - (Required) (String) identifier of the Databricks SQL Alert.
+  * `subscriptions` - (Required) a list of subscription blocks consisting out of one of the required fields: `user_name` for user emails or `destination_id` - for Alert destination's identifier.
+  * `pause_subscriptions` - (Optional) flag that specifies if subscriptions are paused or not.
 * `file` - (Optional) block consisting of single string field: `path` - a relative path to the file (inside the Git repository) with SQL commands to execute.  *Requires `git_source` configuration block*.
 
 Example
@@ -269,6 +276,30 @@ resource "databricks_job" "sql_aggregation_job" {
       warehouse_id = databricks_sql_endpoint.sql_job_warehouse.id
       query {
         query_id = databricks_sql_query.agg_query.id
+      }
+    }
+  }
+  task {
+    task_key = "run_dashboard"
+    sql_task {
+      warehouse_id = databricks_sql_endpoint.sql_job_warehouse.id
+      dashboard {
+        dashboard_id = databricks_sql_dashboard.dash.id
+        subscriptions {
+          user_name = "user@domain.com"
+        }
+      }
+    }
+  }
+  task {
+    task_key = "run_alert"
+    sql_task {
+      warehouse_id = databricks_sql_endpoint.sql_job_warehouse.id
+      alert {
+        alert_id = databricks_sql_alert.alert.id
+        subscriptions {
+          user_name = "user@domain.com"
+        }
       }
     }
   }

--- a/jobs/resource_job.go
+++ b/jobs/resource_job.go
@@ -65,12 +65,22 @@ type SqlQueryTask struct {
 	QueryID string `json:"query_id"`
 }
 
+type SqlSubscription struct {
+	UserName      string `json:"user_name,omitempty"`
+	DestinationID string `json:"destination_id,omitempty"`
+}
+
 type SqlDashboardTask struct {
-	DashboardID string `json:"dashboard_id"`
+	DashboardID        string            `json:"dashboard_id"`
+	Subscriptions      []SqlSubscription `json:"subscriptions,omitempty"`
+	CustomSubject      string            `json:"custom_subject,omitempty"`
+	PauseSubscriptions bool              `json:"pause_subscriptions,omitempty"`
 }
 
 type SqlAlertTask struct {
-	AlertID string `json:"alert_id"`
+	AlertID            string            `json:"alert_id"`
+	Subscriptions      []SqlSubscription `json:"subscriptions"`
+	PauseSubscriptions bool              `json:"pause_subscriptions,omitempty"`
 }
 
 type SqlFileTask struct {


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

It's now possible to subscribe to updates of individual dashboards & alerts in the SQL tasks of Databricks Workflows

This fixes #2436

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] tested manually
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

