### PR TITLE
Use random catalog name in SQL table integration tests

### DIFF
--- a/internal/acceptance/sql_table_test.go
+++ b/internal/acceptance/sql_table_test.go
@@ -8,7 +8,7 @@ func TestUcAccResourceSqlTable_Managed(t *testing.T) {
 	unityWorkspaceLevel(t, step{
 		Template: `
 		resource "databricks_schema" "this" {
-			name 		 = "foom"
+			name         = "{var.STICKY_RANDOM}"
 			catalog_name = "main"
 		}
 
@@ -35,7 +35,7 @@ func TestUcAccResourceSqlTable_Managed(t *testing.T) {
 	}, step{
 		Template: `
 		resource "databricks_schema" "this" {
-			name 		 = "foom"
+			name         = "{var.STICKY_RANDOM}"
 			catalog_name = "main"
 		}
 
@@ -82,7 +82,7 @@ func TestUcAccResourceSqlTable_External(t *testing.T) {
 		}
 				
 		resource "databricks_schema" "this" {
-			name 		 = "fooe"
+			name         = "{var.STICKY_RANDOM}"
 			catalog_name = "main"
 		}
 


### PR DESCRIPTION
## Changes

A static value causes interference on concurrent runs.

## Tests

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [x] relevant acceptance tests are passing
- [ ] using Go SDK

