### PR TITLE
Add doc strings for ResourceFixtures

### DIFF
--- a/qa/testing.go
+++ b/qa/testing.go
@@ -67,42 +67,42 @@ type HTTPFixture struct {
 	MatchAny        bool
 }
 
-// ResourceFixture is a helper to unit test terraform resources. It does this by 
+// ResourceFixture is a helper to unit test terraform resources. It does this by
 // creating a mock Databricks server and client.
 type ResourceFixture struct {
 	// A list of HTTP fixtures representing requests are their corresponding
 	// responses. These are loaded into the mock Databricks server.
-	Fixtures      []HTTPFixture
+	Fixtures []HTTPFixture
 
-	// The resource the unit test is testing. 
-	Resource      *schema.Resource
+	// The resource the unit test is testing.
+	Resource *schema.Resource
 
 	// Set to true if the diff generated in the test will force a recreation
 	// of the resource.
-	RequiresNew   bool
+	RequiresNew bool
 
 	// Existing state of the resource, equivalent to the state stored in a terraform
 	// state file.
 	InstanceState map[string]string
 
-	// Configuration for the resource, equivalent to the configuration a user 
+	// Configuration for the resource, equivalent to the configuration a user
 	// defines in a .tf file
-	State         map[string]any
+	State map[string]any
 
-	// Alternative to State. Allows defining the resource configuration in HCL 
+	// Alternative to State. Allows defining the resource configuration in HCL
 	// which is decoded into a map. Only use one of HCL or State.
-	HCL         string
+	HCL string
 
 	// Mocks the Databricks Command Execution API. This mock is loaded at the client
 	// level so any command execution API requests are not sent to the server.
 	CommandMock common.CommandMock
 
-	// Set one of them to true to test the corresponding CRUD function for the 
+	// Set one of them to true to test the corresponding CRUD function for the
 	// terraform resource.
-	Create      bool
-	Read        bool
-	Update      bool
-	Delete      bool
+	Create bool
+	Read   bool
+	Update bool
+	Delete bool
 
 	Removed     bool
 	ID          string

--- a/qa/testing.go
+++ b/qa/testing.go
@@ -70,7 +70,7 @@ type HTTPFixture struct {
 // ResourceFixture is a helper to unit test terraform resources. It does this by
 // creating a mock Databricks server and client.
 type ResourceFixture struct {
-	// A list of HTTP fixtures representing requests are their corresponding
+	// A list of HTTP fixtures representing requests and their corresponding
 	// responses. These are loaded into the mock Databricks server.
 	Fixtures []HTTPFixture
 

--- a/qa/testing.go
+++ b/qa/testing.go
@@ -67,20 +67,43 @@ type HTTPFixture struct {
 	MatchAny        bool
 }
 
-// ResourceFixture helps testing resources and commands
+// ResourceFixture is a helper to unit test terraform resources. It does this by 
+// creating a mock Databricks server and client.
 type ResourceFixture struct {
+	// A list of HTTP fixtures representing requests are their corresponding
+	// responses. These are loaded into the mock Databricks server.
 	Fixtures      []HTTPFixture
+
+	// The resource the unit test is testing. 
 	Resource      *schema.Resource
+
+	// Set to true if the diff generated in the test will force a recreation
+	// of the resource.
 	RequiresNew   bool
+
+	// Existing state of the resource, equivalent to the state stored in a terraform
+	// state file.
 	InstanceState map[string]string
+
+	// Configuration for the resource, equivalent to the configuration a user 
+	// defines in a .tf file
 	State         map[string]any
-	// HCL might be useful to test nested blocks
+
+	// Alternative to State. Allows defining the resource configuration in HCL 
+	// which is decoded into a map. Only use one of HCL or State.
 	HCL         string
+
+	// Mocks the Databricks Command Execution API. This mock is loaded at the client
+	// level so any command execution API requests are not sent to the server.
 	CommandMock common.CommandMock
+
+	// Set one of them to true to test the corresponding CRUD function for the 
+	// terraform resource.
 	Create      bool
 	Read        bool
 	Update      bool
 	Delete      bool
+
 	Removed     bool
 	ID          string
 	NonWritable bool

--- a/qa/testing.go
+++ b/qa/testing.go
@@ -86,7 +86,7 @@ type ResourceFixture struct {
 	InstanceState map[string]string
 
 	// Configuration for the resource, equivalent to the configuration a user
-	// defines in a .tf file
+	// defines in a .tf file. Only use one of HCL or State.
 	State map[string]any
 
 	// Alternative to State. Allows defining the resource configuration in HCL


### PR DESCRIPTION
## Changes
The resource fixture struct is important for unit testing and forms a part of our SDK to create new terraform resources. This PR adds some relevant comments to help understanding our testing framework easier.

## Tests
No need for testing.
