### PR TITLE
Deprecate `photon` and `graviton` selectors in `databricks_spark_version` data source

### DIFF
--- a/clusters/data_spark_version.go
+++ b/clusters/data_spark_version.go
@@ -128,6 +128,9 @@ func (a ClustersAPI) LatestSparkVersionOrDefault(svr SparkVersionRequest) string
 func DataSourceSparkVersion() *schema.Resource {
 	s := common.StructToSchema(SparkVersionRequest{}, func(
 		s map[string]*schema.Schema) map[string]*schema.Schema {
+
+		s["photon"].Deprecated = "Specify runtime_engine=\"PHOTON\" in the cluster configuration"
+		s["graviton"].Deprecated = "Not required anymore - it's automatically enabled on the Graviton-based node types"
 		return s
 	})
 

--- a/docs/data-sources/spark_version.md
+++ b/docs/data-sources/spark_version.md
@@ -45,11 +45,11 @@ Data source allows you to pick groups by the following attributes:
 * `ml` - (boolean, optional) if we should limit the search only to ML runtimes. Default to `false`.
 * `genomics` - (boolean, optional)  if we should limit the search only to Genomics (HLS) runtimes. Default to `false`.
 * `gpu` - (boolean, optional)  if we should limit the search only to runtimes that support GPUs. Default to `false`.
-* `photon` - (boolean, optional)  if we should limit the search only to Photon runtimes. Default to `false`.
-* `graviton` - (boolean, optional)  if we should limit the search only to runtimes supporting AWS Graviton CPUs. Default to `false`.
 * `beta` - (boolean, optional) if we should limit the search only to runtimes that are in Beta stage. Default to `false`.
 * `scala` - (string, optional) if we should limit the search only to runtimes that are based on specific Scala version. Default to `2.12`.
 * `spark_version` - (string, optional) if we should limit the search only to runtimes that are based on specific Spark version. Default to empty string.  It could be specified as `3`, or `3.0`, or full version, like, `3.0.1`.
+* `photon` - (boolean, optional)  if we should limit the search only to Photon runtimes. Default to `false`. *Deprecated with DBR 14.0 release. Specify `runtime_engine=\"PHOTON\"` in the cluster configuration instead!*
+* `graviton` - (boolean, optional)  if we should limit the search only to runtimes supporting AWS Graviton CPUs. Default to `false`. *Deprecated with DBR 14.0 release. DBR version compiled for Graviton will be automatically installed when nodes with Graviton CPUs are specified in the cluster configuration.* 
 
 ## Attribute Reference
 


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

Since the introduction of the Photon & Graviton support, there were separate DBR versions exposed via APIs for each flavor:

* DBR for Intel CPUs without Photon `13.3.x-scala2.12`
* DBR for Intel CPUs with Photon `13.3.x-photon-scala2.12`
* DBR for Graviton CPUs without Photon `13.3.x-aarch64-scala2.12`
* DBR for Graviton CPUs with Photon `13.3.x-aarch64-photon-scala2.12`
* ML Runtime ...

Since DBR 14.0, no separate DBR versions are exposed for Photon & Graviton flavors, so if you use `photon` and/or `graviton` selectors, then you won't upgrade to DBR 14+.

The migration path is the following:

* Just specify a generic version, like, `14.0.x-scala2.12`.
* To use Photon, you need to specify `runtime_engine="PHOTON"` in the cluster configuration.
* For Graviton, it's just enough to select Graviton node types, and the correct DBR will be installed automatically.


## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

