### PR TITLE
Force recreation of UC Volume when `volume_type` and/or `storage_location` are changed

### DIFF
--- a/catalog/resource_volume.go
+++ b/catalog/resource_volume.go
@@ -24,8 +24,8 @@ type VolumeInfo struct {
 	// The identifier of the user who owns the volume
 	Owner string `json:"owner,omitempty" tf:"computed"`
 	// The storage location on the cloud
-	StorageLocation string             `json:"storage_location,omitempty"`
-	VolumeType      catalog.VolumeType `json:"volume_type"`
+	StorageLocation string             `json:"storage_location,omitempty" tf:"force_new"`
+	VolumeType      catalog.VolumeType `json:"volume_type" tf:"force_new"`
 }
 
 func ResourceVolume() *schema.Resource {

--- a/docs/resources/volume.md
+++ b/docs/resources/volume.md
@@ -82,9 +82,9 @@ The following arguments are supported:
 * `name` - Name of the Volume
 * `catalog_name` - Name of parent Catalog. Change forces creation of a new resource.
 * `schema_name` - Name of parent Schema relative to parent Catalog. Change forces creation of a new resource.
-* `volume_type` - Volume type. `EXTERNAL` or `MANAGED`.
+* `volume_type` - Volume type. `EXTERNAL` or `MANAGED`. Change forces creation of a new resource.
 * `owner` - (Optional) Name of the volume owner.
-* `storage_location` - (Optional) Path inside an External Location. Only used for `EXTERNAL` Volumes.
+* `storage_location` - (Optional) Path inside an External Location. Only used for `EXTERNAL` Volumes. Change forces creation of a new resource.
 * `comment` - (Optional) Free-form text.
 
 ## Attribute Reference


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->


The [UC Volumes update API](https://docs.databricks.com/api/workspace/volumes/update) allows updates only of specific attributes, so we need to force recreation of the volume when `volume_type` or `storage_location` are modified.

This fixes #2692

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

