### PR TITLE
Added `gcp_attributes.local_ssd_count` to `databricks_instance_pool` resource

### DIFF
--- a/docs/resources/instance_pool.md
+++ b/docs/resources/instance_pool.md
@@ -70,7 +70,8 @@ The following options are [available](https://docs.microsoft.com/en-us/azure/dat
 
 The following options are [available](https://docs.gcp.databricks.com/dev-tools/api/latest/clusters.html#gcpavailability):
 
-* `availability` - (Optional) Availability type used for all nodes. Valid values are `PREEMPTIBLE_GCP`, `PREEMPTIBLE_WITH_FALLBACK_GCP` and `ON_DEMAND_GCP`, default: `ON_DEMAND_GCP`.
+* `gcp_availability` - (Optional) Availability type used for all nodes. Valid values are `PREEMPTIBLE_GCP`, `PREEMPTIBLE_WITH_FALLBACK_GCP` and `ON_DEMAND_GCP`, default: `ON_DEMAND_GCP`.
+* `local_ssd_count` (optional, int) Number of local SSD disks (each is 375GB in size) that will be attached to each node of the cluster. 
 
 
 ### disk_spec Configuration Block

--- a/pools/resource_instance_pool.go
+++ b/pools/resource_instance_pool.go
@@ -28,7 +28,8 @@ type InstancePoolAzureAttributes struct {
 // InstancePoolGcpAttributes contains aws attributes for GCP Databricks deployments for instance pools
 // https://docs.gcp.databricks.com/dev-tools/api/latest/instance-pools.html#instancepoolgcpattributes
 type InstancePoolGcpAttributes struct {
-	Availability clusters.Availability `json:"gcp_availability,omitempty" tf:"force_new"`
+	Availability  clusters.Availability `json:"gcp_availability,omitempty" tf:"force_new"`
+	LocalSsdCount int32                 `json:"local_ssd_count,omitempty"`
 }
 
 // InstancePoolDiskType contains disk type information for each of the different cloud service providers


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

Right now added it directly, will start migration to Go SDK soon

Also fixed error in documentation about `gcp_availability` attribute

This fixes #2557

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

