### PR TITLE
Added `acl_principal_id` attribute to `databricks_user`, `databricks_group` & `databricks_service_principal` for easier use with `databricks_access_control_rule_set`

### DIFF
--- a/docs/resources/access_control_rule_set.md
+++ b/docs/resources/access_control_rule_set.md
@@ -32,7 +32,7 @@ resource "databricks_access_control_rule_set" "automation_sp_rule_set" {
   name = "accounts/${local.account_id}/servicePrincipals/${databricks_service_principal.automation_sp.application_id}/ruleSets/default"
 
   grant_rules {
-    principals = ["groups/${data.databricks_group.ds.display_name}"]
+    principals = [data.databricks_group.ds.acl_principal_id]
     role       = "roles/servicePrincipal.user"
   }
 }
@@ -66,7 +66,7 @@ resource "databricks_access_control_rule_set" "automation_sp_rule_set" {
   name = "accounts/${local.account_id}/servicePrincipals/${databricks_service_principal.automation_sp.application_id}/ruleSets/default"
 
   grant_rules {
-    principals = ["groups/${databricks_group.ds.display_name}"]
+    principals = [databricks_group.ds.acl_principal_id]
     role       = "roles/servicePrincipal.user"
   }
 }
@@ -100,7 +100,7 @@ resource "databricks_access_control_rule_set" "automation_sp_rule_set" {
   name = "accounts/${local.account_id}/servicePrincipals/${databricks_service_principal.automation_sp.application_id}/ruleSets/default"
 
   grant_rules {
-    principals = ["groups/${databricks_group.ds.display_name}"]
+    principals = [databricks_group.ds.acl_principal_id]
     role       = "roles/servicePrincipal.user"
   }
 }
@@ -132,7 +132,7 @@ resource "databricks_access_control_rule_set" "automation_sp_rule_set" {
   name = "accounts/${local.account_id}/servicePrincipals/${databricks_service_principal.automation_sp.application_id}/ruleSets/default"
 
   grant_rules {
-    principals = ["groups/${databricks_group.ds.display_name}"]
+    principals = [databricks_group.ds.acl_principal_id]
     role       = "roles/servicePrincipal.user"
   }
 }
@@ -154,7 +154,7 @@ One or more `grant_rules` blocks are required to actually set access rules.
 ```hcl
 grant_rules {
   principals = [
-    "groups/{databricks_group.ds.display_name}"
+    databricks_group.ds.acl_principal_id
   ]
   role = "roles/servicePrincipal.user"
 }
@@ -166,9 +166,9 @@ Arguments of the `grant_rules` block are:
   * `roles/servicePrincipal.manager` - Manager of a service principal.
   * `roles/servicePrincipal.user` - User of a service principal.
 - `principals` - (Required) a list of principals who are granted a role. The following format is supported:
-  * `users/{username}`
-  * `groups/{groupname}`
-  * `servicePrincipals/{applicationId}`
+  * `users/{username}` (also exposed as `acl_principal_id` attribute of `databricks_user` resource).
+  * `groups/{groupname}` (also exposed as `acl_principal_id` attribute of `databricks_group` resource).
+  * `servicePrincipals/{applicationId}` (also exposed as `acl_principal_id` attribute of `databricks_service_principal` resource).
 
 ## Related Resources
 

--- a/docs/resources/group.md
+++ b/docs/resources/group.md
@@ -96,6 +96,7 @@ The following arguments are supported:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` -  The id for the group object.
+* `acl_principal_id` - identifier for use in [databricks_access_control_rule_set](access_control_rule_set.md), e.g. `groups/Some Group`.
 
 ## Import
 

--- a/docs/resources/service_principal.md
+++ b/docs/resources/service_principal.md
@@ -107,6 +107,7 @@ In addition to all arguments above, the following attributes are exported:
 * `id` - Canonical unique identifier for the service principal.
 - `home` - Home folder of the service principal, e.g. `/Users/00000000-0000-0000-0000-000000000000`.
 - `repos` - Personal Repos location of the service principal, e.g. `/Repos/00000000-0000-0000-0000-000000000000`.
+* `acl_principal_id` - identifier for use in [databricks_access_control_rule_set](access_control_rule_set.md), e.g. `servicePrincipals/00000000-0000-0000-0000-000000000000`.
 
 ## Import
 

--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -104,6 +104,7 @@ In addition to all arguments above, the following attributes are exported:
 * `id` - Canonical unique identifier for the user.
 - `home` - Home folder of the user, e.g. `/Users/mr.foo@example.com`.
 - `repos` - Personal Repos location of the user, e.g. `/Repos/mr.foo@example.com`.
+* `acl_principal_id` - identifier for use in [databricks_access_control_rule_set](access_control_rule_set.md), e.g. `users/mr.foo@example.com`.
 
 ## Import
 

