### PR TITLE
Exporter: added support for exporting `databricks_access_control_rule_set` on account level

### DIFF
--- a/docs/guides/experimental-exporter.md
+++ b/docs/guides/experimental-exporter.md
@@ -98,6 +98,7 @@ Exporter aims to generate HCL code for most of the resources within the Databric
 
 | Resource | Generated code | Incremental |
 | --- | --- | --- |
+| [databricks_access_control_rule_set](../resources/access_control_rule_set.md) | Yes | No |
 | [databricks_cluster](../resources/cluster.md) | Yes | No |
 | [databricks_cluster_policy](../resources/cluster_policy.md) | Yes | No |
 | [databricks_dbfs_file](../resources/dbfs_file.md) | Yes | No |

--- a/exporter/context.go
+++ b/exporter/context.go
@@ -287,15 +287,15 @@ func (ic *importContext) Run() error {
 	} else if !info.IsDir() {
 		return fmt.Errorf("the path %s is not a directory", ic.Directory)
 	}
-	w, err := ic.Client.WorkspaceClient()
-	if err != nil {
-		return err
-	}
 
 	ic.accountLevel = ic.Client.Config.IsAccountClient()
 	if ic.accountLevel {
 		ic.meAdmin = true
 	} else {
+		w, err := ic.Client.WorkspaceClient()
+		if err != nil {
+			return err
+		}
 		me, err := w.CurrentUser.Me(ic.Context)
 		if err != nil {
 			return err
@@ -326,7 +326,11 @@ func (ic *importContext) Run() error {
 			continue
 		}
 		if ic.accountLevel && !ir.AccountLevel {
-			log.Printf("[DEBUG] %s (%s service) is not account level", resourceName, ir.Service)
+			log.Printf("[DEBUG] %s (%s service) is not a account level resource", resourceName, ir.Service)
+			continue
+		}
+		if !ic.accountLevel && !ir.WorkspaceLevel {
+			log.Printf("[DEBUG] %s (%s service) is not a workspace level resource", resourceName, ir.Service)
 			continue
 		}
 		ic.waitGroup.Add(1)


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

Added exporting of a given resource. 

Also:
* added some documentation inside the code
* possibility to specify if a resource is a workspace or account level
* fixed bug in the regex matching


## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

There were some problems with emulating account-level APIs, so the unit test will be added a bit later.

- [x] `make test` run locally
- [x] tested manually
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [x] using Go SDK

