### PR TITLE
Added `acl_principal_id` to data sources: `databricks_user`, `databricks_service_principal`, `databricks_group`, `databricks_current_user`

### DIFF
--- a/docs/data-sources/current_user.md
+++ b/docs/data-sources/current_user.md
@@ -62,6 +62,7 @@ Data source exposes the following attributes:
 * `repos` - Personal Repos location of the [user](../resources/user.md), e.g. `/Repos/mr.foo@example.com`.
 * `alphanumeric` - Alphanumeric representation of user local name. e.g. `mr_foo`.
 * `workspace_url` - URL of the current Databricks workspace.
+* `acl_principal_id` - identifier for use in [databricks_access_control_rule_set](../resources/access_control_rule_set.md), e.g. `users/mr.foo@example.com` if current user is user, or `servicePrincipals/00000000-0000-0000-0000-000000000000` if current user is service principal.
 
 ## Related Resources
 

--- a/docs/data-sources/group.md
+++ b/docs/data-sources/group.md
@@ -46,6 +46,7 @@ Data source exposes the following attributes:
 * `instance_profiles` - Set of [instance profile](../resources/instance_profile.md) ARNs, that can be modified by [databricks_group_instance_profile](../resources/group_instance_profile.md) resource.
 * `allow_cluster_create` - True if group members can create [clusters](../resources/cluster.md)
 * `allow_instance_pool_create` - True if group members can create [instance pools](../resources/instance_pool.md)
+* `acl_principal_id` - identifier for use in [databricks_access_control_rule_set](../resources/access_control_rule_set.md), e.g. `groups/Some Group`.
 
 
 ## Related Resources

--- a/docs/data-sources/service_principal.md
+++ b/docs/data-sources/service_principal.md
@@ -43,6 +43,7 @@ Data source exposes the following attributes:
 - `home` - Home folder of the [service principal](../resources/service_principal.md), e.g. `/Users/11111111-2222-3333-4444-555666777888`.
 - `repos` - Repos location of the [service principal](../resources/service_principal.md), e.g. `/Repos/11111111-2222-3333-4444-555666777888`.
 - `active` - Whether service principal is active or not.
+* `acl_principal_id` - identifier for use in [databricks_access_control_rule_set](../resources/access_control_rule_set.md), e.g. `servicePrincipals/00000000-0000-0000-0000-000000000000`.
 
 ## Related Resources
 

--- a/docs/data-sources/user.md
+++ b/docs/data-sources/user.md
@@ -45,6 +45,7 @@ Data source exposes the following attributes:
 - `home` - Home folder of the [user](../resources/user.md), e.g. `/Users/mr.foo@example.com`.
 - `repos` - Personal Repos location of the [user](../resources/user.md), e.g. `/Repos/mr.foo@example.com`.
 - `alphanumeric` - Alphanumeric representation of user local name. e.g. `mr_foo`.
+* `acl_principal_id` - identifier for use in [databricks_access_control_rule_set](../resources/access_control_rule_set.md), e.g. `users/mr.foo@example.com`.
 
 ## Related Resources
 

--- a/scim/data_current_user.go
+++ b/scim/data_current_user.go
@@ -41,6 +41,10 @@ func DataSourceCurrentUser() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"acl_principal_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 		ReadContext: func(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
 			c := m.(*common.DatabricksClient)
