### PR TITLE
Added logging package and fixed issue with API calls not being shown in DEBUG or lower log levels.

### DIFF
--- a/logging/logging.go
+++ b/logging/logging.go
@@ -1,0 +1,69 @@
+package logging
+
+import (
+	"os"
+
+	"github.com/databricks/databricks-sdk-go/logger"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/logging"
+)
+
+// Interface to mock os.Getenv() operations
+type envOperations interface {
+	Getenv(key string) string
+}
+
+type realEnvOperations struct{}
+
+func (r *realEnvOperations) Getenv(key string) string {
+	return os.Getenv(key)
+}
+
+// Unfortunately LogLevel() in terraform plugin sdk v2 is not test friendly so we have to mock it since it calls os.GetEnv() underneath
+type logLevelGetter interface {
+	GetLogLevel() string
+}
+
+type realLogLevelGetter struct{}
+
+func (r *realLogLevelGetter) GetLogLevel() string {
+	return logging.LogLevel()
+}
+
+func SetLogger() {
+	logger.DefaultLogger = &logger.SimpleLogger{
+		Level: terraformToSDKLogLevel(&realEnvOperations{}, &realLogLevelGetter{}),
+	}
+}
+
+// Golang doesn't have mutable maps, having global mutable variable is less safe as compared to a function returning map
+func terraformToSDKLogLevelMapping() map[string]logger.Level {
+	return map[string]logger.Level{
+		"TRACE": logger.LevelTrace,
+		"DEBUG": logger.LevelDebug,
+		"INFO":  logger.LevelInfo,
+		"WARN":  logger.LevelWarn,
+		"ERROR": logger.LevelError,
+	}
+}
+
+func terraformToSDKLogLevel(envOps envOperations, logGetter logLevelGetter) logger.Level {
+	// Exception for unknown log levels are handled in underlying LogLevel() method
+	// Defaulting to TRACE in such cases
+	terraformLogLevel := logGetter.GetLogLevel()
+
+	// If TF_LOG environment variable is not set
+	if terraformLogLevel == "" {
+		// If TF_ACC_LOG_PATH is set, we use TRACE log level to be consistent with LogOutput() method
+		if envOps.Getenv(logging.EnvAccLogFile) != "" {
+			return logger.Level(logger.LevelTrace)
+		} else {
+			// In all other cases we use INFO log level to be consistent with Go SDK
+			return logger.Level(logger.LevelInfo)
+		}
+	}
+
+	// In most cases environment variable won't be passed,
+	// We should only compute the mapping function when it is passed explicitly.
+	mapping := terraformToSDKLogLevelMapping()
+	return mapping[terraformLogLevel]
+}

