### PR TITLE
Exporter: remove `modifiedAt != 0` check in the incremental mode

### DIFF
--- a/exporter/importables.go
+++ b/exporter/importables.go
@@ -1045,7 +1045,7 @@ var resourcesMap map[string]importable = map[string]importable{
 			updatedSinceMs := ic.getUpdatedSinceMs()
 			for offset, gis := range globalInitScripts {
 				modifiedAt := gis.UpdatedAt
-				if ic.incremental && modifiedAt != 0 && modifiedAt < updatedSinceMs {
+				if ic.incremental && modifiedAt < updatedSinceMs {
 					log.Printf("[DEBUG] skipping global init script '%s' that was modified at %d (last active=%d)",
 						gis.Name, modifiedAt, updatedSinceMs)
 					continue
@@ -1214,7 +1214,7 @@ var resourcesMap map[string]importable = map[string]importable{
 			updatedSinceMs := ic.getUpdatedSinceMs()
 			for offset, ipList := range ipLists {
 				modifiedAt := ipList.UpdatedAt
-				if ic.incremental && modifiedAt != 0 && modifiedAt < updatedSinceMs {
+				if ic.incremental && modifiedAt < updatedSinceMs {
 					log.Printf("[DEBUG] skipping IP access list '%s' that was modified at %d (last active=%d)",
 						ipList.Label, modifiedAt, updatedSinceMs)
 					continue
@@ -1719,7 +1719,7 @@ var resourcesMap map[string]importable = map[string]importable{
 						return err
 					}
 					modifiedAt := pipeline.LastModified
-					if modifiedAt != 0 && modifiedAt < updatedSinceMs {
+					if modifiedAt < updatedSinceMs {
 						log.Printf("[DEBUG] skipping DLT Pipeline '%s' that was modified at %d (last active=%d)",
 							pipeline.Name, modifiedAt, updatedSinceMs)
 						continue
@@ -1887,7 +1887,7 @@ var resourcesMap map[string]importable = map[string]importable{
 			updatedSinceMs := ic.getUpdatedSinceMs()
 			for offset, endpoint := range endpointsList {
 				modifiedAt := endpoint.LastUpdatedTimestamp
-				if ic.incremental && modifiedAt != 0 && modifiedAt < updatedSinceMs {
+				if ic.incremental && modifiedAt < updatedSinceMs {
 					log.Printf("[DEBUG] skipping serving endpoint '%s' that was modified at %d (last active=%d)",
 						endpoint.Name, modifiedAt, updatedSinceMs)
 					continue
@@ -1940,7 +1940,7 @@ var resourcesMap map[string]importable = map[string]importable{
 			updatedSinceMs := ic.getUpdatedSinceMs()
 			for offset, webhook := range webhooks {
 				modifiedAt := webhook.LastUpdatedTimestamp
-				if ic.incremental && modifiedAt != 0 && modifiedAt < updatedSinceMs {
+				if ic.incremental && modifiedAt < updatedSinceMs {
 					log.Printf("[DEBUG] skipping MLflow webhook '%s' that was modified at %d (last active=%d)",
 						webhook.Id, modifiedAt, updatedSinceMs)
 					continue

--- a/exporter/util.go
+++ b/exporter/util.go
@@ -630,7 +630,7 @@ func createListWorkspaceObjectsFunc(objType string, resourceType string, objName
 				continue
 			}
 			modifiedAt := wsObjectGetModifiedAt(object)
-			if ic.incremental && modifiedAt != 0 && modifiedAt < updatedSinceMs {
+			if ic.incremental && modifiedAt < updatedSinceMs {
 				log.Printf("[DEBUG] skipping '%s' that was modified at %d (last active=%d)", object.Path,
 					modifiedAt, updatedSinceMs)
 				continue


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

That check caused repeated re-export of the same notebooks in the incremental mode.  This issue happened only in specific customer environment.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

