### PR TITLE
Fix: don't rely on having `@` to check if it's user or SP

### DIFF
--- a/common/util.go
+++ b/common/util.go
@@ -1,0 +1,13 @@
+package common
+
+import (
+	"regexp"
+)
+
+var (
+	uuidRegex = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
+)
+
+func StringIsUUID(s string) bool {
+	return uuidRegex.MatchString(s)
+}

--- a/common/util_test.go
+++ b/common/util_test.go
@@ -1,0 +1,12 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStringIsUUID(t *testing.T) {
+	assert.True(t, StringIsUUID("3f670caf-9a4b-4479-8143-1a0878da8f57"))
+	assert.False(t, StringIsUUID("abc"))
+}

--- a/exporter/importables.go
+++ b/exporter/importables.go
@@ -42,7 +42,6 @@ var (
 	nameNormalizationRegex       = regexp.MustCompile(`\W+`)
 	jobClustersRegex             = regexp.MustCompile(`^((job_cluster|task)\.[0-9]+\.new_cluster\.[0-9]+\.)`)
 	dltClusterRegex              = regexp.MustCompile(`^(cluster\.[0-9]+\.)`)
-	uuidRegex                    = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
 	predefinedClusterPolicies    = []string{"Personal Compute", "Job Compute", "Power User Compute", "Shared Compute"}
 	secretPathRegex              = regexp.MustCompile(`^\{\{secrets\/([^\/]+)\/([^}]+)\}\}$`)
 	sqlParentRegexp              = regexp.MustCompile(`^folders/(\d+)$`)

--- a/exporter/util.go
+++ b/exporter/util.go
@@ -96,13 +96,15 @@ func (ic *importContext) emitUserOrServicePrincipal(userOrSPName string) {
 	if userOrSPName == "" {
 		return
 	}
+	// TODO: think about another way of checking for a user. ideally we need to check against the
+	// list of users/SPs obtained via SCIM API - this will be done in the refactoring requested by the SCIM team
 	if strings.Contains(userOrSPName, "@") {
 		ic.Emit(&resource{
 			Resource:  "databricks_user",
 			Attribute: "user_name",
 			Value:     userOrSPName,
 		})
-	} else if uuidRegex.MatchString(userOrSPName) {
+	} else if common.StringIsUUID(userOrSPName) {
 		ic.Emit(&resource{
 			Resource:  "databricks_service_principal",
 			Attribute: "application_id",
@@ -126,8 +128,10 @@ func (ic *importContext) IsUserOrServicePrincipalDirectory(path, prefix string) 
 	}
 	parts := strings.SplitN(path, "/", 4)
 	if len(parts) == 3 || (len(parts) == 4 && parts[3] == "") {
+		// TODO: think about another way of checking for a user. ideally we need to check against the
+		// list of users/SPs obtained via SCIM API - this will be done in the refactoring requested by the SCIM team
 		userOrSPName := parts[2]
-		return strings.Contains(userOrSPName, "@") || uuidRegex.MatchString(userOrSPName)
+		return strings.Contains(userOrSPName, "@") || common.StringIsUUID(userOrSPName)
 	}
 	return false
 }

--- a/jobs/resource_job.go
+++ b/jobs/resource_job.go
@@ -572,16 +572,14 @@ func (a JobsAPI) Read(id string) (job Job, err error) {
 		job.Settings.sortWebhooksByID()
 	}
 
-	if job.RunAsUserName != "" && job.Settings != nil {
-		userNameIsEmail := strings.Contains(job.RunAsUserName, "@")
-
-		if userNameIsEmail {
+	if job.Settings != nil && job.RunAsUserName != "" && job.RunAsUserName != job.CreatorUserName {
+		if common.StringIsUUID(job.RunAsUserName) {
 			job.Settings.RunAs = &JobRunAs{
-				UserName: job.RunAsUserName,
+				ServicePrincipalName: job.RunAsUserName,
 			}
 		} else {
 			job.Settings.RunAs = &JobRunAs{
-				ServicePrincipalName: job.RunAsUserName,
+				UserName: job.RunAsUserName,
 			}
 		}
 	}

--- a/scim/data_current_user.go
+++ b/scim/data_current_user.go
@@ -59,10 +59,10 @@ func DataSourceCurrentUser() *schema.Resource {
 			d.Set("user_name", me.UserName)
 			d.Set("home", fmt.Sprintf("/Users/%s", me.UserName))
 			d.Set("repos", fmt.Sprintf("/Repos/%s", me.UserName))
-			if strings.Contains(me.UserName, "@") {
-				d.Set("acl_principal_id", fmt.Sprintf("users/%s", me.UserName))
-			} else {
+			if common.StringIsUUID(me.UserName) {
 				d.Set("acl_principal_id", fmt.Sprintf("servicePrincipals/%s", me.UserName))
+			} else {
+				d.Set("acl_principal_id", fmt.Sprintf("users/%s", me.UserName))
 			}
 			d.Set("external_id", me.ExternalId)
 			splits := strings.Split(me.UserName, "@")


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

There are some installations where the user name isn't equal to email - for them, our detection of username vs SP ID is broken, and leads to some problems, like, the generation of erroneous `run_as` blocks in job definitions, etc.

This PR fixes this by validating a given string as UUID, and if it matches, then uses it as SP ID, and the rest as user name.  Changes affect the following:

* `databricks_job` API - besides validation, it also doesn't fill the `RunAs` structure on read when creator user name == run as user name.
* `databricks_current_user` data source - should fix generation of `acl_principal_id`

There will be changes in the exporter as well, but they will be done later, as part of the SCIM refactoring that needs to be done anyway...

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] ~relevant change in `docs/` folder~
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

