### PR TITLE
[SC-135890] Add SSE, AccessPoint to UC External Location resource

### DIFF
--- a/catalog/resource_external_location.go
+++ b/catalog/resource_external_location.go
@@ -17,14 +17,27 @@ func NewExternalLocationsAPI(ctx context.Context, m any) ExternalLocationsAPI {
 	return ExternalLocationsAPI{m.(*common.DatabricksClient), context.WithValue(ctx, common.Api, common.API_2_1)}
 }
 
+type SseEncryptionDetails struct {
+	// algorithm enum values: "AWS_SSE_S3", "AWS_SSE_KMS"
+	Algorithm    string `json:"algorithm,omitempty"`
+	AwsKmsKeyArn string `json:"aws_kms_key_arn,omitempty"`
+}
+
+type EncryptionDetails struct {
+	// This is a oneOf type, but only one type defined currently:
+	SseEncDetails *SseEncryptionDetails `json:"sse_encryption_details,omitempty"`
+}
+
 type ExternalLocationInfo struct {
-	Name           string `json:"name" tf:"force_new"`
-	URL            string `json:"url"`
-	CredentialName string `json:"credential_name"`
-	Comment        string `json:"comment,omitempty"`
-	SkipValidation bool   `json:"skip_validation,omitempty"`
-	Owner          string `json:"owner,omitempty" tf:"computed"`
-	MetastoreID    string `json:"metastore_id,omitempty" tf:"computed"`
+	Name           string             `json:"name" tf:"force_new"`
+	URL            string             `json:"url"`
+	CredentialName string             `json:"credential_name"`
+	Comment        string             `json:"comment,omitempty"`
+	SkipValidation bool               `json:"skip_validation,omitempty"`
+	Owner          string             `json:"owner,omitempty" tf:"computed"`
+	MetastoreID    string             `json:"metastore_id,omitempty" tf:"computed"`
+	AccessPoint    string             `json:"access_point,omitempty"`
+	EncDetails     *EncryptionDetails `json:"encryption_details,omitempty"`
 }
 
 func (a ExternalLocationsAPI) create(el *ExternalLocationInfo) error {

--- a/catalog/resource_external_location_test.go
+++ b/catalog/resource_external_location_test.go
@@ -45,6 +45,53 @@ func TestCreateExternalLocation(t *testing.T) {
 	}.ApplyNoError(t)
 }
 
+func TestCreateExternalLocationWithAPAndEncryptionDetails(t *testing.T) {
+	qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "POST",
+				Resource: "/api/2.1/unity-catalog/external-locations",
+				ExpectedRequest: ExternalLocationInfo{
+					Name:           "abc",
+					URL:            "s3://foo/bar",
+					CredentialName: "bcd",
+					AccessPoint:    "some_access_point",
+					EncDetails: &EncryptionDetails{
+						&SseEncryptionDetails{
+							Algorithm:    "AWS_SSE_KMS",
+							AwsKmsKeyArn: "some_key_arn",
+						},
+					},
+					Comment: "def",
+				},
+			},
+			{
+				Method:   "GET",
+				Resource: "/api/2.1/unity-catalog/external-locations/abc",
+				Response: ExternalLocationInfo{
+					Owner:       "efg",
+					MetastoreID: "fgh",
+				},
+			},
+		},
+		Resource: ResourceExternalLocation(),
+		Create:   true,
+		HCL: `
+		name = "abc"
+		url = "s3://foo/bar"
+		credential_name = "bcd"
+		comment = "def"
+		access_point = "some_access_point"
+	    encryption_details {
+          sse_encryption_details {
+            algorithm     = "AWS_SSE_KMS"
+            aws_kms_key_arn = "some_key_arn"
+		  }
+        }
+		`,
+	}.ApplyNoError(t)
+}
+
 func TestCreateExternalLocationWithOwner(t *testing.T) {
 	qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{


### PR DESCRIPTION
## Changes

* Adds `AccessPoint` and `EncryptionDetails` (for SSE) to External Locations resource.

## Tests

* Added unit test case.
* Tested manually creating External Location resources using AccessPoint, S3 and KMS encryption.

- [X] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

