### PR TITLE
Bump databricks-sdk-go dependency to 0.21.0

### DIFF
--- a/catalog/resource_connection.go
+++ b/catalog/resource_connection.go
@@ -39,6 +39,7 @@ var sensitiveOptions = []string{"user", "password", "personalAccessToken", "acce
 func ResourceConnection() *schema.Resource {
 	s := common.StructToSchema(ConnectionInfo{},
 		func(m map[string]*schema.Schema) map[string]*schema.Schema {
+			m["owner"].Deprecated = "owner field is deprecated due the Catalog API changes."
 			return m
 		})
 	pi := common.NewPairID("metastore_id", "name").Schema(

--- a/catalog/resource_connection.go
+++ b/catalog/resource_connection.go
@@ -25,8 +25,6 @@ type ConnectionInfo struct {
 	NameArg string `json:"-" url:"-"`
 	// A map of key-value properties attached to the securable.
 	Options map[string]string `json:"options" tf:"sensitive"`
-	// Username of current owner of the connection.
-	Owner string `json:"owner,omitempty" tf:"force_new,suppress_diff"`
 	// An object containing map of key-value properties attached to the
 	// connection.
 	Properties map[string]string `json:"properties,omitempty" tf:"force_new"`
@@ -39,7 +37,12 @@ var sensitiveOptions = []string{"user", "password", "personalAccessToken", "acce
 func ResourceConnection() *schema.Resource {
 	s := common.StructToSchema(ConnectionInfo{},
 		func(m map[string]*schema.Schema) map[string]*schema.Schema {
-			m["owner"].Deprecated = "owner field is deprecated due the Catalog API changes."
+			m["owner"] = &schema.Schema{
+				Type:       schema.TypeString,
+				Optional:   true,
+				Deprecated: `owner field is deprecated due the Catalog API changes. Owner cannot be specified when creating a connection.`,
+				Default:    "",
+			}
 			return m
 		})
 	pi := common.NewPairID("metastore_id", "name").Schema(

--- a/catalog/resource_connection_test.go
+++ b/catalog/resource_connection_test.go
@@ -30,7 +30,6 @@ func TestConnectionsCreate(t *testing.T) {
 					Properties: map[string]string{
 						"purpose": "testing",
 					},
-					Owner: "InitialOwner",
 				},
 				Response: catalog.ConnectionInfo{
 					Name:           "testConnectionName",
@@ -102,7 +101,6 @@ func TestConnectionsCreate_Error(t *testing.T) {
 					Options: map[string]string{
 						"host": "test.com",
 					},
-					Owner: "testOwner",
 				},
 				Response: apierr.APIErrorBody{
 					ErrorCode: "SERVER_ERROR",

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/databricks/terraform-provider-databricks
 go 1.19
 
 require (
-	github.com/databricks/databricks-sdk-go v0.20.0
+	github.com/databricks/databricks-sdk-go v0.21.0
 	github.com/golang-jwt/jwt/v4 v4.5.0
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/hcl v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -23,6 +23,8 @@ github.com/cloudflare/circl v1.3.3/go.mod h1:5XYMA4rFBvNIrhs50XuiBJ15vF2pZn4nnUK
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/databricks/databricks-sdk-go v0.20.0 h1:KyVQkvyFYgIlTBjQbazAtW/Y5tZaHy2pF5DRpC35s0s=
 github.com/databricks/databricks-sdk-go v0.20.0/go.mod h1:COiklTN3IdieazXcs4TnMou5GQFwIM7uhMGrz7nEAAk=
+github.com/databricks/databricks-sdk-go v0.21.0 h1:d/T4oljsbvyrO3GQzUfkkWHckw/Z9qe1gL+/KMzRVn8=
+github.com/databricks/databricks-sdk-go v0.21.0/go.mod h1:COiklTN3IdieazXcs4TnMou5GQFwIM7uhMGrz7nEAAk=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
## Changes
Bump databricks-sdk-go dependency to 0.21.0

## Tests
- [X] `make test` run locally
- [X] relevant change in `docs/` folder
- [X] covered with integration tests in `internal/acceptance`
- [X] relevant acceptance tests are passing
- [X] using Go SDK

