### PR TITLE
Add support for `USE_MARKETPLACE_ASSETS` privilege to metastore

### DIFF
--- a/catalog/resource_grants.go
+++ b/catalog/resource_grants.go
@@ -246,6 +246,7 @@ var mapping = securableMapping{
 		"USE_PROVIDER":              true,
 		"USE_SHARE":                 true,
 		"USE_RECIPIENT":             true,
+		"USE_MARKETPLACE_ASSETS":    true,
 		"SET_SHARE_PERMISSION":      true,
 	},
 	"function": {

--- a/docs/resources/grants.md
+++ b/docs/resources/grants.md
@@ -38,7 +38,7 @@ Unlike the [SQL specification](https://docs.databricks.com/sql/language-manual/s
 
 ## Metastore grants
 
-You can grant `CREATE_CATALOG`, `CREATE_CONNECTION`, `CREATE_EXTERNAL_LOCATION`, `CREATE_PROVIDER`, `CREATE_RECIPIENT`, `CREATE_SHARE`, `SET_SHARE_PERMISSION`, `USE_CONNECTION`, `USE_PROVIDER`, `USE_RECIPIENT` and `USE_SHARE` privileges to [databricks_metastore](metastore.md) id specified in `metastore` attribute.
+You can grant `CREATE_CATALOG`, `CREATE_CONNECTION`, `CREATE_EXTERNAL_LOCATION`, `CREATE_PROVIDER`, `CREATE_RECIPIENT`, `CREATE_SHARE`, `SET_SHARE_PERMISSION`, `USE_MARKETPLACE_ASSETS`, `USE_CONNECTION`, `USE_PROVIDER`, `USE_RECIPIENT` and `USE_SHARE` privileges to [databricks_metastore](metastore.md) id specified in `metastore` attribute.
 
 ```hcl
 resource "databricks_grants" "sandbox" {


### PR DESCRIPTION
## Changes
Add support for the USE MARKETPLACE ASSETS privilege for the metastore securable (see [here](https://docs.databricks.com/sql/language-manual/sql-ref-privileges.html#privilege-types)), which allows for access to the Databricks Marketplace without CREATE CATALOG and USE PROVIDER privileges or higher privilege roles.

## Tests
Tested this to work for Azure manually. Let me know if additional tests are needed.

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

