### PR TITLE
Added logger package and fixed issue with API calls not being shown in DEBUG or lower log levels

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -14,7 +14,7 @@ type TfLogger struct {
 }
 
 // This function is always enabled because TfLogger implements the Logger interface from Go SDK and there we check
-// the logging is enabled based on level (which default to Info). This however isn't required in terraform
+// if the logging is enabled based on level (which default to Info). This however isn't required here
 // since we use the tflog package which automatically reads from TF_LOG environment variable.
 func (tfLogger *TfLogger) Enabled(_ context.Context, _ logger.Level) bool {
 	return true

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -14,8 +14,8 @@ type TfLogger struct {
 }
 
 // This function is always enabled because we extend the Logger from Go SDK and there we check
-// the logging based on level (defaulting to Info). This however isn't required in terraform since we use the tflog package
-// which doesn't require this.
+// the logging is enabled based on level (which default to Info). This however isn't required in terraform
+// since we use the tflog package which automatically reads from TF_LOG environment variable.
 func (tfLogger *TfLogger) Enabled(_ context.Context, _ logger.Level) bool {
 	return true
 }

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -15,7 +15,7 @@ type TfLogger struct {
 // This function is always enabled because TfLogger implements the Logger interface from Go SDK and there we check
 // if the logging is enabled based on level (which default to Info).
 // This however isn't possible here since tflog isn't enabled / disabled based on log level.
-// Ommiting is done internally through the `ShouldOmit` method that filters based on logger configurations.
+// Omitting is done internally through the `ShouldOmit` method that filters based on logger configurations.
 func (tfLogger *TfLogger) Enabled(_ context.Context, _ logger.Level) bool {
 	return true
 }

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -2,6 +2,7 @@ package logger
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 
 	"github.com/databricks/databricks-sdk-go/logger"
@@ -9,51 +10,53 @@ import (
 )
 
 type TfLogger struct {
-	Name  string
-	Level logger.Level
+	Name string
 }
 
-func (tfLogger *TfLogger) Enabled(_ context.Context, level logger.Level) bool {
+// This function is always enabled because we extend the Logger from Go SDK and there we check
+// the logging based on level (defaulting to Info). This however isn't required in terraform since we use the tflog package
+// which doesn't require this.
+func (tfLogger *TfLogger) Enabled(_ context.Context, _ logger.Level) bool {
 	return true
 }
 
 func (tfLogger *TfLogger) Tracef(ctx context.Context, format string, v ...any) {
 	if tfLogger == nil {
-		tflog.Trace(ctx, format, convertToMap(v))
+		tflog.Trace(ctx, fmt.Sprintf(format, v...), convertToMap(v))
 	} else {
-		tflog.SubsystemTrace(ctx, tfLogger.Name, format, convertToMap(v))
+		tflog.SubsystemTrace(ctx, tfLogger.Name, fmt.Sprintf(format, v...), convertToMap(v))
 	}
 }
 
 func (tfLogger *TfLogger) Debugf(ctx context.Context, format string, v ...any) {
 	if tfLogger == nil {
-		tflog.Debug(ctx, format, convertToMap(v))
+		tflog.Debug(ctx, fmt.Sprintf(format, v...), convertToMap(v))
 	} else {
-		tflog.SubsystemDebug(ctx, tfLogger.Name, format, convertToMap(v))
+		tflog.SubsystemDebug(ctx, tfLogger.Name, fmt.Sprintf(format, v...), convertToMap(v))
 	}
 }
 
 func (tfLogger *TfLogger) Infof(ctx context.Context, format string, v ...any) {
 	if tfLogger == nil {
-		tflog.Info(ctx, format, convertToMap(v))
+		tflog.Info(ctx, fmt.Sprintf(format, v...), convertToMap(v))
 	} else {
-		tflog.SubsystemInfo(ctx, tfLogger.Name, format, convertToMap(v))
+		tflog.SubsystemInfo(ctx, tfLogger.Name, fmt.Sprintf(format, v...), convertToMap(v))
 	}
 }
 
 func (tfLogger *TfLogger) Warnf(ctx context.Context, format string, v ...any) {
 	if tfLogger == nil {
-		tflog.Warn(ctx, format, convertToMap(v))
+		tflog.Warn(ctx, fmt.Sprintf(format, v...), convertToMap(v))
 	} else {
-		tflog.SubsystemWarn(ctx, tfLogger.Name, format, convertToMap(v))
+		tflog.SubsystemWarn(ctx, tfLogger.Name, fmt.Sprintf(format, v...), convertToMap(v))
 	}
 }
 
 func (tfLogger *TfLogger) Errorf(ctx context.Context, format string, v ...any) {
 	if tfLogger == nil {
-		tflog.Error(ctx, format, convertToMap(v))
+		tflog.Error(ctx, fmt.Sprintf(format, v...), convertToMap(v))
 	} else {
-		tflog.SubsystemError(ctx, tfLogger.Name, format, convertToMap(v))
+		tflog.SubsystemError(ctx, tfLogger.Name, fmt.Sprintf(format, v...), convertToMap(v))
 	}
 }
 

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -13,7 +13,7 @@ type TfLogger struct {
 	Name string
 }
 
-// This function is always enabled because we extend the Logger from Go SDK and there we check
+// This function is always enabled because TfLogger implement the Logger interface from Go SDK and there we check
 // the logging is enabled based on level (which default to Info). This however isn't required in terraform
 // since we use the tflog package which automatically reads from TF_LOG environment variable.
 func (tfLogger *TfLogger) Enabled(_ context.Context, _ logger.Level) bool {

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -3,7 +3,6 @@ package logger
 import (
 	"context"
 	"fmt"
-	"strconv"
 
 	"github.com/databricks/databricks-sdk-go/logger"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -14,59 +13,51 @@ type TfLogger struct {
 }
 
 // This function is always enabled because TfLogger implements the Logger interface from Go SDK and there we check
-// if the logging is enabled based on level (which default to Info). This however isn't required here
-// since we use the tflog package which automatically reads from TF_LOG environment variable.
+// if the logging is enabled based on level (which default to Info).
+// This however isn't possible here since tflog isn't enabled / disabled based on log level.
+// Ommiting is done internally through the `ShouldOmit` method that filters based on logger configurations.
 func (tfLogger *TfLogger) Enabled(_ context.Context, _ logger.Level) bool {
 	return true
 }
 
 func (tfLogger *TfLogger) Tracef(ctx context.Context, format string, v ...any) {
 	if tfLogger == nil {
-		tflog.Trace(ctx, fmt.Sprintf(format, v...), convertToMap(v))
+		tflog.Trace(ctx, fmt.Sprintf(format, v...), nil)
 	} else {
-		tflog.SubsystemTrace(ctx, tfLogger.Name, fmt.Sprintf(format, v...), convertToMap(v))
+		tflog.SubsystemTrace(ctx, tfLogger.Name, fmt.Sprintf(format, v...), nil)
 	}
 }
 
 func (tfLogger *TfLogger) Debugf(ctx context.Context, format string, v ...any) {
 	if tfLogger == nil {
-		tflog.Debug(ctx, fmt.Sprintf(format, v...), convertToMap(v))
+		tflog.Debug(ctx, fmt.Sprintf(format, v...), nil)
 	} else {
-		tflog.SubsystemDebug(ctx, tfLogger.Name, fmt.Sprintf(format, v...), convertToMap(v))
+		tflog.SubsystemDebug(ctx, tfLogger.Name, fmt.Sprintf(format, v...), nil)
 	}
 }
 
 func (tfLogger *TfLogger) Infof(ctx context.Context, format string, v ...any) {
 	if tfLogger == nil {
-		tflog.Info(ctx, fmt.Sprintf(format, v...), convertToMap(v))
+		tflog.Info(ctx, fmt.Sprintf(format, v...), nil)
 	} else {
-		tflog.SubsystemInfo(ctx, tfLogger.Name, fmt.Sprintf(format, v...), convertToMap(v))
+		tflog.SubsystemInfo(ctx, tfLogger.Name, fmt.Sprintf(format, v...), nil)
 	}
 }
 
 func (tfLogger *TfLogger) Warnf(ctx context.Context, format string, v ...any) {
 	if tfLogger == nil {
-		tflog.Warn(ctx, fmt.Sprintf(format, v...), convertToMap(v))
+		tflog.Warn(ctx, fmt.Sprintf(format, v...), nil)
 	} else {
-		tflog.SubsystemWarn(ctx, tfLogger.Name, fmt.Sprintf(format, v...), convertToMap(v))
+		tflog.SubsystemWarn(ctx, tfLogger.Name, fmt.Sprintf(format, v...), nil)
 	}
 }
 
 func (tfLogger *TfLogger) Errorf(ctx context.Context, format string, v ...any) {
 	if tfLogger == nil {
-		tflog.Error(ctx, fmt.Sprintf(format, v...), convertToMap(v))
+		tflog.Error(ctx, fmt.Sprintf(format, v...), nil)
 	} else {
-		tflog.SubsystemError(ctx, tfLogger.Name, fmt.Sprintf(format, v...), convertToMap(v))
+		tflog.SubsystemError(ctx, tfLogger.Name, fmt.Sprintf(format, v...), nil)
 	}
-}
-
-func convertToMap(args ...interface{}) map[string]interface{} {
-	m := make(map[string]interface{})
-	for i, arg := range args {
-		key := strconv.Itoa(i)
-		m[key] = arg
-	}
-	return m
 }
 
 func SetLogger() {

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -1,0 +1,71 @@
+package logger
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/databricks/databricks-sdk-go/logger"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+type TfLogger struct {
+	Name  string
+	Level logger.Level
+}
+
+func (tfLogger *TfLogger) Enabled(_ context.Context, level logger.Level) bool {
+	return true
+}
+
+func (tfLogger *TfLogger) Tracef(ctx context.Context, format string, v ...any) {
+	if tfLogger == nil {
+		tflog.Trace(ctx, format, convertToMap(v))
+	} else {
+		tflog.SubsystemTrace(ctx, tfLogger.Name, format, convertToMap(v))
+	}
+}
+
+func (tfLogger *TfLogger) Debugf(ctx context.Context, format string, v ...any) {
+	if tfLogger == nil {
+		tflog.Debug(ctx, format, convertToMap(v))
+	} else {
+		tflog.SubsystemDebug(ctx, tfLogger.Name, format, convertToMap(v))
+	}
+}
+
+func (tfLogger *TfLogger) Infof(ctx context.Context, format string, v ...any) {
+	if tfLogger == nil {
+		tflog.Info(ctx, format, convertToMap(v))
+	} else {
+		tflog.SubsystemInfo(ctx, tfLogger.Name, format, convertToMap(v))
+	}
+}
+
+func (tfLogger *TfLogger) Warnf(ctx context.Context, format string, v ...any) {
+	if tfLogger == nil {
+		tflog.Warn(ctx, format, convertToMap(v))
+	} else {
+		tflog.SubsystemWarn(ctx, tfLogger.Name, format, convertToMap(v))
+	}
+}
+
+func (tfLogger *TfLogger) Errorf(ctx context.Context, format string, v ...any) {
+	if tfLogger == nil {
+		tflog.Error(ctx, format, convertToMap(v))
+	} else {
+		tflog.SubsystemError(ctx, tfLogger.Name, format, convertToMap(v))
+	}
+}
+
+func convertToMap(args ...interface{}) map[string]interface{} {
+	m := make(map[string]interface{})
+	for i, arg := range args {
+		key := strconv.Itoa(i)
+		m[key] = arg
+	}
+	return m
+}
+
+func SetLogger() {
+	logger.DefaultLogger = &TfLogger{}
+}

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -13,7 +13,7 @@ type TfLogger struct {
 	Name string
 }
 
-// This function is always enabled because TfLogger implement the Logger interface from Go SDK and there we check
+// This function is always enabled because TfLogger implements the Logger interface from Go SDK and there we check
 // the logging is enabled based on level (which default to Info). This however isn't required in terraform
 // since we use the tflog package which automatically reads from TF_LOG environment variable.
 func (tfLogger *TfLogger) Enabled(_ context.Context, _ logger.Level) bool {

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -13,12 +13,6 @@ func TestTfLogger_Enabled(t *testing.T) {
 	assert.True(t, l.Enabled(context.Background(), goLogger.LevelInfo))
 }
 
-func TestConvertToMap(t *testing.T) {
-	m := convertToMap("value1", "value2")
-	assert.Equal(t, "value1", m["0"])
-	assert.Equal(t, "value2", m["1"])
-}
-
 func TestSetLogger(t *testing.T) {
 	SetLogger()
 	assert.IsType(t, &TfLogger{}, goLogger.DefaultLogger)

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -1,0 +1,25 @@
+package logger
+
+import (
+	"context"
+	"testing"
+
+	goLogger "github.com/databricks/databricks-sdk-go/logger"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTfLogger_Enabled(t *testing.T) {
+	l := &TfLogger{}
+	assert.True(t, l.Enabled(context.Background(), goLogger.LevelInfo))
+}
+
+func TestConvertToMap(t *testing.T) {
+	m := convertToMap("value1", "value2")
+	assert.Equal(t, "value1", m["0"])
+	assert.Equal(t, "value2", m["1"])
+}
+
+func TestSetLogger(t *testing.T) {
+	SetLogger()
+	assert.IsType(t, &TfLogger{}, goLogger.DefaultLogger)
+}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -21,6 +21,7 @@ import (
 	"github.com/databricks/terraform-provider-databricks/commands"
 	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/databricks/terraform-provider-databricks/jobs"
+	tflogger "github.com/databricks/terraform-provider-databricks/logger"
 	"github.com/databricks/terraform-provider-databricks/mlflow"
 	"github.com/databricks/terraform-provider-databricks/mws"
 	"github.com/databricks/terraform-provider-databricks/permissions"
@@ -168,6 +169,7 @@ func DatabricksProvider() *schema.Provider {
 		if p.TerraformVersion != "" {
 			useragent.WithUserAgentExtra("terraform", p.TerraformVersion)
 		}
+		tflogger.SetLogger()
 		return configureDatabricksClient(ctx, d)
 	}
 	common.AddContextToAllResources(p, "databricks")


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
Terraform never had logging configured correctly (used to log all levels irrespective of log level specified). The issue (api calls not being shown in `DEBUG` log level) surfaced because in the TF version bump to 1.20.9 which had Go SDK version bump to 0.10.0, the PR: https://github.com/databricks/databricks-sdk-go/pull/426 introduced INFO as basic log level leading to debug level never being enabled even if it is passed through the environment variable. 

Note: `terraform apply` does not show INFO level logs by default. For that `TF_LOG=INFO` needs to be passed which I think is the expected (correct) behaviour.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->
- Tested Manually with using TF_LOG=DEBUG (TF_LOG=debug also works) env which works, not using the env doesn't show logs (correctly), using TF_LOG=TRACE shows right level (TRACE) logs.
- Manually running `TF_LOG=DEBUG terraform apply` shows API calls, 
`````
2023-09-29T14:51:24.653+0200 [DEBUG] provider.terraform-provider-databricks: GET /api/2.1/unity-catalog/catalogs
< HTTP/2.0 200 OK
< {
<   "catalogs": [
<     {
<       "browse_only": false,
<       "catalog_type": "MANAGED_CATALOG",
<       "comment": "",
`````
- Added unit test
- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

