### PR TITLE
Remove callback field from acceptance test framework

### DIFF
--- a/internal/acceptance/group_member_test.go
+++ b/internal/acceptance/group_member_test.go
@@ -31,27 +31,29 @@ resource "databricks_group_member" "rs" {
 func TestMwsAccGroupMemberResource(t *testing.T) {
 	accountLevel(t, step{
 		Template: groupMemberTest,
-		Callback: func(ctx context.Context, client *common.DatabricksClient, id string) error {
-			g, err := scim.NewGroupsAPI(ctx, client).Read(id, "members")
-			if err != nil {
-				return err
-			}
-			assert.Len(t, g.Members, 2)
-			return nil
-		},
+		Check: resourceCheck("databricks_group.root",
+			func(ctx context.Context, client *common.DatabricksClient, id string) error {
+				g, err := scim.NewGroupsAPI(ctx, client).Read(id, "members")
+				if err != nil {
+					return err
+				}
+				assert.Len(t, g.Members, 2)
+				return nil
+			}),
 	})
 }
 
 func TestAccGroupMemberResource(t *testing.T) {
 	workspaceLevel(t, step{
 		Template: groupMemberTest,
-		Callback: func(ctx context.Context, client *common.DatabricksClient, id string) error {
-			g, err := scim.NewGroupsAPI(ctx, client).Read(id, "members")
-			if err != nil {
-				return err
-			}
-			assert.Len(t, g.Members, 2)
-			return nil
-		},
+		Check: resourceCheck("databricks_group.root",
+			func(ctx context.Context, client *common.DatabricksClient, id string) error {
+				g, err := scim.NewGroupsAPI(ctx, client).Read(id, "members")
+				if err != nil {
+					return err
+				}
+				assert.Len(t, g.Members, 2)
+				return nil
+			}),
 	})
 }

--- a/internal/acceptance/init_test.go
+++ b/internal/acceptance/init_test.go
@@ -85,7 +85,6 @@ func unityAccountLevel(t *testing.T, steps ...step) {
 
 type step struct {
 	Template string
-	Callback func(ctx context.Context, client *common.DatabricksClient, id string) error
 	Check    func(*terraform.State) error
 
 	Destroy                   bool
@@ -177,7 +176,6 @@ func run(t *testing.T, steps []step) {
 		Resource *schema.Resource
 	}
 
-	resourceAndName := regexp.MustCompile(`resource\s+"([^"]*)"\s+"([^"]*)"`)
 	resourcesEverCreated := map[testResource]bool{}
 	stepConfig := ""
 	for i, s := range steps {
@@ -186,7 +184,6 @@ func run(t *testing.T, steps []step) {
 		}
 		stepNum := i
 		thisStep := s
-		stepCallback := thisStep.Callback
 		stepCheck := thisStep.Check
 		ts = append(ts, resource.TestStep{
 			PreConfig: func() {
@@ -225,13 +222,6 @@ func run(t *testing.T, steps []step) {
 					if dia != nil {
 						return fmt.Errorf("%v", dia)
 					}
-				}
-				if stepCallback != nil {
-					match := resourceAndName.FindStringSubmatch(stepConfig)
-					rootModule := state.RootModule()
-					res := rootModule.Resources[match[1]+"."+match[2]]
-					id := res.Primary.ID
-					return stepCallback(ctx, client, id)
 				}
 				if stepCheck != nil {
 					return stepCheck(state)


### PR DESCRIPTION
## Changes
Internal terraform helpers provide a `Callback` field that is not a part of the terraform SDK. We already have an alternate available used everywhere else but for `group_member_test.go`

This PR switches to using the `Check` field instead, and removes the callback field.

It's nice to remove this field because it encourages a bad pattern where the assertion is made on the first resource defined in the test template, which is captured using regex capture groups.

## Tests
The tests still pass. Also manually tested using debugger that the assertions now in `Check` are still called.
