### PR TITLE
Add `owner` parameter to `databricks_share` resource

### DIFF
--- a/catalog/resource_share.go
+++ b/catalog/resource_share.go
@@ -27,6 +27,7 @@ const (
 
 type ShareInfo struct {
 	Name      string             `json:"name" tf:"force_new"`
+	Owner     string             `json:"owner,omitempty"`
 	Objects   []SharedDataObject `json:"objects,omitempty" tf:"alias:object"`
 	CreatedAt int64              `json:"created_at,omitempty" tf:"computed"`
 	CreatedBy string             `json:"created_by,omitempty" tf:"computed"`
@@ -52,6 +53,7 @@ type ShareDataChange struct {
 }
 
 type ShareUpdates struct {
+	Owner   string            `json:"owner,omitempty"`
 	Updates []ShareDataChange `json:"updates"`
 }
 
@@ -188,10 +190,11 @@ func ResourceShare() *schema.Resource {
 				return err
 			}
 
-			//can only create empty share, objects have to be added using update API
+			//can only create empty share, objects & owners have to be added using update API
 			var si ShareInfo
 			common.DataToStructPointer(d, shareSchema, &si)
 			shareChanges := si.shareChanges(ShareAdd)
+			shareChanges.Owner = si.Owner
 			if err := NewSharesAPI(ctx, c).update(si.Name, shareChanges); err != nil {
 				//delete orphaned share if update fails
 				if d_err := w.Shares.DeleteByName(ctx, si.Name); d_err != nil {
@@ -218,6 +221,7 @@ func ResourceShare() *schema.Resource {
 			common.DataToStructPointer(d, shareSchema, &afterSi)
 			changes := beforeSi.Diff(afterSi)
 			return NewSharesAPI(ctx, c).update(d.Id(), ShareUpdates{
+				Owner:   afterSi.Owner,
 				Updates: changes,
 			})
 		},

--- a/catalog/resource_share_test.go
+++ b/catalog/resource_share_test.go
@@ -193,6 +193,7 @@ func TestCreateShare(t *testing.T) {
 				Method:   "PATCH",
 				Resource: "/api/2.1/unity-catalog/shares/a",
 				ExpectedRequest: ShareUpdates{
+					Owner: "admin",
 					Updates: []ShareDataChange{
 						{
 							Action: "ADD",
@@ -220,7 +221,8 @@ func TestCreateShare(t *testing.T) {
 				Method:   "GET",
 				Resource: "/api/2.1/unity-catalog/shares/a?include_shared_data=true",
 				Response: ShareInfo{
-					Name: "a",
+					Name:  "a",
+					Owner: "admin",
 					Objects: []SharedDataObject{
 						{
 							Name:           "main.a",
@@ -239,7 +241,8 @@ func TestCreateShare(t *testing.T) {
 		Resource: ResourceShare(),
 		Create:   true,
 		HCL: `
-			name = "a"
+			name  = "a"
+			owner = "admin"
 			object {
 				name = "main.a"
 				comment = "c"
@@ -278,6 +281,7 @@ func TestUpdateShare(t *testing.T) {
 				Method:   "PATCH",
 				Resource: "/api/2.1/unity-catalog/shares/abc",
 				ExpectedRequest: ShareUpdates{
+					Owner: "admin",
 					Updates: []ShareDataChange{
 						{
 							Action: "REMOVE",
@@ -310,7 +314,8 @@ func TestUpdateShare(t *testing.T) {
 				Method:   "GET",
 				Resource: "/api/2.1/unity-catalog/shares/abc?include_shared_data=true",
 				Response: ShareInfo{
-					Name: "abc",
+					Name:  "abc",
+					Owner: "admin",
 					Objects: []SharedDataObject{
 						{
 							Name:           "a",
@@ -339,7 +344,8 @@ func TestUpdateShare(t *testing.T) {
 			"name": "abc",
 		},
 		HCL: `
-			name = "abc"
+			name  = "abc"
+			owner = "admin"
 			object {
 				name = "a"
 				comment = "c"

--- a/docs/resources/share.md
+++ b/docs/resources/share.md
@@ -72,6 +72,7 @@ The following arguments are required:
 ### object Configuration Block
 
 * `name` (Required) - Full name of the object, e.g. `catalog.schema.name` for a table.
+* `owner` - (Optional) User name/group name/sp application_id of the share owner.
 * `data_object_type` (Required) - Type of the object, currently only `TABLE` is allowed.
 * `comment` (Optional) -  Description about the object.
 * `shared_as` (Optional) - A user-provided new name for the data object within the share. If this new name is not provided, the object's original name will be used as the `shared_as` name. The `shared_as` name must be unique within a Share. Change forces creation of a new resource.

--- a/internal/acceptance/share_test.go
+++ b/internal/acceptance/share_test.go
@@ -57,7 +57,8 @@ func TestUcAccCreateShare(t *testing.T) {
 		}			
 		
 		resource "databricks_share" "myshare" {
-			name = "{var.RANDOM}-terraform-delta-share"
+			name  = "{var.RANDOM}-terraform-delta-share"
+			owner = "account users"
 			object {
 				name = databricks_table.mytable.id
 				comment = "c"


### PR DESCRIPTION
## Changes
- Add `owner` paramater to `databricks_share` resource
- Partially close #2587

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [x] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [x] using Go SDK

