### PR TITLE
SQL alert values can also be booleans

### DIFF
--- a/sql/resource_sql_alerts.go
+++ b/sql/resource_sql_alerts.go
@@ -87,6 +87,8 @@ func (a *AlertEntity) fromAPIObject(apiAlert *sql.Alert, s map[string]*schema.Sc
 		a.Options.Value = value
 	case float64:
 		a.Options.Value = strconv.FormatFloat(value, 'f', 0, 64)
+	case bool:
+		a.Options.Value = strconv.FormatBool(value)
 	default:
 		return fmt.Errorf("unexpected type for value: %T", value)
 	}

--- a/sql/resource_sql_alerts_test.go
+++ b/sql/resource_sql_alerts_test.go
@@ -69,3 +69,34 @@ func TestSqlAlertReadNumberValue(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "xyz", d.Id(), "Resource ID should not be empty")
 }
+
+func TestSqlAlertReadBoolValue(t *testing.T) {
+	d, err := qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "GET",
+				Resource: "/api/2.0/preview/sql/alerts/xyz?",
+				Response: sql.Alert{
+					CreatedAt: "2020-01-01T00:00:00.000Z",
+					Id:        "xyz",
+					Parent:    "abc",
+					Name:      "Alert name",
+					Query: &sql.AlertQuery{
+						Id: "abc",
+					},
+					Options: &sql.AlertOptions{
+						Column: "col1",
+						Op:     "==",
+						Value:  true,
+					},
+				},
+			},
+		},
+		Resource: ResourceSqlAlert(),
+		Read:     true,
+		ID:       "xyz",
+	}.Apply(t)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "xyz", d.Id(), "Resource ID should not be empty")
+}


### PR DESCRIPTION
## Changes
SQL alert values can also be booleans

follow up to https://github.com/databricks/terraform-provider-databricks/pull/2494