@@ -55,6 +59,11 @@ func DataSourceCurrentUser() *schema.Resource {
 			d.Set("user_name", me.UserName)
 			d.Set("home", fmt.Sprintf("/Users/%s", me.UserName))
 			d.Set("repos", fmt.Sprintf("/Repos/%s", me.UserName))
+			if strings.Contains(me.UserName, "@") {
+				d.Set("acl_principal_id", fmt.Sprintf("users/%s", me.UserName))
+			} else {
+				d.Set("acl_principal_id", fmt.Sprintf("servicePrincipals/%s", me.UserName))
+			}
 			d.Set("external_id", me.ExternalId)
 			splits := strings.Split(me.UserName, "@")
 			norm := nonAlphanumeric.ReplaceAllLiteralString(splits[0], "_")

--- a/scim/data_current_user_test.go
+++ b/scim/data_current_user_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestDataSourceCurrentUser(t *testing.T) {
+	userName := "mr.test@example.com"
 	d, err := qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
 			{
@@ -16,7 +17,7 @@ func TestDataSourceCurrentUser(t *testing.T) {
 				Resource: "/api/2.0/preview/scim/v2/Me",
 				Response: User{
 					ID:       "123",
-					UserName: "mr.test@example.com",
+					UserName: userName,
 				},
 			},
 		},
@@ -27,8 +28,35 @@ func TestDataSourceCurrentUser(t *testing.T) {
 	}.Apply(t)
 	require.NoError(t, err)
 	assert.Equal(t, "123", d.Id())
-	assert.Equal(t, d.Get("user_name"), "mr.test@example.com")
-	assert.Equal(t, d.Get("home"), "/Users/mr.test@example.com")
-	assert.Equal(t, d.Get("repos"), "/Repos/mr.test@example.com")
+	assert.Equal(t, d.Get("user_name"), userName)
+	assert.Equal(t, d.Get("home"), "/Users/"+userName)
+	assert.Equal(t, d.Get("repos"), "/Repos/"+userName)
+	assert.Equal(t, d.Get("acl_principal_id"), "users/"+userName)
 	assert.Equal(t, d.Get("alphanumeric"), "mr_test")
+}
+
+func TestDataSourceCurrentUserAsSP(t *testing.T) {
+	spId := "11111111-2222-3333-4444-555666777888"
+	d, err := qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "GET",
+				Resource: "/api/2.0/preview/scim/v2/Me",
+				Response: User{
+					ID:       "123",
+					UserName: spId,
+				},
+			},
+		},
+		Read:        true,
+		NonWritable: true,
+		Resource:    DataSourceCurrentUser(),
+		ID:          ".",
+	}.Apply(t)
+	require.NoError(t, err)
+	assert.Equal(t, "123", d.Id())
+	assert.Equal(t, d.Get("user_name"), spId)
+	assert.Equal(t, d.Get("home"), "/Users/"+spId)
+	assert.Equal(t, d.Get("repos"), "/Repos/"+spId)
+	assert.Equal(t, d.Get("acl_principal_id"), "servicePrincipals/"+spId)
 }

