### PR TITLE
add `databricks_artifact_allowlist`

### DIFF
--- a/access/resource_permission_assignment.go
+++ b/access/resource_permission_assignment.go
@@ -82,9 +82,7 @@ func ResourcePermissionAssignment() *schema.Resource {
 		Permissions []string `json:"permissions" tf:"slice_as_set"`
 	}
 	s := common.StructToSchema(entity{},
-		func(m map[string]*schema.Schema) map[string]*schema.Schema {
-			return m
-		})
+		common.NoCustomize)
 	return common.Resource{
 		Schema: s,
 		Create: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {

--- a/catalog/resource_artifact_allowlist.go
+++ b/catalog/resource_artifact_allowlist.go
@@ -1,0 +1,102 @@
+package catalog
+
+import (
+	"context"
+
+	"github.com/databricks/databricks-sdk-go/service/catalog"
+	"github.com/databricks/terraform-provider-databricks/common"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type ArtifactAllowlistInfo struct {
+	// A list of allowed artifact match patterns.
+	ArtifactMatchers []catalog.ArtifactMatcher `json:"artifact_matchers" tf:"slice_set,alias:artifact_matcher"`
+	// The artifact type of the allowlist.
+	ArtifactType catalog.ArtifactType `json:"artifact_type" tf:"force_new"`
+	// Time at which this artifact allowlist was set, in epoch milliseconds.
+	CreatedAt int64 `json:"created_at,omitempty" tf:"computed"`
+	// Username of the user who set the artifact allowlist.
+	CreatedBy string `json:"created_by,omitempty" tf:"computed"`
+	// Unique identifier of parent metastore.
+	MetastoreId string `json:"metastore_id,omitempty" tf:"computed"`
+}
+
+func ResourceArtifactAllowlist() *schema.Resource {
+	allowlistSchema := common.StructToSchema(ArtifactAllowlistInfo{}, common.NoCustomize)
+	p := common.NewPairID("metastore_id", "artifact_type")
+
+	createOrUpdate := func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
+		w, err := c.WorkspaceClient()
+		if err != nil {
+			return err
+		}
+
+		var createAllowlist ArtifactAllowlistInfo
+		common.DataToStructPointer(d, allowlistSchema, &createAllowlist)
+
+		al, err := w.ArtifactAllowlists.Update(ctx, catalog.SetArtifactAllowlist{
+			ArtifactMatchers: createAllowlist.ArtifactMatchers,
+			ArtifactType:     createAllowlist.ArtifactType,
+		})
+
+		if err != nil {
+			return err
+		}
+
+		d.Set("metastore_id", al.MetastoreId)
+		p.Pack(d)
+		return nil
+	}
+	return common.Resource{
+		Schema: allowlistSchema,
+		Create: createOrUpdate,
+		Read: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
+			w, err := c.WorkspaceClient()
+			if err != nil {
+				return err
+			}
+
+			_, artifactType, err := p.Unpack(d)
+			if err != nil {
+				return err
+			}
+
+			al, err := w.ArtifactAllowlists.GetByArtifactType(ctx, catalog.ArtifactType(artifactType))
+			if err != nil {
+				return err
+			}
+
+			allowlist := ArtifactAllowlistInfo{
+				ArtifactMatchers: al.ArtifactMatchers,
+				CreatedAt:        al.CreatedAt,
+				CreatedBy:        al.CreatedBy,
+				MetastoreId:      al.MetastoreId,
+				ArtifactType:     catalog.ArtifactType(artifactType),
+			}
+
+			return common.StructToData(allowlist, allowlistSchema, d)
+		},
+		Update: createOrUpdate,
+		Delete: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
+			w, err := c.WorkspaceClient()
+			if err != nil {
+				return err
+			}
+
+			_, artifactType, err := p.Unpack(d)
+			if err != nil {
+				return err
+			}
+
+			_, err = w.ArtifactAllowlists.Update(ctx, catalog.SetArtifactAllowlist{
+				ArtifactType:     catalog.ArtifactType(artifactType),
+				ArtifactMatchers: []catalog.ArtifactMatcher{},
+			})
+			if err != nil {
+				return err
+			}
+
+			return nil
+		},
+	}.ToResource()
+}

