### PR TITLE
Fixed verification of workspace reachability by using scim/me which is always available 

### DIFF
--- a/mws/resource_mws_workspaces.go
+++ b/mws/resource_mws_workspaces.go
@@ -100,7 +100,6 @@ type Workspace struct {
 	GkeConfig                           *GkeConfig               `json:"gke_config,omitempty" tf:"suppress_diff"`
 	Cloud                               string                   `json:"cloud,omitempty" tf:"computed"`
 	Location                            string                   `json:"location,omitempty"`
-	SkipWorkspaceReachability           bool                     `json:"workspace_reachability,omitempty"`
 }
 
 // this type alias hack is required for Marshaller to work without an infinite loop

--- a/mws/resource_mws_workspaces.go
+++ b/mws/resource_mws_workspaces.go
@@ -198,9 +198,9 @@ func (a WorkspacesAPI) verifyWorkspaceReachable(ws Workspace) *resource.RetryErr
 	if err != nil {
 		return resource.NonRetryableError(err)
 	}
-	// make a request to Tokens API, just to verify there are no errors
+	// make a request to scim/Me API, just to verify there are no errors
 	var response map[string]any
-	err = wsClient.Get(ctx, "/token/list", nil, &response)
+	err = wsClient.Get(ctx, "/scim/Me", nil, &response)
 	var apiError *apierr.APIError
 	if errors.As(err, &apiError) {
 		err = fmt.Errorf("workspace %s is not yet reachable: %s",
@@ -244,12 +244,7 @@ func (a WorkspacesAPI) WaitForRunning(ws Workspace, timeout time.Duration) error
 				// so we'll use it as unit testing shim
 				return nil
 			}
-			if ctx.VerifyWorkspaceReachable == true {
-				log.Printf("[INFO] Verifying workspace reachability")
-				return a.verifyWorkspaceReachable(workspace)
-			} else {
-				return nil
-			}
+			return a.verifyWorkspaceReachable(workspace)
 		case WorkspaceStatusCanceled, WorkspaceStatusFailed:
 			log.Printf("[ERROR] Cannot start workspace: %s", workspace.WorkspaceStatusMessage)
 			err = a.explainWorkspaceFailure(workspace)

--- a/mws/resource_mws_workspaces.go
+++ b/mws/resource_mws_workspaces.go
@@ -198,7 +198,7 @@ func (a WorkspacesAPI) verifyWorkspaceReachable(ws Workspace) *resource.RetryErr
 	if err != nil {
 		return resource.NonRetryableError(err)
 	}
-	// make a request to scim/Me API, just to verify there are no errors
+	// make a request to SCIM API, just to verify there are no errors
 	var response map[string]any
 	err = wsClient.Get(ctx, "/scim/Me", nil, &response)
 	var apiError *apierr.APIError

--- a/mws/resource_mws_workspaces.go
+++ b/mws/resource_mws_workspaces.go
@@ -244,7 +244,12 @@ func (a WorkspacesAPI) WaitForRunning(ws Workspace, timeout time.Duration) error
 				// so we'll use it as unit testing shim
 				return nil
 			}
-			return a.verifyWorkspaceReachable(workspace)
+			if ctx.VerifyWorkspaceReachable == true {
+				log.Printf("[INFO] Verifying workspace reachability")
+				return a.verifyWorkspaceReachable(workspace)
+			} else {
+				return nil
+			}
 		case WorkspaceStatusCanceled, WorkspaceStatusFailed:
 			log.Printf("[ERROR] Cannot start workspace: %s", workspace.WorkspaceStatusMessage)
 			err = a.explainWorkspaceFailure(workspace)

--- a/mws/resource_mws_workspaces.go
+++ b/mws/resource_mws_workspaces.go
@@ -100,6 +100,7 @@ type Workspace struct {
 	GkeConfig                           *GkeConfig               `json:"gke_config,omitempty" tf:"suppress_diff"`
 	Cloud                               string                   `json:"cloud,omitempty" tf:"computed"`
 	Location                            string                   `json:"location,omitempty"`
+	SkipWorkspaceReachability           bool                     `json:"workspace_reachability,omitempty"`
 }
 
 // this type alias hack is required for Marshaller to work without an infinite loop
