### PR TITLE
GitHub Actions workflow to compute provider schema diff

### DIFF
--- a/.github/workflows/schema.yml
+++ b/.github/workflows/schema.yml
@@ -1,0 +1,96 @@
+name: schema
+
+on:
+  workflow_dispatch:
+
+jobs:
+  compute_current:
+    name: "Generate current"
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Setup Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.21.x
+
+      - run: make install
+
+      - name: Generate provider schema
+        run: |
+          cd /tmp
+          cat > main.tf <<EOF
+          terraform {
+            required_providers {
+              databricks = {
+                source = "databricks/databricks"
+              }
+            }
+          }
+          EOF
+          terraform init
+          terraform providers schema -json > provider.json
+
+      - name: 'Upload provider schema'
+        uses: actions/upload-artifact@v3
+        with:
+          name: schema-current
+          path: /tmp/provider.json
+          retention-days: 1
+
+  compute_new:
+    name: "Generate new"
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: 'Setup Go'
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.21.x
+
+      - run: make install
+
+      - name: 'Generate provider schema'
+        run: |
+          cd /tmp
+          cat > main.tf <<EOF
+          terraform {
+            required_providers {
+              databricks = {
+                source = "databricks/databricks"
+              }
+            }
+          }
+          EOF
+          terraform init
+          terraform providers schema -json > provider.json
+
+      - name: 'Upload provider schema'
+        uses: actions/upload-artifact@v3
+        with:
+          name: schema-new
+          path: /tmp/provider.json
+          retention-days: 1
+
+  diff:
+    needs: [compute_current, compute_new]
+
+    name: "Compute diff"
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: my-artifact
+
+      - run: ls -l

--- a/.github/workflows/schema.yml
+++ b/.github/workflows/schema.yml
@@ -12,12 +12,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: main
+          ref: master
 
-      - name: Setup Go
+      - name: 'Setup Go'
         uses: actions/setup-go@v4
         with:
           go-version: 1.21.x
+
+      - name: 'Setup Terraform'
+        uses: hashicorp/setup-terraform@v2
 
       - run: make install
 
@@ -48,19 +51,22 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: 'Checkout'
+      - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: main
+          ref: master
 
       - name: 'Setup Go'
         uses: actions/setup-go@v4
         with:
           go-version: 1.21.x
 
+      - name: 'Setup Terraform'
+        uses: hashicorp/setup-terraform@v2
+
       - run: make install
 
-      - name: 'Generate provider schema'
+      - name: Generate provider schema
         run: |
           cd /tmp
           cat > main.tf <<EOF

--- a/.github/workflows/schema.yml
+++ b/.github/workflows/schema.yml
@@ -27,6 +27,7 @@ jobs:
       - name: Generate provider schema
         shell: bash
         run: |
+          set -ex
           cd /tmp
           cat > main.tf <<EOF
           terraform {
@@ -70,6 +71,7 @@ jobs:
       - name: Generate provider schema
         shell: bash
         run: |
+          set -ex
           cd /tmp
           cat > main.tf <<EOF
           terraform {

--- a/.github/workflows/schema.yml
+++ b/.github/workflows/schema.yml
@@ -25,6 +25,7 @@ jobs:
       - run: make install
 
       - name: Generate provider schema
+        shell: bash
         run: |
           cd /tmp
           cat > main.tf <<EOF
@@ -67,6 +68,7 @@ jobs:
       - run: make install
 
       - name: Generate provider schema
+        shell: bash
         run: |
           cd /tmp
           cat > main.tf <<EOF

--- a/.github/workflows/schema.yml
+++ b/.github/workflows/schema.yml
@@ -95,7 +95,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: 'Setup Go'
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.21.x
+          cache: false
+
+      - run: go install github.com/josephburnett/jd@latest
+
       - name: 'Download provider schemas'
         uses: actions/download-artifact@v3
 
-      - run: ls -l
+      - run: ls -l schema*/*
+
+      - run: jd -color schema-current/provider.json schema-new/provider.json

--- a/.github/workflows/schema.yml
+++ b/.github/workflows/schema.yml
@@ -95,8 +95,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/download-artifact@v3
-        with:
-          name: my-artifact
+      - name: 'Download provider schemas'
+        uses: actions/download-artifact@v3
 
       - run: ls -l

--- a/.github/workflows/schema.yml
+++ b/.github/workflows/schema.yml
@@ -1,7 +1,19 @@
 name: schema
 
 on:
+  pull_request:
+    types: [opened, synchronize]
+
   workflow_dispatch:
+    inputs:
+      base:
+        description: 'Base ref'
+        default: 'master'
+        required: true
+      head:
+        description: 'Head ref'
+        default: 'master'
+        required: true
 
 jobs:
   compute_current:
@@ -9,10 +21,18 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout
+      - if: github.event_name == 'pull_request'
+        name: Checkout
         uses: actions/checkout@v4
         with:
+          # Checkout main branch to generate schema for current release
           ref: master
+
+      - if: github.event_name == 'workflow_dispatch'
+        name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.base }}
 
       - name: 'Setup Go'
         uses: actions/setup-go@v4
@@ -55,10 +75,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout
+      - if: github.event_name == 'pull_request'
+        name: Checkout
+        uses: actions/checkout@v4
+
+      - if: github.event_name == 'workflow_dispatch'
+        name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: master
+          ref: ${{ github.event.inputs.head }}
 
       - name: 'Setup Go'
         uses: actions/setup-go@v4

--- a/.github/workflows/schema.yml
+++ b/.github/workflows/schema.yml
@@ -21,6 +21,8 @@ jobs:
 
       - name: 'Setup Terraform'
         uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_wrapper: false
 
       - run: make install
 
@@ -65,6 +67,8 @@ jobs:
 
       - name: 'Setup Terraform'
         uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_wrapper: false
 
       - run: make install
 

--- a/.github/workflows/schema.yml
+++ b/.github/workflows/schema.yml
@@ -1,4 +1,4 @@
-name: schema
+name: Provider schema
 
 on:
   pull_request:

--- a/.github/workflows/schema.yml
+++ b/.github/workflows/schema.yml
@@ -142,3 +142,4 @@ jobs:
       - run: ls -l schema*/*
 
       - run: jd -color schema-current/provider.json schema-new/provider.json
+        continue-on-error: true


### PR DESCRIPTION
## Changes

A workflow to compute provider schema diff between two versions of the provider. If triggered manually (through the actions UI), it takes inputs for the base ref and head ref to compare. If triggered from a pull request, it compares the schema on the main branch with the schema in the pull request.

The current behavior doesn't fail the workflow if there is a diff. This means folks need to actively look at the output. We can switch this by removing "continue-on-error: true" on the diff command itself.

## Tests

Example run on my own fork (for the diff between v1.25 and v1.27): https://github.com/pietern/terraform-provider-databricks/actions/runs/6337272638/job/17212054575