### PR TITLE
Don't use `computed` for `pause_status` in `databricks_job` resource

### DIFF
--- a/jobs/resource_job.go
+++ b/jobs/resource_job.go
@@ -158,7 +158,7 @@ type Webhook struct {
 type CronSchedule struct {
 	QuartzCronExpression string `json:"quartz_cron_expression"`
 	TimezoneID           string `json:"timezone_id"`
-	PauseStatus          string `json:"pause_status,omitempty" tf:"computed"`
+	PauseStatus          string `json:"pause_status,omitempty" tf:"default:UNPAUSED"`
 }
 
 // BEGIN Jobs + Repo integration preview
@@ -228,7 +228,7 @@ type JobCompute struct {
 }
 
 type ContinuousConf struct {
-	PauseStatus string `json:"pause_status,omitempty" tf:"computed"`
+	PauseStatus string `json:"pause_status,omitempty" tf:"default:UNPAUSED"`
 }
 
 type Queue struct {
@@ -247,7 +247,7 @@ type FileArrival struct {
 
 type Trigger struct {
 	FileArrival *FileArrival `json:"file_arrival"`
-	PauseStatus string       `json:"pause_status,omitempty" tf:"computed"`
+	PauseStatus string       `json:"pause_status,omitempty" tf:"default:UNPAUSED"`
 }
 
 // JobSettings contains the information for configuring a job on databricks
@@ -663,6 +663,12 @@ var jobSchema = common.StructToSchema(JobSettings{},
 		jobSettingsSchema(&s["job_cluster"].Elem.(*schema.Resource).Schema, "job_cluster.0.")
 		gitSourceSchema(s["git_source"].Elem.(*schema.Resource), "")
 		if p, err := common.SchemaPath(s, "schedule", "pause_status"); err == nil {
+			p.ValidateFunc = validation.StringInSlice([]string{"PAUSED", "UNPAUSED"}, false)
+		}
+		if p, err := common.SchemaPath(s, "trigger", "pause_status"); err == nil {
+			p.ValidateFunc = validation.StringInSlice([]string{"PAUSED", "UNPAUSED"}, false)
+		}
+		if p, err := common.SchemaPath(s, "continuous", "pause_status"); err == nil {
 			p.ValidateFunc = validation.StringInSlice([]string{"PAUSED", "UNPAUSED"}, false)
 		}
 		s["max_concurrent_runs"].ValidateDiagFunc = validation.ToDiagFunc(validation.IntAtLeast(0))


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

Right now, the `pause_status` in `schedule`, `continuous` and `trigger` blocks is marked as `computed` because it could be omitted, and the backend will provide a default value.  This leads to the following problems:

- it's not changed to default `UNPAUSED` if you remove it from TF code (same behavior would be with `suppress_diff`) - so you can't unpause the job after you paused it until you explicitly set `pause_status` to `UNPAUSED`
- this field isn't exported by TF exporter (issue #2695)

The solution for these problems is to set the default in the provider's source code.

Also added validators for `pause_status` in `continuous` & `trigger` blocks.

This fixes #2695

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

