### PR TITLE
Exporter: make resource names more unique to avoid duplicate resources errors

### DIFF
--- a/exporter/context.go
+++ b/exporter/context.go
@@ -92,10 +92,10 @@ type mount struct {
 var nameFixes = []regexFix{
 	{regexp.MustCompile(`[0-9a-f]{8}[_-][0-9a-f]{4}[_-][0-9a-f]{4}` +
 		`[_-][0-9a-f]{4}[_-][0-9a-f]{12}[_-]`), ""},
-	{regexp.MustCompile(`[_-][0-9]+[\._-][0-9]+[\._-].*\.([a-z0-9]{1,4})`), "_$1"},
+	//	{regexp.MustCompile(`[_-][0-9]+[\._-][0-9]+[\._-].*\.([a-z0-9]{1,4})`), "_$1"},
 	{regexp.MustCompile(`@.*$`), ""},
 	{regexp.MustCompile(`[-\s\.\|]`), "_"},
-	{regexp.MustCompile(`\W+`), ""},
+	{regexp.MustCompile(`\W+`), "_"},
 	{regexp.MustCompile(`[_]{2,}`), "_"},
 }
 

--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -1254,7 +1254,7 @@ func TestResourceName(t *testing.T) {
 	norm := ic.ResourceName(&resource{
 		Name: "9721431b_bcd3_4526_b90f_f5de2befec8c-dbutils_extensions_2_11_0_0_1-18dc8.jar",
 	})
-	assert.Equal(t, "dbutils_extensions_jar", norm)
+	assert.Equal(t, "dbutils_extensions_2_11_0_0_1_18dc8_jar", norm)
 
 	norm = ic.ResourceName(&resource{
 		Name: "9721431b_bcd3_4526_b90f_f5de2befec8c|8737798193",

--- a/exporter/importables.go
+++ b/exporter/importables.go
@@ -640,7 +640,7 @@ var resourcesMap map[string]importable = map[string]importable{
 							ic.Emit(&resource{
 								Resource: "databricks_group_member",
 								ID:       fmt.Sprintf("%s|%s", g.ID, x.Value),
-								Name:     fmt.Sprintf("%s_%s_%s", g.DisplayName, g.ID, x.Display),
+								Name:     fmt.Sprintf("%s_%s_%s_%s", g.DisplayName, g.ID, x.Display, x.Value),
 							})
 						}
 					}
@@ -653,7 +653,7 @@ var resourcesMap map[string]importable = map[string]importable{
 							ic.Emit(&resource{
 								Resource: "databricks_group_member",
 								ID:       fmt.Sprintf("%s|%s", g.ID, x.Value),
-								Name:     fmt.Sprintf("%s_%s_%s", g.DisplayName, g.ID, x.Display),
+								Name:     fmt.Sprintf("%s_%s_%s_%s", g.DisplayName, g.ID, x.Display, x.Value),
 							})
 						}
 					}
@@ -666,7 +666,7 @@ var resourcesMap map[string]importable = map[string]importable{
 							ic.Emit(&resource{
 								Resource: "databricks_group_member",
 								ID:       fmt.Sprintf("%s|%s", g.ID, x.Value),
-								Name:     fmt.Sprintf("%s_%s_%s", g.DisplayName, g.ID, x.Display),
+								Name:     fmt.Sprintf("%s_%s_%s_%s", g.DisplayName, g.ID, x.Display, x.Value),
 							})
 						}
 					}
@@ -696,9 +696,9 @@ var resourcesMap map[string]importable = map[string]importable{
 			s := d.Get("user_name").(string)
 			// if CLI argument includeUserDomains is set then it includes domain portion as well
 			if ic.includeUserDomains {
-				return nameNormalizationRegex.ReplaceAllString(s, "_")
+				return nameNormalizationRegex.ReplaceAllString(s, "_") + "_" + d.Id()
 			}
-			return nameNormalizationRegex.ReplaceAllString(strings.Split(s, "@")[0], "_")
+			return nameNormalizationRegex.ReplaceAllString(strings.Split(s, "@")[0], "_") + "_" + d.Id()
 		},
 		Search: func(ic *importContext, r *resource) error {
 			u, err := ic.findUserByName(r.Value)


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

This includes following changes:

* Add user ID to the `databricks_user` resource name to avoid clashes on names like, `user+1` and `user_1`
* Add user/sp/group ID to the name of the `databricks_group_member` resource
* Remove too aggressive name normalization pattern that also leads to the generation of the duplicate resource names for different resources

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] tested manually
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

