### PR TITLE
Added `databricks_registered_model` resource

### DIFF
--- a/catalog/resource_grants.go
+++ b/catalog/resource_grants.go
@@ -105,6 +105,9 @@ func getPermissionEndpoint(securable, name string) string {
 	if securable == "foreign_connection" {
 		return fmt.Sprintf("/unity-catalog/permissions/connection/%s", name)
 	}
+	if securable == "model" {
+		return fmt.Sprintf("/unity-catalog/permissions/function/%s", name)
+	}
 	return fmt.Sprintf("/unity-catalog/permissions/%s/%s", securable, name)
 }
 

--- a/catalog/resource_registered_model.go
+++ b/catalog/resource_registered_model.go
@@ -52,11 +52,9 @@ func ResourceRegisteredModel() *schema.Resource {
 			if err != nil {
 				return err
 			}
-			var m catalog.CreateRegisteredModelRequest
 			var u catalog.UpdateRegisteredModelRequest
-			common.DataToStructPointer(d, s, &m)
+			common.DataToStructPointer(d, s, &u)
 			u.FullName = d.Id()
-			u.Comment = m.Comment
 			_, err = w.RegisteredModels.Update(ctx, u)
 			return err
 		},

--- a/catalog/resource_registered_model.go
+++ b/catalog/resource_registered_model.go
@@ -45,11 +45,7 @@ func ResourceRegisteredModel() *schema.Resource {
 			if err != nil {
 				return err
 			}
-			err = common.StructToData(*model, s, d)
-			if err != nil {
-				return err
-			}
-			return nil
+			return common.StructToData(*model, s, d)
 		},
 		Update: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
 			w, err := c.WorkspaceClient()

--- a/catalog/resource_registered_model.go
+++ b/catalog/resource_registered_model.go
@@ -1,0 +1,78 @@
+package catalog
+
+import (
+	"context"
+
+	"github.com/databricks/databricks-sdk-go/service/catalog"
+	"github.com/databricks/terraform-provider-databricks/common"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func ResourceRegisteredModel() *schema.Resource {
+	s := common.StructToSchema(
+		catalog.CreateRegisteredModelRequest{},
+		func(m map[string]*schema.Schema) map[string]*schema.Schema {
+			m["name"].ForceNew = true
+			m["catalog_name"].ForceNew = true
+			m["schema_name"].ForceNew = true
+			m["storage_location"].ForceNew = true
+			m["storage_location"].Computed = true
+
+			return m
+		})
+
+	return common.Resource{
+		Create: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
+			w, err := c.WorkspaceClient()
+			if err != nil {
+				return err
+			}
+			var m catalog.CreateRegisteredModelRequest
+			common.DataToStructPointer(d, s, &m)
+			model, err := w.RegisteredModels.Create(ctx, m)
+			if err != nil {
+				return err
+			}
+			d.SetId(model.FullName)
+			return nil
+		},
+		Read: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
+			w, err := c.WorkspaceClient()
+			if err != nil {
+				return err
+			}
+			model, err := w.RegisteredModels.GetByFullName(ctx, d.Id())
+			if err != nil {
+				return err
+			}
+			err = common.StructToData(*model, s, d)
+			if err != nil {
+				return err
+			}
+			return nil
+		},
+		Update: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
+			w, err := c.WorkspaceClient()
+			if err != nil {
+				return err
+			}
+			var m catalog.CreateRegisteredModelRequest
+			var u catalog.UpdateRegisteredModelRequest
+			common.DataToStructPointer(d, s, &m)
+			u.FullName = d.Id()
+			u.Comment = m.Comment
+			_, err = w.RegisteredModels.Update(ctx, u)
+			return err
+		},
+		Delete: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
+			w, err := c.WorkspaceClient()
+			if err != nil {
+				return err
+			}
+			return w.RegisteredModels.DeleteByFullName(ctx, d.Id())
+		},
+		StateUpgraders: []schema.StateUpgrader{},
+		Schema:         s,
+		SchemaVersion:  0,
+	}.ToResource()
+}