--- a/internal/acceptance/account_rule_set_test.go
+++ b/internal/acceptance/account_rule_set_test.go
@@ -23,7 +23,7 @@ func TestMwsAccAccountRuleSetsFullLifeCycle(t *testing.T) {
 			name = "accounts/{env.DATABRICKS_ACCOUNT_ID}/servicePrincipals/${databricks_service_principal.this.application_id}/ruleSets/default"
 			grant_rules {
 				principals = [
-					"groups/${databricks_group.this.display_name}"
+					databricks_group.this.acl_principal_id
 				]
 				role = "roles/servicePrincipal.manager"
 			}

--- a/scim/resource_group.go
+++ b/scim/resource_group.go
@@ -27,6 +27,11 @@ func ResourceGroup() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 			}
+			m["acl_principal_id"] = &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			}
 			return m
 		})
 	addEntitlementsToSchema(&groupSchema)
@@ -52,6 +57,7 @@ func ResourceGroup() *schema.Resource {
 			}
 			d.Set("display_name", group.DisplayName)
 			d.Set("external_id", group.ExternalID)
+			d.Set("acl_principal_id", fmt.Sprintf("groups/%s", group.DisplayName))
 			d.Set("url", c.FormatURL("#setting/accounts/groups/", d.Id()))
 			return group.Entitlements.readIntoData(d)
 		},

--- a/scim/resource_group_test.go
+++ b/scim/resource_group_test.go
@@ -73,6 +73,7 @@ func TestResourceGroupCreate(t *testing.T) {
 	assert.Equal(t, true, d.Get("allow_cluster_create"))
 	assert.Equal(t, true, d.Get("allow_instance_pool_create"))
 	assert.Equal(t, true, d.Get("databricks_sql_access"))
+	assert.Equal(t, "groups/Data Scientists", d.Get("acl_principal_id"))
 }
 
 func TestResourceGroupCreate_Error(t *testing.T) {

--- a/scim/resource_service_principal.go
+++ b/scim/resource_service_principal.go
@@ -126,6 +126,11 @@ func ResourceServicePrincipal() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 			}
+			m["acl_principal_id"] = &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			}
 			return m
 		})
 	spFromData := func(d *schema.ResourceData) User {
@@ -158,6 +163,7 @@ func ResourceServicePrincipal() *schema.Resource {
 			}
 			d.Set("home", fmt.Sprintf("/Users/%s", sp.ApplicationID))
 			d.Set("repos", fmt.Sprintf("/Repos/%s", sp.ApplicationID))
+			d.Set("acl_principal_id", fmt.Sprintf("servicePrincipals/%s", sp.ApplicationID))
 			err = common.StructToData(sp, servicePrincipalSchema, d)
 			if err != nil {
 				return err

--- a/scim/resource_service_principal_test.go
+++ b/scim/resource_service_principal_test.go
@@ -44,6 +44,7 @@ func TestResourceServicePrincipalRead(t *testing.T) {
 		"allow_cluster_create": true,
 		"home":                 "/Users/bcd",
 		"repos":                "/Repos/bcd",
+		"acl_principal_id":     "servicePrincipals/bcd",
 	})
 }
 

--- a/scim/resource_user.go
+++ b/scim/resource_user.go
@@ -57,6 +57,11 @@ func ResourceUser() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			}
+			m["acl_principal_id"] = &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			}
 			return m
 		})
 	scimUserFromData := func(d *schema.ResourceData) (user User, err error) {
@@ -96,6 +101,7 @@ func ResourceUser() *schema.Resource {
 			d.Set("external_id", user.ExternalID)
 			d.Set("home", fmt.Sprintf("/Users/%s", user.UserName))
 			d.Set("repos", fmt.Sprintf("/Repos/%s", user.UserName))
+			d.Set("acl_principal_id", fmt.Sprintf("users/%s", user.UserName))
 			return user.Entitlements.readIntoData(d)
 		},
 		Update: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {

--- a/scim/resource_user_test.go
+++ b/scim/resource_user_test.go
@@ -49,6 +49,7 @@ func TestResourceUserRead(t *testing.T) {
 	assert.Equal(t, false, d.Get("allow_cluster_create"))
 	assert.Equal(t, "/Users/me@example.com", d.Get("home"))
 	assert.Equal(t, "/Repos/me@example.com", d.Get("repos"))
+	assert.Equal(t, "users/me@example.com", d.Get("acl_principal_id"))
 }
 
 func TestResourceUserRead_NotFound(t *testing.T) {


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

It should simplify specification of principals in the `databricks_access_control_rule_set` so instead of this (string with placeholders):

```
   grant_rules {
     principals = ["groups/${databricks_group.ds.display_name}"]
     role       = "roles/servicePrincipal.user"
   }
```

it will be simpler to refer like this:

```
   grant_rules {
     principals = [databricks_group.ds.acl_principal_id]
     role       = "roles/servicePrincipal.user"
   }
```

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [x] covered with integration tests in `internal/acceptance`
- [x] relevant acceptance tests are passing
- [ ] using Go SDK

