### PR TITLE
Allowing workspaces to update NCC ID

### DIFF
--- a/mws/resource_mws_workspaces.go
+++ b/mws/resource_mws_workspaces.go
@@ -100,6 +100,7 @@ type Workspace struct {
 	GkeConfig                           *GkeConfig               `json:"gke_config,omitempty" tf:"suppress_diff"`
 	Cloud                               string                   `json:"cloud,omitempty" tf:"computed"`
 	Location                            string                   `json:"location,omitempty"`
+	NetworkConnectivityConfigID         string                   `json:"network_connectivity_config_id,omitempty"`
 }
 
 // this type alias hack is required for Marshaller to work without an infinite loop
@@ -257,7 +258,14 @@ func (a WorkspacesAPI) WaitForRunning(ws Workspace, timeout time.Duration) error
 	})
 }
 
-var workspaceRunningUpdatesAllowed = []string{"credentials_id", "network_id", "storage_customer_managed_key_id", "private_access_settings_id", "managed_services_customer_managed_key_id"}
+var workspaceRunningUpdatesAllowed = []string{
+	"credentials_id",
+	"network_id",
+	"storage_customer_managed_key_id",
+	"private_access_settings_id",
+	"managed_services_customer_managed_key_id",
+	"network_connectivity_config_id",
+}
 
 // UpdateRunning will update running workspace with couple of possible fields
 func (a WorkspacesAPI) UpdateRunning(ws Workspace, timeout time.Duration) error {
@@ -281,6 +289,9 @@ func (a WorkspacesAPI) UpdateRunning(ws Workspace, timeout time.Duration) error 
 	}
 	if ws.StorageCustomerManagedKeyID != "" {
 		request["storage_customer_managed_key_id"] = ws.StorageCustomerManagedKeyID
+	}
+	if ws.NetworkConnectivityConfigID != "" {
+		request["network_connectivity_config_id"] = ws.NetworkConnectivityConfigID
 	}
 
 	if len(request) == 0 {
@@ -706,6 +717,10 @@ func workspaceSchemaV2() cty.Type {
 				Computed: true,
 			},
 			"private_access_settings_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"network_connectivity_config_id": {
 				Type:     schema.TypeString,
 				Optional: true,
 			},

--- a/mws/resource_mws_workspaces_test.go
+++ b/mws/resource_mws_workspaces_test.go
@@ -1595,6 +1595,56 @@ func TestResourceWorkspaceRemovePAS_NotAllowed(t *testing.T) {
 	}.ExpectError(t, "cannot remove private access setting from workspace")
 }
 
+func TestResourceWorkspaceUpdateNetworkConnectivityConfigId(t *testing.T) {
+	d, err := qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "PATCH",
+				Resource: "/api/2.0/accounts/abc/workspaces/1234",
+				ExpectedRequest: map[string]any{
+					"network_connectivity_config_id": "ncc",
+				},
+			},
+			{
+				Method:       "GET",
+				ReuseRequest: true,
+				Resource:     "/api/2.0/accounts/abc/workspaces/1234",
+				Response: Workspace{
+					WorkspaceStatus:             WorkspaceStatusRunning,
+					WorkspaceName:               "labdata",
+					DeploymentName:              "900150983cd24fb0",
+					Location:                    "westus",
+					NetworkConnectivityConfigID: "ncc",
+					AccountID:                   "abc",
+					WorkspaceID:                 1234,
+				},
+			},
+		},
+		Resource: ResourceMwsWorkspaces(),
+		InstanceState: map[string]string{
+			"account_id":              "abc",
+			"location":                "westus",
+			"deployment_name":         "900150983cd24fb0",
+			"workspace_name":          "labdata",
+			"is_no_public_ip_enabled": "true",
+			"workspace_id":            "1234",
+		},
+		State: map[string]any{
+			"account_id":                     "abc",
+			"location":                       "westus",
+			"deployment_name":                "900150983cd24fb0",
+			"workspace_name":                 "labdata",
+			"is_no_public_ip_enabled":        true,
+			"network_connectivity_config_id": "ncc",
+			"workspace_id":                   1234,
+		},
+		Update: true,
+		ID:     "abc/1234",
+	}.Apply(t)
+	assert.NoError(t, err)
+	assert.Equal(t, "abc/1234", d.Id(), "Id should be the same as in reading")
+}
+
 func TestResourceWorkspaceCreateGcpManagedVPC(t *testing.T) {
 	qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{


### PR DESCRIPTION
## Changes
This change allows workspace objects to update their NCC ID.

Also updated the documents for how to import Azure workspace states.

## Tests

- [X] `make test` run locally
- [X] relevant change in `docs/` folder
- [x] covered with integration tests in `internal/acceptance`
- [x] relevant acceptance tests are passing
- [X] using Go SDK

Acceptance test doesn't apply for Azure as Azure workspaces don't support create.

Script:

```tcl
terraform {
  required_providers {
    databricks = {
      source = "databricks/databricks"
      version = "1.5.0"
    }
  }
}

provider "databricks" {
  alias = "mws"
  host  = "https://accounts.azuredatabricks.net"
}

resource "databricks_mws_workspaces" "this" {
  provider                       = databricks.mws
  account_id                     = "5a8ac58d-9557-497a-8832-90bd35e641bf"
  location                       = "westus"
  deployment_name                = "adb-6971544276982887.7"
  workspace_name                 = "yankaiz-prod-serverless-test-westus-ws"
  network_connectivity_config_id = "4498487b-a564-4648-a473-a7d5c27bed6f"
}
```

Test result:

```
vscode ➜ /workspaces/terraform-provider-databricks/yankaiz (tf-ws-ncc) $ tf import databricks_mws_workspaces.this 5a8ac58d-9557-497a-8832-90bd35e641bf/6971544276982887
databricks_mws_workspaces.this: Importing from ID "5a8ac58d-9557-497a-8832-90bd35e641bf/6971544276982887"...
databricks_mws_workspaces.this: Import prepared!
  Prepared databricks_mws_workspaces for import
databricks_mws_workspaces.this: Refreshing state... [id=5a8ac58d-9557-497a-8832-90bd35e641bf/6971544276982887]

Import successful!

The resources that were imported are shown above. These resources are now in
your Terraform state and will henceforth be managed by Terraform.

vscode ➜ /workspaces/terraform-provider-databricks/yankaiz (tf-ws-ncc) $ tf apply
databricks_mws_workspaces.this: Refreshing state... [id=5a8ac58d-9557-497a-8832-90bd35e641bf/6971544276982887]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # databricks_mws_workspaces.this will be updated in-place
  ~ resource "databricks_mws_workspaces" "this" {
        id                             = "5a8ac58d-9557-497a-8832-90bd35e641bf/6971544276982887"
      + network_connectivity_config_id = "4498487b-a564-4648-a473-a7d5c27bed6f"
        # (11 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

databricks_mws_workspaces.this: Modifying... [id=5a8ac58d-9557-497a-8832-90bd35e641bf/6971544276982887]
databricks_mws_workspaces.this: Modifications complete after 9s [id=5a8ac58d-9557-497a-8832-90bd35e641bf/6971544276982887]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
```
