### PR TITLE
Remove unused dlvLoadConfig configuration from settings.json

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,15 +1,10 @@
 {
-    "go.testFlags": ["-v"],
+    "go.testFlags": [
+        "-v"
+    ],
     "go.delveConfig": {
-    "dlvLoadConfig": {
-        "followPointers": true,
-        "maxVariableRecurse": 1,
-        "maxStringLen": 2055,
-        "maxArrayValues": 64,
-        "maxStructFields": -1
-    },
-    "apiVersion": 2,
-    "showGlobalVariables": true
+        "apiVersion": 2,
+        "showGlobalVariables": true
     },
     "go.useCodeSnippetsOnFunctionSuggest": true,
     "go.useCodeSnippetsOnFunctionSuggestWithoutType": true


### PR DESCRIPTION
## Changes
The `dlvLoadConfig` setting used to customize the rendering of variables in the explorer pane during debugging [has been deprecated](https://github.com/golang/vscode-go/blob/master/docs/debugging.md#settings). This PR removes this no-longer used configuration. This PR removes the popup that shows up saying that this configuration is no longer used.

## Tests
Debugged a test, and the warning was no longer present. I could still see debugging information in the debug pane.

