### PR TITLE
Fixed databricks_access_control_rule_set integration test in Azure

### DIFF
--- a/internal/acceptance/account_rule_set_test.go
+++ b/internal/acceptance/account_rule_set_test.go
@@ -3,6 +3,7 @@ package acceptance
 import (
 	"context"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/databricks/databricks-sdk-go/service/iam"
@@ -14,7 +15,7 @@ import (
 
 // Application ID is mandatory in Azure today.
 func getServicePrincipalResource(cloudEnv string) string {
-	if cloudEnv == "azure" {
+	if strings.HasPrefix(cloudEnv, "azure") {
 		return `
 		resource "databricks_service_principal" "this" {
 			application_id = "{var.RANDOM_UUID}"
@@ -30,6 +31,7 @@ func getServicePrincipalResource(cloudEnv string) string {
 }
 
 func TestMwsAccAccountServicePrincipalRuleSetsFullLifeCycle(t *testing.T) {
+	loadDebugEnvIfRunsFromIDE(t, "account")
 	cloudEnv := os.Getenv("CLOUD_ENV")
 	spResource := getServicePrincipalResource(cloudEnv)
 	accountLevel(t, step{


### PR DESCRIPTION
## Changes
This PR makes two changes:
1. Use string prefix to match on the cloud environment rather than exact match. This fixes the underlying issue.
2. Load environment before calling `accountTest`. This allows users to debug this test from VS Code without needing to run it in CI.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [x] covered with integration tests in `internal/acceptance`
- [x] relevant acceptance tests are passing
- [ ] using Go SDK