--- a/logging/logging_test.go
+++ b/logging/logging_test.go
@@ -1,0 +1,111 @@
+package logging
+
+import (
+	"testing"
+
+	"github.com/databricks/databricks-sdk-go/logger"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/logging"
+	"github.com/stretchr/testify/assert"
+)
+
+type mockEnvOperations struct {
+	values map[string]string
+}
+
+func (m *mockEnvOperations) Getenv(key string) string {
+	return m.values[key]
+}
+
+type mockLogLevelGetter struct {
+	level string
+}
+
+func (m *mockLogLevelGetter) GetLogLevel() string {
+	if m.level == "" {
+		return m.level
+	}
+	mapping := terraformToSDKLogLevelMapping()
+	if _, ok := mapping[m.level]; ok {
+		return m.level
+	}
+	return "TRACE"
+}
+
+func TestTerraformToSDKLogLevel_NoEnvSet(t *testing.T) {
+	mock := &mockEnvOperations{
+		values: map[string]string{},
+	}
+	logMock := &mockLogLevelGetter{
+		level: "",
+	}
+	logLevel := terraformToSDKLogLevel(mock, logMock)
+	expectedLogLevel := logger.Level(logger.LevelInfo)
+	actualLogLevel := logLevel
+	assert.Equal(t, expectedLogLevel, actualLogLevel)
+}
+
+func TestTerraformToSDKLogLevel_TFLOGSet_FileEnvNotSet(t *testing.T) {
+	TF_LOG := "DEBUG"
+	mock := &mockEnvOperations{
+		values: map[string]string{
+			logging.EnvLog: TF_LOG,
+		},
+	}
+	logMock := &mockLogLevelGetter{
+		level: TF_LOG,
+	}
+	logLevel := terraformToSDKLogLevel(mock, logMock)
+	expectedLogLevel := logger.Level(logger.LevelDebug)
+	actualLogLevel := logLevel
+	assert.Equal(t, expectedLogLevel, actualLogLevel)
+}
+
+func TestTerraformToSDKLogLevel_TFLOGSet_FileEnvSet(t *testing.T) {
+	TF_LOG := "DEBUG"
+	mock := &mockEnvOperations{
+		values: map[string]string{
+			logging.EnvLog:        TF_LOG,
+			logging.EnvAccLogFile: "/path/to/file",
+		},
+	}
+	logMock := &mockLogLevelGetter{
+		level: TF_LOG,
+	}
+	logLevel := terraformToSDKLogLevel(mock, logMock)
+	expectedLogLevel := logger.Level(logger.LevelDebug)
+	actualLogLevel := logLevel
+	assert.Equal(t, expectedLogLevel, actualLogLevel)
+}
+
+func TestTerraformToSDKLogLevel_TFLOGNotSet_FileEnvSet(t *testing.T) {
+	TF_LOG := ""
+	mock := &mockEnvOperations{
+		values: map[string]string{
+			logging.EnvLog:        TF_LOG,
+			logging.EnvAccLogFile: "/path/to/file",
+		},
+	}
+	logMock := &mockLogLevelGetter{
+		level: TF_LOG,
+	}
+	logLevel := terraformToSDKLogLevel(mock, logMock)
+	expectedLogLevel := logger.Level(logger.LevelTrace)
+	actualLogLevel := logLevel
+	assert.Equal(t, expectedLogLevel, actualLogLevel)
+}
+
+func TestTerraformToSDKLogLevel_TFLOGInvalid(t *testing.T) {
+	TF_LOG := "NonValid"
+	mock := &mockEnvOperations{
+		values: map[string]string{
+			logging.EnvLog: TF_LOG,
+		},
+	}
+	logMock := &mockLogLevelGetter{
+		level: TF_LOG,
+	}
+	logLevel := terraformToSDKLogLevel(mock, logMock)
+	expectedLogLevel := logger.Level(logger.LevelTrace)
+	actualLogLevel := logLevel
+	assert.Equal(t, expectedLogLevel, actualLogLevel)
+}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -21,6 +21,7 @@ import (
 	"github.com/databricks/terraform-provider-databricks/commands"
 	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/databricks/terraform-provider-databricks/jobs"
+	"github.com/databricks/terraform-provider-databricks/logging"
 	"github.com/databricks/terraform-provider-databricks/mlflow"
 	"github.com/databricks/terraform-provider-databricks/mws"
 	"github.com/databricks/terraform-provider-databricks/permissions"
@@ -41,6 +42,7 @@ func init() {
 	// IMPORTANT: this line cannot be changed, because it's used for
 	// internal purposes at Databricks.
 	useragent.WithProduct("databricks-tf-provider", common.Version())
+	logging.SetLogger()
 }
 
 // DatabricksProvider returns the entire terraform provider object


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
Terraform never had logging configured correctly (used to log all levels irrespective of log level specified). The issue (api calls not being shown in `DEBUG` log level) surfaced because in the TF version bump to 1.20.9 which had Go SDK version bump to 0.10.0, the PR: https://github.com/databricks/databricks-sdk-go/pull/426 introduced INFO as basic log level leading to debug level never being enabled even if it is passed through the environment variable. 

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->
Unit tests added, Integration tests are running...

Also tested manually
```
 terraform {
  required_providers {
    databricks = {
      source  = "databricks/databricks"
      version = "1.26.0"
    }
  }
}

provider "databricks" {
    profile = <redacted>
}

data "databricks_catalogs" "all" {}

output "all_catalogs" {
  value = data.databricks_catalogs.all
}
```

shows the api calls

> 2023-09-21T03:03:41.340+0200 [DEBUG] provider.terraform-provider-databricks: GET /api/2.1/unity-catalog/catalogs
< HTTP/2.0 

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

