### PR TITLE
Deprecate `cluster_mount_info` block in `databricks_cluster` resource

### DIFF
--- a/clusters/resource_cluster.go
+++ b/clusters/resource_cluster.go
@@ -91,6 +91,8 @@ func resourceClusterSchema() map[string]*schema.Schema {
 
 		s["runtime_engine"].ValidateFunc = validation.StringInSlice([]string{"PHOTON", "STANDARD"}, false)
 
+		s["cluster_mount_info"].Deprecated = "cluster_mount_info block is deprecated due the Clusters API changes."
+
 		s["is_pinned"] = &schema.Schema{
 			Type:     schema.TypeBool,
 			Optional: true,

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -473,7 +473,7 @@ resource "databricks_cluster" "this" {
 }
 ```
 
-## cluster_mount_info blocks
+## cluster_mount_info blocks (deprecated)
 
 It's possible to mount NFS (Network File System) resources into the Spark containers inside the cluster.  You can specify one or more `cluster_mount_info` blocks describing the mount. This block has following attributes:
 


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

The `cluster_mount_info` isn't part of official Clusters API anymore, and may go away at any point of time, so putting the deprecation message to prevent surprises.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