--- a/catalog/resource_registered_model_test.go
+++ b/catalog/resource_registered_model_test.go
@@ -1,0 +1,228 @@
+package catalog
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/databricks/databricks-sdk-go/apierr"
+	"github.com/databricks/databricks-sdk-go/service/catalog"
+	"github.com/databricks/terraform-provider-databricks/qa"
+)
+
+func TestRegisteredModelCornerCases(t *testing.T) {
+	qa.ResourceCornerCases(t, ResourceRegisteredModel())
+}
+
+func TestRegisteredModelCreate(t *testing.T) {
+	qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   http.MethodPost,
+				Resource: "/api/2.1/unity-catalog/models",
+				ExpectedRequest: catalog.CreateRegisteredModelRequest{
+					Name:        "model",
+					CatalogName: "catalog",
+					SchemaName:  "schema",
+					Comment:     "comment",
+				},
+				Response: catalog.RegisteredModelInfo{
+					Name:        "model",
+					CatalogName: "catalog",
+					SchemaName:  "schema",
+					FullName:    "catalog.schema.model",
+					Comment:     "comment",
+				},
+			},
+			{
+				Method:   http.MethodGet,
+				Resource: "/api/2.1/unity-catalog/models/catalog.schema.model?",
+				Response: catalog.RegisteredModelInfo{
+					Name:        "model",
+					CatalogName: "catalog",
+					SchemaName:  "schema",
+					FullName:    "catalog.schema.model",
+					Comment:     "comment",
+				},
+			},
+		},
+		Resource: ResourceRegisteredModel(),
+		HCL: `
+			name = "model"
+			catalog_name = "catalog"
+			schema_name = "schema"
+			comment = "comment"
+			`,
+		Create: true,
+	}.ApplyNoError(t)
+}
+
+func TestRegisteredModelCreate_Error(t *testing.T) {
+	qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   http.MethodPost,
+				Resource: "/api/2.1/unity-catalog/models",
+				Response: apierr.APIErrorBody{
+					ErrorCode: "INVALID_REQUEST",
+					Message:   "Internal error happened",
+				},
+				Status: 400,
+			},
+		},
+		Resource: ResourceRegisteredModel(),
+		Create:   true,
+	}.ExpectError(t, "Internal error happened")
+}
+
+func TestRegisteredModelRead(t *testing.T) {
+	qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   http.MethodGet,
+				Resource: "/api/2.1/unity-catalog/models/catalog.schema.model?",
+				Response: catalog.RegisteredModelInfo{
+					Name:        "model",
+					CatalogName: "catalog",
+					SchemaName:  "schema",
+					FullName:    "catalog.schema.model",
+					Comment:     "comment",
+				},
+			},
+		},
+		Resource: ResourceRegisteredModel(),
+		Read:     true,
+		ID:       "catalog.schema.model",
+	}.ApplyNoError(t)
+}
+
+func TestRegisteredModelRead_Error(t *testing.T) {
+	qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   http.MethodGet,
+				Resource: "/api/2.1/unity-catalog/models/catalog.schema.model?",
+				Response: apierr.APIErrorBody{
+					ErrorCode: "INVALID_REQUEST",
+					Message:   "Internal error happened",
+				},
+				Status: 400,
+			},
+		},
+		Resource: ResourceRegisteredModel(),
+		Read:     true,
+		ID:       "catalog.schema.model",
+	}.ExpectError(t, "Internal error happened")
+}
+
+func TestRegisteredModelUpdate(t *testing.T) {
+	qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   http.MethodPatch,
+				Resource: "/api/2.1/unity-catalog/models/catalog.schema.model",
+				ExpectedRequest: catalog.UpdateRegisteredModelRequest{
+					FullName: "catalog.schema.model",
+					Comment:  "new comment",
+				},
+				Response: catalog.RegisteredModelInfo{
+					Name:        "model",
+					CatalogName: "catalog",
+					SchemaName:  "schema",
+					FullName:    "catalog.schema.model",
+					Comment:     "new comment",
+				},
+			},
+			{
+				Method:   http.MethodGet,
+				Resource: "/api/2.1/unity-catalog/models/catalog.schema.model?",
+				Response: catalog.RegisteredModelInfo{
+					Name:        "model",
+					CatalogName: "catalog",
+					SchemaName:  "schema",
+					FullName:    "catalog.schema.model",
+					Comment:     "new comment",
+				},
+			},
+		},
+		Resource: ResourceRegisteredModel(),
+		Update:   true,
+		ID:       "catalog.schema.model",
+		InstanceState: map[string]string{
+			"name":         "model",
+			"catalog_name": "catalog",
+			"schema_name":  "schema",
+			"comment":      "comment",
+		},
+		HCL: `
+			name = "model"
+			catalog_name = "catalog"
+			schema_name = "schema"
+			comment = "new comment"
+			`,
+	}.ApplyNoError(t)
+}
+
+func TestRegisteredModelUpdate_Error(t *testing.T) {
+	qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   http.MethodPatch,
+				Resource: "/api/2.1/unity-catalog/models/catalog.schema.model",
+				Response: apierr.APIErrorBody{
+					ErrorCode: "INVALID_REQUEST",
+					Message:   "Internal error happened",
+				},
+				Status: 400,
+			},
+		},
+		Resource: ResourceRegisteredModel(),
+		Update:   true,
+		ID:       "catalog.schema.model",
+		InstanceState: map[string]string{
+			"name":         "model",
+			"catalog_name": "catalog",
+			"schema_name":  "schema",
+			"comment":      "comment",
+		},
+		HCL: `
+			name = "model"
+			catalog_name = "catalog"
+			schema_name = "schema"
+			comment = "new comment"
+			`,
+	}.ExpectError(t, "Internal error happened")
+}
+
+func TestRegisteredModelDelete(t *testing.T) {
+	qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   http.MethodDelete,
+				Resource: "/api/2.1/unity-catalog/models/catalog.schema.model?",
+				Response: "",
+			},
+		},
+		Resource: ResourceRegisteredModel(),
+		Delete:   true,
+		ID:       "catalog.schema.model",
+	}.ApplyNoError(t)
+}
+
+func TestRegisteredModelDelete_Error(t *testing.T) {
+	qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   http.MethodDelete,
+				Resource: "/api/2.1/unity-catalog/models/catalog.schema.model?",
+				Response: apierr.APIErrorBody{
+					ErrorCode: "INVALID_REQUEST",
+					Message:   "Internal error happened",
+				},
+				Status: 400,
+			},
+		},
+		Resource: ResourceRegisteredModel(),
+		Delete:   true,
+		ID:       "catalog.schema.model",
+	}.ExpectError(t, "Internal error happened")
+}

