### PR TITLE
correct `force_new` attributes for `databricks_schema` and `databricks_volume`

### DIFF
--- a/catalog/resource_schema.go
+++ b/catalog/resource_schema.go
@@ -11,7 +11,7 @@ import (
 
 type SchemaInfo struct {
 	Name        string            `json:"name" tf:"force_new"`
-	CatalogName string            `json:"catalog_name"`
+	CatalogName string            `json:"catalog_name" tf:"force_new"`
 	StorageRoot string            `json:"storage_root,omitempty" tf:"force_new"`
 	Comment     string            `json:"comment,omitempty"`
 	Properties  map[string]string `json:"properties,omitempty"`

--- a/catalog/resource_schema_test.go
+++ b/catalog/resource_schema_test.go
@@ -121,6 +121,7 @@ func TestUpdateSchema(t *testing.T) {
 				Resource: "/api/2.1/unity-catalog/schemas/b.a?",
 				Response: catalog.SchemaInfo{
 					Name:        "a",
+					CatalogName: "b",
 					MetastoreId: "d",
 					Comment:     "c",
 					Owner:       "administrators",

--- a/catalog/resource_schema_test.go
+++ b/catalog/resource_schema_test.go
@@ -145,6 +145,53 @@ func TestUpdateSchema(t *testing.T) {
 	}.ApplyNoError(t)
 }
 
+func TestUpdateSchemaForceNew(t *testing.T) {
+	qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "PATCH",
+				Resource: "/api/2.1/unity-catalog/schemas/b.a",
+				ExpectedRequest: catalog.UpdateSchema{
+					Owner:   "administrators",
+					Name:    "a",
+					Comment: "c",
+				},
+				Response: catalog.SchemaInfo{
+					FullName: "b.a",
+					Comment:  "c",
+					Owner:    "administrators",
+				},
+			},
+			{
+				Method:   "GET",
+				Resource: "/api/2.1/unity-catalog/schemas/b.a?",
+				Response: catalog.SchemaInfo{
+					Name:        "a",
+					MetastoreId: "d",
+					Comment:     "c",
+					Owner:       "administrators",
+				},
+			},
+		},
+		RequiresNew: true,
+		Resource:    ResourceSchema(),
+		Update:      true,
+		ID:          "b.a",
+		InstanceState: map[string]string{
+			"metastore_id": "d",
+			"name":         "a",
+			"catalog_name": "b",
+			"comment":      "c",
+		},
+		HCL: `
+		name = "a"
+		catalog_name = "x"
+		comment = "c"
+		owner = "administrators"
+		`,
+	}.ApplyNoError(t)
+}
+
 func TestDeleteSchema(t *testing.T) {
 	qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{

--- a/catalog/resource_volume.go
+++ b/catalog/resource_volume.go
@@ -13,11 +13,11 @@ import (
 // We also need to annotate tf:"computed" for the Owner field.
 type VolumeInfo struct {
 	// The name of the catalog where the schema and the volume are
-	CatalogName string `json:"catalog_name"`
+	CatalogName string `json:"catalog_name" tf:"force_new"`
 	// The comment attached to the volume
 	Comment string `json:"comment,omitempty"`
 	// The name of the schema where the volume is
-	SchemaName  string `json:"schema_name"`
+	SchemaName  string `json:"schema_name" tf:"force_new"`
 	FullNameArg string `json:"-" url:"-"`
 	// The name of the volume
 	Name string `json:"name"`

--- a/catalog/resource_volume_test.go
+++ b/catalog/resource_volume_test.go
@@ -329,7 +329,11 @@ func TestVolumesUpdate(t *testing.T) {
 		},
 		Resource: ResourceVolume(),
 		Update:   true,
-		ID:       "testCatalogName.testSchemaName.testName",
+		InstanceState: map[string]string{
+			"catalog_name": "testCatalogName",
+			"schema_name":  "testSchemaName",
+		},
+		ID: "testCatalogName.testSchemaName.testName",
 		HCL: `
 		name = "testNameNew"
 		volume_type = "testVolumeType"

--- a/catalog/resource_volume_test.go
+++ b/catalog/resource_volume_test.go
@@ -427,7 +427,11 @@ func TestVolumeUpdate_Error(t *testing.T) {
 		},
 		Resource: ResourceVolume(),
 		Update:   true,
-		ID:       "testCatalogName.testSchemaName.testName",
+		InstanceState: map[string]string{
+			"catalog_name": "testCatalogName",
+			"schema_name":  "testSchemaName",
+		},
+		ID: "testCatalogName.testSchemaName.testName",
 		HCL: `
 		name = "testNameNew"
 		volume_type = "testVolumeType"

--- a/catalog/resource_volume_test.go
+++ b/catalog/resource_volume_test.go
@@ -347,6 +347,62 @@ func TestVolumesUpdate(t *testing.T) {
 	assert.Equal(t, "This is a new test comment.", d.Get("comment"))
 }
 
+func TestVolumesUpdateForceNew(t *testing.T) {
+	d, err := qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   http.MethodGet,
+				Resource: "/api/2.1/unity-catalog/volumes/testCatalogNameNew.testSchemaName.testName?",
+				Response: catalog.VolumeInfo{
+					Name:        "testNameNew",
+					VolumeType:  catalog.VolumeType("testVolumeType"),
+					CatalogName: "testCatalogNameNew",
+					SchemaName:  "testSchemaName",
+					Comment:     "This is a new test comment.",
+					FullName:    "testCatalogName.testSchemaName.testNameNew",
+					Owner:       "testOwnerNew",
+				},
+			},
+			{
+				Method:   http.MethodPatch,
+				Resource: "/api/2.1/unity-catalog/volumes/testCatalogName.testSchemaName.testName",
+				ExpectedRequest: catalog.UpdateVolumeRequestContent{
+					Name:    "testNameNew",
+					Comment: "This is a new test comment.",
+					Owner:   "testOwnerNew",
+				},
+				Response: catalog.VolumeInfo{
+					Name:        "testNameNew",
+					VolumeType:  catalog.VolumeType("testVolumeType"),
+					CatalogName: "testCatalogNameNew",
+					SchemaName:  "testSchemaName",
+					Comment:     "This is a new test comment.",
+					FullName:    "testCatalogNameNew.testSchemaName.testName",
+					Owner:       "testOwnerNew",
+				},
+			},
+		},
+		Resource:    ResourceVolume(),
+		RequiresNew: true,
+		Update:      true,
+		ID:          "testCatalogName.testSchemaName.testName",
+		HCL: `
+		name = "testNameNew"
+		volume_type = "testVolumeType"
+		catalog_name = "testCatalogNameNew"
+		schema_name = "testSchemaName"
+		comment = "This is a new test comment."
+		owner = "testOwnerNew"
+		`,
+	}.Apply(t)
+	assert.NoError(t, err)
+	assert.Equal(t, "testNameNew", d.Get("name"))
+	assert.Equal(t, "testVolumeType", d.Get("volume_type"))
+	assert.Equal(t, "testCatalogNameNew", d.Get("catalog_name"))
+	assert.Equal(t, "testSchemaName", d.Get("schema_name"))
+	assert.Equal(t, "This is a new test comment.", d.Get("comment"))
+}
+
 func TestVolumeUpdate_Error(t *testing.T) {
 	_, err := qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{

--- a/docs/resources/schema.md
+++ b/docs/resources/schema.md
@@ -34,7 +34,7 @@ resource "databricks_schema" "things" {
 The following arguments are required:
 
 * `name` - Name of Schema relative to parent catalog. Change forces creation of a new resource.
-* `catalog_name` - Name of parent catalog
+* `catalog_name` - Name of parent catalog. Change forces creation of a new resource.
 * `storage_root` - (Optional) Managed location of the schema. Location in cloud storage where data for managed tables will be stored. If not specified, the location will default to the metastore root location. Change forces creation of a new resource.
 * `owner` - (Optional) Username/groupname/sp application_id of the schema owner.
 * `comment` - (Optional) User-supplied free-form text.
@@ -46,7 +46,7 @@ The following arguments are required:
 This resource can be imported by its full name:
 
 ```bash
-$ terraform import databricks_schema.this <catalog_name>.<name>
+terraform import databricks_schema.this <catalog_name>.<name>
 ```
 
 ## Related Resources

--- a/docs/resources/volume.md
+++ b/docs/resources/volume.md
@@ -80,8 +80,8 @@ resource "databricks_volume" "this" {
 The following arguments are supported:
 
 * `name` - Name of the Volume
-* `catalog_name` - Name of parent Catalog
-* `schema_name` - Name of parent Schema relative to parent Catalog
+* `catalog_name` - Name of parent Catalog. Change forces creation of a new resource.
+* `schema_name` - Name of parent Schema relative to parent Catalog. Change forces creation of a new resource.
 * `volume_type` - Volume type. `EXTERNAL` or `MANAGED`.
 * `owner` - (Optional) Name of the volume owner.
 * `storage_location` - (Optional) Path inside an External Location. Only used for `EXTERNAL` Volumes.


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
- Changing parent catalog name force creation of a new `databricks_schema`
- Changing parent catalog & schema name force creation of a new `databricks_volume`

Close #2246

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [x] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [x] using Go SDK

