### PR TITLE
Document missing `id` attributes in a number of resources

### DIFF
--- a/docs/resources/catalog.md
+++ b/docs/resources/catalog.md
@@ -36,6 +36,12 @@ The following arguments are required:
 * `options` - (Optional) For Foreign Catalogs: the name of the entity from an external data source that maps to a catalog. For example, the database name in a PostgreSQL server.
 * `force_destroy` - (Optional) Delete catalog regardless of its contents.
 
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - ID of this catalog - same as the `name`.
+
 ## Import
 
 This resource can be imported by name:

--- a/docs/resources/connection.md
+++ b/docs/resources/connection.md
@@ -40,10 +40,16 @@ The following arguments are supported:
 - `properties` -  (Optional) Free-form connection properties.
 - `comment` - (Optional) Free-form text.
 
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - ID of this connection in form of `<metastore_id>|<name>`.
+
 ## Import
 
-This resource can be imported by `name`
+This resource can be imported by `id`:
 
 ```bash
-terraform import databricks_connection.this <connection_name>
+terraform import databricks_connection.this '<metastore_id>|<name>'
 ```

--- a/docs/resources/external_location.md
+++ b/docs/resources/external_location.md
@@ -128,9 +128,15 @@ The following arguments are required:
 - `access_point` - (Optional) The ARN of the s3 access point to use with the external location (AWS).
 - `encryption_details` - (Optional) The options for Server-Side Encryption to be used by each Databricks s3 client when connecting to S3 cloud storage (AWS).
 
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - ID of this external location - same as `name`.
+
 ## Import
 
-This resource can be imported by name:
+This resource can be imported by `name`:
 
 ```bash
 terraform import databricks_external_location.this <name>

--- a/docs/resources/metastore.md
+++ b/docs/resources/metastore.md
@@ -58,6 +58,11 @@ The following arguments are required:
 * `delta_sharing_organization_name` - (Optional) The organization name of a Delta Sharing entity. This field is used for Databricks to Databricks sharing. Once this is set it cannot be removed and can only be modified to another valid value. To delete this value please taint and recreate the resource.
 * `force_destroy` - (Optional) Destroy metastore regardless of its contents.
 
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - system-generated ID of this Unity Catalog Metastore.
 ## Import
 
 This resource can be imported by ID:

--- a/docs/resources/metastore_assignment.md
+++ b/docs/resources/metastore_assignment.md
@@ -29,3 +29,9 @@ The following arguments are required:
 * `metastore_id` - Unique identifier of the parent Metastore
 * `workspace_id` - id of the workspace for the assignment
 * `default_catalog_name` - (Optional) Default catalog used for this assignment, default to `hive_metastore`
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - ID of this metastore assignment in form of `<metastore_id>|<metastore_id>`.

--- a/docs/resources/metastore_data_access.md
+++ b/docs/resources/metastore_data_access.md
@@ -77,6 +77,12 @@ The following arguments are required:
 * `application_id` - The application ID of the application registration within the referenced AAD tenant
 * `client_secret` - The client secret generated for the above app ID in AAD. **This field is redacted on output**
 
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - ID of this data access configuration in form of `<metastore_id>|<name>`.
+
 ## Import
 
 -> **Note** Importing this resource is not currently supported.

--- a/docs/resources/provider.md
+++ b/docs/resources/provider.md
@@ -36,6 +36,12 @@ The following arguments are required:
 * `authentication_type` - (Optional) The delta sharing authentication type. Valid values are `TOKEN`.
 * `recipient_profile_str` - (Optional) This is the json file that is created from a recipient url.
 
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - ID of this provider - same as the `name`.
+
 ## Related Resources
 
 The following resources are used in the same context:

--- a/docs/resources/recipient.md
+++ b/docs/resources/recipient.md
@@ -100,6 +100,12 @@ In addition to all arguments above, the following attributes are exported:
   * `updated_at` - Time at which this recipient Token was updated, in epoch milliseconds.
   * `updated_by` - Username of recipient Token updater.
 
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - ID of this recipient - same as the `name`.
+
 ## Related Resources
 
 The following resources are often used in the same context:

--- a/docs/resources/schema.md
+++ b/docs/resources/schema.md
@@ -41,6 +41,12 @@ The following arguments are required:
 * `properties` - (Optional) Extensible Schema properties.
 * `force_destroy` - (Optional) Delete schema regardless of its contents.
 
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - ID of this schema in form of `<catalog_name>.<name>`.
+
 ## Import
 
 This resource can be imported by its full name:

--- a/docs/resources/sql_table.md
+++ b/docs/resources/sql_table.md
@@ -91,6 +91,12 @@ Currently, changing the column definitions for a table will require dropping and
 * `comment` - (Optional) User-supplied free-form text.
 * `nullable` - (Optional) Whether field is nullable (Default: `true`)
 
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - ID of this table in form of `<catalog_name>.<schema_name>.<name>`.
+
 ## Import
 
 This resource can be imported by its full name:

--- a/docs/resources/storage_credential.md
+++ b/docs/resources/storage_credential.md
@@ -94,6 +94,12 @@ The following arguments are required:
 - `email` (output only) - The email of the GCP service account created, to be granted access to relevant buckets.
 - `read_only` - (Optional) Indicates whether the storage credential is only usable for read operations.
 
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - ID of this storage credential - same as the `name`.
+
 ## Import
 
 This resource can be imported by name:

--- a/docs/resources/volume.md
+++ b/docs/resources/volume.md
@@ -87,9 +87,15 @@ The following arguments are supported:
 * `storage_location` - (Optional) Path inside an External Location. Only used for `EXTERNAL` Volumes.
 * `comment` - (Optional) Free-form text.
 
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - ID of this Unity Catalog Volume in form of `<catalog>.<schema>.<name>`.
+
 ## Import
 
-This resource can be imported by `full_name` which is the 3-level Volume identifier: `<catalog>.<schema>.<volume>`
+This resource can be imported by `full_name` which is the 3-level Volume identifier: `<catalog>.<schema>.<name>`
 
 ```bash
 terraform import databricks_volume.this <catalog_name>.<schema_name>.<name>


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

Some customers are confused when to use `id` vs other attributes/parameters when creating dependencies between resources, so adding missing documentation for exported attributes.

Also fixed import documentation for `databricks_connection` resource.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] ~`make test` run locally~
- [x] relevant change in `docs/` folder
- [ ] ~covered with integration tests in `internal/acceptance`~
- [ ] ~relevant acceptance tests are passing~
- [ ] ~using Go SDK~