--- a/catalog/resource_artifact_allowlist_test.go
+++ b/catalog/resource_artifact_allowlist_test.go
@@ -1,0 +1,279 @@
+package catalog
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/databricks/databricks-sdk-go/apierr"
+	"github.com/databricks/databricks-sdk-go/service/catalog"
+	"github.com/databricks/terraform-provider-databricks/qa"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestArtifactAllowlistCornerCases(t *testing.T) {
+	qa.ResourceCornerCases(t, ResourceArtifactAllowlist(), qa.CornerCaseID("a|b"))
+}
+
+var id = "abc|INIT_SCRIPT"
+
+var setArtifact = catalog.SetArtifactAllowlist{
+	ArtifactType: catalog.ArtifactTypeInitScript,
+	ArtifactMatchers: []catalog.ArtifactMatcher{
+		{
+			Artifact:  "/Volumes/inits",
+			MatchType: catalog.MatchTypePrefixMatch,
+		},
+	},
+}
+
+var updateArtifact = catalog.SetArtifactAllowlist{
+	ArtifactType: catalog.ArtifactTypeInitScript,
+	ArtifactMatchers: []catalog.ArtifactMatcher{
+		{
+			Artifact:  "/Volumes/inits",
+			MatchType: catalog.MatchTypePrefixMatch,
+		},
+		{
+			Artifact:  "/Volumes/new_inits",
+			MatchType: catalog.MatchTypePrefixMatch,
+		},
+	},
+}
+
+var artifactInfo = catalog.ArtifactAllowlistInfo{
+	ArtifactMatchers: []catalog.ArtifactMatcher{
+		{
+			Artifact:  "/Volumes/inits",
+			MatchType: catalog.MatchTypePrefixMatch,
+		},
+	},
+	CreatedAt:   12345,
+	CreatedBy:   "admin",
+	MetastoreId: "abc",
+}
+
+func TestArtifactAllowlistCreate(t *testing.T) {
+	d, err := qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:          http.MethodPut,
+				Resource:        "/api/2.1/unity-catalog/artifact-allowlists/INIT_SCRIPT",
+				ExpectedRequest: setArtifact,
+				Response:        artifactInfo,
+			},
+			{
+				Method:   http.MethodGet,
+				Resource: "/api/2.1/unity-catalog/artifact-allowlists/INIT_SCRIPT?",
+				Response: artifactInfo,
+			},
+		},
+		Resource: ResourceArtifactAllowlist(),
+		Create:   true,
+		HCL: `
+		artifact_type = "INIT_SCRIPT"
+		artifact_matcher {
+			artifact = "/Volumes/inits"
+			match_type = "PREFIX_MATCH"
+		}
+		`,
+	}.Apply(t)
+	assert.NoError(t, err)
+	assert.Equal(t, id, d.Id())
+	assert.Equal(t, 12345, d.Get("created_at"))
+}
+
+func TestArtifactAllowlistCreate_Error(t *testing.T) {
+	_, err := qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:          http.MethodPut,
+				Resource:        "/api/2.1/unity-catalog/artifact-allowlists/INIT_SCRIPT",
+				ExpectedRequest: setArtifact,
+				Response: apierr.APIErrorBody{
+					ErrorCode: "SERVER_ERROR",
+					Message:   "Something unexpected happened",
+				},
+				Status: 500,
+			},
+		},
+		Resource: ResourceArtifactAllowlist(),
+		Create:   true,
+		HCL: `
+		artifact_type = "INIT_SCRIPT"
+		artifact_matcher {
+			artifact = "/Volumes/inits"
+			match_type = "PREFIX_MATCH"
+		}
+		`,
+	}.Apply(t)
+	qa.AssertErrorStartsWith(t, err, "Something unexpected")
+}
+
+func TestArtifactAllowlistRead(t *testing.T) {
+	d, err := qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   http.MethodGet,
+				Resource: "/api/2.1/unity-catalog/artifact-allowlists/INIT_SCRIPT?",
+				Response: artifactInfo,
+			},
+		},
+		Resource: ResourceArtifactAllowlist(),
+		Read:     true,
+		ID:       id,
+		HCL: `
+		artifact_type = "INIT_SCRIPT"
+		artifact_matcher {
+			artifact = "/Volumes/inits"
+			match_type = "PREFIX_MATCH"
+		}
+		`,
+	}.Apply(t)
+	assert.NoError(t, err)
+	assert.Equal(t, "INIT_SCRIPT", d.Get("artifact_type"))
+	assert.Equal(t, 1, d.Get("artifact_matcher.#"))
+}
+
+func TestResourceArtifactAllowlistRead_Error(t *testing.T) {
+	d, err := qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "GET",
+				Resource: "/api/2.1/unity-catalog/artifact-allowlists/INIT_SCRIPT?",
+				Response: apierr.APIErrorBody{
+					ErrorCode: "INVALID_REQUEST",
+					Message:   "Internal error happened",
+				},
+				Status: 400,
+			},
+		},
+		Resource: ResourceArtifactAllowlist(),
+		Read:     true,
+		ID:       id,
+	}.Apply(t)
+	qa.AssertErrorStartsWith(t, err, "Internal error happened")
+	assert.Equal(t, id, d.Id(), "Id should not be empty for error reads")
+}
+
+func TestArtifactAllowlistUpdate(t *testing.T) {
+	d, err := qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:          http.MethodPut,
+				Resource:        "/api/2.1/unity-catalog/artifact-allowlists/INIT_SCRIPT",
+				ExpectedRequest: updateArtifact,
+				Response:        artifactInfo,
+			},
+			{
+				Method:   http.MethodGet,
+				Resource: "/api/2.1/unity-catalog/artifact-allowlists/INIT_SCRIPT?",
+				Response: artifactInfo,
+			},
+		},
+		Resource: ResourceArtifactAllowlist(),
+		Update:   true,
+		InstanceState: map[string]string{
+			"artifact_type":                 "INIT_SCRIPT",
+			"artifact_matcher.#":            "1",
+			"artifact_matcher.0.artifact":   "/Volumes/new_inits",
+			"artifact_matcher.0.match_type": "PREFIX_MATCH",
+		},
+		ID: id,
+		HCL: `
+		artifact_type = "INIT_SCRIPT"
+		artifact_matcher {
+			artifact = "/Volumes/new_inits"
+			match_type = "PREFIX_MATCH"
+		}
+		artifact_matcher {
+			artifact = "/Volumes/inits"
+			match_type = "PREFIX_MATCH"
+		}		
+		`,
+	}.Apply(t)
+	assert.NoError(t, err)
+	assert.Equal(t, "INIT_SCRIPT", d.Get("artifact_type"))
+	assert.Equal(t, 1, d.Get("artifact_matcher.#"))
+}
+
+func TestArtifactAllowlistUpdate_Error(t *testing.T) {
+	_, err := qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:          http.MethodPut,
+				Resource:        "/api/2.1/unity-catalog/artifact-allowlists/INIT_SCRIPT",
+				ExpectedRequest: updateArtifact,
+				Response: apierr.APIErrorBody{
+					ErrorCode: "SERVER_ERROR",
+					Message:   "Something unexpected happened",
+				},
+				Status: 500,
+			},
+		},
+		Resource: ResourceArtifactAllowlist(),
+		Update:   true,
+		InstanceState: map[string]string{
+			"artifact_type":                 "INIT_SCRIPT",
+			"artifact_matcher.#":            "1",
+			"artifact_matcher.0.artifact":   "/Volumes/new_inits",
+			"artifact_matcher.0.match_type": "PREFIX_MATCH",
+		},
+		ID: id,
+		HCL: `
+		artifact_type = "INIT_SCRIPT"
+		artifact_matcher {
+			artifact = "/Volumes/new_inits"
+			match_type = "PREFIX_MATCH"
+		}
+		artifact_matcher {
+			artifact = "/Volumes/inits"
+			match_type = "PREFIX_MATCH"
+		}	
+		`,
+	}.Apply(t)
+	qa.AssertErrorStartsWith(t, err, "Something unexpected")
+}
+
+func TestArtifactAllowlistDelete(t *testing.T) {
+	d, err := qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   http.MethodPut,
+				Resource: "/api/2.1/unity-catalog/artifact-allowlists/INIT_SCRIPT",
+				ExpectedRequest: catalog.SetArtifactAllowlist{
+					ArtifactType:     catalog.ArtifactTypeInitScript,
+					ArtifactMatchers: []catalog.ArtifactMatcher{},
+				},
+			},
+		},
+		Resource: ResourceArtifactAllowlist(),
+		Delete:   true,
+		ID:       id,
+	}.Apply(t)
+	assert.NoError(t, err)
+	assert.Equal(t, id, d.Id())
+}
+
+func TestArtifactAllowlistDelete_Error(t *testing.T) {
+	qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   http.MethodPut,
+				Resource: "/api/2.1/unity-catalog/artifact-allowlists/INIT_SCRIPT",
+				ExpectedRequest: catalog.SetArtifactAllowlist{
+					ArtifactType:     catalog.ArtifactTypeInitScript,
+					ArtifactMatchers: []catalog.ArtifactMatcher{},
+				},
+				Response: apierr.APIErrorBody{
+					ErrorCode: "INVALID_STATE",
+					Message:   "Something went wrong",
+				},
+				Status: 400,
+			},
+		},
+		Resource: ResourceArtifactAllowlist(),
+		Delete:   true,
+		Removed:  true,
+		ID:       id,
+	}.ExpectError(t, "Something went wrong")
+}

