### PR TITLE
Mark attributes in the `run_as` block in `databricks_job` as `ExactlyOneOf`

### DIFF
--- a/docs/resources/job.md
+++ b/docs/resources/job.md
@@ -146,12 +146,12 @@ resource "databricks_job" "this" {
 ### run_as Configuration Block
 
 The `run_as` block allows specifying the user or the service principal that the job runs as. If not specified, the job runs as the user or service
-principal that created the job.
+principal that created the job. Only one of `user_name` or `service_principal_name` can be specified. 
 
 * `user_name` - (Optional) The email of an active workspace user. Non-admin users can only set this field to their own email.
 * `service_principal_name` - (Optional) The application ID of an active service principal. Setting this field requires the `servicePrincipal/user` role.
 
-Example
+Example:
 
 ```hcl
 resource "databricks_job" "this" {

--- a/jobs/resource_job.go
+++ b/jobs/resource_job.go
@@ -690,6 +690,12 @@ var jobSchema = common.StructToSchema(JobSettings{},
 		s["schedule"].ConflictsWith = []string{"continuous", "trigger"}
 		s["continuous"].ConflictsWith = []string{"schedule", "trigger"}
 		s["trigger"].ConflictsWith = []string{"schedule", "continuous"}
+
+		// we need to have only of of user name vs service principal in the run_as block
+		run_as_eoo := []string{"run_as.0.user_name", "run_as.0.service_principal_name"}
+		common.MustSchemaPath(s, "run_as", "user_name").ExactlyOneOf = run_as_eoo
+		common.MustSchemaPath(s, "run_as", "service_principal_name").ExactlyOneOf = run_as_eoo
+
 		return s
 	})
 


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

This prevents error when the user specifies both at the same time or don't specify any of them in the existing `run_as` block.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] tested manually 
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

