### PR TITLE
Provided `application_id` when creating SP in `databricks_access_control_rule_set` resource integration test (and temporarily disabled this test outside of AWS)

### DIFF
--- a/internal/acceptance/account_rule_set_test.go
+++ b/internal/acceptance/account_rule_set_test.go
@@ -29,7 +29,13 @@ func getServicePrincipalResource(cloudEnv string) string {
 }
 
 func TestMwsAccAccountRuleSetsFullLifeCycle(t *testing.T) {
-	spResource := getServicePrincipalResource(os.Getenv("CLOUD_ENV"))
+	// This endpoint is restricted to basic auth today, used only by AWS account-level tests.
+	// Remove this skip when this restriction is lifted in Azure & GCP.
+	cloudEnv := os.Getenv("CLOUD_ENV")
+	if cloudEnv != "aws" {
+		t.Skip("Skipping test in Azure")
+	}
+	spResource := getServicePrincipalResource(cloudEnv)
 	accountLevel(t, step{
 		Template: spResource + `
 		resource "databricks_group" "this" {


### PR DESCRIPTION
## Changes
Two fixes are needed to fix nightly integration tests for Terraform:
1. Server-side, there is a restriction that only users using basic auth can authenticate to this API. This restriction needs to be lifted, @gauthamsunjay is working on this. Our AWS environment uses basic auth, but Azure and GCP do not. For now, we'll only run this test in AWS. Once the server-side issue is fixed, this restriction can be lifted.
2. SP creation in Azure requires providing an application ID. 

## Tests

- [x] relevant acceptance tests are passing


