### PR TITLE
Support new delve binary name format

### DIFF
--- a/internal/acceptance/init_test.go
+++ b/internal/acceptance/init_test.go
@@ -357,7 +357,7 @@ func skipf(t *testing.T) func(format string, args ...any) {
 // detects if test is run from "debug test" feature in VSCode
 func isInDebug() bool {
 	ex, _ := os.Executable()
-	return path.Base(ex) == "__debug_bin"
+	return strings.HasPrefix(path.Base(ex), "__debug_bin")
 }
 
 // loads debug environment from ~/.databricks/debug-env.json


### PR DESCRIPTION
## Changes
After upgrading delve to latest, isInDebug() no longer works, as the name of the executable generated by Delve is __debug_bin<numbers>. Checking for whether the basename has __debug_bin as a prefix should work for old and new Delve versions.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

