### PR TITLE
fix read method for `databricks_metastore` at account level

### DIFF
--- a/catalog/resource_metastore.go
+++ b/catalog/resource_metastore.go
@@ -95,7 +95,7 @@ func ResourceMetastore() *schema.Resource {
 				if err != nil {
 					return err
 				}
-				return common.StructToData(mi, s, d)
+				return common.StructToData(mi.MetastoreInfo, s, d)
 			}, func(w *databricks.WorkspaceClient) error {
 				mi, err := w.Metastores.GetById(ctx, d.Id())
 				if err != nil {

--- a/catalog/resource_metastore_test.go
+++ b/catalog/resource_metastore_test.go
@@ -3,6 +3,7 @@ package catalog
 import (
 	"testing"
 
+	"github.com/databricks/databricks-sdk-go/apierr"
 	"github.com/databricks/databricks-sdk-go/service/catalog"
 	"github.com/databricks/terraform-provider-databricks/qa"
 )
@@ -531,4 +532,97 @@ func TestUpdateAccountMetastore_DeltaSharingScopeOnly(t *testing.T) {
 		delta_sharing_recipient_token_lifetime_in_seconds = 1002
 		`,
 	}.ApplyNoError(t)
+}
+
+func TestReadAccountMetastore(t *testing.T) {
+	qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "GET",
+				Resource: "/api/2.0/accounts/100/metastores/abc?",
+				Response: catalog.AccountsMetastoreInfo{
+					MetastoreInfo: &catalog.MetastoreInfo{
+						StorageRoot: "s3://b/abc",
+						Name:        "a",
+						Region:      "us-east1",
+					},
+				},
+			},
+		},
+		Resource:  ResourceMetastore(),
+		AccountID: "100",
+		ID:        "abc",
+		Read:      true,
+		New:       true,
+	}.ApplyAndExpectData(t,
+		map[string]any{
+			"id":           "abc",
+			"storage_root": "s3://b/abc",
+			"name":         "a",
+			"region":       "us-east1",
+		})
+}
+
+func TestReadAccountMetastore_Error(t *testing.T) {
+	qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "GET",
+				Resource: "/api/2.0/accounts/100/metastores/abc?",
+				Response: apierr.APIErrorBody{
+					ErrorCode: "RESOURCE_DOES_NOT_EXIST",
+					Message:   "Metastore with the given ID could not be found.",
+				},
+				Status: 404,
+			},
+		},
+		Resource:  ResourceMetastore(),
+		AccountID: "100",
+		ID:        "abc",
+		Read:      true,
+	}.ExpectError(t, "resource is not expected to be removed")
+}
+
+func TestReadMetastore(t *testing.T) {
+	qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "GET",
+				Resource: "/api/2.1/unity-catalog/metastores/abc?",
+				Response: catalog.MetastoreInfo{
+					StorageRoot: "s3://b/abc",
+					Name:        "a",
+				},
+			},
+		},
+		Resource: ResourceMetastore(),
+		ID:       "abc",
+		Read:     true,
+		New:      true,
+	}.ApplyAndExpectData(t,
+		map[string]any{
+			"id":           "abc",
+			"storage_root": "s3://b/abc",
+			"name":         "a",
+		})
+}
+
+func TestReadMetastore_Error(t *testing.T) {
+	qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "GET",
+				Resource: "/api/2.1/unity-catalog/metastores/abc?",
+				Response: apierr.APIErrorBody{
+					ErrorCode: "RESOURCE_DOES_NOT_EXIST",
+					Message:   "Metastore with the given ID could not be found.",
+				},
+				Status: 404,
+			},
+		},
+		Resource: ResourceMetastore(),
+		ID:       "abc",
+		Read:     true,
+		New:      true,
+	}.ExpectError(t, "resource is not expected to be removed")
 }


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
- fix read method for `databricks_metastore` at account level
- add integration tests

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] covered with integration tests in `internal/acceptance`
- [x] relevant acceptance tests are passing
- [x] using Go SDK

