### PR TITLE
Added support for Unity Catalog `databricks_metastore` data source

### DIFF
--- a/catalog/data_metastore.go
+++ b/catalog/data_metastore.go
@@ -11,8 +11,8 @@ import (
 
 func DataSourceMetastore() *schema.Resource {
 	type AccountMetastoreByID struct {
-		Id        string                 `json:"id"`
-		Metastore *catalog.MetastoreInfo `json:"metastore_info,omitempty"`
+		Id        string                 `json:"metastore_id"`
+		Metastore *catalog.MetastoreInfo `json:"metastore_info,omitempty" tf:"computed" `
 	}
 	return common.AccountData(func(ctx context.Context, data *AccountMetastoreByID, acc *databricks.AccountClient) error {
 		metastore, err := acc.Metastores.GetByMetastoreId(ctx, data.Id)

--- a/catalog/data_metastore.go
+++ b/catalog/data_metastore.go
@@ -1,0 +1,25 @@
+package catalog
+
+import (
+	"context"
+
+	"github.com/databricks/databricks-sdk-go"
+	"github.com/databricks/databricks-sdk-go/service/catalog"
+	"github.com/databricks/terraform-provider-databricks/common"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func DataSourceMetastore() *schema.Resource {
+	type AccountMetastoreByID struct {
+		Id        string                 `json:"id"`
+		Metastore *catalog.MetastoreInfo `json:"metastore_info,omitempty"`
+	}
+	return common.AccountData(func(ctx context.Context, data *AccountMetastoreByID, acc *databricks.AccountClient) error {
+		metastore, err := acc.Metastores.GetByMetastoreId(ctx, data.Id)
+		if err != nil {
+			return err
+		}
+		data.Metastore = metastore.MetastoreInfo
+		return nil
+	})
+}

--- a/catalog/data_metastore_test.go
+++ b/catalog/data_metastore_test.go
@@ -7,27 +7,6 @@ import (
 	"github.com/databricks/terraform-provider-databricks/qa"
 )
 
-func TestMetastoreDataApply(t *testing.T) {
-	qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:   "GET",
-				Resource: "/api/2.0/accounts/testaccount/metastores/abc?",
-				Response: catalog.MetastoreInfo{
-					Name:        "xyz",
-					MetastoreId: "abc",
-					Owner:       "pqr",
-				},
-			},
-		},
-		Resource:    DataSourceMetastore(),
-		Read:        true,
-		NonWritable: true,
-		ID:          "abc",
-		AccountID:   "testaccount",
-	}.ApplyNoError(t)
-}
-
 func TestMetastoreDataVerify(t *testing.T) {
 	qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
@@ -55,11 +34,10 @@ func TestMetastoreDataVerify(t *testing.T) {
 		"metastore_info.0.name":         "xyz",
 		"metastore_info.0.owner":        "pqr",
 		"metastore_info.0.metastore_id": "abc",
-	},
-	)
+	})
 }
 
-func TestMetastoreData_Error(t *testing.T) {
+func TestMetastoreDataError(t *testing.T) {
 	qa.ResourceFixture{
 		Fixtures:    qa.HTTPFailures,
 		Resource:    DataSourceMetastore(),

--- a/catalog/data_metastore_test.go
+++ b/catalog/data_metastore_test.go
@@ -1,0 +1,61 @@
+package catalog
+
+import (
+	"testing"
+
+	"github.com/databricks/databricks-sdk-go/service/catalog"
+	"github.com/databricks/terraform-provider-databricks/qa"
+)
+
+func TestMetastoreDataApply(t *testing.T) {
+	qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "GET",
+				Resource: "/api/2.0/accounts/testaccount/metastores/abc?",
+				Response: catalog.MetastoreInfo{
+					Name:        "xyz",
+					MetastoreId: "abc",
+					Owner:       "pqr",
+				},
+			},
+		},
+		Resource:    DataSourceMetastore(),
+		Read:        true,
+		NonWritable: true,
+		ID:          "abc",
+		AccountID:   "testaccount",
+	}.ApplyNoError(t)
+}
+
+func TestMetastoreDataVerify(t *testing.T) {
+	qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "GET",
+				Resource: "/api/2.0/accounts/testaccount/metastores/abc?",
+				Response: catalog.MetastoreInfo{
+					Name:        "xyz",
+					MetastoreId: "abc",
+					Owner:       "pqr",
+				},
+			},
+		},
+		Resource:    DataSourceMetastore(),
+		Read:        true,
+		NonWritable: true,
+		ID:          "abc",
+		AccountID:   "testaccount",
+	}.ApplyAndExpectData(t, map[string]any{})
+}
+
+func TestMetastoreData_Error(t *testing.T) {
+	qa.ResourceFixture{
+		Fixtures:    qa.HTTPFailures,
+		Resource:    DataSourceMetastore(),
+		Read:        true,
+		NonWritable: true,
+		ID:          "_",
+		AccountID:   "_",
+	}.ExpectError(t, "I'm a teapot")
+}

