### PR TITLE
Exporter: fix a logic for omitting some fields

### DIFF
--- a/exporter/importables.go
+++ b/exporter/importables.go
@@ -816,13 +816,19 @@ var resourcesMap map[string]importable = map[string]importable{
 			return nil
 		},
 		ShouldOmitField: func(ic *importContext, pathString string, as *schema.Schema, d *schema.ResourceData) bool {
-			// application_id should be provided only on Azure
-			if pathString == "display_name" && ic.Client.IsAzure() {
-				applicationID := d.Get("application_id").(string)
-				displayName := d.Get("display_name").(string)
-				return applicationID == displayName
+			if pathString == "display_name" {
+				if ic.Client.IsAzure() {
+					applicationID := d.Get("application_id").(string)
+					displayName := d.Get("display_name").(string)
+					return applicationID == displayName
+				}
+				return false
 			}
-			return (pathString == "application_id" && !ic.Client.IsAzure()) || defaultShouldOmitFieldFunc(ic, pathString, as, d)
+			// application_id should be provided only on Azure
+			if pathString == "application_id" {
+				return !ic.Client.IsAzure()
+			}
+			return defaultShouldOmitFieldFunc(ic, pathString, as, d)
 		},
 		Import: func(ic *importContext, r *resource) error {
 			applicationID := r.Data.Get("application_id").(string)


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

`application_id` was ignored on Azure as well, although it's required - because the corresponding field is marked as `computed`. Also, make `display_name` required for AWS/GCP.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

