### PR TITLE
Detect run_as drift in job resource

### DIFF
--- a/jobs/resource_job.go
+++ b/jobs/resource_job.go
@@ -574,6 +574,21 @@ func (a JobsAPI) Read(id string) (job Job, err error) {
 		job.Settings.sortTasksByKey()
 		job.Settings.sortWebhooksByID()
 	}
+
+	if job.RunAsUserName != "" && job.Settings != nil {
+		userNameIsEmail := strings.Contains(job.RunAsUserName, "@")
+
+		if userNameIsEmail {
+			job.Settings.RunAs = &JobRunAs{
+				UserName: job.RunAsUserName,
+			}
+		} else {
+			job.Settings.RunAs = &JobRunAs{
+				UserName: job.RunAsUserName,
+			}
+		}
+	}
+
 	return
 }
 

--- a/jobs/resource_job_test.go
+++ b/jobs/resource_job_test.go
@@ -87,6 +87,9 @@ func TestResourceJobCreate(t *testing.T) {
 							PauseStatus:          "PAUSED",
 						},
 						Queue: &Queue{},
+						RunAs: &JobRunAs{
+							UserName: "user@mail.com",
+						},
 					},
 				},
 			},


### PR DESCRIPTION
## Changes
run_as field in jobs is asymmetric: it's JobSettings.RunAs in create/update requests and RunAsUserName in read requests. As a result, when the job drifts, terraform can't detect the drift. To fix that, adjust the Read function in terraform to fill in the RunAs struct based on the RunAsUsername field.

## Tests
Tested locally E2E

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

