### PR TITLE
Exporter: parallel listing of workspace objects

### DIFF
--- a/exporter/importables.go
+++ b/exporter/importables.go
@@ -1102,6 +1102,7 @@ var resourcesMap map[string]importable = map[string]importable{
 			return nil
 		},
 		List: func(ic *importContext) error {
+			// TODO: Should we use parallel listing instead?
 			repoList, err := repos.NewReposAPI(ic.Context, ic.Client).ListAll()
 			if err != nil {
 				return err

--- a/exporter/util.go
+++ b/exporter/util.go
@@ -163,7 +163,7 @@ func (ic *importContext) getAllWorkspaceObjects() []workspace.ObjectStatus {
 		t1 := time.Now()
 		log.Printf("[DEBUG] %v. Starting to list all workspace objects", t1.Local().Format(time.RFC3339))
 		notebooksAPI := workspace.NewNotebooksAPI(ic.Context, ic.Client)
-		ic.allWorkspaceObjects, _ = notebooksAPI.ListParallel("/", true, true)
+		ic.allWorkspaceObjects, _ = notebooksAPI.ListParallel("/", true)
 		t2 := time.Now()
 		log.Printf("[DEBUG] %v. Finished listing of all workspace objects. %d objects in total. %v seconds",
 			t2.Local().Format(time.RFC3339), len(ic.allWorkspaceObjects), t2.Sub(t1).Seconds())

--- a/workspace/resource_notebook.go
+++ b/workspace/resource_notebook.go
@@ -172,13 +172,13 @@ func (a NotebooksAPI) recursiveAddPathsParallel(path string, dirChannel chan str
 	}
 }
 
-func (a NotebooksAPI) ListParallel(path string, recursive bool, ignoreErrors bool) ([]ObjectStatus, error) {
+func (a NotebooksAPI) ListParallel(path string, recursive bool) ([]ObjectStatus, error) {
 	var answer syncAnswer
 	wg := &sync.WaitGroup{}
 
 	numWorkers := 5
-	if os.Getenv("EXPORTER_PARALLLELISM") != "" {
-		t, _ := strconv.ParseInt(os.Getenv("EXPORTER_PARALLLELISM"), 10, 32)
+	if os.Getenv("EXPORTER_WS_LIST_PARALLELISM") != "" {
+		t, _ := strconv.ParseInt(os.Getenv("EXPORTER_WS_LIST_PARALLELISM"), 10, 32)
 		numWorkers = int(t)
 	}
 	channelSize := 100000

--- a/workspace/resource_notebook_test.go
+++ b/workspace/resource_notebook_test.go
@@ -1,13 +1,16 @@
 package workspace
 
 import (
+	"context"
 	"net/http"
+	"os"
 	"testing"
 
 	"github.com/databricks/databricks-sdk-go/apierr"
 	"github.com/databricks/terraform-provider-databricks/qa"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestResourceNotebookRead(t *testing.T) {
@@ -375,4 +378,67 @@ func TestNotebookLanguageSuppressSourceDiff(t *testing.T) {
 	d.Set("source", "this.PY")
 	suppress := r.Schema["language"].DiffSuppressFunc
 	assert.True(t, suppress("language", Python, Python, d))
+}
+
+func TestParallelListing(t *testing.T) {
+	client, server, err := qa.HttpFixtureClient(t, []qa.HTTPFixture{
+		{
+			Method:   "GET",
+			Resource: "/api/2.0/workspace/list?path=%2F",
+			Response: ObjectList{
+				Objects: []ObjectStatus{
+					{
+						ObjectID:   1,
+						ObjectType: Directory,
+						Path:       "/a",
+					},
+					{
+						ObjectID:   2,
+						ObjectType: Directory,
+						Path:       "/b",
+					},
+				},
+			},
+		},
+		{
+			Method:   "GET",
+			Resource: "/api/2.0/workspace/list?path=%2Fa",
+			Response: ObjectList{
+				Objects: []ObjectStatus{
+					{
+						ObjectID:   3,
+						ObjectType: Notebook,
+						Language:   Python,
+						Path:       "/a/e",
+					},
+				},
+			},
+		},
+		{
+			Method:   "GET",
+			Resource: "/api/2.0/workspace/list?path=%2Fb",
+			Response: ObjectList{
+				Objects: []ObjectStatus{
+					{
+						ObjectID:   4,
+						ObjectType: Notebook,
+						Language:   SQL,
+						Path:       "/b/c",
+					},
+				},
+			},
+		},
+	})
+	defer server.Close()
+	require.NoError(t, err)
+
+	os.Setenv("EXPORTER_WS_LIST_PARALLLELISM", "2")
+	os.Setenv("EXPORTER_CHANNEL_SIZE", "100")
+	ctx := context.Background()
+	api := NewNotebooksAPI(ctx, client)
+	objects, err := api.ListParallel("/", true)
+
+	require.NoError(t, err)
+	require.Equal(t, 4, len(objects))
+
 }


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

Right now listing of workspace objects (files/directories) is a bottleneck, especially in the incremental export mode. This PR tries to solve this problem by using multiple goroutines listing multiple directories in parallel

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

