### PR TITLE
Exporter: export references in `run_as` block of `databricks_job`

### DIFF
--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -841,6 +841,10 @@ func TestImportingJobs_JobList(t *testing.T) {
 					JobID: 14,
 					Settings: &jobs.JobSettings{
 						RetryOnTimeout: true,
+						RunAs: &jobs.JobRunAs{
+							UserName:             "user@domain.com",
+							ServicePrincipalName: "0000-1111-2222-3333-4444-5555",
+						},
 						Libraries: []libraries.Library{
 							{Jar: "dbfs:/FileStore/jars/test.jar"},
 						},

--- a/exporter/importables.go
+++ b/exporter/importables.go
@@ -386,6 +386,8 @@ var resourcesMap map[string]importable = map[string]importable{
 			{Path: "job_cluster.new_cluster.instance_pool_id", Resource: "databricks_instance_pool"},
 			{Path: "job_cluster.new_cluster.driver_instance_pool_id", Resource: "databricks_instance_pool"},
 			{Path: "job_cluster.new_cluster.policy_id", Resource: "databricks_cluster_policy"},
+			{Path: "run_as.user_name", Resource: "databricks_user", Match: "user_name"},
+			{Path: "run_as.service_principal_name", Resource: "databricks_service_principal", Match: "application_id"},
 		},
 		Import: func(ic *importContext, r *resource) error {
 			var job jobs.JobSettings
@@ -512,6 +514,22 @@ var resourcesMap map[string]importable = map[string]importable{
 			}
 			for _, jc := range job.JobClusters {
 				ic.importCluster(jc.NewCluster)
+			}
+			if job.RunAs != nil {
+				if job.RunAs.UserName != "" {
+					ic.Emit(&resource{
+						Resource:  "databricks_user",
+						Attribute: "user_name",
+						Value:     job.RunAs.UserName,
+					})
+				}
+				if job.RunAs.ServicePrincipalName != "" {
+					ic.Emit(&resource{
+						Resource:  "databricks_service_principal",
+						Attribute: "application_id",
+						Value:     job.RunAs.ServicePrincipalName,
+					})
+				}
 			}
 
 			return ic.importLibraries(r.Data, s)


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

User names or SP ID weren't resolved for the `run_as` block of `databricks_job` resource.

This fixes #2689

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

