### PR TITLE
Change validation for `max_concurrent_runs` in `databricjs_job` to allow 0 value

### DIFF
--- a/jobs/resource_job.go
+++ b/jobs/resource_job.go
@@ -662,7 +662,7 @@ var jobSchema = common.StructToSchema(JobSettings{},
 		if p, err := common.SchemaPath(s, "schedule", "pause_status"); err == nil {
 			p.ValidateFunc = validation.StringInSlice([]string{"PAUSED", "UNPAUSED"}, false)
 		}
-		s["max_concurrent_runs"].ValidateDiagFunc = validation.ToDiagFunc(validation.IntAtLeast(1))
+		s["max_concurrent_runs"].ValidateDiagFunc = validation.ToDiagFunc(validation.IntAtLeast(0))
 		s["max_concurrent_runs"].Default = 1
 		s["url"] = &schema.Schema{
 			Type:     schema.TypeString,


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

Jobs API allows 0 value for `max_concurrent_runs` attribute [API docs](https://docs.databricks.com/api/workspace/jobs/create), but TF required to specify at least `1`.

This fixes #2681


## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [x] relevant acceptance tests are passing
- [ ] using Go SDK