--- a/catalog/resource_artifact_allowlist_test.go
+++ b/catalog/resource_artifact_allowlist_test.go
@@ -52,6 +52,22 @@ var artifactInfo = catalog.ArtifactAllowlistInfo{
 	MetastoreId: "abc",
 }
 
+var updatedArtifactInfo = catalog.ArtifactAllowlistInfo{
+	ArtifactMatchers: []catalog.ArtifactMatcher{
+		{
+			Artifact:  "/Volumes/inits",
+			MatchType: catalog.MatchTypePrefixMatch,
+		},
+		{
+			Artifact:  "/Volumes/new_inits",
+			MatchType: catalog.MatchTypePrefixMatch,
+		},
+	},
+	CreatedAt:   12345,
+	CreatedBy:   "admin",
+	MetastoreId: "abc",
+}
+
 func TestArtifactAllowlistCreate(t *testing.T) {
 	d, err := qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
@@ -167,7 +183,7 @@ func TestArtifactAllowlistUpdate(t *testing.T) {
 			{
 				Method:   http.MethodGet,
 				Resource: "/api/2.1/unity-catalog/artifact-allowlists/INIT_SCRIPT?",
-				Response: artifactInfo,
+				Response: updatedArtifactInfo,
 			},
 		},
 		Resource: ResourceArtifactAllowlist(),
@@ -193,7 +209,7 @@ func TestArtifactAllowlistUpdate(t *testing.T) {
 	}.Apply(t)
 	assert.NoError(t, err)
 	assert.Equal(t, "INIT_SCRIPT", d.Get("artifact_type"))
-	assert.Equal(t, 1, d.Get("artifact_matcher.#"))
+	assert.Equal(t, 2, d.Get("artifact_matcher.#"))
 }
 
 func TestArtifactAllowlistUpdate_Error(t *testing.T) {

--- a/catalog/resource_connection.go
+++ b/catalog/resource_connection.go
@@ -39,9 +39,7 @@ var sensitiveOptions = []string{"user", "password", "personalAccessToken", "acce
 
 func ResourceConnection() *schema.Resource {
 	s := common.StructToSchema(ConnectionInfo{},
-		func(m map[string]*schema.Schema) map[string]*schema.Schema {
-			return m
-		})
+		common.NoCustomize)
 	pi := common.NewPairID("metastore_id", "name").Schema(
 		func(m map[string]*schema.Schema) map[string]*schema.Schema {
 			return s

--- a/catalog/resource_table.go
+++ b/catalog/resource_table.go
@@ -65,9 +65,7 @@ func (a TablesAPI) deleteTable(name string) error {
 
 func ResourceTable() *schema.Resource {
 	tableSchema := common.StructToSchema(TableInfo{},
-		func(m map[string]*schema.Schema) map[string]*schema.Schema {
-			return m
-		})
+		common.NoCustomize)
 	update := updateFunctionFactory("/unity-catalog/tables", []string{
 		"owner", "name", "data_source_format", "columns", "storage_location",
 		"view_definition", "comment", "properties"})

--- a/common/resource.go
+++ b/common/resource.go
@@ -331,3 +331,7 @@ func EqualFoldDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
 	}
 	return false
 }
+
+func NoCustomize(m map[string]*schema.Schema) map[string]*schema.Schema {
+	return m
+}

--- a/common/resource_test.go
+++ b/common/resource_test.go
@@ -183,3 +183,13 @@ func TestEqualFoldDiffSuppress(t *testing.T) {
 	assert.True(t, EqualFoldDiffSuppress("k", "A", "a", nil))
 	assert.False(t, EqualFoldDiffSuppress("k", "A", "A2", nil))
 }
+
+func TestNoCustomize(t *testing.T) {
+	dummySchema := map[string]*schema.Schema{
+		"dummy": {
+			Type:     schema.TypeBool,
+			Required: true,
+		},
+	}
+	assert.Equal(t, dummySchema, NoCustomize(dummySchema))
+}

--- a/docs/resources/artifact_allowlist.md
+++ b/docs/resources/artifact_allowlist.md
@@ -1,0 +1,55 @@
+---
+subcategory: "Unity Catalog"
+---
+# databricks_artifact_allowlist Resource
+
+-> **Note**
+  It is required to define all allowlist for an artifact type in a single resource, otherwise Terraform cannot guarantee config drift prevention.
+
+In Databricks Runtime 13.3 and above, you can add libraries and init scripts to the allowlist in UC so that users can leverage these artifacts on compute configured with shared access mode.
+
+## Example Usage
+
+```hcl
+resource "databricks_artifact_allowlist" "init_scripts" {
+  artifact_type = "INIT_SCRIPT"
+  artifact_matcher {
+    artifact = "/Volumes/inits"
+    match_type = "PREFIX_MATCH"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `artifact_type` - The artifact type of the allowlist. Can be `INIT_SCRIPT`, `LIBRARY_JAR` or `LIBRARY_MAVEN`. Change forces creation of a new resource.
+
+One or more `artifact_matcher` blocks with the following arguments:
+
+* `artifact` - The artifact path or maven coordinate.
+* `match_type` - The pattern matching type of the artifact. Only `PREFIX_MATCH` is supported.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `metastore_id` - ID of the parent metastore.
+* `created_at` -  Time at which this artifact allowlist was set.
+* `created_by` -  Identity that set the artifact allowlist.
+
+## Import
+
+This resource can be imported by name:
+
+```bash
+terraform import databricks_artifact_allowlist.this <metastore_id>|<artifact_type>
+```
+
+## Related Resources
+
+The following resources are used in the same context:
+
+* [databricks_cluster](cluster.md) to create [Databricks Clusters](https://docs.databricks.com/clusters/index.html).
+* [databricks_library](library.md) to install a [library](https://docs.databricks.com/libraries/index.html) on [databricks_cluster](cluster.md).

--- a/docs/resources/artifact_allowlist.md
+++ b/docs/resources/artifact_allowlist.md
@@ -6,6 +6,9 @@ subcategory: "Unity Catalog"
 -> **Note**
   It is required to define all allowlist for an artifact type in a single resource, otherwise Terraform cannot guarantee config drift prevention.
 
+-> **Note**
+  This resource is managed via **workspace-level APIs**.
+
 In Databricks Runtime 13.3 and above, you can add libraries and init scripts to the allowlist in UC so that users can leverage these artifacts on compute configured with shared access mode.
 
 ## Example Usage

--- a/internal/acceptance/artifact_allowlist_test.go
+++ b/internal/acceptance/artifact_allowlist_test.go
@@ -1,0 +1,32 @@
+package acceptance
+
+import (
+	"testing"
+)
+
+func TestUcAccArtifactAllowlistResourceFullLifecycle(t *testing.T) {
+	unityWorkspaceLevel(t, step{
+		Template: `
+		resource "databricks_artifact_allowlist" "init" {
+			artifact_type = "INIT_SCRIPT"
+			artifact_matcher {
+				artifact = "/Volumes/inits"
+				match_type = "PREFIX_MATCH"
+			}
+		}
+		resource "databricks_artifact_allowlist" "maven" {
+			artifact_type = "LIBRARY_MAVEN"
+			artifact_matcher {
+				artifact = "com.databricks:spark-xml"
+				match_type = "PREFIX_MATCH"
+			}
+		}
+		resource "databricks_artifact_allowlist" "jar" {
+			artifact_type = "LIBRARY_JAR"
+			artifact_matcher {
+				artifact = "/Volumes/inits"
+				match_type = "PREFIX_MATCH"
+			}
+		}`,
+	})
+}

--- a/mlflow/resource_mlflow_experiment.go
+++ b/mlflow/resource_mlflow_experiment.go
@@ -70,9 +70,7 @@ func (a ExperimentsAPI) Delete(id string) error {
 func ResourceMlflowExperiment() *schema.Resource {
 	s := common.StructToSchema(
 		Experiment{},
-		func(m map[string]*schema.Schema) map[string]*schema.Schema {
-			return m
-		})
+		common.NoCustomize)
 
 	return common.Resource{
 		Create: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {

--- a/mws/resource_mws_permission_assignment.go
+++ b/mws/resource_mws_permission_assignment.go
@@ -96,9 +96,7 @@ func ResourceMwsPermissionAssignment() *schema.Resource {
 		Permissions []string `json:"permissions" tf:"slice_as_set"`
 	}
 	s := common.StructToSchema(entity{},
-		func(m map[string]*schema.Schema) map[string]*schema.Schema {
-			return m
-		})
+		common.NoCustomize)
 	pair := common.NewPairID("workspace_id", "principal_id").Schema(
 		func(m map[string]*schema.Schema) map[string]*schema.Schema {
 			return s

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -86,6 +86,7 @@ func DatabricksProvider() *schema.Provider {
 		},
 		ResourcesMap: map[string]*schema.Resource{ // must be in alphabetical order
 			"databricks_access_control_rule_set":     permissions.ResourceAccessControlRuleSet(),
+			"databricks_artifact_allowlist":          catalog.ResourceArtifactAllowlist(),
 			"databricks_aws_s3_mount":                storage.ResourceAWSS3Mount(),
 			"databricks_azure_adls_gen1_mount":       storage.ResourceAzureAdlsGen1Mount(),
 			"databricks_azure_adls_gen2_mount":       storage.ResourceAzureAdlsGen2Mount(),

--- a/sql/resource_sql_dashboard.go
+++ b/sql/resource_sql_dashboard.go
@@ -96,9 +96,7 @@ func (a DashboardAPI) Delete(dashboardID string) error {
 func ResourceSqlDashboard() *schema.Resource {
 	s := common.StructToSchema(
 		DashboardEntity{},
-		func(m map[string]*schema.Schema) map[string]*schema.Schema {
-			return m
-		})
+		common.NoCustomize)
 
 	return common.Resource{
 		Create: func(ctx context.Context, data *schema.ResourceData, c *common.DatabricksClient) error {


### PR DESCRIPTION
## Changes
- Add new resource `databricks_artifact_allowlist` to support [Unity Catalog allowlist](https://docs.databricks.com/en/data-governance/unity-catalog/manage-privileges/allowlist.html)
- Add `common.NoCustomize` function to simplify schema creation
- 
close #2688

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [x] covered with integration tests in `internal/acceptance`
- [x] relevant acceptance tests are passing
- [x] using Go SDK

