### PR TITLE
Add `dashboard_filters_enabled` attribute to `databricks_sql_dashboard` resource

### DIFF
--- a/sql/api/dashboard.go
+++ b/sql/api/dashboard.go
@@ -4,11 +4,12 @@ import "encoding/json"
 
 // Dashboard ...
 type Dashboard struct {
-	ID        string            `json:"id"`
-	Name      string            `json:"name"`
-	Tags      []string          `json:"tags,omitempty"`
-	Widgets   []json.RawMessage `json:"widgets,omitempty"`
-	Parent    string            `json:"parent,omitempty"`
-	CreatedAt string            `json:"created_at,omitempty"`
-	UpdatedAt string            `json:"updated_at,omitempty"`
+	ID                      string            `json:"id"`
+	Name                    string            `json:"name"`
+	Tags                    []string          `json:"tags,omitempty"`
+	Widgets                 []json.RawMessage `json:"widgets,omitempty"`
+	Parent                  string            `json:"parent,omitempty"`
+	CreatedAt               string            `json:"created_at,omitempty"`
+	UpdatedAt               string            `json:"updated_at,omitempty"`
+	DashboardFiltersEnabled bool              `json:"dashboard_filters_enabled,omitempty"`
 }

--- a/sql/resource_sql_dashboard.go
+++ b/sql/resource_sql_dashboard.go
@@ -11,11 +11,12 @@ import (
 
 // DashboardEntity defines the parameters that can be set in the resource.
 type DashboardEntity struct {
-	Name      string   `json:"name"`
-	Tags      []string `json:"tags,omitempty"`
-	Parent    string   `json:"parent,omitempty" tf:"suppress_diff,force_new"`
-	CreatedAt string   `json:"created_at,omitempty" tf:"computed"`
-	UpdatedAt string   `json:"updated_at,omitempty" tf:"computed"`
+	Name                    string   `json:"name"`
+	Tags                    []string `json:"tags,omitempty"`
+	Parent                  string   `json:"parent,omitempty" tf:"suppress_diff,force_new"`
+	CreatedAt               string   `json:"created_at,omitempty" tf:"computed"`
+	UpdatedAt               string   `json:"updated_at,omitempty" tf:"computed"`
+	DashboardFiltersEnabled bool     `json:"dashboard_filters_enabled,omitempty"`
 }
 
 func (d *DashboardEntity) toAPIObject(schema map[string]*schema.Schema, data *schema.ResourceData) (*api.Dashboard, error) {
@@ -28,6 +29,7 @@ func (d *DashboardEntity) toAPIObject(schema map[string]*schema.Schema, data *sc
 	ad.Name = d.Name
 	ad.Tags = append([]string{}, d.Tags...)
 	ad.Parent = d.Parent
+	ad.DashboardFiltersEnabled = d.DashboardFiltersEnabled
 
 	return &ad, nil
 }
@@ -39,6 +41,7 @@ func (d *DashboardEntity) fromAPIObject(ad *api.Dashboard, schema map[string]*sc
 	d.Parent = ad.Parent
 	d.UpdatedAt = ad.UpdatedAt
 	d.CreatedAt = ad.CreatedAt
+	d.DashboardFiltersEnabled = ad.DashboardFiltersEnabled
 
 	// Pass to ResourceData.
 	if err := common.StructToData(*d, schema, data); err != nil {


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->


When `dashboard_filters_enabled` is set to `true` then filters are shown on the SQL Dashboard level. In this case, the `databricks_sql_widget` should have following block to use it:

```
  parameter {
    type   = "dashboard-level"
    name   = "Limit"
    map_to = "Limit"
  }
```

This fixes #2172

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] tested manually
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

