### PR TITLE
Revert "Refactor `databricks_recipient` to Go SDK (#2592)"

### DIFF
--- a/catalog/resource_recipient_test.go
+++ b/catalog/resource_recipient_test.go
@@ -1,13 +1,9 @@
 package catalog
 
 import (
-	"net/http"
 	"testing"
 
-	"github.com/databricks/databricks-sdk-go/apierr"
-	"github.com/databricks/databricks-sdk-go/service/sharing"
 	"github.com/databricks/terraform-provider-databricks/qa"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestRecipientCornerCases(t *testing.T) {
@@ -18,15 +14,15 @@ func TestCreateRecipient(t *testing.T) {
 	qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
 			{
-				Method:   http.MethodPost,
+				Method:   "POST",
 				Resource: "/api/2.1/unity-catalog/recipients",
-				ExpectedRequest: sharing.CreateRecipient{
+				ExpectedRequest: RecipientInfo{
 					Name:               "a",
 					Comment:            "b",
 					SharingCode:        "c",
 					AuthenticationType: "TOKEN",
-					Owner:              "InitialOwner",
-					IpAccessList: &sharing.IpAccessList{
+					Tokens:             nil,
+					IpAccessList: &IpAccessList{
 						AllowedIpAddresses: []string{"0.0.0.0/0"},
 					},
 				},
@@ -35,16 +31,15 @@ func TestCreateRecipient(t *testing.T) {
 				},
 			},
 			{
-				Method:   http.MethodGet,
-				Resource: "/api/2.1/unity-catalog/recipients/a?",
-				Response: sharing.RecipientInfo{
+				Method:   "GET",
+				Resource: "/api/2.1/unity-catalog/recipients/a",
+				Response: RecipientInfo{
 					Name:               "a",
 					Comment:            "b",
 					SharingCode:        "c",
 					AuthenticationType: "TOKEN",
-					Owner:              "InitialOwner",
 					Tokens:             nil,
-					IpAccessList: &sharing.IpAccessList{
+					IpAccessList: &IpAccessList{
 						AllowedIpAddresses: []string{"0.0.0.0/0"},
 					},
 				},
@@ -57,17 +52,11 @@ func TestCreateRecipient(t *testing.T) {
 		comment = "b"
 		authentication_type = "TOKEN"
 		sharing_code = "c"
-		owner = "InitialOwner"
 		ip_access_list {
 		   allowed_ip_addresses = ["0.0.0.0/0"]
 		}
 		`,
-	}.ApplyAndExpectData(t, map[string]any{
-		"name":                "a",
-		"owner":               "InitialOwner",
-		"authentication_type": "TOKEN",
-		"comment":             "b",
-	})
+	}.ApplyNoError(t)
 }
 
 func TestCreateRecipient_InvalidAuthType(t *testing.T) {
@@ -88,75 +77,4 @@ func TestCreateRecipient_InvalidAuthType(t *testing.T) {
 		"[authentication_type] expected authentication_type "+
 		"to be one of [TOKEN DATABRICKS], got temp")
 
-}
-
-func TestReadRecipient(t *testing.T) {
-	qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:   http.MethodGet,
-				Resource: "/api/2.1/unity-catalog/recipients/a?",
-				Response: sharing.RecipientInfo{
-					Name:               "a",
-					Comment:            "b",
-					SharingCode:        "c",
-					AuthenticationType: "TOKEN",
-					Tokens:             nil,
-					IpAccessList: &sharing.IpAccessList{
-						AllowedIpAddresses: []string{"0.0.0.0/0"},
-					},
-				},
-			},
-		},
-		Resource: ResourceRecipient(),
-		Read:     true,
-		ID:       "a",
-		HCL: `
-		name = "a"
-		comment = "b"
-		authentication_type = "TOKEN"
-		sharing_code = "c"
-		ip_access_list {
-		   allowed_ip_addresses = ["0.0.0.0/0"]
-		}
-		`,
-	}.ApplyAndExpectData(t, map[string]any{
-		"name":    "a",
-		"comment": "b",
-	})
-}
-
-func TestDeleteRecipient(t *testing.T) {
-	d, err := qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:   http.MethodDelete,
-				Resource: "/api/2.1/unity-catalog/recipients/testRecipient?",
-			},
-		},
-		Resource: ResourceRecipient(),
-		Delete:   true,
-		ID:       "testRecipient",
-	}.Apply(t)
-	assert.NoError(t, err)
-	assert.Equal(t, "testRecipient", d.Id())
-}
-
-func TestDeleteRecipientError(t *testing.T) {
-	qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:   http.MethodDelete,
-				Resource: "/api/2.1/unity-catalog/recipients/testRecipient?",
-				Response: apierr.APIErrorBody{
-					ErrorCode: "INVALID_STATE",
-					Message:   "Something went wrong",
-				},
-				Status: 400,
-			},
-		},
-		Resource: ResourceRecipient(),
-		Delete:   true,
-		ID:       "testRecipient",
-	}.ExpectError(t, "Something went wrong")
 }

--- a/docs/resources/recipient.md
+++ b/docs/resources/recipient.md
@@ -67,14 +67,13 @@ The following arguments are required:
 * `name` - Name of recipient. Change forces creation of a new resource.
 * `comment` - (Optional) Description about the recipient.
 * `sharing_code` - (Optional) The one-time sharing code provided by the data recipient.
-* `owner` - (Optional) Username/groupname/sp application_id of the recipient owner.
 * `authentication_type` - (Optional) The delta sharing authentication type. Valid values are `TOKEN` and `DATABRICKS`.
 * `data_recipient_global_metastore_id` - Required when authentication_type is DATABRICKS.
 * `ip_access_list` - (Optional) The one-time sharing code provided by the data recipient.
 
 ### Ip Access List Argument
 
-Only one `ip_access_list` blocks is allowed in a recipient. It conflicts with authentication type `DATABRICKS`.
+Only one `ip_access_list` blocks is allowed in a recipient. It conflicts with authentication type DATABRICKS.
 
 ```hcl
 ip_access_list {


### PR DESCRIPTION
This reverts commit 8dc13d4d703fee2ad85b6c60fedba72f0b0b87b1.

## Changes
<!-- Summary of your changes that are easy to understand -->

PR https://github.com/databricks/terraform-provider-databricks/pull/2592/files refactored `databricks_recepient` resource to Go SDK. This lead to the `CreateRecipientDb2DbAws` test failure with:
```
=== PAUSE ***CreateRecipientDb2DbAws
=== CONT  ***CreateRecipientDb2DbAws
    init_test.go:243: Step 1/1 error: Error running apply: exit status 1
        
        Error: cannot create recipient: panic: reflect: call of reflect.Value.SetString on interface Value
        
          with databricks_recipient.db2db,
          on terraform_plugin_test.tf line 12, in resource "databricks_recipient" "db2db":
          12: resource "databricks_recipient" "db2db" {
```

Running this test on revert passes.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [x] relevant acceptance tests are passing
- [ ] using Go SDK

