### PR TITLE
[DRAFT] Do not provision compute for model serving resources in acceptance test

### DIFF
--- a/internal/acceptance/model_serving_test.go
+++ b/internal/acceptance/model_serving_test.go
@@ -114,7 +114,6 @@ func TestAccModelServing(t *testing.T) {
 						model_name = "%[1]s-model"
 						model_version = "2"
 						workload_size = "Small"
-						scale_to_zero_enabled = false
 					}
 					traffic_config {
 						routes {


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

