### PR TITLE
Fix workspace binding acceptance tests

### DIFF
--- a/internal/acceptance/catalog_workspace_binding_test.go
+++ b/internal/acceptance/catalog_workspace_binding_test.go
@@ -4,31 +4,33 @@ import (
 	"testing"
 )
 
-func TestUcAccCatalogWorkspaceBinding(t *testing.T) {
-	workspaceLevel(t, step{
+func TestUcAccCatalogWorkspaceBindingToOtherWorkspace(t *testing.T) {
+	unityWorkspaceLevel(t, step{
 		Template: `
 		resource "databricks_catalog" "dev" {
 			name           = "dev{var.RANDOM}"
 			isolation_mode = "ISOLATED"
 		}
 
-		resource "databricks_catalog" "test" {
-			name           = "test{var.RANDOM}"
+		resource "databricks_catalog_workspace_binding" "test" {
+			catalog_name = databricks_catalog.dev.name
+			workspace_id = {env.TEST_WORKSPACE_ID} # dummy workspace, not the authenticated workspace in this test
+		}
+		`,
+	})
+}
+
+func TestUcAccCatalogWorkspaceBindingToSameWorkspace(t *testing.T) {
+	unityWorkspaceLevel(t, step{
+		Template: `
+		resource "databricks_catalog" "dev" {
+			name           = "dev{var.RANDOM}"
 			isolation_mode = "ISOLATED"
 		}
 
-		resource "databricks_catalog" "prod" {
-			name = "prod{var.RANDOM}"
-		}
-
-		resource "databricks_catalog_workspace_binding" "dev" {
+		resource "databricks_catalog_workspace_binding" "test" {
 			catalog_name = databricks_catalog.dev.name
 			workspace_id = {env.THIS_WORKSPACE_ID}
-		}
-
-		resource "databricks_catalog_workspace_binding" "test" {
-			catalog_name = databricks_catalog.test.name
-			workspace_id = {env.TEST_WORKSPACE_ID}
 		}
 		`,
 	})


### PR DESCRIPTION
## Changes
This PR fixes the workspace binding acceptance tests. There are two changes:
1. it simplifies the test cases considerably: two tests, one where a binding is created for the current workspace, and one where a binding is created for a separate workspace.
2. it fixes the delete implementation for catalog to add the current workspace to the workspace bindings for the catalog if the catalog is isolated. If the workspace is not in the bindings for an isolated catalog, even metastore admins cannot delete it via the workspace-level API.

Note that isolated catalogs automatically use the workspace binding mechanism to add the current workspace to the catalog bindings on creation, so the second change is only in case of the workspace being listed in a workspace_binding resource. In this case, the workspace binding will be cleaned up first, removing this workspace from bindings, so it must be added back first before deleting the catalog.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [x] covered with integration tests in `internal/acceptance`
- [x] relevant acceptance tests are passing
- [x] using Go SDK