@@ -200,7 +201,7 @@ func (a WorkspacesAPI) verifyWorkspaceReachable(ws Workspace) *resource.RetryErr
 	}
 	// make a request to SCIM API, just to verify there are no errors
 	var response map[string]any
-	err = wsClient.Get(ctx, "/scim/Me", nil, &response)
+	err = wsClient.Get(ctx, "/preview/scim/v2/Me", nil, &response)
 	var apiError *apierr.APIError
 	if errors.As(err, &apiError) {
 		err = fmt.Errorf("workspace %s is not yet reachable: %s",

--- a/mws/resource_mws_workspaces_test.go
+++ b/mws/resource_mws_workspaces_test.go
@@ -1069,7 +1069,7 @@ func TestWorkspace_WaitForResolve(t *testing.T) {
 	})
 }
 
-func updateWorkspaceTokenFixture(t *testing.T, fixtures []qa.HTTPFixture, state map[string]string, hcl string) {
+func updateWorkspaceScimFixture(t *testing.T, fixtures []qa.HTTPFixture, state map[string]string, hcl string) {
 	accountsAPI := []qa.HTTPFixture{
 		{
 			Method:       "GET",
@@ -1077,16 +1077,16 @@ func updateWorkspaceTokenFixture(t *testing.T, fixtures []qa.HTTPFixture, state 
 			Resource:     "/api/2.0/accounts/c/workspaces/0",
 		},
 	}
-	tokensAPI := []qa.HTTPFixture{
+	scimAPI := []qa.HTTPFixture{
 		{
 			Method:   "GET",
-			Resource: "/api/2.0/token/list",
+			Resource: "/api/2.0/preview/scim/v2/Me",
 			Response: `{}`, // we just need a JSON for this
 		},
 	}
-	tokensAPI = append(tokensAPI, fixtures...)
+	scimAPI = append(scimAPI, fixtures...)
 	// outer HTTP server is used for inner request for "just created" workspace
-	qa.HTTPFixturesApply(t, tokensAPI, func(ctx context.Context, wsClient *common.DatabricksClient) {
+	qa.HTTPFixturesApply(t, scimAPI, func(ctx context.Context, wsClient *common.DatabricksClient) {
 		// a bit hacky, but the whole thing is more readable
 		accountsAPI[0].Response = Workspace{
 			WorkspaceStatus: "RUNNING",
@@ -1111,7 +1111,7 @@ func updateWorkspaceTokenFixture(t *testing.T, fixtures []qa.HTTPFixture, state 
 	})
 }
 
-func updateWorkspaceTokenFixtureWithPatch(t *testing.T, fixtures []qa.HTTPFixture, state map[string]string, hcl string) {
+func updateWorkspaceScimFixtureWithPatch(t *testing.T, fixtures []qa.HTTPFixture, state map[string]string, hcl string) {
 	accountsAPI := []qa.HTTPFixture{
 		{
 			Method:   "PATCH",
@@ -1158,7 +1158,7 @@ func updateWorkspaceTokenFixtureWithPatch(t *testing.T, fixtures []qa.HTTPFixtur
 }
 
 func TestUpdateWorkspace_AddToken(t *testing.T) {
-	updateWorkspaceTokenFixture(t, []qa.HTTPFixture{
+	updateWorkspaceScimFixture(t, []qa.HTTPFixture{
 		{
 			Method:   "POST",
 			Resource: "/api/2.0/token/create",
@@ -1179,7 +1179,7 @@ func TestUpdateWorkspace_AddToken(t *testing.T) {
 }
 
 func TestUpdateWorkspace_AddTokenAndChangeNetworkId(t *testing.T) {
-	updateWorkspaceTokenFixtureWithPatch(t, []qa.HTTPFixture{
+	updateWorkspaceScimFixtureWithPatch(t, []qa.HTTPFixture{
 		{
 			Method:   "POST",
 			Resource: "/api/2.0/token/create",
@@ -1204,7 +1204,7 @@ func TestUpdateWorkspace_AddTokenAndChangeNetworkId(t *testing.T) {
 }
 
 func TestUpdateWorkspace_DeleteTokenAndChangeNetworkId(t *testing.T) {
-	updateWorkspaceTokenFixtureWithPatch(t, []qa.HTTPFixture{
+	updateWorkspaceScimFixtureWithPatch(t, []qa.HTTPFixture{
 		{
 			Method:   "POST",
 			Resource: "/api/2.0/token/delete",
@@ -1226,7 +1226,7 @@ func TestUpdateWorkspace_DeleteTokenAndChangeNetworkId(t *testing.T) {
 }
 
 func TestUpdateWorkspace_DeleteToken(t *testing.T) {
-	updateWorkspaceTokenFixture(t, []qa.HTTPFixture{
+	updateWorkspaceScimFixture(t, []qa.HTTPFixture{
 		{
 			Method:   "POST",
 			Resource: "/api/2.0/token/delete",
@@ -1244,7 +1244,7 @@ func TestUpdateWorkspace_DeleteToken(t *testing.T) {
 }
 
 func TestUpdateWorkspace_ReplaceTokenAndChangeNetworkId(t *testing.T) {
-	updateWorkspaceTokenFixtureWithPatch(t, []qa.HTTPFixture{
+	updateWorkspaceScimFixtureWithPatch(t, []qa.HTTPFixture{
 		{
 			Method:   "POST",
 			Resource: "/api/2.0/token/delete",
@@ -1282,7 +1282,7 @@ func TestUpdateWorkspace_ReplaceTokenAndChangeNetworkId(t *testing.T) {
 }
 
 func TestUpdateWorkspace_ReplaceToken(t *testing.T) {
-	updateWorkspaceTokenFixture(t, []qa.HTTPFixture{
+	updateWorkspaceScimFixture(t, []qa.HTTPFixture{
 		{
 			Method:   "POST",
 			Resource: "/api/2.0/token/delete",

--- a/mws/resource_mws_workspaces_test.go
+++ b/mws/resource_mws_workspaces_test.go
@@ -1123,16 +1123,16 @@ func updateWorkspaceTokenFixtureWithPatch(t *testing.T, fixtures []qa.HTTPFixtur
 			Resource:     "/api/2.0/accounts/c/workspaces/0",
 		},
 	}
-	tokensAPI := []qa.HTTPFixture{
+	scimAPI := []qa.HTTPFixture{
 		{
 			Method:   "GET",
-			Resource: "/api/2.0/token/list",
+			Resource: "/api/2.0/preview/scim/v2/Me",
 			Response: `{}`, // we just need a JSON for this
 		},
 	}
-	tokensAPI = append(tokensAPI, fixtures...)
+	scimAPI = append(scimAPI, fixtures...)
 	// outer HTTP server is used for inner request for "just created" workspace
-	qa.HTTPFixturesApply(t, tokensAPI, func(ctx context.Context, wsClient *common.DatabricksClient) {
+	qa.HTTPFixturesApply(t, scimAPI, func(ctx context.Context, wsClient *common.DatabricksClient) {
 		// a bit hacky, but the whole thing is more readable
 		accountsAPI[1].Response = Workspace{
 			WorkspaceStatus: "RUNNING",
@@ -1172,11 +1172,6 @@ func TestUpdateWorkspace_AddToken(t *testing.T) {
 					TokenID: "abcdef",
 				},
 			},
-		},
-		{
-			Method:   "GET",
-			Resource: "/api/2.0/preview/scim/v2/Me",
-			Response: `{}`, // we just need a JSON for this
 		},
 	}, map[string]string{
 		// no token in state

--- a/mws/resource_mws_workspaces_test.go
+++ b/mws/resource_mws_workspaces_test.go
@@ -1173,6 +1173,11 @@ func TestUpdateWorkspace_AddToken(t *testing.T) {
 				},
 			},
 		},
+		{
+			Method:   "GET",
+			Resource: "/api/2.0/preview/scim/v2/Me",
+			Response: `{}`, // we just need a JSON for this
+		},
 	}, map[string]string{
 		// no token in state
 	}, `token {}`)

--- a/mws/resource_mws_workspaces_test.go
+++ b/mws/resource_mws_workspaces_test.go
@@ -1041,7 +1041,7 @@ func TestWorkspace_WaitForResolve(t *testing.T) {
 	qa.HTTPFixturesApply(t, []qa.HTTPFixture{
 		{
 			Method:   "GET",
-			Resource: "/api/2.0/token/list",
+			Resource: "/api/2.0/preview/scim/v2/Me",
 			Response: `{}`, // we just need a JSON for this
 		},
 	}, func(ctx context.Context, wsClient *common.DatabricksClient) {

--- a/provider/gen/main.go
+++ b/provider/gen/main.go
@@ -21,7 +21,6 @@ func main() {
 	flag.StringVar(&ctx.DocCategory, "category", "Other", "documentation category")
 	flag.BoolVar(&ctx.DataSource, "is-data", false, "is this a data resource")
 	flag.BoolVar(&ctx.DryRun, "dry-run", true, "print to stdout instead of real files")
-	flag.BoolVar(&ctx.VerifyWorkspaceReachable, "verify-workspace-reachability", true, "verify if workspace is reachable")
 
 	flag.Parse()
 
@@ -39,13 +38,12 @@ func main() {
 }
 
 type Context struct {
-	Package                  string
-	Name                     string
-	DocCategory              string
-	DataSource               bool
-	DryRun                   bool
-	BT                       string
-	VerifyWorkspaceReachable bool
+	Package     string
+	Name        string
+	DocCategory string
+	DataSource  bool
+	DryRun      bool
+	BT          string
 
 	tmpl *template.Template
 }

--- a/provider/gen/main.go
+++ b/provider/gen/main.go
@@ -21,6 +21,7 @@ func main() {
 	flag.StringVar(&ctx.DocCategory, "category", "Other", "documentation category")
 	flag.BoolVar(&ctx.DataSource, "is-data", false, "is this a data resource")
 	flag.BoolVar(&ctx.DryRun, "dry-run", true, "print to stdout instead of real files")
+	flag.BoolVar(&ctx.VerifyWorkspaceReachable, "verify-reachability", true, "verify if workspace is reachable")
 
 	flag.Parse()
 
@@ -38,12 +39,13 @@ func main() {
 }
 
 type Context struct {
-	Package     string
-	Name        string
-	DocCategory string
-	DataSource  bool
-	DryRun      bool
-	BT          string
+	Package                  string
+	Name                     string
+	DocCategory              string
+	DataSource               bool
+	DryRun                   bool
+	BT                       string
+	VerifyWorkspaceReachable bool
 
 	tmpl *template.Template
 }

--- a/provider/gen/main.go
+++ b/provider/gen/main.go
@@ -21,7 +21,7 @@ func main() {
 	flag.StringVar(&ctx.DocCategory, "category", "Other", "documentation category")
 	flag.BoolVar(&ctx.DataSource, "is-data", false, "is this a data resource")
 	flag.BoolVar(&ctx.DryRun, "dry-run", true, "print to stdout instead of real files")
-	flag.BoolVar(&ctx.VerifyWorkspaceReachable, "verify-reachability", true, "verify if workspace is reachable")
+	flag.BoolVar(&ctx.VerifyWorkspaceReachable, "verify-workspace-reachability", true, "verify if workspace is reachable")
 
 	flag.Parse()
 


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
For PAT token, workspace verification fails if workspace is not configured to allows tokens. This happens because we use `token/list`

To fix this, we use SCIM API that is always available.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->
Before change the terraform apply doesn't work on the below repro and leads to `provider.terraform-provider-databricks: workspace https:/<test-name>.cloud.databricks.com/ is not yet reachable: Tokens are disabled.`

After change terraform apply is successful.

Repro:
1. Created mws workspace with username and password
2.  enabled pat tokens with "enableTokensConfig" = "true" in databricks_workspace_conf resource
3. run terraform apply --> successful 
4. disable pat token in step 2
5. run terraform apply --> fail 

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

