### PR TITLE
Add one more item to the troubleshooting guide

### DIFF
--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -120,3 +120,6 @@ This kind of errors happens when the 32-bit version of Databricks Terraform prov
 
 This error may appear when creating Databricks users/groups/service principals on Databricks account level when no `account_id` is specified in the provider's configuration.  Make sure that `account_id` is specified & has a correct value.
 
+## Error: oauth-m2m: oidc: parse .well-known: invalid character '<' looking for beginning of value.
+
+This similar to previous item.  Make sure that `account_id` is specified in the provider configuration & it has a correct value.


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

It's related to use OAuth for authentication but not providing `account_id` in the provider configuration.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

