### PR TITLE
Add `managed_identity_id` to `databricks_storage_credential` to support user-assigned managed identities

### DIFF
--- a/catalog/resource_metastore_data_access.go
+++ b/catalog/resource_metastore_data_access.go
@@ -16,17 +16,6 @@ type AwsIamRole struct {
 	RoleARN string `json:"role_arn"`
 }
 
-type AzureServicePrincipal struct {
-	DirectoryID   string `json:"directory_id"`
-	ApplicationID string `json:"application_id"`
-	ClientSecret  string `json:"client_secret" tf:"sensitive"`
-}
-
-type AzureManagedIdentity struct {
-	AccessConnectorID string `json:"access_connector_id"`
-	ManagedIdentityID string `json:"managed_identity_id,omitempty"`
-}
-
 type GcpServiceAccountKey struct {
 	Email        string `json:"email"`
 	PrivateKeyId string `json:"private_key_id"`
@@ -38,21 +27,38 @@ type DbGcpServiceAccount struct {
 }
 
 type DataAccessConfiguration struct {
-	ID                string                 `json:"id,omitempty" tf:"computed"`
-	Name              string                 `json:"name"`
-	ConfigurationType string                 `json:"configuration_type,omitempty" tf:"computed"`
-	Aws               *AwsIamRole            `json:"aws_iam_role,omitempty" tf:"group:access"`
-	Azure             *AzureServicePrincipal `json:"azure_service_principal,omitempty" tf:"group:access"`
-	AzMI              *AzureManagedIdentity  `json:"azure_managed_identity,omitempty" tf:"group:access"`
-	GcpSAKey          *GcpServiceAccountKey  `json:"gcp_service_account_key,omitempty" tf:"group:access"`
-	DBGcpSA           *DbGcpServiceAccount   `json:"databricks_gcp_service_account,omitempty" tf:"group:access"`
+	ID                string                         `json:"id,omitempty" tf:"computed"`
+	Name              string                         `json:"name"`
+	ConfigurationType string                         `json:"configuration_type,omitempty" tf:"computed"`
+	Aws               *AwsIamRole                    `json:"aws_iam_role,omitempty" tf:"group:access"`
+	Azure             *catalog.AzureServicePrincipal `json:"azure_service_principal,omitempty" tf:"group:access"`
+	AzMI              *catalog.AzureManagedIdentity  `json:"azure_managed_identity,omitempty" tf:"group:access"`
+	GcpSAKey          *GcpServiceAccountKey          `json:"gcp_service_account_key,omitempty" tf:"group:access"`
+	DBGcpSA           *DbGcpServiceAccount           `json:"databricks_gcp_service_account,omitempty" tf:"group:access"`
 }
 
-var alofCred = []string{"aws_iam_role", "azure_service_principal", "azure_managed_identity", "gcp_service_account_key", "databricks_gcp_service_account"}
+var alofCred = []string{"aws_iam_role", "azure_service_principal", "azure_managed_identity",
+	"gcp_service_account_key", "databricks_gcp_service_account"}
 
 func SuppressGcpSAKeyDiff(k, old, new string, d *schema.ResourceData) bool {
 	//ignore changes in private_key
 	return !d.HasChanges("gcp_service_account_key.0.email", "gcp_service_account_key.0.private_key_id")
+}
+
+// it's used by both ResourceMetastoreDataAccess & ResourceStorageCredential
+func adjustDataAccessSchema(m map[string]*schema.Schema) map[string]*schema.Schema {
+	m["aws_iam_role"].AtLeastOneOf = alofCred
+	m["azure_service_principal"].AtLeastOneOf = alofCred
+	m["azure_managed_identity"].AtLeastOneOf = alofCred
+	m["gcp_service_account_key"].AtLeastOneOf = alofCred
+	m["databricks_gcp_service_account"].AtLeastOneOf = alofCred
+
+	// suppress changes for private_key
+	m["gcp_service_account_key"].DiffSuppressFunc = SuppressGcpSAKeyDiff
+
+	common.MustSchemaPath(m, "azure_managed_identity", "credential_id").Computed = true
+
+	return m
 }
 
 var dacSchema = common.StructToSchema(DataAccessConfiguration{},
@@ -68,15 +74,8 @@ var dacSchema = common.StructToSchema(DataAccessConfiguration{},
 			Type:     schema.TypeBool,
 			Optional: true,
 		}
-		m["aws_iam_role"].AtLeastOneOf = alofCred
-		m["azure_service_principal"].AtLeastOneOf = alofCred
-		m["azure_managed_identity"].AtLeastOneOf = alofCred
-		m["gcp_service_account_key"].AtLeastOneOf = alofCred
-		m["databricks_gcp_service_account"].AtLeastOneOf = alofCred
 
-		// suppress changes for private_key
-		m["gcp_service_account_key"].DiffSuppressFunc = SuppressGcpSAKeyDiff
-		return m
+		return adjustDataAccessSchema(m)
 	})
 
 func ResourceMetastoreDataAccess() *schema.Resource {

--- a/catalog/resource_metastore_data_access.go
+++ b/catalog/resource_metastore_data_access.go
@@ -24,6 +24,7 @@ type AzureServicePrincipal struct {
 
 type AzureManagedIdentity struct {
 	AccessConnectorID string `json:"access_connector_id"`
+	ManagedIdentityID string `json:"managed_identity_id,omitempty"`
 }
 
 type GcpServiceAccountKey struct {

--- a/catalog/resource_metastore_data_access_test.go
+++ b/catalog/resource_metastore_data_access_test.go
@@ -74,8 +74,9 @@ func TestCreateDacWithAzMI(t *testing.T) {
 				Resource: "/api/2.1/unity-catalog/storage-credentials",
 				ExpectedRequest: DataAccessConfiguration{
 					Name: "bcd",
-					AzMI: &AzureManagedIdentity{
-						AccessConnectorID: "def",
+					AzMI: &catalog.AzureManagedIdentity{
+						AccessConnectorId: "def",
+						ManagedIdentityId: "/..../subscription",
 					},
 				},
 				Response: catalog.StorageCredentialInfo{
@@ -96,6 +97,7 @@ func TestCreateDacWithAzMI(t *testing.T) {
 					Name: "bcd",
 					AzureManagedIdentity: &catalog.AzureManagedIdentity{
 						AccessConnectorId: "def",
+						ManagedIdentityId: "/..../subscription",
 					},
 				},
 			},
@@ -115,6 +117,7 @@ func TestCreateDacWithAzMI(t *testing.T) {
 		is_default = true
 		azure_managed_identity {
 			access_connector_id = "def"
+			managed_identity_id = "/..../subscription"
 		}
 		`,
 	}.ApplyNoError(t)

--- a/catalog/resource_storage_credential.go
+++ b/catalog/resource_storage_credential.go
@@ -10,16 +10,16 @@ import (
 )
 
 type StorageCredentialInfo struct {
-	Name        string                 `json:"name" tf:"force_new"`
-	Owner       string                 `json:"owner,omitempty" tf:"computed"`
-	Comment     string                 `json:"comment,omitempty"`
-	Aws         *AwsIamRole            `json:"aws_iam_role,omitempty" tf:"group:access"`
-	Azure       *AzureServicePrincipal `json:"azure_service_principal,omitempty" tf:"group:access"`
-	AzMI        *AzureManagedIdentity  `json:"azure_managed_identity,omitempty" tf:"group:access"`
-	GcpSAKey    *GcpServiceAccountKey  `json:"gcp_service_account_key,omitempty" tf:"group:access"`
-	DBGcpSA     *DbGcpServiceAccount   `json:"databricks_gcp_service_account,omitempty" tf:"computed"`
-	MetastoreID string                 `json:"metastore_id,omitempty" tf:"computed"`
-	ReadOnly    bool                   `json:"read_only,omitempty"`
+	Name        string                         `json:"name" tf:"force_new"`
+	Owner       string                         `json:"owner,omitempty" tf:"computed"`
+	Comment     string                         `json:"comment,omitempty"`
+	Aws         *AwsIamRole                    `json:"aws_iam_role,omitempty" tf:"group:access"`
+	Azure       *catalog.AzureServicePrincipal `json:"azure_service_principal,omitempty" tf:"group:access"`
+	AzMI        *catalog.AzureManagedIdentity  `json:"azure_managed_identity,omitempty" tf:"group:access"`
+	GcpSAKey    *GcpServiceAccountKey          `json:"gcp_service_account_key,omitempty" tf:"group:access"`
+	DBGcpSA     *DbGcpServiceAccount           `json:"databricks_gcp_service_account,omitempty" tf:"computed"`
+	MetastoreID string                         `json:"metastore_id,omitempty" tf:"computed"`
+	ReadOnly    bool                           `json:"read_only,omitempty"`
 }
 
 func removeGcpSaField(originalSchema map[string]*schema.Schema) map[string]*schema.Schema {
@@ -39,16 +39,7 @@ func ResourceStorageCredential() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 			}
-			m["aws_iam_role"].AtLeastOneOf = alofCred
-			m["azure_service_principal"].AtLeastOneOf = alofCred
-			m["azure_managed_identity"].AtLeastOneOf = alofCred
-			m["gcp_service_account_key"].AtLeastOneOf = alofCred
-			m["databricks_gcp_service_account"].AtLeastOneOf = alofCred
-
-			// suppress changes for private_key
-			m["gcp_service_account_key"].DiffSuppressFunc = SuppressGcpSAKeyDiff
-
-			return m
+			return adjustDataAccessSchema(m)
 		})
 	return common.Resource{
 		Schema: s,

--- a/catalog/resource_storage_credential_test.go
+++ b/catalog/resource_storage_credential_test.go
@@ -221,8 +221,8 @@ func TestCreateStorageCredentialWithAzMI(t *testing.T) {
 				Resource: "/api/2.1/unity-catalog/storage-credentials",
 				ExpectedRequest: StorageCredentialInfo{
 					Name: "a",
-					AzMI: &AzureManagedIdentity{
-						AccessConnectorID: "def",
+					AzMI: &catalog.AzureManagedIdentity{
+						AccessConnectorId: "def",
 					},
 					Comment: "c",
 				},
@@ -235,8 +235,8 @@ func TestCreateStorageCredentialWithAzMI(t *testing.T) {
 				Resource: "/api/2.1/unity-catalog/storage-credentials/a",
 				ExpectedRequest: StorageCredentialInfo{
 					Name: "a",
-					AzMI: &AzureManagedIdentity{
-						AccessConnectorID: "def",
+					AzMI: &catalog.AzureManagedIdentity{
+						AccessConnectorId: "def",
 					},
 					Comment: "c",
 				},
@@ -277,9 +277,9 @@ func TestUpdateAzStorageCredentials(t *testing.T) {
 				ExpectedRequest: StorageCredentialInfo{
 					Name:    "a",
 					Comment: "c",
-					Azure: &AzureServicePrincipal{
-						DirectoryID:   "CHANGED",
-						ApplicationID: "CHANGED",
+					Azure: &catalog.AzureServicePrincipal{
+						DirectoryId:   "CHANGED",
+						ApplicationId: "CHANGED",
 						ClientSecret:  "CHANGED",
 					},
 				},
@@ -379,8 +379,8 @@ func TestUpdateAzStorageCredentialMI(t *testing.T) {
 				ExpectedRequest: StorageCredentialInfo{
 					Name:    "a",
 					Comment: "c",
-					AzMI: &AzureManagedIdentity{
-						AccessConnectorID: "CHANGED",
+					AzMI: &catalog.AzureManagedIdentity{
+						AccessConnectorId: "CHANGED",
 					},
 				},
 			},

--- a/docs/resources/metastore_data_access.md
+++ b/docs/resources/metastore_data_access.md
@@ -64,7 +64,8 @@ The following arguments are required:
 
 `azure_managed_identity` optional configuration block for using managed identity as credential details for Azure (Recommended):
 
-* `access_connector_id` - The Resource ID of the Azure Databricks Access Connector resource, of the form `/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-name/providers/Microsoft.Databricks/accessConnectors/connector-name`
+* `access_connector_id` - The Resource ID of the Azure Databricks Access Connector resource, of the form `/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-name/providers/Microsoft.Databricks/accessConnectors/connector-name`.
+* `managed_identity_id` - (Optional) The Resource ID of the Azure User Assigned Managed Identity associated with Azure Databricks Access Connector, of the form `/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-name/providers/Microsoft.ManagedIdentity/userAssignedIdentities/user-managed-identity-name`.
 
 `databricks_gcp_service_account` optional configuration block for creating a Databricks-managed GCP Service Account:
 

--- a/docs/resources/storage_credential.md
+++ b/docs/resources/storage_credential.md
@@ -80,7 +80,8 @@ The following arguments are required:
 
 `azure_managed_identity` optional configuration block for using managed identity as credential details for Azure (recommended over service principal):
 
-- `access_connector_id` - The Resource ID of the Azure Databricks Access Connector resource, of the form `/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-name/providers/Microsoft.Databricks/accessConnectors/connector-name`
+- `access_connector_id` - The Resource ID of the Azure Databricks Access Connector resource, of the form `/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-name/providers/Microsoft.Databricks/accessConnectors/connector-name`.
+* `managed_identity_id` - (Optional) The Resource ID of the Azure User Assigned Managed Identity associated with Azure Databricks Access Connector, of the form `/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-name/providers/Microsoft.ManagedIdentity/userAssignedIdentities/user-managed-identity-name`.
 
 `azure_service_principal` optional configuration block to use service principal as credential details for Azure:
 


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

This fixes #2532 

@nkvuong I think that the metastore data access should be also updated, but I couldn't find documentation on that API


## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [x] relevant acceptance tests are passing
- [x] using Go SDK

