### PR TITLE
Use prefix of the error message to check existence of `databricks_user` with `force = true`

### DIFF
--- a/scim/resource_user.go
+++ b/scim/resource_user.go
@@ -167,7 +167,8 @@ func createForceOverridesManuallyAddedUser(err error, d *schema.ResourceData, us
 	}
 	// corner-case for overriding manually provisioned users
 	userName := strings.ReplaceAll(u.UserName, "'", "")
-	if (err.Error() != userExistsErrorMessage(userName, false)) && (err.Error() != userExistsErrorMessage(userName, true)) {
+	if (!strings.HasPrefix(err.Error(), userExistsErrorMessage(userName, false))) &&
+		(!strings.HasPrefix(err.Error(), userExistsErrorMessage(userName, true))) {
 		return err
 	}
 	userList, err := usersAPI.Filter(fmt.Sprintf("userName eq '%s'", userName), true)


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

This fixes #2500

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [x] relevant acceptance tests are passing
- [ ] using Go SDK

