### PR TITLE
Document job_parameters support for run_job_task

### DIFF
--- a/docs/resources/job.md
+++ b/docs/resources/job.md
@@ -314,6 +314,7 @@ You also need to include a `git_source` block to configure the repository that c
 ### run_job_task Configuration Block
 
 * `job_id` - (Required)(String) ID of the job
+* `job_parameters` - (Optional)(Map) Job parameters for the task
 
 ### sql_task Configuration Block
 


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
Add `job_parameters` field to the docs to show support for `run_job_task`

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [x] using Go SDK

