### PR TITLE
Add support for init scripts from Unity Catalog Volumes in `databricks_cluster` resource

### DIFF
--- a/clusters/clusters_api.go
+++ b/clusters/clusters_api.go
@@ -220,12 +220,13 @@ type StorageInfo struct {
 
 // InitScriptStorageInfo captures the allowed sources of init scripts.
 type InitScriptStorageInfo struct {
-	Dbfs      *DbfsStorageInfo   `json:"dbfs,omitempty" tf:"group:storage"`
-	Gcs       *GcsStorageInfo    `json:"gcs,omitempty" tf:"group:storage"`
-	S3        *S3StorageInfo     `json:"s3,omitempty" tf:"group:storage"`
-	Abfss     *AbfssStorageInfo  `json:"abfss,omitempty" tf:"group:storage"`
-	File      *LocalFileInfo     `json:"file,omitempty"`
-	Workspace *WorkspaceFileInfo `json:"workspace,omitempty"`
+	Dbfs      *DbfsStorageInfo            `json:"dbfs,omitempty" tf:"group:storage"`
+	Gcs       *GcsStorageInfo             `json:"gcs,omitempty" tf:"group:storage"`
+	S3        *S3StorageInfo              `json:"s3,omitempty" tf:"group:storage"`
+	Abfss     *AbfssStorageInfo           `json:"abfss,omitempty" tf:"group:storage"`
+	File      *LocalFileInfo              `json:"file,omitempty"`
+	Workspace *WorkspaceFileInfo          `json:"workspace,omitempty"`
+	Volumes   *compute.VolumesStorageInfo `json:"volumes,omitempty"`
 }
 
 // SparkNodeAwsAttributes is the struct that determines if the node is a spot instance or not

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -270,6 +270,16 @@ init_scripts {
 }
 ```
 
+Example of using a file from Unity Catalog Volume as init script:
+
+```hcl
+init_scripts {
+  volumes {
+    destination = "/Volumes/Catalog/default/init-scripts/init-script.sh"
+  }
+}
+```
+
 Example of taking init script from DBFS (deprecated):
 
 ```hcl


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

Since DBR 13.3 we're supporting execution of init scripts from Unity Catalog volumes.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [x] using Go SDK

