### PR TITLE
Add `owner` & `force_destroy` to `databricks_metastore_data_access`

### DIFF
--- a/catalog/resource_metastore_data_access.go
+++ b/catalog/resource_metastore_data_access.go
@@ -22,21 +22,6 @@ type GcpServiceAccountKey struct {
 	PrivateKey   string `json:"private_key" tf:"sensitive"`
 }
 
-type DbGcpServiceAccount struct {
-	Email string `json:"email,omitempty" tf:"computed"`
-}
-
-type DataAccessConfiguration struct {
-	ID                string                         `json:"id,omitempty" tf:"computed"`
-	Name              string                         `json:"name"`
-	ConfigurationType string                         `json:"configuration_type,omitempty" tf:"computed"`
-	Aws               *AwsIamRole                    `json:"aws_iam_role,omitempty" tf:"group:access"`
-	Azure             *catalog.AzureServicePrincipal `json:"azure_service_principal,omitempty" tf:"group:access"`
-	AzMI              *catalog.AzureManagedIdentity  `json:"azure_managed_identity,omitempty" tf:"group:access"`
-	GcpSAKey          *GcpServiceAccountKey          `json:"gcp_service_account_key,omitempty" tf:"group:access"`
-	DBGcpSA           *DbGcpServiceAccount           `json:"databricks_gcp_service_account,omitempty" tf:"group:access"`
-}
-
 var alofCred = []string{"aws_iam_role", "azure_service_principal", "azure_managed_identity",
 	"gcp_service_account_key", "databricks_gcp_service_account"}
 
@@ -58,10 +43,15 @@ func adjustDataAccessSchema(m map[string]*schema.Schema) map[string]*schema.Sche
 
 	common.MustSchemaPath(m, "azure_managed_identity", "credential_id").Computed = true
 
+	m["force_destroy"] = &schema.Schema{
+		Type:     schema.TypeBool,
+		Optional: true,
+	}
+
 	return m
 }
 
