### PR TITLE
Use default cluster for model serving integration test

### DIFF
--- a/internal/acceptance/model_serving_test.go
+++ b/internal/acceptance/model_serving_test.go
@@ -20,31 +20,36 @@ func TestAccModelServing(t *testing.T) {
 		t.Skipf("not available on %s", cloudEnv)
 	}
 
+	clusterID := os.Getenv("TEST_DEFAULT_CLUSTER_ID")
+	if clusterID == "" {
+		t.Skipf("default cluster not available")
+	}
+	// data "databricks_spark_version" "latest" {
+	// }
+	// resource "databricks_cluster" "this" {
+	// 	cluster_name = "singlenode-{var.RANDOM}"
+	// 	spark_version = data.databricks_spark_version.latest.id
+	// 	instance_pool_id = "{env.TEST_INSTANCE_POOL_ID}"
+	// 	num_workers = 0
+	// 	autotermination_minutes = 10
+	// 	spark_conf = {
+	// 		"spark.databricks.cluster.profile" = "singleNode"
+	// 		"spark.master" = "local[*]"
+	// 	}
+	// 	custom_tags = {
+	// 		"ResourceClass" = "SingleNode"
+	// 	}
+	// 	library {
+	// 		pypi {
+	// 			package = "mlflow"
+	// 		}
+	// 	}
+	// }
+
 	name := fmt.Sprintf("terraform-test-model-serving-%[1]s",
 		acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum))
 	workspaceLevel(t, step{
 		Template: fmt.Sprintf(`
-		data "databricks_spark_version" "latest" {
-		}
-		resource "databricks_cluster" "this" {
-			cluster_name = "singlenode-{var.RANDOM}"
-			spark_version = data.databricks_spark_version.latest.id
-			instance_pool_id = "{env.TEST_INSTANCE_POOL_ID}"
-			num_workers = 0
-			autotermination_minutes = 10
-			spark_conf = {
-				"spark.databricks.cluster.profile" = "singleNode"
-				"spark.master" = "local[*]"
-			}
-			custom_tags = {
-				"ResourceClass" = "SingleNode"
-			}
-			library {
-				pypi {
-					package = "mlflow"
-				}
-			}
-		}
 		resource "databricks_mlflow_experiment" "exp" {
 			name = "/Shared/%[1]s-exp"
 		}
@@ -54,7 +59,6 @@ func TestAccModelServing(t *testing.T) {
 		`, name),
 		Check: func(s *terraform.State) error {
 			w := databricks.Must(databricks.NewWorkspaceClient())
-			clusterID := s.RootModule().Resources["databricks_cluster.this"].Primary.ID
 			ctx := context.Background()
 			executor, err := w.CommandExecution.Start(ctx, clusterID, compute.LanguagePython)
 			if err != nil {

--- a/internal/acceptance/model_serving_test.go
+++ b/internal/acceptance/model_serving_test.go
@@ -13,7 +13,6 @@ import (
 )
 
 func TestAccModelServing(t *testing.T) {
-	t.Skip("created ticket for ML Prod team to fix this test")
 	cloudEnv := os.Getenv("CLOUD_ENV")
 	switch cloudEnv {
 	case "aws", "azure":

--- a/internal/acceptance/model_serving_test.go
+++ b/internal/acceptance/model_serving_test.go
@@ -24,27 +24,6 @@ func TestAccModelServing(t *testing.T) {
 	if clusterID == "" {
 		t.Skipf("default cluster not available")
 	}
-	// data "databricks_spark_version" "latest" {
-	// }
-	// resource "databricks_cluster" "this" {
-	// 	cluster_name = "singlenode-{var.RANDOM}"
-	// 	spark_version = data.databricks_spark_version.latest.id
-	// 	instance_pool_id = "{env.TEST_INSTANCE_POOL_ID}"
-	// 	num_workers = 0
-	// 	autotermination_minutes = 10
-	// 	spark_conf = {
-	// 		"spark.databricks.cluster.profile" = "singleNode"
-	// 		"spark.master" = "local[*]"
-	// 	}
-	// 	custom_tags = {
-	// 		"ResourceClass" = "SingleNode"
-	// 	}
-	// 	library {
-	// 		pypi {
-	// 			package = "mlflow"
-	// 		}
-	// 	}
-	// }
 
 	name := fmt.Sprintf("terraform-test-model-serving-%[1]s",
 		acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum))
@@ -56,6 +35,13 @@ func TestAccModelServing(t *testing.T) {
 		resource "databricks_mlflow_model" "model" {
 			name = "%[1]s-model"
 		}
+		resource "databricks_library" "fbprophet" {
+			cluster_id = "{env.TEST_DEFAULT_CLUSTER_ID}"
+			pypi {
+			  package = "mlflow"
+			}
+		  }
+		  
 		`, name),
 		Check: func(s *terraform.State) error {
 			w := databricks.Must(databricks.NewWorkspaceClient())


### PR DESCRIPTION
## Changes
Uses the default cluster we have in our test infra to run the test. This can cut down on the test time needed to spin up a new cluster
## Tests
Self testing. Integration test passes now

Builds on top of https://github.com/databricks/terraform-provider-databricks/pull/2460

