### PR TITLE
Suppress diff for `user_name` in `databricks_user` when the changes only in character case

### DIFF
--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -87,7 +87,7 @@ resource "databricks_user" "account_user" {
 
 The following arguments are available:
 
-* `user_name` - (Required) This is the username of the given user and will be their form of access and identity.
+* `user_name` - (Required) This is the username of the given user and will be their form of access and identity.  Provided username will be converted to lower case if it contains upper case characters.
 * `display_name` - (Optional) This is an alias for the username that can be the full name of the user.
 * `external_id` - (Optional) ID of the user in an external identity provider.
 * `allow_cluster_create` -  (Optional) Allow the user to have [cluster](cluster.md) create privileges. Defaults to false. More fine grained permissions could be assigned with [databricks_permissions](permissions.md#Cluster-usage) and `cluster_id` argument. Everyone without `allow_cluster_create` argument set, but with [permission to use](permissions.md#Cluster-Policy-usage) Cluster Policy would be able to create clusters, but within boundaries of that specific policy.

--- a/internal/acceptance/user_test.go
+++ b/internal/acceptance/user_test.go
@@ -138,7 +138,8 @@ func TestAccUserResource(t *testing.T) {
 		user_name = "tf-derde+{var.RANDOM}@example.com"
 		display_name = "Derde {var.RANDOM}"
 		allow_instance_pool_create = true
-	}`
+	}
+	`
 	workspaceLevel(t, step{
 		Template: differentUsers,
 		Check: resource.ComposeTestCheckFunc(
@@ -151,5 +152,20 @@ func TestAccUserResource(t *testing.T) {
 		),
 	}, step{
 		Template: differentUsers,
+	})
+}
+
+func TestAccUserResourceCaseInsensitive(t *testing.T) {
+	username := "CSTF-" + qa.RandomEmail()
+	csUser := `resource "databricks_user" "first" {
+		user_name = "` + username + `"
+		}`
+	workspaceLevel(t, step{
+		Template: csUser,
+		Check: resource.ComposeTestCheckFunc(
+			resource.TestCheckResourceAttr("databricks_user.first", "user_name", strings.ToLower(username)),
+		),
+	}, step{
+		Template: csUser,
 	})
 }

--- a/scim/resource_user.go
+++ b/scim/resource_user.go
@@ -29,6 +29,7 @@ func ResourceUser() *schema.Resource {
 	userSchema := common.StructToSchema(entity{},
 		func(m map[string]*schema.Schema) map[string]*schema.Schema {
 			addEntitlementsToSchema(&m)
+			m["user_name"].DiffSuppressFunc = common.EqualFoldDiffSuppress
 			m["active"].Default = true
 			m["force"] = &schema.Schema{
 				Type:     schema.TypeBool,

--- a/scim/resource_user_test.go
+++ b/scim/resource_user_test.go
@@ -727,3 +727,10 @@ func TestCreateForceOverwriteFindsAndSetsAccID(t *testing.T) {
 		assert.Equal(t, "abc", d.Id())
 	})
 }
+
+func TestUserResource_SparkConfDiffSuppress(t *testing.T) {
+	jr := ResourceUser()
+	scs := jr.Schema["user_name"]
+	assert.True(t, scs.DiffSuppressFunc("user_name", "abcdef@example.com", "AbcDef@example.com", nil))
+	assert.False(t, scs.DiffSuppressFunc("user_name", "abcdef@example.com", "abcdef2@example.com", nil))
+}


### PR DESCRIPTION

The identity management team rolled out the changes for AWS workspaces to force user names be lower-cased by default (to match behavior on GCP & Azure).  But these changes are causing the permanent configuration drift because `user_name` is marked as `force_new`.  To mitigate this problem, added a suppress diff function that ignores changes in case.

## Changes
<!-- Summary of your changes that are easy to understand -->

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [x] covered with integration tests in `internal/acceptance`
- [x] relevant acceptance tests are passing
- [ ] using Go SDK

