### PR TITLE
Export: parallel export of resources

### DIFF
--- a/docs/guides/experimental-exporter.md
+++ b/docs/guides/experimental-exporter.md
@@ -5,9 +5,9 @@ page_title: "Experimental resource exporter"
 
 -> **Note** This tooling is experimental and provided as is. It has an evolving interface, which may change or be removed in future versions of the provider.
 
--> **Note** Use the same user who did the exporting to import the exported templates.  Otherwise it could cause changes in the jobs ownership.
+-> **Note** Use the same user who did the exporting to import the exported templates.  Otherwise, it could cause changes in the ownership of the objects.
 
-Generates `*.tf` files for Databricks resources as well as `import.sh` to run import state. Available as part of provider binary. The only possible way to authenticate is through [environment variables](../index.md#Environment-variables). It's best used when you need to quickly export Terraform configuration for an existing Databricks workspace. After generating configuration, we strongly recommend manually review all created files.
+Generates `*.tf` files for Databricks resources as well as `import.sh` that is used to import objects into the Terraform state. Available as part of provider binary. The only possible way to authenticate is through [environment variables](../index.md#Environment-variables). It's best used when you need to quickly export Terraform configuration for an existing Databricks workspace. After generating the configuration, we strongly recommend manually reviewing all created files.
 
 ## Example Usage
 
@@ -33,33 +33,33 @@ export DATABRICKS_TOKEN=...
 
 All arguments are optional and they tune what code is being generated.
 
-* `-directory` - Path to directory, where `*.tf` and `import.sh` files would be written. By default it's set to the current working directory.
+* `-directory` - Path to a directory, where `*.tf` and `import.sh` files would be written. By default, it's set to the current working directory.
 * `-module` - Name of module in Terraform state, that would affect reference resolution and prefixes for generated commands in `import.sh`.
-* `-last-active-days` - Items older than `-last-active-days` won't be imported. By default the value is set to 3650 (10 years). Has an effect on listing [databricks_cluster](../resources/cluster.md) and [databricks_job](../resources/job.md) resources.
-* `-services` - Comma-separated list of services to import. By default all services are imported. 
+* `-last-active-days` - Items older than `-last-active-days` won't be imported. By default, the value is set to 3650 (10 years). Has an effect on listing [databricks_cluster](../resources/cluster.md) and [databricks_job](../resources/job.md) resources.
+* `-services` - Comma-separated list of services to import. By default, all services are imported. 
 * `-listing` - Comma-separated list of services to be listed and further passed on for importing. `-services` parameter controls which transitive dependencies will be processed. We recommend limiting with `-listing` more often, than with `-services`.
-* `-match` - Match resource names during listing operation. This filter applies to all resources that are getting listed, so if you want to import all dependencies of just one cluster, specify `-match=autoscaling -listing=compute`. By default it is empty, which matches everything.
+* `-match` - Match resource names during listing operation. This filter applies to all resources that are getting listed, so if you want to import all dependencies of just one cluster, specify `-match=autoscaling -listing=compute`. By default, it is empty, which matches everything.
 * `-mounts` - List DBFS mount points, which is an extremely slow operation and would not trigger unless explicitly specified.
-* `-generateProviderDeclaration` - flag that toggles generation of `databricks.tf` file with declaration of the Databricks Terraform provider that is necessary for Terraform versions since Terraform 0.13 (disabled by default).
-* `-prefix` - optional prefix that will be added to the name of all exported resources - that's useful for exporting resources multiple workspaces for merging into a single one.
+* `-generateProviderDeclaration` - the flag that toggles the generation of `databricks.tf` file with the declaration of the Databricks Terraform provider that is necessary for Terraform versions since Terraform 0.13 (disabled by default).
+* `-prefix` - optional prefix that will be added to the name of all exported resources - that's useful for exporting resources from multiple workspaces for merging into a single one.
 * `-skip-interactive` - optionally run in a non-interactive mode.
 * `-includeUserDomains` - optionally include domain name into generated resource name for `databricks_user` resource.
-* `-importAllUsers` - optionally include all users and service principals even if they only part of the `users` group.
-* `-incremental` - experimental option for incremental export of modified resources and merging with existing resources. *Please note that only limited set of resources (notebooks, SQL queries/dashboards/alerts, ...) provides information about last modified date - all other resources will be re-exported again! Also, it's not possible to detect deletion of the resources, so you will need to do periodic full export if resources are deleted!*   **Requires** `-updated-since` option if no `exporter-run-stats.json` file exists in the output directory.
-* `-updated-since` - timestamp (in ISO8601 format supported by Go language) for exporting of resources modified since a giving timestamp. I.e. `2023-07-24T00:00:00Z`. If not specified, exporter will try to load last run timestamp from the `exporter-run-stats.json` file generated during the export, and use it.
-* `-notebooksFormat` - optional format for exporting of notebooks. Supported values are `SOURCE` (default), `DBC`, `JUPYTER`.  This could be used to export of notebooks with embedded dashboards.
-* `-noformat` - optionally disable execution of `terraform fmt` on the exported files (enabled by default).
+* `-importAllUsers` - optionally include all users and service principals even if they are only part of the `users` group.
+* `-incremental` - experimental option for incremental export of modified resources and merging with existing resources. *Please note that only a limited set of resources (notebooks, SQL queries/dashboards/alerts, ...) provides information about the last modified date - all other resources will be re-exported again! Also, it's not possible to detect the deletion of the resources, so you will need to do periodic full export if resources are deleted!*   **Requires** `-updated-since` option if no `exporter-run-stats.json` file exists in the output directory.
+* `-updated-since` - timestamp (in ISO8601 format supported by Go language) for exporting of resources modified since a given timestamp. I.e. `2023-07-24T00:00:00Z`. If not specified, the exporter will try to load the last run timestamp from the `exporter-run-stats.json` file generated during the export, and use it.
+* `-notebooksFormat` - optional format for exporting of notebooks. Supported values are `SOURCE` (default), `DBC`, `JUPYTER`.  This could be used to export notebooks with embedded dashboards.
+* `-noformat` - optionally disable the execution of `terraform fmt` on the exported files (enabled by default).
 
 ## Services
 
-Services are just logical groups of resources used for filtering and organization in files written in `-directory`. All resources are globally sorted by their resource name, which technically allows you to use generated files for compliance purposes. Nevertheless, managing the entire Databricks workspace with Terraform is the prefered way. With the exception of notebooks and possibly libraries, which may have their own CI/CD processes.
+Services are just logical groups of resources used for filtering and organization in files written in `-directory`. All resources are globally sorted by their resource name, which technically allows you to use generated files for compliance purposes. Nevertheless, managing the entire Databricks workspace with Terraform is the preferred way. With the exception of notebooks and possibly libraries, which may have their own CI/CD processes.
 
 * `access` - [databricks_permissions](../resources/permissions.md), [databricks_instance_profile](../resources/instance_profile.md) and [databricks_ip_access_list](../resources/ip_access_list.md).
 * `compute` - **listing** [databricks_cluster](../resources/cluster.md). Includes [cluster policies](../resources/cluster_policy.md).
 * `directories` - **listing** [databricks_directory](../resources/directory.md)
 * `dlt` - **listing** [databricks_pipeline](../resources/pipeline.md)
 * `groups` - [databricks_group](../data-sources/group.md) with [membership](../resources/group_member.md) and [data access](../resources/group_instance_profile.md).
-* `jobs` - **listing** [databricks_job](../resources/job.md). Usually there are more automated jobs than interactive clusters, so they get their own file in this tool's output.
+* `jobs` - **listing** [databricks_job](../resources/job.md). Usually, there are more automated jobs than interactive clusters, so they get their own file in this tool's output.
 * `mlflow-webhooks` - **listing** [databricks_mlflow_webhook](../resources/mlflow_webhook.md).
 * `model-serving` - **listing** [databricks_model_serving](../resources/model_serving.md).
 * `mounts` - **listing** works only in combination with `-mounts` command-line option.
@@ -73,20 +73,20 @@ Services are just logical groups of resources used for filtering and organizatio
 * `sql-endpoints` - **listing** [databricks_sql_endpoint](../resources/sql_endpoint.md) along with [databricks_sql_global_config](../resources/sql_global_config.md)
 * `sql-queries` - **listing** [databricks_sql_query](../resources/sql_query.md)
 * `storage` - any referenced [databricks_dbfs_file](../resources/dbfs_file.md) will be downloaded locally and properly arranged into terraform state.
-* `users` - [databricks_user](../resources/user.md) and [databricks_service_principal](../resources/service_principal.md) are written to their own file, simply because of their amount. If you use SCIM provisioning, the only use-case for importing `users` service is to migrate workspaces.
+* `users` - [databricks_user](../resources/user.md) and [databricks_service_principal](../resources/service_principal.md) are written to their own file, simply because of their amount. If you use SCIM provisioning, the only use case for importing `users` service is to migrate workspaces.
 * `workspace` - [databricks_workspace_conf](../resources/workspace_conf.md) and [databricks_global_init_script](../resources/global_init_script.md)
 
 ## Secrets
 
-For security reasons, [databricks_secret](../resources/secret.md) cannot contain actual plaintext secrets. Importer will create a variable in `vars.tf`, that would have the same name as secret. You are supposed to [fill in the value of the secret](https://blog.gruntwork.io/a-comprehensive-guide-to-managing-secrets-in-your-terraform-code-1d586955ace1#0e7d) after that.
+For security reasons, [databricks_secret](../resources/secret.md) cannot contain actual plaintext secrets. Importer will create a variable in `vars.tf`, that would have the same name as the secret. You are supposed to [fill in the value of the secret](https://blog.gruntwork.io/a-comprehensive-guide-to-managing-secrets-in-your-terraform-code-1d586955ace1#0e7d) after that.
 
 ## Parallel execution
 
-To speedup export, Terraform Exporter performs many operations, such as, listing & actual data exporting, in parallel using Goroutines.  There are built-in defaults controlling the parallelism, but it's also possible to tune some parameters using environment variables specific to exporter:
+To speed up export, Terraform Exporter performs many operations, such as listing & actual data exporting, in parallel using Goroutines.  There are built-in defaults controlling the parallelism, but it's also possible to tune some parameters using environment variables specific to the exporter:
 
 * `EXPORTER_WS_LIST_PARALLELISM` (default: `5`) controls how many Goroutines are used to perform parallel listing of Databricks Workspace objects (notebooks, directories, workspace files, ...).
-* `EXPORTER_DIRECTORIES_CHANNEL_SIZE` (default: `100000`) controls capacity of the channel that is used when listing workspace objects. Please make sure that this value is big enough (default value should be ok), otherwise there is a chance of deadlock. 
-* `EXPORTER_PARALLELISM_NNN` - number of Goroutines used to process resources of specific type (replace `NNN` with resource name, for example, `EXPORTER_PARALLELISM_databricks_notebook=10` sets number of Goroutines for `databricks_notebook` resource to `10`).  Defaults for some resources are defined by the `goroutinesNumber` map in `exporter/context.go`, or equal to `2` if there is no value there.  *Don't increase default values too much to avoid REST API throttling!*
+* `EXPORTER_DIRECTORIES_CHANNEL_SIZE` (default: `100000`) controls the capacity of the channel that is used when listing workspace objects. Please make sure that this value is big enough (bigger than the number of directories in the workspace, default value should be ok for most cases), otherwise, there is a chance of deadlock. 
+* `EXPORTER_PARALLELISM_NNN` - number of Goroutines used to process resources of a specific type (replace `NNN` with the exact resource name, for example, `EXPORTER_PARALLELISM_databricks_notebook=10` sets the number of Goroutines for `databricks_notebook` resource to `10`).  Defaults for some resources are defined by the `goroutinesNumber` map in `exporter/context.go`, or equal to `2` if there is no value there.  *Don't increase default values too much to avoid REST API throttling!*
 
 
 ## Support Matrix

--- a/docs/guides/experimental-exporter.md
+++ b/docs/guides/experimental-exporter.md
@@ -48,6 +48,7 @@ All arguments are optional and they tune what code is being generated.
 * `-incremental` - experimental option for incremental export of modified resources and merging with existing resources. *Please note that only limited set of resources (notebooks, SQL queries/dashboards/alerts, ...) provides information about last modified date - all other resources will be re-exported again! Also, it's not possible to detect deletion of the resources, so you will need to do periodic full export if resources are deleted!*   **Requires** `-updated-since` option if no `exporter-run-stats.json` file exists in the output directory.
 * `-updated-since` - timestamp (in ISO8601 format supported by Go language) for exporting of resources modified since a giving timestamp. I.e. `2023-07-24T00:00:00Z`. If not specified, exporter will try to load last run timestamp from the `exporter-run-stats.json` file generated during the export, and use it.
 * `-notebooksFormat` - optional format for exporting of notebooks. Supported values are `SOURCE` (default), `DBC`, `JUPYTER`.  This could be used to export of notebooks with embedded dashboards.
+* `-noformat` - optionally disable execution of `terraform fmt` on the exported files (enabled by default).
 
 ## Services
 

--- a/docs/guides/experimental-exporter.md
+++ b/docs/guides/experimental-exporter.md
@@ -79,6 +79,15 @@ Services are just logical groups of resources used for filtering and organizatio
 
 For security reasons, [databricks_secret](../resources/secret.md) cannot contain actual plaintext secrets. Importer will create a variable in `vars.tf`, that would have the same name as secret. You are supposed to [fill in the value of the secret](https://blog.gruntwork.io/a-comprehensive-guide-to-managing-secrets-in-your-terraform-code-1d586955ace1#0e7d) after that.
 
+## Parallel execution
+
+To speedup export, Terraform Exporter performs many operations, such as, listing & actual data exporting, in parallel using Goroutines.  There are built-in defaults controlling the parallelism, but it's also possible to tune some parameters using environment variables specific to exporter:
+
+* `EXPORTER_WS_LIST_PARALLELISM` (default: `5`) controls how many Goroutines are used to perform parallel listing of Databricks Workspace objects (notebooks, directories, workspace files, ...).
+* `EXPORTER_DIRECTORIES_CHANNEL_SIZE` (default: `100000`) controls capacity of the channel that is used when listing workspace objects. Please make sure that this value is big enough (default value should be ok), otherwise there is a chance of deadlock. 
+* `EXPORTER_PARALLELISM_NNN` - number of Goroutines used to process resources of specific type (replace `NNN` with resource name, for example, `EXPORTER_PARALLELISM_databricks_notebook=10` sets number of Goroutines for `databricks_notebook` resource to `10`).  Defaults for some resources are defined by the `goroutinesNumber` map in `exporter/context.go`, or equal to `2` if there is no value there.  *Don't increase default values too much to avoid REST API throttling!*
+
+
 ## Support Matrix
 
 Exporter aims to generate HCL code for the most of resources within the Databricks workspace:

--- a/exporter/command.go
+++ b/exporter/command.go
@@ -104,6 +104,7 @@ func Run(args ...string) error {
 	flags.Int64Var(&ic.lastActiveDays, "last-active-days", 3650,
 		"Items with older than activity specified won't be imported.")
 	flags.BoolVar(&ic.incremental, "incremental", false, "Incremental export of the data. Requires -updated-since parameter")
+	flags.BoolVar(&ic.noFormat, "noformat", false, "Don't run `terraform fmt` on exported files")
 	flags.StringVar(&ic.updatedSinceStr, "updated-since", "",
 		"Include only resources updated since a given timestamp (in ISO8601 format, i.e. 2023-07-01T00:00:00Z)")
 	flags.BoolVar(&ic.debug, "debug", false, "Print extra debug information.")

--- a/exporter/context.go
+++ b/exporter/context.go
@@ -645,6 +645,7 @@ func (ic *importContext) Find(r *resource, pick string, ref reference) (string, 
 			res := ref.Regexp.FindStringSubmatch(r.Value)
 			if len(res) < 2 {
 				log.Printf("[WARN] no match for regexp: %v in string %s", ref.Regexp, r.Value)
+				continue
 			}
 			matchValue = res[1]
 		}

--- a/exporter/context.go
+++ b/exporter/context.go
@@ -107,6 +107,14 @@ type importContext struct {
 	groupsMutex sync.Mutex
 
 	//
+	allUsers   map[string]scim.User
+	usersMutex sync.RWMutex
+
+	//
+	allSps   map[string]scim.User
+	spsMutex sync.RWMutex
+
+	//
 	importing      map[string]bool
 	importingMutex sync.RWMutex
 
@@ -156,6 +164,7 @@ const (
 	defaultNumRoutines = 2
 )
 
+// TODO: think how to customize this
 var goroutinesNumber = map[string]int{
 	"databricks_notebook":          7,
 	"databricks_directory":         5,
@@ -203,6 +212,8 @@ func newImportContext(c *common.DatabricksClient) *importContext {
 		workspaceConfKeys:   workspaceConfKeys,
 		shImports:           make(map[string]bool),
 		notebooksFormat:     "SOURCE",
+		allUsers:            map[string]scim.User{},
+		allSps:              map[string]scim.User{},
 	}
 }
 

--- a/exporter/context.go
+++ b/exporter/context.go
@@ -79,6 +79,7 @@ type importContext struct {
 	debug               bool
 	incremental         bool
 	mounts              bool
+	noFormat            bool
 	services            string
 	listing             string
 	match               string
@@ -437,14 +438,15 @@ func (ic *importContext) Run() error {
 		}
 	}
 
-	// TODO: add a command-line option to skip formatting
-	// format generated source code
-	cmd := exec.CommandContext(context.Background(), "terraform", "fmt")
-	cmd.Dir = ic.Directory
-	err = cmd.Run()
-	if err != nil {
-		log.Printf("[ERROR] problems when formatting the generated code: %v", err)
-		return err
+	if !ic.noFormat {
+		// format generated source code
+		cmd := exec.CommandContext(context.Background(), "terraform", "fmt")
+		cmd.Dir = ic.Directory
+		err = cmd.Run()
+		if err != nil {
+			log.Printf("[ERROR] problems when formatting the generated code: %v", err)
+			return err
+		}
 	}
 	log.Printf("[INFO] Done. Please edit the files and roll out new environment.")
 	return nil

--- a/exporter/context.go
+++ b/exporter/context.go
@@ -169,9 +169,10 @@ const (
 var goroutinesNumber = map[string]int{
 	"databricks_notebook":          7,
 	"databricks_directory":         5,
-	"databricks_workspace_file":    3,
-	"databricks_user":              2,
-	"databricks_service_principal": 2,
+	"databricks_workspace_file":    5,
+	"databricks_dbfs_file":         3,
+	"databricks_user":              1,
+	"databricks_service_principal": 1,
 	"databricks_sql_dashboard":     3,
 	"databricks_sql_query":         5,
 	"databricks_sql_alert":         2,
@@ -441,12 +442,6 @@ func (ic *importContext) Run() error {
 		return err
 	}
 
-	cmd := exec.CommandContext(context.Background(), "terraform", "fmt")
-	cmd.Dir = ic.Directory
-	err = cmd.Run()
-	if err != nil {
-		return err
-	}
 	//
 	if stats, err := os.Create(statsFileName); err == nil {
 		defer stats.Close()
@@ -459,6 +454,16 @@ func (ic *importContext) Run() error {
 		if _, err = stats.Write(statsBytes); err != nil {
 			return err
 		}
+	}
+
+	// TODO: add a command-line option to skip formatting
+	// format generated source code
+	cmd := exec.CommandContext(context.Background(), "terraform", "fmt")
+	cmd.Dir = ic.Directory
+	err = cmd.Run()
+	if err != nil {
+		log.Printf("[ERROR] problems when formatting the generated code: %v", err)
+		return err
 	}
 	log.Printf("[INFO] Done. Please edit the files and roll out new environment.")
 	return nil

--- a/exporter/context.go
+++ b/exporter/context.go
@@ -819,7 +819,7 @@ func (ic *importContext) Emit(r *resource) {
 	// from here, it should be done by the goroutine...  send resource into the channel
 	ch, exists := ic.channels[r.Resource]
 	if exists {
-		log.Printf("[DEBUG] increasing counter & sending to the channel for resource %s", r.Resource)
+		log.Printf("[TRACE] increasing counter & sending to the channel for resource %s", r.Resource)
 		ic.waitGroup.Add(1)
 		ch <- r
 	} else {

--- a/exporter/context.go
+++ b/exporter/context.go
@@ -800,10 +800,15 @@ func (ic *importContext) Emit(r *resource) {
 		log.Printf("[DEBUG] %s (%s service) is not part of the import", r.Resource, ir.Service)
 		return
 	}
-	// from here, it should be done by the goroutine...
-	// send resource into the channel
-	ic.waitGroup.Add(1)
-	ic.channels[r.Resource] <- r
+	// from here, it should be done by the goroutine...  send resource into the channel
+	ch, exists := ic.channels[r.Resource]
+	if exists {
+		log.Printf("[DEBUG] increasing counter & sending to the channel for resource %s", r.Resource)
+		ic.waitGroup.Add(1)
+		ch <- r
+	} else {
+		log.Printf("[WARN] Can't find channel for resource %s", r.Resource)
+	}
 }
 
 func (ic *importContext) getTraversalTokens(ref reference, value string) hclwrite.Tokens {

--- a/exporter/context_test.go
+++ b/exporter/context_test.go
@@ -21,7 +21,7 @@ func TestMatchesName(t *testing.T) {
 func TestImportContextFindSkips(t *testing.T) {
 	_, traversal := (&importContext{
 		State: stateApproximation{
-			Resources: []resourceApproximation{
+			resources: []resourceApproximation{
 				{
 					Type: "a",
 					Instances: []instanceApproximation{
@@ -45,7 +45,7 @@ func TestImportContextFindSkips(t *testing.T) {
 func TestImportContextHas(t *testing.T) {
 	assert.True(t, (&importContext{
 		State: stateApproximation{
-			Resources: []resourceApproximation{
+			resources: []resourceApproximation{
 				{
 					Type: "a",
 					Instances: []instanceApproximation{

--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -204,9 +204,10 @@ func TestImportingMounts(t *testing.T) {
 			err := ic.Importables["databricks_mount"].List(ic)
 			assert.NoError(t, err)
 
-			for i := 0; i < len(ic.Scope); i++ {
+			resources := ic.Scope.Sorted()
+			for i := 0; i < len(resources); i++ {
 				err = ic.Importables["databricks_mount"].Body(ic,
-					hclwrite.NewEmptyFile().Body(), ic.Scope[i])
+					hclwrite.NewEmptyFile().Body(), resources[i])
 				assert.NoError(t, err)
 			}
 		})
@@ -967,7 +968,8 @@ func TestImportingJobs_JobList(t *testing.T) {
 			err := ic.Importables["databricks_job"].List(ic)
 			assert.NoError(t, err)
 
-			for _, res := range ic.Scope {
+			resources := ic.Scope.Sorted()
+			for _, res := range resources {
 				if res.Resource != "databricks_job" {
 					continue
 				}
@@ -1216,7 +1218,8 @@ func TestImportingJobs_JobListMultiTask(t *testing.T) {
 			err := ic.Importables["databricks_job"].List(ic)
 			assert.NoError(t, err)
 
-			for _, res := range ic.Scope {
+			resources := ic.Scope.Sorted()
+			for _, res := range resources {
 				if res.Resource != "databricks_job" {
 					continue
 				}

--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -675,7 +675,7 @@ func TestImportingClusters(t *testing.T) {
 				Method:   "POST",
 				Resource: "/api/2.0/clusters/events",
 				ExpectedRequest: clusters.EventsRequest{
-					ClusterID:  "test1",
+					ClusterID:  "test2",
 					Order:      "DESC",
 					EventTypes: []clusters.ClusterEventType{"PINNED", "UNPINNED"},
 					Limit:      1,
@@ -753,6 +753,7 @@ func TestImportingClusters(t *testing.T) {
 			},
 		},
 		func(ctx context.Context, client *common.DatabricksClient) {
+			os.Setenv("EXPORTER_PARALLELISM_databricks_cluster", "1")
 			tmpDir := fmt.Sprintf("/tmp/tf-%s", qa.RandomName())
 			defer os.RemoveAll(tmpDir)
 

--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -205,7 +205,7 @@ func TestImportingMounts(t *testing.T) {
 			assert.NoError(t, err)
 
 			resources := ic.Scope.Sorted()
-			for i := 0; i < len(resources); i++ {
+			for i := range resources {
 				err = ic.Importables["databricks_mount"].Body(ic,
 					hclwrite.NewEmptyFile().Body(), resources[i])
 				assert.NoError(t, err)

--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -675,7 +675,7 @@ func TestImportingClusters(t *testing.T) {
 				Method:   "POST",
 				Resource: "/api/2.0/clusters/events",
 				ExpectedRequest: clusters.EventsRequest{
-					ClusterID:  "test2",
+					ClusterID:  "test1",
 					Order:      "DESC",
 					EventTypes: []clusters.ClusterEventType{"PINNED", "UNPINNED"},
 					Limit:      1,

--- a/exporter/importables.go
+++ b/exporter/importables.go
@@ -768,6 +768,7 @@ var resourcesMap map[string]importable = map[string]importable{
 			}
 			return nameNormalizationRegex.ReplaceAllString(strings.Split(s, "@")[0], "_") + "_" + d.Id()
 		},
+		// TODO: we need to add List operation here as well
 		Search: func(ic *importContext, r *resource) error {
 			u, err := ic.findUserByName(r.Value)
 			if err != nil {
@@ -805,6 +806,7 @@ var resourcesMap map[string]importable = map[string]importable{
 			}
 			return name + "_" + d.Id()
 		},
+		// TODO: we need to add List operation here as well
 		Search: func(ic *importContext, r *resource) error {
 			u, err := ic.findSpnByAppID(r.Value)
 			if err != nil {

--- a/exporter/importables.go
+++ b/exporter/importables.go
@@ -1102,19 +1102,18 @@ var resourcesMap map[string]importable = map[string]importable{
 			return nil
 		},
 		List: func(ic *importContext) error {
-			// TODO: Should we use parallel listing instead?
-			repoList, err := repos.NewReposAPI(ic.Context, ic.Client).ListAll()
+			objList, err := repos.NewReposAPI(ic.Context, ic.Client).ListAll()
 			if err != nil {
 				return err
 			}
-			for offset, repo := range repoList {
+			for offset, repo := range objList {
 				if repo.Url != "" {
 					ic.Emit(&resource{
 						Resource: "databricks_repo",
 						ID:       fmt.Sprintf("%d", repo.ID),
 					})
 				}
-				log.Printf("[INFO] Scanned %d of %d repos", offset+1, len(repoList))
+				log.Printf("[INFO] Scanned %d of %d repos", offset+1, len(objList))
 			}
 			return nil
 		},

--- a/exporter/importables_test.go
+++ b/exporter/importables_test.go
@@ -362,30 +362,6 @@ func TestJobListNoNameMatch(t *testing.T) {
 	assert.Equal(t, 0, len(ic.testEmits))
 }
 
-func TestJobList_FailGetRuns(t *testing.T) {
-	qa.HTTPFixturesApply(t, []qa.HTTPFixture{
-		{
-			Method:   "GET",
-			Resource: "/api/2.0/jobs/runs/list?completed_only=true&job_id=1&limit=1",
-			Status:   404,
-			Response: apierr.NotFound("nope"),
-		},
-	}, func(ctx context.Context, client *common.DatabricksClient) {
-		ic := importContextForTest()
-		ic.Client = client
-		ic.Context = ctx
-		ic.importJobs([]jobs.Job{
-			{
-				JobID: 1,
-				Settings: &jobs.JobSettings{
-					Name: "abc",
-				},
-			},
-		})
-		assert.Equal(t, 0, len(ic.testEmits))
-	})
-}
-
 func TestClusterPolicyWrongDef(t *testing.T) {
 	d := policies.ResourceClusterPolicy().TestResourceData()
 	d.Set("name", "abc")

--- a/exporter/util.go
+++ b/exporter/util.go
@@ -718,3 +718,14 @@ func (ic *importContext) getUpdatedSinceStr() string {
 func (ic *importContext) getUpdatedSinceMs() int64 {
 	return ic.updatedSinceMs
 }
+
+func getEnvAsInt(envName string, defaultValue int) int {
+	if val, exists := os.LookupEnv(envName); exists {
+		parsedVal, err := strconv.Atoi(val)
+		if err == nil {
+			return parsedVal
+		}
+	}
+	return defaultValue
+}
+

--- a/exporter/util.go
+++ b/exporter/util.go
@@ -151,6 +151,7 @@ func (ic *importContext) getAllDirectories() []workspace.ObjectStatus {
 	if len(ic.allDirectories) == 0 {
 		objects := ic.getAllWorkspaceObjects()
 		ic.wsObjectsMutex.Lock()
+		defer ic.wsObjectsMutex.Unlock()
 		if len(ic.allDirectories) == 0 {
 			for _, v := range objects {
 				if v.ObjectType == workspace.Directory {
@@ -158,7 +159,6 @@ func (ic *importContext) getAllDirectories() []workspace.ObjectStatus {
 				}
 			}
 		}
-		ic.wsObjectsMutex.Unlock()
 	}
 	return ic.allDirectories
 }
@@ -717,6 +717,7 @@ func getEnvAsInt(envName string, defaultValue int) int {
 		if err == nil {
 			return parsedVal
 		}
+		log.Printf("[ERROR] Can't parse value '%s' of environment variable '%s'", val, envName)
 	}
 	return defaultValue
 }

--- a/exporter/util.go
+++ b/exporter/util.go
@@ -163,6 +163,7 @@ func (ic *importContext) getAllDirectories() []workspace.ObjectStatus {
 	return ic.allDirectories
 }
 
+// TODO: Ignore databricks_automl as well?
 var directoriesToIgnore = []string{".ide", ".bundle", "__pycache__"}
 
 func excludeAuxiliaryDirectories(v workspace.ObjectStatus) bool {

--- a/exporter/util_test.go
+++ b/exporter/util_test.go
@@ -1,6 +1,7 @@
 package exporter
 
 import (
+	"os"
 	"testing"
 
 	"github.com/databricks/terraform-provider-databricks/clusters"
@@ -86,7 +87,6 @@ func TestEmitNotebookOrRepo(t *testing.T) {
 }
 
 func TestIsUserOrServicePrincipalDirectory(t *testing.T) {
-
 	ic := importContextForTest()
 	result_false_partslength_more_than_3 := ic.IsUserOrServicePrincipalDirectory("/Users/user@domain.com/abc", "/Users")
 	assert.False(t, result_false_partslength_more_than_3)
@@ -114,4 +114,14 @@ func TestIsUserOrServicePrincipalDirectory(t *testing.T) {
 	ic = importContextForTest()
 	result_true_sp_directory := ic.IsUserOrServicePrincipalDirectory("/Users/0e561119-c5a0-4f29-b246-5a953adb9575", "/Users")
 	assert.True(t, result_true_sp_directory)
+}
+
+func TestGetEnvAsInt(t *testing.T) {
+	os.Setenv("a", "10")
+	assert.Equal(t, 10, getEnvAsInt("a", 1))
+	//
+	os.Setenv("a", "abc")
+	assert.Equal(t, 1, getEnvAsInt("a", 1))
+	//
+	assert.Equal(t, 1, getEnvAsInt("b", 1))
 }

--- a/exporter/util_test.go
+++ b/exporter/util_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/databricks/terraform-provider-databricks/clusters"
+	"github.com/databricks/terraform-provider-databricks/workspace"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -124,4 +125,18 @@ func TestGetEnvAsInt(t *testing.T) {
 	assert.Equal(t, 1, getEnvAsInt("a", 1))
 	//
 	assert.Equal(t, 1, getEnvAsInt("b", 1))
+}
+
+func TestExcludeAuxiliaryDirectories(t *testing.T) {
+	assert.True(t, excludeAuxiliaryDirectories(workspace.ObjectStatus{Path: "", ObjectType: workspace.Directory}))
+	assert.True(t, excludeAuxiliaryDirectories(workspace.ObjectStatus{ObjectType: workspace.File}))
+	assert.True(t, excludeAuxiliaryDirectories(workspace.ObjectStatus{Path: "/Users/user@domain.com/abc",
+		ObjectType: workspace.Directory}))
+	// should be ignored
+	assert.False(t, excludeAuxiliaryDirectories(workspace.ObjectStatus{Path: "/Users/user@domain.com/.ide",
+		ObjectType: workspace.Directory}))
+	assert.False(t, excludeAuxiliaryDirectories(workspace.ObjectStatus{Path: "/Shared/.bundle",
+		ObjectType: workspace.Directory}))
+	assert.False(t, excludeAuxiliaryDirectories(workspace.ObjectStatus{Path: "/Users/user@domain.com/abc/__pycache__",
+		ObjectType: workspace.Directory}))
 }

--- a/workspace/resource_notebook.go
+++ b/workspace/resource_notebook.go
@@ -163,7 +163,7 @@ type directoryInfo struct {
 const (
 	directoryListingMaxAttempts = 3
 	envVarListParallelism       = "EXPORTER_WS_LIST_PARALLELISM"
-	envVarDirectoryChannelSize  = "EXPORTER_CHANNEL_SIZE"
+	envVarDirectoryChannelSize  = "EXPORTER_DIRECTORIES_CHANNEL_SIZE"
 	defaultWorkersPoolSize      = 10
 	defaultDirectoryChannelSize = 100000
 )

--- a/workspace/resource_notebook.go
+++ b/workspace/resource_notebook.go
@@ -164,7 +164,7 @@ const (
 	directoryListingMaxAttempts = 3
 	envVarListParallelism       = "EXPORTER_WS_LIST_PARALLELISM"
 	envVarDirectoryChannelSize  = "EXPORTER_CHANNEL_SIZE"
-	defaultWorkersPoolSize      = 5
+	defaultWorkersPoolSize      = 10
 	defaultDirectoryChannelSize = 100000
 )
 

--- a/workspace/resource_notebook_test.go
+++ b/workspace/resource_notebook_test.go
@@ -436,7 +436,7 @@ func TestParallelListing(t *testing.T) {
 	os.Setenv("EXPORTER_CHANNEL_SIZE", "100")
 	ctx := context.Background()
 	api := NewNotebooksAPI(ctx, client)
-	objects, err := api.ListParallel("/", true)
+	objects, err := api.ListParallel("/", nil)
 
 	require.NoError(t, err)
 	require.Equal(t, 4, len(objects))


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

This change significantly speeds up the exporting of resources. I.e. for a workspace with approximately 5k TF resources export now takes ~4 minutes vs 50+ minutes.

The following changes are made:

- Isolate mutable parts & protect different mutable objects by dedicated mutexes. 
- Actual export is done in parallel by running listing & exporting operations in separate goroutines. Exporting goroutines are allocated by resource type, with multiple routines per type (configurable). Each resource type also has dedicated channels.
- Code generation is the single-threaded operation performed after export is done

Other changes include:

- Fixed panic when reading SQL Alert without Query attribute (happens when the underlying query is deleted)
- added `-noformat` option to skip running `terraform fmt` on the exported data
- skipping auxiliary directories to reduce the number of objects to export: `.ide`, `.bundle`, `__pycache__`. (It will be further expanded by implementing#2574)
- added caching of users’ and service principals’ information to decrease load on the SCIM backend (additional work is required there)
- export all jobs, not only that were run "recently" (It will be further expanded by implementing #2574)

P.S. The code coverage drop could be related to the use of goroutines - the relevant tests didn't change.

TODOs:

- [x] make sure tests are running
- [x] investigate panics when exporting SQL alerts
- [x] validate exported results
- [x] update docs

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

