### PR TITLE
Fix `databricks_metastore_data_access` and `databricks_storage_credential` creation on GCP

### DIFF
--- a/catalog/resource_metastore_data_access_test.go
+++ b/catalog/resource_metastore_data_access_test.go
@@ -129,8 +129,9 @@ func TestCreateDacWithDbGcpSA(t *testing.T) {
 			{
 				Method:   "POST",
 				Resource: "/api/2.1/unity-catalog/storage-credentials",
-				ExpectedRequest: DataAccessConfiguration{
-					Name: "bcd",
+				ExpectedRequest: catalog.CreateStorageCredential{
+					Name:                        "bcd",
+					DatabricksGcpServiceAccount: struct{}{},
 				},
 				Response: catalog.StorageCredentialInfo{
 					Id: "bcd",
@@ -149,9 +150,9 @@ func TestCreateDacWithDbGcpSA(t *testing.T) {
 			{
 				Method:   "GET",
 				Resource: "/api/2.1/unity-catalog/storage-credentials/bcd?",
-				Response: DataAccessConfiguration{
+				Response: catalog.StorageCredentialInfo{
 					Name: "bcd",
-					DBGcpSA: &DbGcpServiceAccount{
+					DatabricksGcpServiceAccount: &catalog.DatabricksGcpServiceAccountResponse{
 						Email: "a@example.com",
 					},
 				},

--- a/catalog/resource_metastore_data_access_test.go
+++ b/catalog/resource_metastore_data_access_test.go
@@ -315,7 +315,8 @@ func TestCreateAccountDacWithDbGcpSA(t *testing.T) {
 				ExpectedRequest: catalog.AccountsCreateStorageCredential{
 					MetastoreId: "abc",
 					CredentialInfo: &catalog.CreateStorageCredential{
-						Name: "bcd",
+						Name:                        "bcd",
+						DatabricksGcpServiceAccount: struct{}{},
 					},
 				},
 				Response: catalog.AccountsStorageCredentialInfo{

--- a/catalog/resource_storage_credential.go
+++ b/catalog/resource_storage_credential.go
@@ -35,6 +35,10 @@ func removeGcpSaField(originalSchema map[string]*schema.Schema) map[string]*sche
 func ResourceStorageCredential() *schema.Resource {
 	s := common.StructToSchema(StorageCredentialInfo{},
 		func(m map[string]*schema.Schema) map[string]*schema.Schema {
+			m["force_destroy"] = &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+			}
 			return adjustDataAccessSchema(m)
 		})
 	return common.Resource{

--- a/catalog/resource_storage_credential.go
+++ b/catalog/resource_storage_credential.go
@@ -35,10 +35,6 @@ func removeGcpSaField(originalSchema map[string]*schema.Schema) map[string]*sche
 func ResourceStorageCredential() *schema.Resource {
 	s := common.StructToSchema(StorageCredentialInfo{},
 		func(m map[string]*schema.Schema) map[string]*schema.Schema {
-			m["force_destroy"] = &schema.Schema{
-				Type:     schema.TypeBool,
-				Optional: true,
-			}
 			return adjustDataAccessSchema(m)
 		})
 	return common.Resource{
@@ -51,6 +47,11 @@ func ResourceStorageCredential() *schema.Resource {
 			var update catalog.UpdateStorageCredential
 			common.DataToStructPointer(d, tmpSchema, &create)
 			common.DataToStructPointer(d, tmpSchema, &update)
+
+			//manually add empty struct back for databricks_gcp_service_account
+			if _, ok := d.GetOk("databricks_gcp_service_account"); ok {
+				create.DatabricksGcpServiceAccount = struct{}{}
+			}
 
 			return c.AccountOrWorkspaceRequest(func(acc *databricks.AccountClient) error {
 				storageCredential, err := acc.StorageCredentials.Create(ctx,

--- a/catalog/resource_storage_credential_test.go
+++ b/catalog/resource_storage_credential_test.go
@@ -323,9 +323,10 @@ func TestCreateStorageCredentialWithDbGcpSA(t *testing.T) {
 			{
 				Method:   "POST",
 				Resource: "/api/2.1/unity-catalog/storage-credentials",
-				ExpectedRequest: StorageCredentialInfo{
-					Name:    "a",
-					Comment: "c",
+				ExpectedRequest: catalog.CreateStorageCredential{
+					Name:                        "a",
+					DatabricksGcpServiceAccount: struct{}{},
+					Comment:                     "c",
 				},
 				Response: catalog.StorageCredentialInfo{
 					Name: "a",


### PR DESCRIPTION
## Changes
- Always send empty struct for `databricks_gcp_service_account` in the create request. Closes #2628

## Tests
Test e2e locally

- [x] `make test` run locally
- [ ] relevant acceptance tests are passing
- [x] using Go SDK