--- a/scim/data_group.go
+++ b/scim/data_group.go
@@ -2,6 +2,7 @@ package scim
 
 import (
 	"context"
+	"fmt"
 	"sort"
 	"strings"
 
@@ -23,6 +24,7 @@ func DataSourceGroup() *schema.Resource {
 		Groups            []string `json:"groups,omitempty" tf:"slice_set,computed"`
 		InstanceProfiles  []string `json:"instance_profiles,omitempty" tf:"slice_set,computed"`
 		ExternalID        string   `json:"external_id,omitempty" tf:"computed"`
+		AclPrincipalID    string   `json:"acl_principal_id,omitempty" tf:"computed"`
 	}
 
 	s := common.StructToSchema(entity{}, func(
@@ -79,6 +81,7 @@ func DataSourceGroup() *schema.Resource {
 				}
 			}
 			this.ExternalID = group.ExternalID
+			this.AclPrincipalID = fmt.Sprintf("groups/%s", group.DisplayName)
 			sort.Strings(this.Groups)
 			sort.Strings(this.Members)
 			sort.Strings(this.Users)

--- a/scim/data_group_test.go
+++ b/scim/data_group_test.go
@@ -91,6 +91,7 @@ func TestDataSourceGroup(t *testing.T) {
 	}.Apply(t)
 	require.NoError(t, err)
 	assert.Equal(t, "eerste", d.Id())
+	assert.Equal(t, d.Get("acl_principal_id"), "groups/ds")
 	assertContains(t, d.Get("instance_profiles"), "a")
 	assertContains(t, d.Get("instance_profiles"), "b")
 	assertContains(t, d.Get("members"), "1112")

--- a/scim/data_service_principal.go
+++ b/scim/data_service_principal.go
@@ -11,14 +11,15 @@ import (
 // DataSourceServicePrincipal returns information about the spn specified by the application_id
 func DataSourceServicePrincipal() *schema.Resource {
 	type spnData struct {
-		ApplicationID string `json:"application_id,omitempty" tf:"computed"`
-		DisplayName   string `json:"display_name,omitempty" tf:"computed"`
-		SpID          string `json:"sp_id,omitempty" tf:"computed"`
-		ID            string `json:"id,omitempty" tf:"computed"`
-		Home          string `json:"home,omitempty" tf:"computed"`
-		Repos         string `json:"repos,omitempty" tf:"computed"`
-		Active        bool   `json:"active,omitempty" tf:"computed"`
-		ExternalID    string `json:"external_id,omitempty" tf:"computed"`
+		ApplicationID  string `json:"application_id,omitempty" tf:"computed"`
+		DisplayName    string `json:"display_name,omitempty" tf:"computed"`
+		SpID           string `json:"sp_id,omitempty" tf:"computed"`
+		ID             string `json:"id,omitempty" tf:"computed"`
+		Home           string `json:"home,omitempty" tf:"computed"`
+		Repos          string `json:"repos,omitempty" tf:"computed"`
+		Active         bool   `json:"active,omitempty" tf:"computed"`
+		ExternalID     string `json:"external_id,omitempty" tf:"computed"`
+		AclPrincipalID string `json:"acl_principal_id,omitempty" tf:"computed"`
 	}
 	return common.DataResource(spnData{}, func(ctx context.Context, e any, c *common.DatabricksClient) error {
 		response := e.(*spnData)
@@ -34,6 +35,7 @@ func DataSourceServicePrincipal() *schema.Resource {
 		response.DisplayName = sp.DisplayName
 		response.Home = fmt.Sprintf("/Users/%s", sp.ApplicationID)
 		response.Repos = fmt.Sprintf("/Repos/%s", sp.ApplicationID)
+		response.AclPrincipalID = fmt.Sprintf("servicePrincipals/%s", sp.ApplicationID)
 		response.ExternalID = sp.ExternalID
 		response.Active = sp.Active
 		response.SpID = sp.ID

--- a/scim/data_service_principal_test.go
+++ b/scim/data_service_principal_test.go
@@ -41,13 +41,14 @@ func TestDataServicePrincipalReadByAppId(t *testing.T) {
 		NonWritable: true,
 		ID:          "abc",
 	}.ApplyAndExpectData(t, map[string]any{
-		"sp_id":          "abc",
-		"id":             "abc",
-		"application_id": "abc",
-		"display_name":   "Example Service Principal",
-		"active":         true,
-		"home":           "/Users/abc",
-		"repos":          "/Repos/abc",
+		"sp_id":            "abc",
+		"id":               "abc",
+		"application_id":   "abc",
+		"display_name":     "Example Service Principal",
+		"active":           true,
+		"home":             "/Users/abc",
+		"repos":            "/Repos/abc",
+		"acl_principal_id": "servicePrincipals/abc",
 	})
 }
 

--- a/scim/data_user.go
+++ b/scim/data_user.go
@@ -63,6 +63,10 @@ func DataSourceUser() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"acl_principal_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 		ReadContext: func(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
 			usersAPI := NewUsersAPI(ctx, m)
@@ -74,6 +78,7 @@ func DataSourceUser() *schema.Resource {
 			d.Set("display_name", user.DisplayName)
 			d.Set("home", fmt.Sprintf("/Users/%s", user.UserName))
 			d.Set("repos", fmt.Sprintf("/Repos/%s", user.UserName))
+			d.Set("acl_principal_id", fmt.Sprintf("users/%s", user.UserName))
 			d.Set("external_id", user.ExternalID)
 			d.Set("application_id", user.ApplicationID)
 			splits := strings.Split(user.UserName, "@")

--- a/scim/data_user_test.go
+++ b/scim/data_user_test.go
@@ -39,6 +39,7 @@ func TestDataSourceUser(t *testing.T) {
 	assert.Equal(t, "123", d.Id())
 	assert.Equal(t, d.Get("user_name"), "mr.test@example.com")
 	assert.Equal(t, d.Get("home"), "/Users/mr.test@example.com")
+	assert.Equal(t, d.Get("acl_principal_id"), "users/mr.test@example.com")
 	assert.Equal(t, d.Get("alphanumeric"), "mr_test")
 }
 


### PR DESCRIPTION

## Changes
<!-- Summary of your changes that are easy to understand -->

This is to have parity between resources & data sources


## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

