### PR TITLE
Configured merge queue for the provider

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -3,8 +3,8 @@ name: build
 on:
   pull_request:
     types: [opened, synchronize]
-  push:
-    branches: [master]
+  merge_group:
+    types: [checks_requested]
 
 jobs:
   tests:


### PR DESCRIPTION
## Changes
This PR is one of two changes to enable the merge queue for the provider repo. This will allow changes to merge to master without needing to be manually updated to the tip of the release branch. One this change is merged, I will enable the "Require merge queue" setting on the repo. We'll use the same settings as configured for the CLI.

![Screenshot 2023-07-31 at 10 41 11](https://github.com/databricks/terraform-provider-databricks/assets/1850319/9c84884f-29d4-4cbd-8cd3-717a70bb9317)

See https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue for more information.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

