### PR TITLE
Fix incorrect reference in the `databricks_git_credential` documentation

### DIFF
--- a/docs/resources/git_credential.md
+++ b/docs/resources/git_credential.md
@@ -47,4 +47,4 @@ $ terraform import databricks_git_credential.this <git-credential-id>
 
 The following resources are often used in the same context:
 
-* [databricks_repo](git_repo.md) to manage Databricks Repos.
+* [databricks_repo](repo.md) to manage Databricks Repos.


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

this fixes #2654

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

