### PR TITLE
Fix catalog workspace binding test

### DIFF
--- a/internal/acceptance/catalog_workspace_binding_test.go
+++ b/internal/acceptance/catalog_workspace_binding_test.go
@@ -7,6 +7,12 @@ import (
 func TestUcAccCatalogWorkspaceBindingToOtherWorkspace(t *testing.T) {
 	unityWorkspaceLevel(t, step{
 		Template: `
+		# The dummy workspace needs to be assigned to the metastore for this test to pass
+		resource "databricks_metastore_assignment" "this" {
+			metastore_id = "{env.TEST_METASTORE_ID}"
+			workspace_id = {env.TEST_WORKSPACE_ID}
+		}
+
 		resource "databricks_catalog" "dev" {
 			name           = "dev{var.RANDOM}"
 			isolation_mode = "ISOLATED"


### PR DESCRIPTION
## Changes
This integration test depends on the metastore assignment of the test metastore to the test workspace. Adding this resource to the integration test fixes the issue that the workspace is not assigned to the metastore.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [x] relevant acceptance tests are passing
- [ ] using Go SDK

