### PR TITLE
Exporter: command-line option to control output format for notebooks

### DIFF
--- a/docs/guides/experimental-exporter.md
+++ b/docs/guides/experimental-exporter.md
@@ -47,6 +47,7 @@ All arguments are optional and they tune what code is being generated.
 * `-importAllUsers` - optionally include all users and service principals even if they only part of the `users` group.
 * `-incremental` - experimental option for incremental export of modified resources and merging with existing resources. *Please note that only limited set of resources (notebooks, SQL queries/dashboards/alerts, ...) provides information about last modified date - all other resources will be re-exported again! Also, it's not possible to detect deletion of the resources, so you will need to do periodic full export if resources are deleted!*   **Requires** `-updated-since` option if no `exporter-run-stats.json` file exists in the output directory.
 * `-updated-since` - timestamp (in ISO8601 format supported by Go language) for exporting of resources modified since a giving timestamp. I.e. `2023-07-24T00:00:00Z`. If not specified, exporter will try to load last run timestamp from the `exporter-run-stats.json` file generated during the export, and use it.
+* `-notebooksFormat` - optional format for exporting of notebooks. Supported values are `SOURCE` (default), `DBC`, `JUPYTER`.  This could be used to export of notebooks with embedded dashboards.
 
 ## Services
 

--- a/exporter/command.go
+++ b/exporter/command.go
@@ -110,6 +110,8 @@ func Run(args ...string) error {
 	flags.BoolVar(&ic.mounts, "mounts", false, "List DBFS mount points.")
 	flags.BoolVar(&ic.generateDeclaration, "generateProviderDeclaration", true,
 		"Generate Databricks provider declaration.")
+	flags.StringVar(&ic.notebooksFormat, "notebooksFormat", "SOURCE",
+		"Format to export notebooks: SOURCE, DBC, JUPYTER. Default: SOURCE")
 	services, listing := ic.allServicesAndListing()
 	flags.StringVar(&ic.services, "services", services,
 		"Comma-separated list of services to import. By default all services are imported.")

--- a/exporter/context.go
+++ b/exporter/context.go
@@ -91,6 +91,7 @@ type importContext struct {
 	prefix              string
 	accountLevel        bool
 	shImports           map[string]bool
+	notebooksFormat     string
 }
 
 type mount struct {
@@ -153,6 +154,7 @@ func newImportContext(c *common.DatabricksClient) *importContext {
 		allWorkspaceObjects: []workspace.ObjectStatus{},
 		workspaceConfKeys:   workspaceConfKeys,
 		shImports:           make(map[string]bool),
+		notebooksFormat:     "SOURCE",
 	}
 }
 
@@ -200,6 +202,12 @@ func (ic *importContext) Run() error {
 
 	log.Printf("[INFO] Importing %s module into %s directory Databricks resources of %s services",
 		ic.Module, ic.Directory, ic.services)
+
+	ic.notebooksFormat = strings.ToUpper(ic.notebooksFormat)
+	_, supportedFormat := fileExtensionFormatMapping[ic.notebooksFormat]
+	if !supportedFormat && ic.notebooksFormat != "SOURCE" {
+		return fmt.Errorf("unsupported notebook format: '%s'", ic.notebooksFormat)
+	}
 
 	info, err := os.Stat(ic.Directory)
 	if os.IsNotExist(err) {

--- a/exporter/importables_test.go
+++ b/exporter/importables_test.go
@@ -803,14 +803,64 @@ func TestNotebookGeneration(t *testing.T) {
 			},
 		},
 	}, "notebooks", func(ic *importContext) {
+		ic.notebooksFormat = "SOURCE"
 		err := resourcesMap["databricks_notebook"].List(ic)
 		assert.NoError(t, err)
-
 		ic.generateHclForResources(nil)
 		assert.Equal(t, commands.TrimLeadingWhitespace(`
 		resource "databricks_notebook" "first_second_123" {
 		  source = "${path.module}/notebooks/First/Second.py"
 		  path   = "/First/Second"
+		}`), string(ic.Files["notebooks"].Bytes()))
+	})
+}
+
+func TestNotebookGenerationJupyter(t *testing.T) {
+	testGenerate(t, []qa.HTTPFixture{
+		{
+			Method:   "GET",
+			Resource: "/api/2.0/workspace/list?path=%2F",
+			Response: workspace.ObjectList{
+				Objects: []workspace.ObjectStatus{
+					{
+						Path:       "/Repos/Foo/Bar",
+						ObjectType: "NOTEBOOK",
+					},
+					{
+						Path:       "/First/Second",
+						ObjectType: "NOTEBOOK",
+					},
+				},
+			},
+		},
+		{
+			Method:   "GET",
+			Resource: "/api/2.0/workspace/get-status?path=%2FFirst%2FSecond",
+			Response: workspace.ObjectStatus{
+				ObjectID:   123,
+				ObjectType: "NOTEBOOK",
+				Path:       "/First/Second",
+				Language:   "PYTHON",
+			},
+		},
+		{
+			Method:   "GET",
+			Resource: "/api/2.0/workspace/export?format=JUPYTER&path=%2FFirst%2FSecond",
+			Response: workspace.ExportPath{
+				Content: "YWJj",
+			},
+		},
+	}, "notebooks", func(ic *importContext) {
+		ic.notebooksFormat = "JUPYTER"
+		err := resourcesMap["databricks_notebook"].List(ic)
+		assert.NoError(t, err)
+		ic.generateHclForResources(nil)
+		assert.Equal(t, commands.TrimLeadingWhitespace(`
+		resource "databricks_notebook" "first_second_123" {
+		  source   = "${path.module}/notebooks/First/Second.ipynb"
+		  path     = "/First/Second"
+		  language = "PYTHON"
+		  format   = "JUPYTER"
 		}`), string(ic.Files["notebooks"].Bytes()))
 	})
 }

--- a/exporter/util.go
+++ b/exporter/util.go
@@ -630,6 +630,9 @@ func createListWorkspaceObjectsFunc(objType string, resourceType string, objName
 					modifiedAt, updatedSinceMs)
 				continue
 			}
+			if !ic.MatchesName(object.Path) {
+				continue
+			}
 			ic.Emit(&resource{
 				Resource:    resourceType,
 				ID:          object.Path,


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

New command-line option `-notebooksFormat` allows to export notebooks in DBC and IPython formats.

This fixes #2568

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