--- a/catalog/data_metastore_test.go
+++ b/catalog/data_metastore_test.go
@@ -34,19 +34,29 @@ func TestMetastoreDataVerify(t *testing.T) {
 			{
 				Method:   "GET",
 				Resource: "/api/2.0/accounts/testaccount/metastores/abc?",
-				Response: catalog.MetastoreInfo{
-					Name:        "xyz",
-					MetastoreId: "abc",
-					Owner:       "pqr",
+				Response: catalog.AccountsMetastoreInfo{
+					MetastoreInfo: &catalog.MetastoreInfo{
+						Name:        "xyz",
+						MetastoreId: "abc",
+						Owner:       "pqr",
+					},
 				},
 			},
 		},
 		Resource:    DataSourceMetastore(),
 		Read:        true,
 		NonWritable: true,
-		ID:          "abc",
+		ID:          "_",
 		AccountID:   "testaccount",
-	}.ApplyAndExpectData(t, map[string]any{})
+		HCL: `
+		metastore_id = "abc"
+		`,
+	}.ApplyAndExpectData(t, map[string]any{
+		"metastore_info.0.name":         "xyz",
+		"metastore_info.0.owner":        "pqr",
+		"metastore_info.0.metastore_id": "abc",
+	},
+	)
 }
 
 func TestMetastoreData_Error(t *testing.T) {

--- a/docs/data-sources/metastore.md
+++ b/docs/data-sources/metastore.md
@@ -12,7 +12,9 @@ Retrieves information about metastore for a given id of [databricks_metastore](.
 MetastoreInfo response for a given metastore id
 
 ```hcl
-data "databricks_metastore" "this" {}
+data "databricks_metastore" "this" {
+  id = 
+}
 
 output "some_metastore" {
   value = data.databricks_metastore.this.metastore_info
@@ -20,13 +22,19 @@ output "some_metastore" {
 ```
 
 ## Argument Reference
-* `id` - id of metastore to be fetched
+* `metastore_id` - Id of metastore to be fetched
 
 ## Attribute Reference
 
 This data source exports the following attributes:
-* `id` - id of the metastore
-* `metastore_info` - MetastoreInfo object for an id of [databricks_metastore](../resources/metastore.md)
+* `metastore_info` - MetastoreInfo object for a [databricks_metastore](../resources/metastore.md). This contains the following attributes:
+  * `name` - Name of metastore.
+  * `storage_root` - Path on cloud storage account, where managed `databricks_table` are stored. Change forces creation of a new resource.
+  * `owner` - Username/groupname/sp application_id of the metastore owner.
+  * `delta_sharing_scope` - Used to enable delta sharing on the metastore. Valid values: INTERNAL, INTERNAL_AND_EXTERNAL.
+  * `delta_sharing_recipient_token_lifetime_in_seconds` - Used to set expiration duration in seconds on recipient data access tokens.
+  * `delta_sharing_organization_name` - The organization name of a Delta Sharing entity. This field is used for Databricks to Databricks sharing. 
+
 
 ## Related Resources
 

--- a/docs/data-sources/metastore.md
+++ b/docs/data-sources/metastore.md
@@ -1,0 +1,36 @@
+---
+subcategory: "Unity Catalog"
+---
+# databricks_metastore Data Source
+
+Retrieves information about metastore for a given id of [databricks_metastore](../resources/metastore.md) object, that was created by Terraform or manually, so that special handling could be applied.
+
+-> **Note** If you have a fully automated setup with workspaces created by [databricks_mws_workspaces](../resources/mws_workspaces.md) or [azurerm_databricks_workspace](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/databricks_workspace), please make sure to add [depends_on attribute](../index.md#data-resources-and-authentication-is-not-configured-errors) in order to prevent _authentication is not configured for provider_ errors.
+
+## Example Usage
+
+MetastoreInfo response for a given metastore id
+
+```hcl
+data "databricks_metastore" "this" {}
+
+output "some_metastore" {
+  value = data.databricks_metastore.this.metastore_info
+}
+```
+
+## Argument Reference
+* `id` - id of metastore to be fetched
+
+## Attribute Reference
+
+This data source exports the following attributes:
+* `id` - id of the metastore
+* `metastore_info` - MetastoreInfo object for an id of [databricks_metastore](../resources/metastore.md)
+
+## Related Resources
+
+The following resources are used in the same context:
+* [databricks_metastores] (./metastores.md) to get list of all metastores
+* [databricks_metastore](../resources/metastore.md) to manage Metastores within Unity Catalog.
+* [databricks_catalog](../resources/catalog.md) to manage catalogs within Unity Catalog.

--- a/docs/data-sources/metastore.md
+++ b/docs/data-sources/metastore.md
@@ -12,17 +12,26 @@ Retrieves information about metastore for a given id of [databricks_metastore](.
 MetastoreInfo response for a given metastore id
 
 ```hcl
+
+resource "databricks_metastore" "this" {
+  provider      = databricks.workspace
+  name          = "primary"
+  storage_root  = "s3://${aws_s3_bucket.metastore.id}/metastore"
+  owner         = var.unity_admin_group
+  force_destroy = true
+}
+
 data "databricks_metastore" "this" {
-  id = 
+  id = databricks_metastore.this.id
 }
 
 output "some_metastore" {
-  value = data.databricks_metastore.this.metastore_info
+  value = data.databricks_metastore.this.metastore_info[0]
 }
 ```
 
 ## Argument Reference
-* `metastore_id` - Id of metastore to be fetched
+* `metastore_id` - Id of the metastore to be fetched
 
 ## Attribute Reference
 

--- a/internal/acceptance/data_metastore_test.go
+++ b/internal/acceptance/data_metastore_test.go
@@ -20,7 +20,7 @@ func TestUcAccDataSourceMetastore(t *testing.T) {
 			}
 			metastore_info := r.Primary.Attributes["metastore_info.0.%"]
 			if metastore_info == "" {
-				return fmt.Errorf("metastoreInfo is empty: %v", r.Primary.Attributes)
+				return fmt.Errorf("MetastoreInfo is empty: %v", r.Primary.Attributes)
 			}
 			return nil
 		},

--- a/internal/acceptance/data_metastore_test.go
+++ b/internal/acceptance/data_metastore_test.go
@@ -1,0 +1,25 @@
+package acceptance
+
+import (
+	"testing"
+)
+
+func TestUcAccDataSourceMetastore(t *testing.T) {
+	accountLevel(t, step{
+		Template: `
+
+		resource "databricks_metastore" "test" {
+			name          = "primary-{var.RANDOM}"
+			storage_root  = "s3://{env.TEST_BUCKET}/test{var.RANDOM}"
+			force_destroy = true
+		}
+
+		data "databricks_metastore" "this" {
+			id = databricks_metastore.test.id
+		}
+
+		output "some_metastore" {
+			value = data.databricks_metastore.this.metastore_info
+		}`,
+	})
+}

--- a/jobs/resource_job.go
+++ b/jobs/resource_job.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/databricks/databricks-sdk-go/service/jobs"
 	"log"
 	"sort"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/databricks/databricks-sdk-go/service/jobs"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -62,11 +62,8 @@ func DatabricksProvider() *schema.Provider {
 			"databricks_instance_pool":           pools.DataSourceInstancePool(),
 			"databricks_jobs":                    jobs.DataSourceJobs(),
 			"databricks_job":                     jobs.DataSourceJob(),
-<<<<<<< HEAD
 			"databricks_metastore":               catalog.DataSourceMetastore(),
-=======
 			"databricks_metastores":              catalog.DataSourceMetastores(),
->>>>>>> 0a23d5e301df4c79875c8e91a8a710f17859aab5
 			"databricks_mws_credentials":         mws.DataSourceMwsCredentials(),
 			"databricks_mws_workspaces":          mws.DataSourceMwsWorkspaces(),
 			"databricks_node_type":               clusters.DataSourceNodeType(),

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -62,6 +62,7 @@ func DatabricksProvider() *schema.Provider {
 			"databricks_instance_pool":           pools.DataSourceInstancePool(),
 			"databricks_jobs":                    jobs.DataSourceJobs(),
 			"databricks_job":                     jobs.DataSourceJob(),
+			"databricks_metastore":               catalog.DataSourceMetastore(),
 			"databricks_mws_credentials":         mws.DataSourceMwsCredentials(),
 			"databricks_mws_workspaces":          mws.DataSourceMwsWorkspaces(),
 			"databricks_node_type":               clusters.DataSourceNodeType(),


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
Enable fetching account level metastore information through id for a single metastore. 

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [x] covered with integration tests in `internal/acceptance`
- [x] relevant acceptance tests are passing
- [x] using Go SDK

