### PR TITLE
`databricks_job`: `instance_pool_id` takes precedence over `node_type_id` in `Update`

### DIFF
--- a/clusters/clusters_api.go
+++ b/clusters/clusters_api.go
@@ -458,7 +458,7 @@ func (cluster *Cluster) ModifyRequestOnInstancePool() {
 		cluster.AwsAttributes = &awsAttributes
 	}
 	if cluster.AzureAttributes != nil {
-		cluster.AzureAttributes = nil
+		cluster.AzureAttributes = &AzureAttributes{}
 	}
 	if cluster.GcpAttributes != nil {
 		gcpAttributes := GcpAttributes{

--- a/clusters/clusters_api.go
+++ b/clusters/clusters_api.go
@@ -444,6 +444,19 @@ func (cluster Cluster) Validate() error {
 	return fmt.Errorf("NumWorkers could be 0 only for SingleNode clusters. See https://docs.databricks.com/clusters/single-node.html for more details")
 }
 
+// ResolveComputedAttributesForAPIRequest prepocesses the cluster configuration to remove conflicting computed attributes before we can make an API request.
+func (cluster *Cluster) ResolveComputedAttributesForAPIRequest() {
+	// NodeTypeID cannot be set in jobsAPI.Update if InstancePoolID is specified.
+	// If both are specified, assume InstancePoolID takes precedence and NodeTypeID is only computed.
+	if cluster.InstancePoolID != "" {
+		cluster.NodeTypeID = ""
+	}
+	// Same for Driver.
+	if cluster.DriverInstancePoolID != "" {
+		cluster.DriverNodeTypeID = ""
+	}
+}
+
 // ModifyRequestOnInstancePool helps remove all request fields that should not be submitted when instance pool is selected.
 func (cluster *Cluster) ModifyRequestOnInstancePool() {
 	// Instance profile id does not exist or not set

--- a/clusters/clusters_api.go
+++ b/clusters/clusters_api.go
@@ -401,10 +401,10 @@ type Cluster struct {
 	EnableElasticDisk         bool       `json:"enable_elastic_disk,omitempty" tf:"computed"`
 	EnableLocalDiskEncryption bool       `json:"enable_local_disk_encryption,omitempty" tf:"computed"`
 
-	NodeTypeID             string           `json:"node_type_id,omitempty" tf:"group:node_type"`
-	DriverNodeTypeID       string           `json:"driver_node_type_id,omitempty" tf:"group:node_type"`
+	NodeTypeID             string           `json:"node_type_id,omitempty" tf:"group:node_type,computed"`
+	DriverNodeTypeID       string           `json:"driver_node_type_id,omitempty" tf:"group:node_type,computed"`
 	InstancePoolID         string           `json:"instance_pool_id,omitempty" tf:"group:node_type"`
-	DriverInstancePoolID   string           `json:"driver_instance_pool_id,omitempty" tf:"group:node_type"`
+	DriverInstancePoolID   string           `json:"driver_instance_pool_id,omitempty" tf:"group:node_type,computed"`
 	AwsAttributes          *AwsAttributes   `json:"aws_attributes,omitempty" tf:"conflicts:instance_pool_id,suppress_diff"`
 	AzureAttributes        *AzureAttributes `json:"azure_attributes,omitempty" tf:"conflicts:instance_pool_id,suppress_diff"`
 	GcpAttributes          *GcpAttributes   `json:"gcp_attributes,omitempty" tf:"conflicts:instance_pool_id,suppress_diff"`

--- a/clusters/clusters_api.go
+++ b/clusters/clusters_api.go
@@ -444,19 +444,6 @@ func (cluster Cluster) Validate() error {
 	return fmt.Errorf("NumWorkers could be 0 only for SingleNode clusters. See https://docs.databricks.com/clusters/single-node.html for more details")
 }
 
-// ResolveComputedAttributesForAPIRequest prepocesses the cluster configuration to remove conflicting computed attributes before we can make an API request.
-func (cluster *Cluster) ResolveComputedAttributesForAPIRequest() {
-	// NodeTypeID cannot be set in jobsAPI.Update if InstancePoolID is specified.
-	// If both are specified, assume InstancePoolID takes precedence and NodeTypeID is only computed.
-	if cluster.InstancePoolID != "" {
-		cluster.NodeTypeID = ""
-	}
-	// Same for Driver.
-	if cluster.DriverInstancePoolID != "" {
-		cluster.DriverNodeTypeID = ""
-	}
-}
-
 // ModifyRequestOnInstancePool helps remove all request fields that should not be submitted when instance pool is selected.
 func (cluster *Cluster) ModifyRequestOnInstancePool() {
 	// Instance profile id does not exist or not set

--- a/clusters/clusters_api.go
+++ b/clusters/clusters_api.go
@@ -401,10 +401,10 @@ type Cluster struct {
 	EnableElasticDisk         bool       `json:"enable_elastic_disk,omitempty" tf:"computed"`
 	EnableLocalDiskEncryption bool       `json:"enable_local_disk_encryption,omitempty" tf:"computed"`
 
-	NodeTypeID             string           `json:"node_type_id,omitempty" tf:"group:node_type,computed"`
-	DriverNodeTypeID       string           `json:"driver_node_type_id,omitempty" tf:"group:node_type,computed"`
+	NodeTypeID             string           `json:"node_type_id,omitempty" tf:"group:node_type"`
+	DriverNodeTypeID       string           `json:"driver_node_type_id,omitempty" tf:"group:node_type"`
 	InstancePoolID         string           `json:"instance_pool_id,omitempty" tf:"group:node_type"`
-	DriverInstancePoolID   string           `json:"driver_instance_pool_id,omitempty" tf:"group:node_type,computed"`
+	DriverInstancePoolID   string           `json:"driver_instance_pool_id,omitempty" tf:"group:node_type"`
 	AwsAttributes          *AwsAttributes   `json:"aws_attributes,omitempty" tf:"conflicts:instance_pool_id,suppress_diff"`
 	AzureAttributes        *AzureAttributes `json:"azure_attributes,omitempty" tf:"conflicts:instance_pool_id,suppress_diff"`
 	GcpAttributes          *GcpAttributes   `json:"gcp_attributes,omitempty" tf:"conflicts:instance_pool_id,suppress_diff"`

--- a/clusters/resource_cluster_test.go
+++ b/clusters/resource_cluster_test.go
@@ -1567,7 +1567,7 @@ func TestModifyClusterRequestAzure(t *testing.T) {
 		DriverNodeTypeID:  "e",
 	}
 	c.ModifyRequestOnInstancePool()
-	assert.Nil(t, c.AzureAttributes)
+	assert.Equal(t, &AzureAttributes{}, c.AzureAttributes)
 	assert.Equal(t, "", c.NodeTypeID)
 	assert.Equal(t, "", c.DriverNodeTypeID)
 	assert.Equal(t, false, c.EnableElasticDisk)

--- a/jobs/resource_job.go
+++ b/jobs/resource_job.go
@@ -825,11 +825,11 @@ func ResourceJob() *schema.Resource {
 			}
 			// NodeTypeID cannot be set in jobsAPI.Update if InstancePoolID is specified.
 			// If both are specified, assume InstancePoolID takes precedence and NodeTypeID is only computed.
-			if js.NewCluster.InstancePoolID != "" {
+			if js.NewCluster != nil && js.NewCluster.InstancePoolID != "" {
 				js.NewCluster.NodeTypeID = ""
 			}
 			// Same for Driver.
-			if js.NewCluster.DriverInstancePoolID != "" {
+			if js.NewCluster != nil && js.NewCluster.DriverInstancePoolID != "" {
 				js.NewCluster.DriverNodeTypeID = ""
 			}
 			jobsAPI := NewJobsAPI(ctx, c)

--- a/jobs/resource_job.go
+++ b/jobs/resource_job.go
@@ -823,15 +823,21 @@ func ResourceJob() *schema.Resource {
 			if js.isMultiTask() {
 				ctx = context.WithValue(ctx, common.Api, common.API_2_1)
 			}
-			// NodeTypeID cannot be set in jobsAPI.Update if InstancePoolID is specified.
-			// If both are specified, assume InstancePoolID takes precedence and NodeTypeID is only computed.
-			if js.NewCluster != nil && js.NewCluster.InstancePoolID != "" {
-				js.NewCluster.NodeTypeID = ""
+
+			if js.NewCluster != nil {
+				js.NewCluster.ResolveComputedAttributesForAPIRequest()
 			}
-			// Same for Driver.
-			if js.NewCluster != nil && js.NewCluster.DriverInstancePoolID != "" {
-				js.NewCluster.DriverNodeTypeID = ""
+			for _, task := range js.Tasks {
+				if task.NewCluster != nil {
+					task.NewCluster.ResolveComputedAttributesForAPIRequest()
+				}
 			}
+			for _, jc := range js.JobClusters {
+				if jc.NewCluster != nil {
+					jc.NewCluster.ResolveComputedAttributesForAPIRequest()
+				}
+			}
+
 			jobsAPI := NewJobsAPI(ctx, c)
 			err := jobsAPI.Update(d.Id(), js)
 			if err != nil {

--- a/jobs/resource_job.go
+++ b/jobs/resource_job.go
@@ -749,16 +749,16 @@ func (c controlRunStateLifecycleManager) OnUpdate(ctx context.Context) error {
 
 func prepareJobSettingsForUpdate(js JobSettings) {
 	if js.NewCluster != nil {
-		js.NewCluster.ResolveComputedAttributesForAPIRequest()
+		js.NewCluster.ModifyRequestOnInstancePool()
 	}
 	for _, task := range js.Tasks {
 		if task.NewCluster != nil {
-			task.NewCluster.ResolveComputedAttributesForAPIRequest()
+			task.NewCluster.ModifyRequestOnInstancePool()
 		}
 	}
 	for _, jc := range js.JobClusters {
 		if jc.NewCluster != nil {
-			jc.NewCluster.ResolveComputedAttributesForAPIRequest()
+			jc.NewCluster.ModifyRequestOnInstancePool()
 		}
 	}
 }

--- a/jobs/resource_job.go
+++ b/jobs/resource_job.go
@@ -823,6 +823,15 @@ func ResourceJob() *schema.Resource {
 			if js.isMultiTask() {
 				ctx = context.WithValue(ctx, common.Api, common.API_2_1)
 			}
+			// NodeTypeID cannot be set in jobsAPI.Update if InstancePoolID is specified.
+			// If both are specified, assume InstancePoolID takes precedence and NodeTypeID is only computed.
+			if js.NewCluster.InstancePoolID != "" {
+				js.NewCluster.NodeTypeID = ""
+			}
+			// Same for Driver.
+			if js.NewCluster.DriverInstancePoolID != "" {
+				js.NewCluster.DriverNodeTypeID = ""
+			}
 			jobsAPI := NewJobsAPI(ctx, c)
 			err := jobsAPI.Update(d.Id(), js)
 			if err != nil {

--- a/jobs/resource_job_test.go
+++ b/jobs/resource_job_test.go
@@ -1485,12 +1485,12 @@ func TestResourceJobUpdate_NodeTypeToInstancePool(t *testing.T) {
 		Update:   true,
 		Resource: ResourceJob(),
 		InstanceState: map[string]string{
-			"new_cluster.0.node_type_id":                      "node-type-id",
-			"new_cluster.0.driver_node_type_id":               "driver-node-type-id",
-			"task.0.new_cluster.0.node_type_id":               "node-type-id-task",
-			"task.0.new_cluster.0.driver_node_type_id":        "driver-node-type-id-task",
-			"job_cluster.0.new_cluster.0.node_type_id":        "node-type-id-job",
-			"job_cluster.0.new_cluster.0.driver_node_type_id": "driver-node-type-id-job",
+			"new_cluster.0.node_type_id":                      "node-type-id-worker",
+			"new_cluster.0.driver_node_type_id":               "node-type-id-driver",
+			"task.0.new_cluster.0.node_type_id":               "node-type-id-worker-task",
+			"task.0.new_cluster.0.driver_node_type_id":        "node-type-id-driver-task",
+			"job_cluster.0.new_cluster.0.node_type_id":        "node-type-id-worker-job",
+			"job_cluster.0.new_cluster.0.driver_node_type_id": "node-type-id-driver-job",
 		},
 		HCL: `
 		new_cluster = {

--- a/jobs/resource_job_test.go
+++ b/jobs/resource_job_test.go
@@ -1424,7 +1424,7 @@ func TestResourceJobUpdate_NodeTypeToInstancePool(t *testing.T) {
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   "POST",
-				Resource: "/api/2.0/jobs/reset",
+				Resource: "/api/2.1/jobs/reset",
 				ExpectedRequest: UpdateJobRequest{
 					JobID: 789,
 					NewSettings: &JobSettings{
@@ -1433,6 +1433,26 @@ func TestResourceJobUpdate_NodeTypeToInstancePool(t *testing.T) {
 							DriverInstancePoolID: "instance-pool-driver",
 							SparkVersion:         "spark-1",
 							NumWorkers:           1,
+						},
+						Tasks: []JobTaskSettings{
+							{
+								NewCluster: &clusters.Cluster{
+									InstancePoolID:       "instance-pool-worker-task",
+									DriverInstancePoolID: "instance-pool-driver-task",
+									SparkVersion:         "spark-2",
+									NumWorkers:           2,
+								},
+							},
+						},
+						JobClusters: []JobCluster{
+							{
+								NewCluster: &clusters.Cluster{
+									InstancePoolID:       "instance-pool-worker-job",
+									DriverInstancePoolID: "instance-pool-driver-job",
+									SparkVersion:         "spark-3",
+									NumWorkers:           3,
+								},
+							},
 						},
 						Name:                   "Featurizer New",
 						MaxRetries:             3,
@@ -1444,7 +1464,7 @@ func TestResourceJobUpdate_NodeTypeToInstancePool(t *testing.T) {
 			},
 			{
 				Method:   "GET",
-				Resource: "/api/2.0/jobs/get?job_id=789",
+				Resource: "/api/2.1/jobs/get?job_id=789",
 				Response: Job{
 					JobID: 789,
 					Settings: &JobSettings{
@@ -1465,8 +1485,12 @@ func TestResourceJobUpdate_NodeTypeToInstancePool(t *testing.T) {
 		Update:   true,
 		Resource: ResourceJob(),
 		InstanceState: map[string]string{
-			"new_cluster.0.node_type_id":        "node-type-id",
-			"new_cluster.0.driver_node_type_id": "driver-node-type-id",
+			"new_cluster.0.node_type_id":                      "node-type-id",
+			"new_cluster.0.driver_node_type_id":               "driver-node-type-id",
+			"task.0.new_cluster.0.node_type_id":               "node-type-id-task",
+			"task.0.new_cluster.0.driver_node_type_id":        "driver-node-type-id-task",
+			"job_cluster.0.new_cluster.0.node_type_id":        "node-type-id-job",
+			"job_cluster.0.new_cluster.0.driver_node_type_id": "driver-node-type-id-job",
 		},
 		HCL: `
 		new_cluster = {
@@ -1474,6 +1498,22 @@ func TestResourceJobUpdate_NodeTypeToInstancePool(t *testing.T) {
 			driver_instance_pool_id = "instance-pool-driver"
 			spark_version = "spark-1"
 			num_workers = 1
+		}
+		task = {
+			new_cluster = {
+				instance_pool_id = "instance-pool-worker-task"
+				driver_instance_pool_id = "instance-pool-driver-task"
+				spark_version = "spark-2"
+				num_workers = 2
+			}
+		}
+		job_cluster = {
+			new_cluster = {
+				instance_pool_id = "instance-pool-worker-job"
+				driver_instance_pool_id = "instance-pool-driver-job"
+				spark_version = "spark-3"
+				num_workers = 3
+			}
 		}
 		max_concurrent_runs = 1
 		max_retries = 3

--- a/jobs/resource_job_test.go
+++ b/jobs/resource_job_test.go
@@ -1419,6 +1419,73 @@ func TestResourceJobUpdate(t *testing.T) {
 	assert.Equal(t, "Featurizer New", d.Get("name"))
 }
 
+func TestResourceJobUpdate_NodeTypeToInstancePool(t *testing.T) {
+	d, err := qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "POST",
+				Resource: "/api/2.0/jobs/reset",
+				ExpectedRequest: UpdateJobRequest{
+					JobID: 789,
+					NewSettings: &JobSettings{
+						NewCluster: &clusters.Cluster{
+							InstancePoolID:       "instance-pool-worker",
+							DriverInstancePoolID: "instance-pool-driver",
+							SparkVersion:         "spark-1",
+							NumWorkers:           1,
+						},
+						Name:                   "Featurizer New",
+						MaxRetries:             3,
+						MinRetryIntervalMillis: 5000,
+						RetryOnTimeout:         true,
+						MaxConcurrentRuns:      1,
+					},
+				},
+			},
+			{
+				Method:   "GET",
+				Resource: "/api/2.0/jobs/get?job_id=789",
+				Response: Job{
+					JobID: 789,
+					Settings: &JobSettings{
+						NewCluster: &clusters.Cluster{
+							NodeTypeID:       "node-type-id",
+							DriverNodeTypeID: "driver-node-type-id",
+						},
+						Name:                   "Featurizer New",
+						MaxRetries:             3,
+						MinRetryIntervalMillis: 5000,
+						RetryOnTimeout:         true,
+						MaxConcurrentRuns:      1,
+					},
+				},
+			},
+		},
+		ID:       "789",
+		Update:   true,
+		Resource: ResourceJob(),
+		InstanceState: map[string]string{
+			"new_cluster.0.node_type_id":        "node-type-id",
+			"new_cluster.0.driver_node_type_id": "driver-node-type-id",
+		},
+		HCL: `
+		new_cluster = {
+			instance_pool_id = "instance-pool-worker"
+			driver_instance_pool_id = "instance-pool-driver"
+			spark_version = "spark-1"
+			num_workers = 1
+		}
+		max_concurrent_runs = 1
+		max_retries = 3
+		min_retry_interval_millis = 5000
+		name = "Featurizer New"
+		retry_on_timeout = true`,
+	}.Apply(t)
+	assert.NoError(t, err)
+	assert.Equal(t, "789", d.Id(), "Id should be the same as in reading")
+	assert.Equal(t, "Featurizer New", d.Get("name"))
+}
+
 func TestResourceJobUpdate_Tasks(t *testing.T) {
 	qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{


### PR DESCRIPTION
## Changes
`NodeTypeID` cannot be set in `jobsAPI.Update()` if `InstancePoolID` is specified.
If both are specified, assume `InstancePoolID` takes precedence and `NodeTypeID` is only computed.

Closes #2502.
Closes #2141.

## Tests
- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