--- a/catalog/resource_registered_model_test.go
+++ b/catalog/resource_registered_model_test.go
@@ -53,7 +53,11 @@ func TestRegisteredModelCreate(t *testing.T) {
 			comment = "comment"
 			`,
 		Create: true,
-	}.ApplyNoError(t)
+	}.ApplyAndExpectData(t,
+		map[string]any{
+			"id": "catalog.schema.model",
+		},
+	)
 }
 
 func TestRegisteredModelCreate_Error(t *testing.T) {
@@ -92,7 +96,11 @@ func TestRegisteredModelRead(t *testing.T) {
 		Resource: ResourceRegisteredModel(),
 		Read:     true,
 		ID:       "catalog.schema.model",
-	}.ApplyNoError(t)
+	}.ApplyAndExpectData(t,
+		map[string]any{
+			"id": "catalog.schema.model",
+		},
+	)
 }
 
 func TestRegisteredModelRead_Error(t *testing.T) {

--- a/catalog/resource_registered_model_test.go
+++ b/catalog/resource_registered_model_test.go
@@ -131,6 +131,7 @@ func TestRegisteredModelUpdate(t *testing.T) {
 				ExpectedRequest: catalog.UpdateRegisteredModelRequest{
 					FullName: "catalog.schema.model",
 					Comment:  "new comment",
+					Name:     "model",
 				},
 				Response: catalog.RegisteredModelInfo{
 					Name:        "model",

--- a/docs/index.md
+++ b/docs/index.md
@@ -56,7 +56,7 @@ Machine Learning
 
 * Create [models in Unity Catalog](resources/registered_model.md).
 * Create [MLflow experiments](resources/mlflow_experiment.md).
-* Create [workspace models](resources/mlflow_model.md).
+* Create [models in the workspace model registry](resources/mlflow_model.md).
 * Create [model serving endpoints](resources/model_serving.md).
 
 ## Example Usage

--- a/docs/index.md
+++ b/docs/index.md
@@ -52,10 +52,12 @@ Databricks SQL
 * Manage [dashboards](resources/sql_dashboard.md) and their [widgets](resources/sql_widget.md).
 * Provide [global configuration for all SQL warehouses](docs/resources/sql_global_config.md)
 
-MLFlow
+Machine Learning
 
-* Create [MLFlow models](resources/mlflow_model.md).
-* Create [MLFlow experiments](resources/mlflow_experiment.md).
+* Create [models in Unity Catalog](resources/registered_model.md).
+* Create [MLflow experiments](resources/mlflow_experiment.md).
+* Create [workspace models](resources/mlflow_model.md).
+* Create [model serving endpoints](resources/model_serving.md).
 
 ## Example Usage
 

--- a/docs/resources/grants.md
+++ b/docs/resources/grants.md
@@ -194,9 +194,9 @@ resource "databricks_grants" "volume" {
 }
 ```
 
-## Function grants
+## Registered model grants
 
-You can grant `ALL_PRIVILEGES`, `APPLY_TAG`, and `EXECUTE` privileges to [_`catalog.schema.function`_](registered_model.md) specified in the `function` attribute.
+You can grant `ALL_PRIVILEGES`, `APPLY_TAG`, and `EXECUTE` privileges to [_`catalog.schema.model`_](registered_model.md) specified in the `function` attribute.
 
 ```hcl
 resource "databricks_grants" "customers" {

--- a/docs/resources/grants.md
+++ b/docs/resources/grants.md
@@ -194,6 +194,24 @@ resource "databricks_grants" "volume" {
 }
 ```
 
+## Function grants
+
+You can grant `ALL_PRIVILEGES`, `APPLY_TAG`, and `EXECUTE` privileges to [_`catalog.schema.function`_](registered_model.md) specified in the `function` attribute.
+
+```hcl
+resource "databricks_grants" "customers" {
+  function = "main.reporting.customer_model"
+  grant {
+    principal  = "Data Engineers"
+    privileges = ["APPLY_TAG", "EXECUTE"]
+  }
+  grant {
+    principal  = "Data Analysts"
+    privileges = ["EXECUTE"]
+  }
+}
+```
+
 ## Storage credential grants
 
 You can grant `ALL_PRIVILEGES`, `CREATE_EXTERNAL_LOCATION`, `CREATE_EXTERNAL_TABLE`, `READ_FILES` and `WRITE_FILES` privileges to [databricks_storage_credential](storage_credential.md) id specified in `storage_credential` attribute:

--- a/docs/resources/grants.md
+++ b/docs/resources/grants.md
@@ -196,11 +196,11 @@ resource "databricks_grants" "volume" {
 
 ## Registered model grants
 
-You can grant `ALL_PRIVILEGES`, `APPLY_TAG`, and `EXECUTE` privileges to [_`catalog.schema.model`_](registered_model.md) specified in the `function` attribute.
+You can grant `ALL_PRIVILEGES`, `APPLY_TAG`, and `EXECUTE` privileges to [_`catalog.schema.model`_](registered_model.md) specified in the `model` attribute.
 
 ```hcl
 resource "databricks_grants" "customers" {
-  function = "main.reporting.customer_model"
+  model = "main.reporting.customer_model"
   grant {
     principal  = "Data Engineers"
     privileges = ["APPLY_TAG", "EXECUTE"]

--- a/docs/resources/mlflow_experiment.md
+++ b/docs/resources/mlflow_experiment.md
@@ -44,7 +44,7 @@ The following resources are often used in the same context:
 * [databricks_registered_model](registered_model.md) to create [Models in Unity Catalog](https://docs.databricks.com/en/mlflow/models-in-uc.html) in Databricks.
 * [End to end workspace management](../guides/workspace-management.md) guide.
 * [databricks_directory](directory.md) to manage directories in [Databricks Workpace](https://docs.databricks.com/workspace/workspace-objects.html).
-* [databricks_mlflow_model](mlflow_model.md) to create [MLflow models](https://docs.databricks.com/applications/mlflow/models.html) in Databricks.
+* [databricks_mlflow_model](mlflow_model.md) to create models in the [workspace model registry](https://docs.databricks.com/en/mlflow/model-registry.html) in Databricks.
 * [databricks_notebook](notebook.md) to manage [Databricks Notebooks](https://docs.databricks.com/notebooks/index.html).
 * [databricks_notebook](../data-sources/notebook.md) data to export a notebook from Databricks Workspace.
 * [databricks_repo](repo.md) to manage [Databricks Repos](https://docs.databricks.com/repos.html).

--- a/docs/resources/mlflow_experiment.md
+++ b/docs/resources/mlflow_experiment.md
@@ -41,6 +41,7 @@ $ terraform import databricks_mlflow_experiment.this <experiment-id>
 
 The following resources are often used in the same context:
 
+* [databricks_registered_model](registered_model.md) to create [Models in Unity Catalog](https://docs.databricks.com/en/mlflow/models-in-uc.html) in Databricks.
 * [End to end workspace management](../guides/workspace-management.md) guide.
 * [databricks_directory](directory.md) to manage directories in [Databricks Workpace](https://docs.databricks.com/workspace/workspace-objects.html).
 * [databricks_mlflow_model](mlflow_model.md) to create [MLflow models](https://docs.databricks.com/applications/mlflow/models.html) in Databricks.

--- a/docs/resources/mlflow_model.md
+++ b/docs/resources/mlflow_model.md
@@ -48,6 +48,7 @@ $ terraform import databricks_mlflow_model.this <name>
 
 The following resources are often used in the same context:
 
+* [databricks_registered_model](registered_model.md) to create [Models in Unity Catalog](https://docs.databricks.com/en/mlflow/models-in-uc.html) in Databricks.
 * [End to end workspace management](../guides/workspace-management.md) guide.
 * [databricks_model_serving](model_serving.md) to serve this model on a Databricks serving endpoint.
 * [databricks_directory](directory.md) to manage directories in [Databricks Workspace](https://docs.databricks.com/workspace/workspace-objects.html).

--- a/docs/resources/mlflow_model.md
+++ b/docs/resources/mlflow_model.md
@@ -5,6 +5,8 @@ subcategory: "MLflow"
 
 This resource allows you to create [MLflow models](https://docs.databricks.com/applications/mlflow/models.html) in Databricks.
 
+**Note** This documentation covers the Workspace Model Registry. Databricks recommends using [Models in Unity Catalog](registered_model.md). Models in Unity Catalog provides centralized model governance, cross-workspace access, lineage, and deployment. Workspace Model Registry will be deprecated in the future.
+
 ## Example Usage
 
 ```hcl

--- a/docs/resources/mlflow_model.md
+++ b/docs/resources/mlflow_model.md
@@ -5,7 +5,7 @@ subcategory: "MLflow"
 
 This resource allows you to create [MLflow models](https://docs.databricks.com/applications/mlflow/models.html) in Databricks.
 
-**Note** This documentation covers the Workspace Model Registry. Databricks recommends using [Models in Unity Catalog](registered_model.md). Models in Unity Catalog provides centralized model governance, cross-workspace access, lineage, and deployment. Workspace Model Registry will be deprecated in the future.
+**Note** This documentation covers the Workspace Model Registry. Databricks recommends using [Models in Unity Catalog](registered_model.md). Models in Unity Catalog provides centralized model governance, cross-workspace access, lineage, and deployment.
 
 ## Example Usage
 

--- a/docs/resources/model_serving.md
+++ b/docs/resources/model_serving.md
@@ -106,7 +106,7 @@ The following resources are often used in the same context:
 * [databricks_registered_model](registered_model.md) to create [Models in Unity Catalog](https://docs.databricks.com/en/mlflow/models-in-uc.html) in Databricks.
 * [End to end workspace management](../guides/workspace-management.md) guide.
 * [databricks_directory](directory.md) to manage directories in [Databricks Workspace](https://docs.databricks.com/workspace/workspace-objects.html).
-* [databricks_mlflow_model](mlflow_model.md) to create [workspace models](https://docs.databricks.com/applications/mlflow/models.html) in Databricks.
+* [databricks_mlflow_model](mlflow_model.md) to create models in the [workspace model registry](https://docs.databricks.com/en/mlflow/model-registry.html) in Databricks.
 * [databricks_notebook](notebook.md) to manage [Databricks Notebooks](https://docs.databricks.com/notebooks/index.html).
 * [databricks_notebook](../data-sources/notebook.md) data to export a notebook from Databricks Workspace.
 * [databricks_repo](repo.md) to manage [Databricks Repos](https://docs.databricks.com/repos.html).

--- a/docs/resources/model_serving.md
+++ b/docs/resources/model_serving.md
@@ -103,9 +103,10 @@ $ terraform import databricks_model_serving.this <model-serving-endpoint-name>
 
 The following resources are often used in the same context:
 
+* [databricks_registered_model](registered_model.md) to create [Models in Unity Catalog](https://docs.databricks.com/en/mlflow/models-in-uc.html) in Databricks.
 * [End to end workspace management](../guides/workspace-management.md) guide.
 * [databricks_directory](directory.md) to manage directories in [Databricks Workspace](https://docs.databricks.com/workspace/workspace-objects.html).
-* [databricks_mlflow_model](mlflow_model.md) to create [MLflow models](https://docs.databricks.com/applications/mlflow/models.html) in Databricks.
+* [databricks_mlflow_model](mlflow_model.md) to create [workspace models](https://docs.databricks.com/applications/mlflow/models.html) in Databricks.
 * [databricks_notebook](notebook.md) to manage [Databricks Notebooks](https://docs.databricks.com/notebooks/index.html).
 * [databricks_notebook](../data-sources/notebook.md) data to export a notebook from Databricks Workspace.
 * [databricks_repo](repo.md) to manage [Databricks Repos](https://docs.databricks.com/repos.html).

--- a/docs/resources/registered_model.md
+++ b/docs/resources/registered_model.md
@@ -1,0 +1,53 @@
+---
+subcategory: "Unity Catalog"
+---
+# databricks_registered_model Resource
+
+This resource allows you to create [Models in Unity Catalog](https://docs.databricks.com/en/mlflow/models-in-uc.html) in Databricks.
+
+## Example Usage
+
+```hcl
+resource "databricks_registered_model" "this" {
+  name = "my_model"
+  catalog_name = "main"
+  schema_name = "default"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the registered model.
+* `catalog_name` - (Required) The name of the catalog where the schema and the registered model reside.
+* `schema_name` - (Required) The name of the schema where the registered model resides.
+* `comment` - The comment attached to the registered model.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Equal to the full name of the model (`catalog_name.schema_name.name`) and used to identify the model uniquely across the metastore.
+
+## Access Control
+
+* [databricks_grants](grants.md#function-grants) can be used to grant principals `ALL_PRIVILEGES`, `APPLY_TAG`, and `EXECUTE` privileges. NOTE: the securable type for this resource is `function`.
+
+## Import
+
+The registered model resource can be imported using the full (3-level) name of the model.
+
+```bash
+$ terraform import databricks_registered_model.this <catalog_name.schema_name.model_name>
+```
+
+## Related Resources
+
+The following resources are often used in the same context:
+
+* [databricks_model_serving](model_serving.md) to serve this model on a Databricks serving endpoint.
+* [databricks_mlflow_experiment](mlflow_experiment.md) to manage [MLflow experiments](https://docs.databricks.com/data/data-sources/mlflow-experiment.html) in Databricks.
+* [databricks_table](tables.md) data to manage tables within Unity Catalog.
+* [databricks_schema](schemas.md) data to manage schemas within Unity Catalog.
+* [databricks_catalog](catalogs.md) data to manage catalogs within Unity Catalog.

--- a/docs/resources/registered_model.md
+++ b/docs/resources/registered_model.md
@@ -32,7 +32,7 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Access Control
 
-* [databricks_grants](grants.md#function-grants) can be used to grant principals `ALL_PRIVILEGES`, `APPLY_TAG`, and `EXECUTE` privileges. NOTE: the securable type for this resource is `function`.
+* [databricks_grants](grants.md#registered-model-grants) can be used to grant principals `ALL_PRIVILEGES`, `APPLY_TAG`, and `EXECUTE` privileges. NOTE: the securable type for this resource is `function`.
 
 ## Import
 

--- a/docs/resources/registered_model.md
+++ b/docs/resources/registered_model.md
@@ -32,7 +32,7 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Access Control
 
-* [databricks_grants](grants.md#registered-model-grants) can be used to grant principals `ALL_PRIVILEGES`, `APPLY_TAG`, and `EXECUTE` privileges. NOTE: the securable type for this resource is `function`.
+* [databricks_grants](grants.md#registered-model-grants) can be used to grant principals `ALL_PRIVILEGES`, `APPLY_TAG`, and `EXECUTE` privileges.
 
 ## Import
 

--- a/internal/acceptance/registered_model_test.go
+++ b/internal/acceptance/registered_model_test.go
@@ -1,20 +1,15 @@
 package acceptance
 
 import (
-	"fmt"
 	"testing"
-
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 )
 
-func TestAccRegisteredModel(t *testing.T) {
-	name := fmt.Sprintf("terraform-test-registered-model-%[1]s",
-		acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum))
-	workspaceLevel(t,
+func TestUcAccRegisteredModel(t *testing.T) {
+	unityWorkspaceLevel(t,
 		step{
-			Template: fmt.Sprintf(`
+			Template: `
 			resource "databricks_registered_model" "model" {
-				name = "%[1]s"
+				name = "terraform-test-registered-model-{var.STICKY_RANDOM}"
 				catalog_name = "main"
 				schema_name = "default"
 			}
@@ -27,17 +22,27 @@ func TestAccRegisteredModel(t *testing.T) {
 				  privileges = ["EXECUTE"]
 				}
 			
-		`, name),
+		`,
 		},
 		step{
-			Template: fmt.Sprintf(`
+			Template: `
 			resource "databricks_registered_model" "model" {
-				name = "%[1]s"
+				name = "terraform-test-registered-model-{var.STICKY_RANDOM}"
 				catalog_name = "main"
 				schema_name = "default"
 				comment = "new comment"
 			}
-		`, name),
+		`,
+		},
+		step{
+			Template: `
+			resource "databricks_registered_model" "model" {
+				name = "terraform-test-registered-model-update-{var.STICKY_RANDOM}"
+				catalog_name = "main"
+				schema_name = "default"
+				comment = "new comment"
+			}
+		`,
 		},
 	)
 }

--- a/internal/acceptance/registered_model_test.go
+++ b/internal/acceptance/registered_model_test.go
@@ -20,7 +20,7 @@ func TestAccRegisteredModel(t *testing.T) {
 			}
 			
 			resource "databricks_grants" "model_grants" {
-				function = "main.default.%[1]s"
+				function = databricks_registered_model.model.id
 			  
 				grant {
 				  principal = "account users"

--- a/internal/acceptance/registered_model_test.go
+++ b/internal/acceptance/registered_model_test.go
@@ -21,7 +21,7 @@ func TestUcAccRegisteredModel(t *testing.T) {
 				  principal = "account users"
 				  privileges = ["EXECUTE"]
 				}
-			
+			}
 		`,
 		},
 		step{

--- a/internal/acceptance/registered_model_test.go
+++ b/internal/acceptance/registered_model_test.go
@@ -1,0 +1,43 @@
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+)
+
+func TestAccRegisteredModel(t *testing.T) {
+	name := fmt.Sprintf("terraform-test-registered-model-%[1]s",
+		acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum))
+	workspaceLevel(t,
+		step{
+			Template: fmt.Sprintf(`
+			resource "databricks_registered_model" "model" {
+				name = "%[1]s"
+				catalog_name = "main"
+				schema_name = "default"
+			}
+			
+			resource "databricks_grants" "model_grants" {
+				function = "main.default.%[1]s"
+			  
+				grant {
+				  principal = "account users"
+				  privileges = ["EXECUTE"]
+				}
+			
+		`, name),
+		},
+		step{
+			Template: fmt.Sprintf(`
+			resource "databricks_registered_model" "model" {
+				name = "%[1]s"
+				catalog_name = "main"
+				schema_name = "default"
+				comment = "new comment"
+			}
+		`, name),
+		},
+	)
+}

--- a/internal/acceptance/registered_model_test.go
+++ b/internal/acceptance/registered_model_test.go
@@ -20,7 +20,7 @@ func TestAccRegisteredModel(t *testing.T) {
 			}
 			
 			resource "databricks_grants" "model_grants" {
-				function = databricks_registered_model.model.id
+				model = databricks_registered_model.model.id
 			  
 				grant {
 				  principal = "account users"

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -135,6 +135,7 @@ func DatabricksProvider() *schema.Provider {
 			"databricks_pipeline":                    pipelines.ResourcePipeline(),
 			"databricks_provider":                    catalog.ResourceProvider(),
 			"databricks_recipient":                   catalog.ResourceRecipient(),
+			"databricks_registered_model":            catalog.ResourceRegisteredModel(),
 			"databricks_repo":                        repos.ResourceRepo(),
 			"databricks_schema":                      catalog.ResourceSchema(),
 			"databricks_secret":                      secrets.ResourceSecret(),


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
This PR adds [Models in UC](https://docs.databricks.com/en/mlflow/models-in-uc.html) as a Terraform resource to the [Databricks Terraform Provider](https://registry.terraform.io/providers/databricks/databricks/latest), named in a future-proof way and to disambiguate from the soon-to-be deprecated [workspace MLflow models](https://registry.terraform.io/providers/databricks/databricks/latest/docs/resources/mlflow_model).

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [X] `make test` run locally
- [X] relevant change in `docs/` folder
- [X] covered with integration tests in `internal/acceptance`
- [X] relevant acceptance tests are passing
- [X] using Go SDK

Also tested manually using the `make install`-version of the Terraform provider that includes these changes and the Dogfood staging workspace.
<img width="995" alt="Screenshot 2023-10-06 at 10 54 46 AM" src="https://github.com/databricks/terraform-provider-databricks/assets/87999496/d534cb72-0370-459b-b8e6-4d79fbb37955">
<img width="994" alt="Screenshot 2023-10-06 at 11 55 21 AM" src="https://github.com/databricks/terraform-provider-databricks/assets/87999496/528a3eba-7fa7-4a09-8140-20d05f7f4f7d">
<img width="1787" alt="Screenshot 2023-10-06 at 11 52 26 AM" src="https://github.com/databricks/terraform-provider-databricks/assets/87999496/7668ac3b-e129-46d1-992e-6622d86ebe0c">