-var dacSchema = common.StructToSchema(DataAccessConfiguration{},
+var dacSchema = common.StructToSchema(StorageCredentialInfo{},
 	func(m map[string]*schema.Schema) map[string]*schema.Schema {
 		m["metastore_id"] = &schema.Schema{
 			Type:     schema.TypeString,
@@ -183,6 +173,7 @@ func ResourceMetastoreDataAccess() *schema.Resource {
 		},
 		Delete: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
 			metastoreId, dacName, err := p.Unpack(d)
+			force := d.Get("force_destroy").(bool)
 			if err != nil {
 				return err
 			}
@@ -190,9 +181,13 @@ func ResourceMetastoreDataAccess() *schema.Resource {
 				return acc.StorageCredentials.Delete(ctx, catalog.DeleteAccountStorageCredentialRequest{
 					MetastoreId: metastoreId,
 					Name:        dacName,
+					Force:       force,
 				})
 			}, func(w *databricks.WorkspaceClient) error {
-				return w.StorageCredentials.DeleteByName(ctx, dacName)
+				return w.StorageCredentials.Delete(ctx, catalog.DeleteStorageCredentialRequest{
+					Name:  dacName,
+					Force: force,
+				})
 			})
 		},
 	}.ToResource()

--- a/catalog/resource_metastore_data_access_test.go
+++ b/catalog/resource_metastore_data_access_test.go
@@ -18,10 +18,10 @@ func TestCreateDac(t *testing.T) {
 			{
 				Method:   "POST",
 				Resource: "/api/2.1/unity-catalog/storage-credentials",
-				ExpectedRequest: DataAccessConfiguration{
+				ExpectedRequest: catalog.CreateStorageCredential{
 					Name: "bcd",
-					Aws: &AwsIamRole{
-						RoleARN: "def",
+					AwsIamRole: &catalog.AwsIamRole{
+						RoleArn: "def",
 					},
 				},
 				Response: catalog.StorageCredentialInfo{
@@ -72,9 +72,9 @@ func TestCreateDacWithAzMI(t *testing.T) {
 			{
 				Method:   "POST",
 				Resource: "/api/2.1/unity-catalog/storage-credentials",
-				ExpectedRequest: DataAccessConfiguration{
+				ExpectedRequest: catalog.CreateStorageCredential{
 					Name: "bcd",
-					AzMI: &catalog.AzureManagedIdentity{
+					AzureManagedIdentity: &catalog.AzureManagedIdentity{
 						AccessConnectorId: "def",
 						ManagedIdentityId: "/..../subscription",
 					},

--- a/catalog/resource_storage_credential.go
+++ b/catalog/resource_storage_credential.go
@@ -10,16 +10,16 @@ import (
 )
 
 type StorageCredentialInfo struct {
-	Name        string                         `json:"name" tf:"force_new"`
-	Owner       string                         `json:"owner,omitempty" tf:"computed"`
-	Comment     string                         `json:"comment,omitempty"`
-	Aws         *AwsIamRole                    `json:"aws_iam_role,omitempty" tf:"group:access"`
-	Azure       *catalog.AzureServicePrincipal `json:"azure_service_principal,omitempty" tf:"group:access"`
-	AzMI        *catalog.AzureManagedIdentity  `json:"azure_managed_identity,omitempty" tf:"group:access"`
-	GcpSAKey    *GcpServiceAccountKey          `json:"gcp_service_account_key,omitempty" tf:"group:access"`
-	DBGcpSA     *DbGcpServiceAccount           `json:"databricks_gcp_service_account,omitempty" tf:"computed"`
-	MetastoreID string                         `json:"metastore_id,omitempty" tf:"computed"`
-	ReadOnly    bool                           `json:"read_only,omitempty"`
+	Name        string                                       `json:"name" tf:"force_new"`
+	Owner       string                                       `json:"owner,omitempty" tf:"computed"`
+	Comment     string                                       `json:"comment,omitempty"`
+	Aws         AwsIamRole                                   `json:"aws_iam_role,omitempty" tf:"group:access"`
+	Azure       *catalog.AzureServicePrincipal               `json:"azure_service_principal,omitempty" tf:"group:access"`
+	AzMI        *catalog.AzureManagedIdentity                `json:"azure_managed_identity,omitempty" tf:"group:access"`
+	GcpSAKey    *GcpServiceAccountKey                        `json:"gcp_service_account_key,omitempty" tf:"group:access"`
+	DBGcpSA     *catalog.DatabricksGcpServiceAccountResponse `json:"databricks_gcp_service_account,omitempty" tf:"computed"`
+	MetastoreID string                                       `json:"metastore_id,omitempty" tf:"computed"`
+	ReadOnly    bool                                         `json:"read_only,omitempty"`
 }
 
 func removeGcpSaField(originalSchema map[string]*schema.Schema) map[string]*schema.Schema {
@@ -32,20 +32,17 @@ func removeGcpSaField(originalSchema map[string]*schema.Schema) map[string]*sche
 	return tmpSchema
 }
 
+var storageCredentialSchema = common.StructToSchema(StorageCredentialInfo{},
+	func(m map[string]*schema.Schema) map[string]*schema.Schema {
+		return adjustDataAccessSchema(m)
+	})
+
 func ResourceStorageCredential() *schema.Resource {
-	s := common.StructToSchema(StorageCredentialInfo{},
-		func(m map[string]*schema.Schema) map[string]*schema.Schema {
-			m["force_destroy"] = &schema.Schema{
-				Type:     schema.TypeBool,
-				Optional: true,
-			}
-			return adjustDataAccessSchema(m)
-		})
 	return common.Resource{
-		Schema: s,
+		Schema: storageCredentialSchema,
 		Create: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
 			metastoreId := d.Get("metastore_id").(string)
-			tmpSchema := removeGcpSaField(s)
+			tmpSchema := removeGcpSaField(storageCredentialSchema)
 
 			var create catalog.CreateStorageCredential
 			var update catalog.UpdateStorageCredential
@@ -110,18 +107,18 @@ func ResourceStorageCredential() *schema.Resource {
 				if err != nil {
 					return err
 				}
-				return common.StructToData(storageCredential, s, d)
+				return common.StructToData(storageCredential, storageCredentialSchema, d)
 			}, func(w *databricks.WorkspaceClient) error {
 				storageCredential, err := w.StorageCredentials.GetByName(ctx, d.Id())
 				if err != nil {
 					return err
 				}
-				return common.StructToData(storageCredential, s, d)
+				return common.StructToData(storageCredential, storageCredentialSchema, d)
 			})
 		},
 		Update: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
 			var update catalog.UpdateStorageCredential
-			common.DataToStructPointer(d, s, &update)
+			common.DataToStructPointer(d, storageCredentialSchema, &update)
 
 			return c.AccountOrWorkspaceRequest(func(acc *databricks.AccountClient) error {
 				_, err := acc.StorageCredentials.Update(ctx, catalog.AccountsUpdateStorageCredential{

--- a/catalog/resource_storage_credential_test.go
+++ b/catalog/resource_storage_credential_test.go
@@ -17,10 +17,10 @@ func TestCreateStorageCredentials(t *testing.T) {
 			{
 				Method:   "POST",
 				Resource: "/api/2.1/unity-catalog/storage-credentials",
-				ExpectedRequest: StorageCredentialInfo{
+				ExpectedRequest: catalog.CreateStorageCredential{
 					Name: "a",
-					Aws: &AwsIamRole{
-						RoleARN: "def",
+					AwsIamRole: &catalog.AwsIamRole{
+						RoleArn: "def",
 					},
 					Comment: "c",
 				},
@@ -58,10 +58,10 @@ func TestCreateStorageCredentialWithOwner(t *testing.T) {
 			{
 				Method:   "POST",
 				Resource: "/api/2.1/unity-catalog/storage-credentials",
-				ExpectedRequest: StorageCredentialInfo{
+				ExpectedRequest: catalog.CreateStorageCredential{
 					Name: "a",
-					Aws: &AwsIamRole{
-						RoleARN: "def",
+					AwsIamRole: &catalog.AwsIamRole{
+						RoleArn: "def",
 					},
 					Comment: "c",
 				},
@@ -72,10 +72,10 @@ func TestCreateStorageCredentialWithOwner(t *testing.T) {
 			{
 				Method:   "PATCH",
 				Resource: "/api/2.1/unity-catalog/storage-credentials/a",
-				ExpectedRequest: StorageCredentialInfo{
+				ExpectedRequest: catalog.UpdateStorageCredential{
 					Name: "a",
-					Aws: &AwsIamRole{
-						RoleARN: "def",
+					AwsIamRole: &catalog.AwsIamRole{
+						RoleArn: "def",
 					},
 					Comment: "c",
 					Owner:   "administrators",
@@ -116,10 +116,10 @@ func TestCreateStorageCredentialsReadOnly(t *testing.T) {
 			{
 				Method:   "POST",
 				Resource: "/api/2.1/unity-catalog/storage-credentials",
-				ExpectedRequest: StorageCredentialInfo{
+				ExpectedRequest: catalog.CreateStorageCredential{
 					Name: "a",
-					Aws: &AwsIamRole{
-						RoleARN: "def",
+					AwsIamRole: &catalog.AwsIamRole{
+						RoleArn: "def",
 					},
 					Comment:  "c",
 					ReadOnly: true,
@@ -131,10 +131,10 @@ func TestCreateStorageCredentialsReadOnly(t *testing.T) {
 			{
 				Method:   "PATCH",
 				Resource: "/api/2.1/unity-catalog/storage-credentials/a",
-				ExpectedRequest: StorageCredentialInfo{
+				ExpectedRequest: catalog.UpdateStorageCredential{
 					Name: "a",
-					Aws: &AwsIamRole{
-						RoleARN: "def",
+					AwsIamRole: &catalog.AwsIamRole{
+						RoleArn: "def",
 					},
 					Comment:  "c",
 					ReadOnly: true,
@@ -175,10 +175,10 @@ func TestUpdateStorageCredentials(t *testing.T) {
 			{
 				Method:   "PATCH",
 				Resource: "/api/2.1/unity-catalog/storage-credentials/a",
-				ExpectedRequest: StorageCredentialInfo{
+				ExpectedRequest: catalog.UpdateStorageCredential{
 					Name: "a",
-					Aws: &AwsIamRole{
-						RoleARN: "CHANGED",
+					AwsIamRole: &catalog.AwsIamRole{
+						RoleArn: "CHANGED",
 					},
 					Comment: "c",
 				},
@@ -186,12 +186,12 @@ func TestUpdateStorageCredentials(t *testing.T) {
 			{
 				Method:   "GET",
 				Resource: "/api/2.1/unity-catalog/storage-credentials/a?",
-				Response: StorageCredentialInfo{
+				Response: catalog.StorageCredentialInfo{
 					Name: "a",
-					Aws: &AwsIamRole{
-						RoleARN: "CHANGED",
+					AwsIamRole: &catalog.AwsIamRole{
+						RoleArn: "CHANGED",
 					},
-					MetastoreID: "d",
+					MetastoreId: "d",
 					Comment:     "c",
 				},
 			},
@@ -219,9 +219,9 @@ func TestCreateStorageCredentialWithAzMI(t *testing.T) {
 			{
 				Method:   "POST",
 				Resource: "/api/2.1/unity-catalog/storage-credentials",
-				ExpectedRequest: StorageCredentialInfo{
+				ExpectedRequest: catalog.CreateStorageCredential{
 					Name: "a",
-					AzMI: &catalog.AzureManagedIdentity{
+					AzureManagedIdentity: &catalog.AzureManagedIdentity{
 						AccessConnectorId: "def",
 					},
 					Comment: "c",
@@ -233,9 +233,9 @@ func TestCreateStorageCredentialWithAzMI(t *testing.T) {
 			{
 				Method:   "PATCH",
 				Resource: "/api/2.1/unity-catalog/storage-credentials/a",
-				ExpectedRequest: StorageCredentialInfo{
+				ExpectedRequest: catalog.UpdateStorageCredential{
 					Name: "a",
-					AzMI: &catalog.AzureManagedIdentity{
+					AzureManagedIdentity: &catalog.AzureManagedIdentity{
 						AccessConnectorId: "def",
 					},
 					Comment: "c",
@@ -274,10 +274,10 @@ func TestUpdateAzStorageCredentials(t *testing.T) {
 			{
 				Method:   "PATCH",
 				Resource: "/api/2.1/unity-catalog/storage-credentials/a",
-				ExpectedRequest: StorageCredentialInfo{
+				ExpectedRequest: catalog.UpdateStorageCredential{
 					Name:    "a",
 					Comment: "c",
-					Azure: &catalog.AzureServicePrincipal{
+					AzureServicePrincipal: &catalog.AzureServicePrincipal{
 						DirectoryId:   "CHANGED",
 						ApplicationId: "CHANGED",
 						ClientSecret:  "CHANGED",
@@ -325,8 +325,8 @@ func TestCreateStorageCredentialWithDbGcpSA(t *testing.T) {
 				Resource: "/api/2.1/unity-catalog/storage-credentials",
 				ExpectedRequest: catalog.CreateStorageCredential{
 					Name:                        "a",
-					DatabricksGcpServiceAccount: struct{}{},
 					Comment:                     "c",
+					DatabricksGcpServiceAccount: struct{}{},
 				},
 				Response: catalog.StorageCredentialInfo{
 					Name: "a",
@@ -338,7 +338,7 @@ func TestCreateStorageCredentialWithDbGcpSA(t *testing.T) {
 			{
 				Method:   "PATCH",
 				Resource: "/api/2.1/unity-catalog/storage-credentials/a",
-				ExpectedRequest: StorageCredentialInfo{
+				ExpectedRequest: catalog.UpdateStorageCredential{
 					Name:    "a",
 					Comment: "c",
 				},
@@ -377,10 +377,10 @@ func TestUpdateAzStorageCredentialMI(t *testing.T) {
 			{
 				Method:   "PATCH",
 				Resource: "/api/2.1/unity-catalog/storage-credentials/a",
-				ExpectedRequest: StorageCredentialInfo{
+				ExpectedRequest: catalog.UpdateStorageCredential{
 					Name:    "a",
 					Comment: "c",
-					AzMI: &catalog.AzureManagedIdentity{
+					AzureManagedIdentity: &catalog.AzureManagedIdentity{
 						AccessConnectorId: "CHANGED",
 					},
 				},

--- a/docs/resources/metastore_data_access.md
+++ b/docs/resources/metastore_data_access.md
@@ -57,6 +57,8 @@ The following arguments are required:
 
 * `name` - Name of Data Access Configuration, which must be unique within the [databricks_metastore](metastore.md). Change forces creation of a new resource.
 * `metastore_id` - Unique identifier of the parent Metastore
+* `owner` - (Optional) Username/groupname/sp application_id of the data access configuration owner.
+* `force_destroy` - (Optional) Delete the data access configuration regardless of its dependencies.
 
 `aws_iam_role` optional configuration block for credential details for AWS:
 

--- a/docs/resources/storage_credential.md
+++ b/docs/resources/storage_credential.md
@@ -74,6 +74,7 @@ The following arguments are required:
 - `name` - Name of Storage Credentials, which must be unique within the [databricks_metastore](metastore.md). Change forces creation of a new resource.
 - `metastore_id` - (Required for account-level) Unique identifier of the parent Metastore
 - `owner` - (Optional) Username/groupname/sp application_id of the storage credential owner.
+- `force_destroy` - (Optional) Delete storage credential regardless of its dependencies.
 
 `aws_iam_role` optional configuration block for credential details for AWS:
 
@@ -82,24 +83,26 @@ The following arguments are required:
 `azure_managed_identity` optional configuration block for using managed identity as credential details for Azure (recommended over service principal):
 
 - `access_connector_id` - The Resource ID of the Azure Databricks Access Connector resource, of the form `/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-name/providers/Microsoft.Databricks/accessConnectors/connector-name`.
-* `managed_identity_id` - (Optional) The Resource ID of the Azure User Assigned Managed Identity associated with Azure Databricks Access Connector, of the form `/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-name/providers/Microsoft.ManagedIdentity/userAssignedIdentities/user-managed-identity-name`.
 
-`azure_service_principal` optional configuration block to use service principal as credential details for Azure:
+- `managed_identity_id` - (Optional) The Resource ID of the Azure User Assigned Managed Identity associated with Azure Databricks Access Connector, of the form `/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-name/providers/Microsoft.ManagedIdentity/userAssignedIdentities/user-managed-identity-name`.
+
+`databricks_gcp_service_account` optional configuration block for creating a Databricks-managed GCP Service Account:
+
+- `email` (output only) - The email of the GCP service account created, to be granted access to relevant buckets.
+
+- `read_only` - (Optional) Indicates whether the storage credential is only usable for read operations.
+
+`azure_service_principal` optional configuration block to use service principal as credential details for Azure (Legacy):
 
 - `directory_id` - The directory ID corresponding to the Azure Active Directory (AAD) tenant of the application
 - `application_id` - The application ID of the application registration within the referenced AAD tenant
 - `client_secret` - The client secret generated for the above app ID in AAD. **This field is redacted on output**
 
-`databricks_gcp_service_account` optional configuration block for creating a Databricks-managed GCP Service Account:
-
-- `email` (output only) - The email of the GCP service account created, to be granted access to relevant buckets.
-- `read_only` - (Optional) Indicates whether the storage credential is only usable for read operations.
-
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - ID of this storage credential - same as the `name`.
+- `id` - ID of this storage credential - same as the `name`.
 
 ## Import
 


### PR DESCRIPTION
## Changes

- Refactor to make `databricks_metastore_data_access` consistent with `databricks_storage_credential
- Close #2651

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [x] covered with integration tests in `internal/acceptance`
- [x] relevant acceptance tests are passing
- [x] using Go SDK

