### PR TITLE
Add `empty_result_state` attribute to the `databricks_sql_alert` resource

### DIFF
--- a/docs/resources/sql_alert.md
+++ b/docs/resources/sql_alert.md
@@ -50,6 +50,7 @@ The following arguments are available:
   * `custom_body` - (Optional, String) Custom body of alert notification, if it exists. See [Alerts API reference](https://docs.databricks.com/sql/user/alerts/index.html) for custom templating instructions.
 * `parent` - (Optional, String) The identifier of the workspace folder containing the alert. The default is ther user's home folder. The folder identifier is formatted as `folder/<folder_id>`.
 * `rearm` - (Optional, Integer) Number of seconds after being triggered before the alert rearms itself and can be triggered again. If not defined, alert will never be triggered again. 
+* `empty_result_state` - (Optional, String) State that alert evaluates to when query result is empty.  Currently supported values are `unknown`, `triggered`, `ok` - check [API documentation](https://docs.databricks.com/api/workspace/alerts/create) for full list of supported values.
 
 ## Related Resources
 


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

This fixes #2662

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [x] tested manually
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

