### PR TITLE
Fixed `databricks_job` update from instance pool to regular node type

### DIFF
--- a/clusters/resource_cluster.go
+++ b/clusters/resource_cluster.go
@@ -225,17 +225,6 @@ func hasClusterConfigChanged(d *schema.ResourceData) bool {
 	return false
 }
 
-// https://github.com/databricks/terraform-provider-databricks/issues/824
-func fixInstancePoolChangeIfAny(d *schema.ResourceData, cluster *Cluster) {
-	oldInstancePool, newInstancePool := d.GetChange("instance_pool_id")
-	oldDriverPool, newDriverPool := d.GetChange("driver_instance_pool_id")
-	if oldInstancePool != newInstancePool &&
-		oldDriverPool == oldInstancePool &&
-		oldDriverPool == newDriverPool {
-		cluster.DriverInstancePoolID = cluster.InstancePoolID
-	}
-}
-
 func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
 	clusters := NewClustersAPI(ctx, c)
 	clusterID := d.Id()
@@ -250,7 +239,7 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, c *commo
 			return err
 		}
 		cluster.ModifyRequestOnInstancePool()
-		fixInstancePoolChangeIfAny(d, &cluster)
+		cluster.FixInstancePoolChangeIfAny(d)
 
 		// We can only call the resize api if the cluster is in the running state
 		// and only the cluster size (ie num_workers OR autoscale) is being changed

--- a/jobs/resource_job.go
+++ b/jobs/resource_job.go
@@ -758,18 +758,21 @@ func (c controlRunStateLifecycleManager) OnUpdate(ctx context.Context) error {
 	return api.StopActiveRun(jobID, c.d.Timeout(schema.TimeoutUpdate))
 }
 
-func prepareJobSettingsForUpdate(js JobSettings) {
+func prepareJobSettingsForUpdate(d *schema.ResourceData, js JobSettings) {
 	if js.NewCluster != nil {
 		js.NewCluster.ModifyRequestOnInstancePool()
+		js.NewCluster.FixInstancePoolChangeIfAny(d)
 	}
 	for _, task := range js.Tasks {
 		if task.NewCluster != nil {
 			task.NewCluster.ModifyRequestOnInstancePool()
+			task.NewCluster.FixInstancePoolChangeIfAny(d)
 		}
 	}
 	for _, jc := range js.JobClusters {
 		if jc.NewCluster != nil {
 			jc.NewCluster.ModifyRequestOnInstancePool()
+			jc.NewCluster.FixInstancePoolChangeIfAny(d)
 		}
 	}
 }
@@ -851,7 +854,7 @@ func ResourceJob() *schema.Resource {
 				ctx = context.WithValue(ctx, common.Api, common.API_2_1)
 			}
 
-			prepareJobSettingsForUpdate(js)
+			prepareJobSettingsForUpdate(d, js)
 
 			jobsAPI := NewJobsAPI(ctx, c)
 			err := jobsAPI.Update(d.Id(), js)


### PR DESCRIPTION
## Changes
When a job cluster was updated from instance pool to regular, the computed `driver_instance_pool_id` was still being sent, which then caused failure of the cluster to start with error in the UI "Worker must use a pool if driver uses a pool".

This resets the driver_instance_pool_id if instance_pool_id is not set.

Also I noticed there was a function FixInstancePoolChangeIfAny that was only used on `databricks_cluster`. Looking at https://github.com/databricks/terraform-provider-databricks/pull/850, I believe it's also relevant for jobs clusters, so applying it too.

## Tests
Tested updating a jobs cluster from regular to pool and back.

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

