### PR TITLE
updated share and recipient docs; terrafmt

### DIFF
--- a/docs/data-sources/aws_bucket_policy.md
+++ b/docs/data-sources/aws_bucket_policy.md
@@ -28,8 +28,8 @@ Bucket policy with full access:
 
 ```hcl
 resource "aws_s3_bucket" "ds" {
-  bucket = "${var.prefix}-ds"
-  acl    = "private"
+  bucket        = "${var.prefix}-ds"
+  acl           = "private"
   force_destroy = true
   tags = merge(var.tags, {
     Name = "${var.prefix}-ds"

--- a/docs/guides/aws-workspace.md
+++ b/docs/guides/aws-workspace.md
@@ -202,8 +202,8 @@ Once [VPC](#vpc) is ready, create AWS S3 bucket for DBFS workspace storage, whic
 
 ```hcl
 resource "aws_s3_bucket" "root_storage_bucket" {
-  bucket = "${local.prefix}-rootbucket"
-  acl    = "private"
+  bucket        = "${local.prefix}-rootbucket"
+  acl           = "private"
   force_destroy = true
   tags = merge(var.tags, {
     Name = "${local.prefix}-rootbucket"

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -144,7 +144,7 @@ resource "databricks_grants" "catalog_grants" {
   catalog = databricks_catalog.catalog_raw.name
 
   dynamic "grant" {
-    for_each = local.groups    
+    for_each = local.groups
     content {
       principal  = grant.value
       privileges = ["ALL_PRIVILEGES"]

--- a/docs/guides/unity-catalog-azure.md
+++ b/docs/guides/unity-catalog-azure.md
@@ -130,17 +130,17 @@ A [databricks_metastore](../resources/metastore.md) is the top level container f
 
 ```hcl
 resource "databricks_metastore" "this" {
-  provider  = databricks.accounts
-  name = "primary"
+  provider = databricks.accounts
+  name     = "primary"
   storage_root = format("abfss://%s@%s.dfs.core.windows.net/",
     azurerm_storage_container.unity_catalog.name,
   azurerm_storage_account.unity_catalog.name)
   force_destroy = true
-  region = data.azurerm_resource_group.this.location
+  region        = data.azurerm_resource_group.this.location
 }
 
 resource "databricks_metastore_data_access" "first" {
-  provider  = databricks.accounts
+  provider     = databricks.accounts
   metastore_id = databricks_metastore.this.id
   name         = "the-keys"
   azure_managed_identity {

--- a/docs/guides/unity-catalog-gcp.md
+++ b/docs/guides/unity-catalog-gcp.md
@@ -128,7 +128,7 @@ resource "google_storage_bucket_iam_member" "unity_sa_reader" {
 }
 
 resource "databricks_metastore_assignment" "this" {
-   provider            = databricks.accounts
+  provider             = databricks.accounts
   workspace_id         = var.databricks_workspace_id
   metastore_id         = databricks_metastore.this.id
   default_catalog_name = "hive_metastore"

--- a/docs/guides/unity-catalog.md
+++ b/docs/guides/unity-catalog.md
@@ -136,8 +136,8 @@ The first step is to create the required AWS objects:
 
 ```hcl
 resource "aws_s3_bucket" "metastore" {
-  bucket = "${local.prefix}-metastore"
-  acl    = "private"
+  bucket        = "${local.prefix}-metastore"
+  acl           = "private"
   force_destroy = true
   tags = merge(local.tags, {
     Name = "${local.prefix}-metastore"

--- a/docs/resources/external_location.md
+++ b/docs/resources/external_location.md
@@ -96,7 +96,7 @@ Example `encryption_details` specifying SSE_S3 encryption:
 ```hcl
 encryption_details {
   sse_encryption_details {
-    algorithm     = "AWS_SSE_S3"
+    algorithm = "AWS_SSE_S3"
   }
 }
 ```
@@ -106,7 +106,7 @@ Example `encryption_details` specifying SSE_KMS encryption with KMS key that has
 ```hcl
 encryption_details {
   sse_encryption_details {
-    algorithm     = "AWS_SSE_KMS"
+    algorithm       = "AWS_SSE_KMS"
     aws_kms_key_arn = "some_key_arn"
   }
 }

--- a/docs/resources/mws_customer_managed_keys.md
+++ b/docs/resources/mws_customer_managed_keys.md
@@ -92,7 +92,7 @@ variable "cmek_resource_id" {
 resource "databricks_mws_customer_managed_keys" "managed_services" {
   account_id = var.databricks_account_id
   gcp_key_info {
-    kms_key_id   = var.cmek_resource_id
+    kms_key_id = var.cmek_resource_id
   }
   use_cases = ["MANAGED_SERVICES"]
 }
@@ -215,7 +215,7 @@ variable "cmek_resource_id" {
 resource "databricks_mws_customer_managed_keys" "storage" {
   account_id = var.databricks_account_id
   gcp_key_info {
-    kms_key_id   = var.cmek_resource_id
+    kms_key_id = var.cmek_resource_id
   }
   use_cases = ["STORAGE"]
 }

--- a/docs/resources/mws_log_delivery.md
+++ b/docs/resources/mws_log_delivery.md
@@ -21,8 +21,8 @@ variable "databricks_account_id" {
 }
 
 resource "aws_s3_bucket" "logdelivery" {
-  bucket = "${var.prefix}-logdelivery"
-  acl    = "private"
+  bucket        = "${var.prefix}-logdelivery"
+  acl           = "private"
   force_destroy = true
   tags = merge(var.tags, {
     Name = "${var.prefix}-logdelivery"

--- a/docs/resources/mws_workspaces.md
+++ b/docs/resources/mws_workspaces.md
@@ -135,8 +135,8 @@ resource "databricks_mws_credentials" "this" {
 }
 
 resource "aws_s3_bucket" "root_storage_bucket" {
-  bucket = "${local.prefix}-rootbucket"
-  acl    = "private"
+  bucket        = "${local.prefix}-rootbucket"
+  acl           = "private"
   force_destroy = true
   tags          = var.tags
 }

--- a/docs/resources/recipient.md
+++ b/docs/resources/recipient.md
@@ -91,7 +91,14 @@ Exactly one of the below arguments is required:
 
 In addition to all arguments above, the following attributes are exported:
 
-* `tokens` - List of Recipient Tokens.
+* `tokens` - List of Recipient Tokens. This field is only present when the authentication_type is TOKEN. Each list element is an object with following attributes:
+  * `id` - Unique ID of the recipient token.
+  * `created_at` - Time at which this recipient Token was created, in epoch milliseconds.
+  * `created_by` - Username of recipient token creator.
+  * `activation_url` - Full activation URL to retrieve the access token. It will be empty if the token is already retrieved.
+  * `expiration_time` - Expiration timestamp of the token in epoch milliseconds.
+  * `updated_at` - Time at which this recipient Token was updated, in epoch milliseconds.
+  * `updated_by` - Username of recipient Token updater.
 
 ## Related Resources
 

--- a/docs/resources/share.md
+++ b/docs/resources/share.md
@@ -68,11 +68,11 @@ resource "databricks_share" "some" {
 The following arguments are required:
 
 * `name` (Required) - Name of share. Change forces creation of a new resource.
+* `owner` (Optional) -  User name/group name/sp application_id of the share owner.
 
 ### object Configuration Block
 
 * `name` (Required) - Full name of the object, e.g. `catalog.schema.name` for a table.
-* `owner` - (Optional) User name/group name/sp application_id of the share owner.
 * `data_object_type` (Required) - Type of the object, currently only `TABLE` is allowed.
 * `comment` (Optional) -  Description about the object.
 * `shared_as` (Optional) - A user-provided new name for the data object within the share. If this new name is not provided, the object's original name will be used as the `shared_as` name. The `shared_as` name must be unique within a Share. Change forces creation of a new resource.


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
Updated `databricks_share` documentation, an owner attribute has to be outside of `object` configuration block.

Added more detailed description to `databricks_recipient` attribute reference `token` attribute.

Updated all docs using 'terrafmt' .

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

Validated using `make fmt-docs`. Only documentation files are changed.

