### PR TITLE
Fix missing `registered_model_id` attribute in `databricks_mlflow_model` resource

### DIFF
--- a/internal/acceptance/mlflow_model_test.go
+++ b/internal/acceptance/mlflow_model_test.go
@@ -16,6 +16,14 @@ func TestAccMLflowModel(t *testing.T) {
 				value = "{var.RANDOM}"
 			}
 		}
+
+		resource "databricks_permissions" "mlflow_model_permissions" {
+			registered_model_id = databricks_mlflow_model.m1.registered_model_id
+			access_control {
+			  group_name       = "users"
+			  permission_level = "CAN_READ"
+			}
+		  }
 		`,
 	})
 }

--- a/mlflow/resource_mlflow_model.go
+++ b/mlflow/resource_mlflow_model.go
@@ -18,6 +18,10 @@ func ResourceMlflowModel() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			}
+			s["registered_model_id"] = &schema.Schema{
+				Computed: true,
+				Type:     schema.TypeString,
+			}
 			return s
 		})
 
@@ -40,7 +44,6 @@ func ResourceMlflowModel() *schema.Resource {
 				return err
 			}
 			d.SetId(model.RegisteredModelDatabricks.Name)
-			d.Set("registered_model_id", model.RegisteredModelDatabricks.Id) // alias
 			return nil
 		},
 		Read: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
@@ -55,7 +58,12 @@ func ResourceMlflowModel() *schema.Resource {
 			if err != nil {
 				return err
 			}
-			return common.StructToData(res, s, d)
+			err = common.StructToData(res, s, d)
+			if err != nil {
+				return err
+			}
+			d.Set("registered_model_id", res.RegisteredModelDatabricks.Id) // alias
+			return nil
 		},
 		Update: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
 			w, err := c.WorkspaceClient()

--- a/mlflow/resource_mlflow_model_test.go
+++ b/mlflow/resource_mlflow_model_test.go
@@ -39,17 +39,10 @@ func TestModelCreateMVP(t *testing.T) {
 				Response: ml.GetModelResponse{
 					RegisteredModelDatabricks: &ml.ModelDatabricks{
 						Name: "xyz",
+						Id:   "123",
 					},
 				},
-			},
-			{
-				Method:   "GET",
-				Resource: "/api/2.0/mlflow/databricks/registered-models/get?name=xyz",
-				Response: ml.GetModelResponse{
-					RegisteredModelDatabricks: &ml.ModelDatabricks{
-						Name: "xyz",
-					},
-				},
+				ReuseRequest: true,
 			},
 		},
 		Resource: ResourceMlflowModel(),
@@ -57,7 +50,7 @@ func TestModelCreateMVP(t *testing.T) {
 		HCL: `
 		name = "xyz"
 		`,
-	}.ApplyNoError(t)
+	}.ApplyAndExpectData(t, map[string]any{"id": "xyz", "registered_model_id": "123"})
 }
 
 func TestModelCreateWithTags(t *testing.T) {


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->


This attribute was lost during refactoring in #2257, and it broke the assignment of permissions.  Also expanded the corresponding integration test to have a check for that

This fixes #2730

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

