### PR TITLE
Add `binding_type` attribute to `databricks_catalog_workspace_binding` resource

### DIFF
--- a/catalog/resource_catalog_workspace_binding.go
+++ b/catalog/resource_catalog_workspace_binding.go
@@ -2,66 +2,102 @@ package catalog
 
 import (
 	"context"
-	"strconv"
+	"fmt"
 
 	"github.com/databricks/databricks-sdk-go/apierr"
 	"github.com/databricks/databricks-sdk-go/service/catalog"
 	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
+var getSecurableName = func(d *schema.ResourceData) string {
+	securableName, ok := d.GetOk("catalog_name")
+	if !ok {
+		securableName = d.Get("securable_name")
+	}
+	return securableName.(string)
+}
+
 func ResourceCatalogWorkspaceBinding() *schema.Resource {
-	return common.NewPairID("catalog_name", "workspace_id").Schema(func(
-		m map[string]*schema.Schema) map[string]*schema.Schema {
-		return m
-	}).BindResource(common.BindResource{
-		CreateContext: func(ctx context.Context, catalogName, workspaceId string, c *common.DatabricksClient) error {
+	p := common.NewPairID("workspace_id", fmt.Sprintf("%s|%s", "securable_type", "securable_name"))
+	workspaceBindingSchema := common.StructToSchema(catalog.WorkspaceBinding{},
+		func(m map[string]*schema.Schema) map[string]*schema.Schema {
+			m["catalog_name"] = &schema.Schema{
+				Type:         schema.TypeString,
+				Optional:     true,
+				AtLeastOneOf: []string{"catalog_name", "securable_name"},
+				Deprecated:   "Please use 'securable_name' and 'securable_type instead.",
+			}
+			m["securable_name"] = &schema.Schema{
+				Type:         schema.TypeString,
+				Optional:     true,
+				AtLeastOneOf: []string{"catalog_name", "securable_name"},
+			}
+			m["securable_type"] = &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "catalog",
+			}
+			m["binding_type"].Default = catalog.WorkspaceBindingBindingTypeBindingTypeReadWrite
+			m["binding_type"].ValidateFunc = validation.StringInSlice([]string{
+				string(catalog.WorkspaceBindingBindingTypeBindingTypeReadWrite),
+				string(catalog.WorkspaceBindingBindingTypeBindingTypeReadOnly),
+			}, false)
+			return m
+		},
+	)
+	return common.Resource{
+		Schema: workspaceBindingSchema,
+		Create: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
 			w, err := c.WorkspaceClient()
 			if err != nil {
 				return err
 			}
-			i64WorkspaceId, err := strconv.ParseInt(workspaceId, 10, 64)
+			var update catalog.WorkspaceBinding
+			common.DataToStructPointer(d, workspaceBindingSchema, &update)
+			_, err = w.WorkspaceBindings.UpdateBindings(ctx, catalog.UpdateWorkspaceBindingsParameters{
+				Add:           []catalog.WorkspaceBinding{update},
+				SecurableName: getSecurableName(d),
+				SecurableType: d.Get("securable_type").(string),
+			})
+			d.Set("securable_name", getSecurableName(d))
+			p.Pack(d)
+			return err
+		},
+		Read: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
+			w, err := c.WorkspaceClient()
 			if err != nil {
 				return err
 			}
-			_, err = w.WorkspaceBindings.Update(ctx, catalog.UpdateWorkspaceBindings{
-				Name:             catalogName,
-				AssignWorkspaces: []int64{i64WorkspaceId},
+			workspaceId := int64(d.Get("workspace_id").(int))
+			bindings, err := w.WorkspaceBindings.GetBindings(ctx, catalog.GetBindingsRequest{
+				SecurableName: getSecurableName(d),
+				SecurableType: d.Get("securable_type").(string),
+			})
+			if err != nil {
+				return err
+			}
+			for _, binding := range bindings.Bindings {
+				if binding.WorkspaceId == workspaceId {
+					return common.StructToData(binding, workspaceBindingSchema, d)
+				}
+			}
+			return apierr.NotFound("Catalog has no binding to this workspace")
+		},
+		Delete: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
+			w, err := c.WorkspaceClient()
+			if err != nil {
+				return err
+			}
+			var update catalog.WorkspaceBinding
+			common.DataToStructPointer(d, workspaceBindingSchema, &update)
+			_, err = w.WorkspaceBindings.UpdateBindings(ctx, catalog.UpdateWorkspaceBindingsParameters{
+				Remove:        []catalog.WorkspaceBinding{update},
+				SecurableName: getSecurableName(d),
+				SecurableType: d.Get("securable_type").(string),
 			})
 			return err
 		},
-		ReadContext: func(ctx context.Context, catalogName, workspaceId string, c *common.DatabricksClient) error {
-			w, err := c.WorkspaceClient()
-			if err != nil {
-				return err
-			}
-			i64WorkspaceId, err := strconv.ParseInt(workspaceId, 10, 64)
-			if err != nil {
-				return err
-			}
-			bindings, err := w.WorkspaceBindings.GetByName(ctx, catalogName)
-			if err != nil {
-				return err
-			}
-			if !contains(bindings.Workspaces, i64WorkspaceId) {
-				return apierr.NotFound("Catalog has no binding to this workspace")
-			}
-			return nil
-		},
-		DeleteContext: func(ctx context.Context, catalogName, workspaceId string, c *common.DatabricksClient) error {
-			w, err := c.WorkspaceClient()
-			if err != nil {
-				return err
-			}
-			i64WorkspaceId, err := strconv.ParseInt(workspaceId, 10, 64)
-			if err != nil {
-				return err
-			}
-			_, err = w.WorkspaceBindings.Update(ctx, catalog.UpdateWorkspaceBindings{
-				Name:               catalogName,
-				UnassignWorkspaces: []int64{i64WorkspaceId},
-			})
-			return err
-		},
-	})
+	}.ToResource()
 }

--- a/catalog/resource_catalog_workspace_binding.go
+++ b/catalog/resource_catalog_workspace_binding.go
@@ -25,13 +25,13 @@ func ResourceCatalogWorkspaceBinding() *schema.Resource {
 			m["catalog_name"] = &schema.Schema{
 				Type:         schema.TypeString,
 				Optional:     true,
-				AtLeastOneOf: []string{"catalog_name", "securable_name"},
+				ExactlyOneOf: []string{"catalog_name", "securable_name"},
 				Deprecated:   "Please use 'securable_name' and 'securable_type instead.",
 			}
 			m["securable_name"] = &schema.Schema{
 				Type:         schema.TypeString,
 				Optional:     true,
-				AtLeastOneOf: []string{"catalog_name", "securable_name"},
+				ExactlyOneOf: []string{"catalog_name", "securable_name"},
 			}
 			m["securable_type"] = &schema.Schema{
 				Type:     schema.TypeString,

--- a/catalog/resource_catalog_workspace_binding.go
+++ b/catalog/resource_catalog_workspace_binding.go
@@ -12,9 +12,9 @@ import (
 )
 
 var getSecurableName = func(d *schema.ResourceData) string {
-	securableName, ok := d.GetOk("catalog_name")
+	securableName, ok := d.GetOk("securable_name")
 	if !ok {
-		securableName = d.Get("securable_name")
+		securableName = d.Get("catalog_name")
 	}
 	return securableName.(string)
 }

--- a/catalog/resource_catalog_workspace_binding_test.go
+++ b/catalog/resource_catalog_workspace_binding_test.go
@@ -14,23 +14,39 @@ func TestCatalogWorkspaceBindingsCornerCases(t *testing.T) {
 }
 
 func TestCatalogWorkspaceBindings_Create(t *testing.T) {
-	resource := qa.ResourceFixture{
+	qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   "PATCH",
-				Resource: "/api/2.1/unity-catalog/workspace-bindings/catalogs/my_catalog",
-				ExpectedRequest: catalog.UpdateWorkspaceBindings{
-					Name:             "my_catalog",
-					AssignWorkspaces: []int64{1234567890101112},
+				Resource: "/api/2.1/unity-catalog/bindings/catalog/my_catalog",
+				ExpectedRequest: catalog.UpdateWorkspaceBindingsParameters{
+					Add: []catalog.WorkspaceBinding{
+						{
+							BindingType: catalog.WorkspaceBindingBindingTypeBindingTypeReadWrite,
+							WorkspaceId: int64(1234567890101112),
+						},
+					},
+					SecurableName: "my_catalog",
+					SecurableType: "catalog",
 				},
-				Response: catalog.CurrentWorkspaceBindings{
-					Workspaces: []int64{1234567890101112},
+				Response: catalog.WorkspaceBindingsResponse{
+					Bindings: []catalog.WorkspaceBinding{
+						{
+							BindingType: catalog.WorkspaceBindingBindingTypeBindingTypeReadWrite,
+							WorkspaceId: int64(1234567890101112),
+						},
+					},
 				},
 			}, {
 				Method:   "GET",
-				Resource: "/api/2.1/unity-catalog/workspace-bindings/catalogs/my_catalog?",
-				Response: catalog.CurrentWorkspaceBindings{
-					Workspaces: []int64{1234567890101112},
+				Resource: "/api/2.1/unity-catalog/bindings/catalog/my_catalog?",
+				Response: catalog.WorkspaceBindingsResponse{
+					Bindings: []catalog.WorkspaceBinding{
+						{
+							BindingType: catalog.WorkspaceBindingBindingTypeBindingTypeReadWrite,
+							WorkspaceId: int64(1234567890101112),
+						},
+					},
 				},
 			},
 		},
@@ -40,6 +56,149 @@ func TestCatalogWorkspaceBindings_Create(t *testing.T) {
 		catalog_name = "my_catalog"
 		workspace_id = "1234567890101112"
 		`,
-	}
-	resource.ApplyNoError(t)
+	}.ApplyNoError(t)
+}
+
+func TestCatalogWorkspaceBindingsReadOnly_Create(t *testing.T) {
+	qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "PATCH",
+				Resource: "/api/2.1/unity-catalog/bindings/catalog/my_catalog",
+				ExpectedRequest: catalog.UpdateWorkspaceBindingsParameters{
+					Add: []catalog.WorkspaceBinding{
+						{
+							BindingType: catalog.WorkspaceBindingBindingTypeBindingTypeReadOnly,
+							WorkspaceId: int64(1234567890101112),
+						},
+					},
+					SecurableName: "my_catalog",
+					SecurableType: "catalog",
+				},
+				Response: catalog.WorkspaceBindingsResponse{
+					Bindings: []catalog.WorkspaceBinding{
+						{
+							BindingType: catalog.WorkspaceBindingBindingTypeBindingTypeReadOnly,
+							WorkspaceId: int64(1234567890101112),
+						},
+					},
+				},
+			}, {
+				Method:   "GET",
+				Resource: "/api/2.1/unity-catalog/bindings/catalog/my_catalog?",
+				Response: catalog.WorkspaceBindingsResponse{
+					Bindings: []catalog.WorkspaceBinding{
+						{
+							BindingType: catalog.WorkspaceBindingBindingTypeBindingTypeReadOnly,
+							WorkspaceId: int64(1234567890101112),
+						},
+					},
+				},
+			},
+		},
+		Resource: ResourceCatalogWorkspaceBinding(),
+		Create:   true,
+		HCL: `
+		catalog_name = "my_catalog"
+		workspace_id = "1234567890101112"
+		binding_type = "BINDING_TYPE_READ_ONLY"
+		`,
+	}.ApplyNoError(t)
+}
+
+func TestSecurableWorkspaceBindings_Create(t *testing.T) {
+	qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "PATCH",
+				Resource: "/api/2.1/unity-catalog/bindings/catalog/my_catalog",
+				ExpectedRequest: catalog.UpdateWorkspaceBindingsParameters{
+					Add: []catalog.WorkspaceBinding{
+						{
+							BindingType: catalog.WorkspaceBindingBindingTypeBindingTypeReadOnly,
+							WorkspaceId: int64(1234567890101112),
+						},
+					},
+					SecurableName: "my_catalog",
+					SecurableType: "catalog",
+				},
+				Response: catalog.WorkspaceBindingsResponse{
+					Bindings: []catalog.WorkspaceBinding{
+						{
+							BindingType: catalog.WorkspaceBindingBindingTypeBindingTypeReadOnly,
+							WorkspaceId: int64(1234567890101112),
+						},
+					},
+				},
+			}, {
+				Method:   "GET",
+				Resource: "/api/2.1/unity-catalog/bindings/catalog/my_catalog?",
+				Response: catalog.WorkspaceBindingsResponse{
+					Bindings: []catalog.WorkspaceBinding{
+						{
+							BindingType: catalog.WorkspaceBindingBindingTypeBindingTypeReadOnly,
+							WorkspaceId: int64(1234567890101112),
+						},
+					},
+				},
+			},
+		},
+		Resource: ResourceCatalogWorkspaceBinding(),
+		Create:   true,
+		HCL: `
+		securable_name = "my_catalog"
+		securable_type = "catalog"
+		workspace_id   = "1234567890101112"
+		binding_type   = "BINDING_TYPE_READ_ONLY"
+		`,
+	}.ApplyNoError(t)
+}
+
+func TestSecurableWorkspaceBindings_Delete(t *testing.T) {
+	qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "PATCH",
+				Resource: "/api/2.1/unity-catalog/bindings/catalog/my_catalog",
+				ExpectedRequest: catalog.UpdateWorkspaceBindingsParameters{
+					Remove: []catalog.WorkspaceBinding{
+						{
+							BindingType: catalog.WorkspaceBindingBindingTypeBindingTypeReadOnly,
+							WorkspaceId: int64(1234567890101112),
+						},
+					},
+					SecurableName: "my_catalog",
+					SecurableType: "catalog",
+				},
+				Response: catalog.WorkspaceBindingsResponse{
+					Bindings: []catalog.WorkspaceBinding{
+						{
+							BindingType: catalog.WorkspaceBindingBindingTypeBindingTypeReadOnly,
+							WorkspaceId: int64(1234567890101112),
+						},
+					},
+				},
+			}, {
+				Method:   "GET",
+				Resource: "/api/2.1/unity-catalog/bindings/catalog/my_catalog?",
+				Response: catalog.WorkspaceBindingsResponse{
+					Bindings: []catalog.WorkspaceBinding{
+						{
+							BindingType: catalog.WorkspaceBindingBindingTypeBindingTypeReadOnly,
+							WorkspaceId: int64(1234567890101112),
+						},
+					},
+				},
+			},
+		},
+		Resource: ResourceCatalogWorkspaceBinding(),
+		Delete:   true,
+		ID:       "1234567890101112|catalog|my_catalog",
+		HCL: `
+		securable_name = "my_catalog"
+		securable_type = "catalog"
+		workspace_id   = "1234567890101112"
+		binding_type   = "BINDING_TYPE_READ_ONLY"
+		`,
+	}.ApplyNoError(t)
 }

--- a/docs/resources/catalog_workspace_binding.md
+++ b/docs/resources/catalog_workspace_binding.md
@@ -5,7 +5,7 @@ subcategory: "Unity Catalog"
 
 If you use workspaces to isolate user data access, you may want to limit catalog access to specific workspaces in your account, also known as workspace-catalog binding
 
-By default, Databricks assigns the catalog to all workspaces attached to the current metastore. By using `databricks_catalog_workspace_binding`, the catalog will be unassigned from all workspaces and only assigned explicitly using this resource. 
+By default, Databricks assigns the catalog to all workspaces attached to the current metastore. By using `databricks_catalog_workspace_binding`, the catalog will be unassigned from all workspaces and only assigned explicitly using this resource.
 
 -> **Note**
   To use this resource the catalog must have its isolation mode set to `ISOLATED` in the [`databricks_catalog`](https://registry.terraform.io/providers/databricks/databricks/latest/docs/resources/catalog#isolation_mode) resource. Alternatively, the isolation mode can be set using the UI or API by following [this guide](https://docs.databricks.com/data-governance/unity-catalog/create-catalogs.html#configuration).
@@ -31,8 +31,10 @@ resource "databricks_catalog_workspace_binding" "sandbox" {
 
 The following arguments are required:
 
-* `catalog_name` - Name of Catalog. Change forces creation of a new resource.
 * `workspace_id` - ID of the workspace. Change forces creation of a new resource.
+* `securable_name` - Name of securable. Change forces creation of a new resource.
+* `securable_type` - Type of securable. Default to `catalog`. Change forces creation of a new resource.
+* `binding_type` - Binding mode. Possible values are `BINDING_TYPE_READ_ONLY`, `BINDING_TYPE_READ_WRITE`
 
 ## Import
 

--- a/docs/resources/catalog_workspace_binding.md
+++ b/docs/resources/catalog_workspace_binding.md
@@ -34,7 +34,7 @@ The following arguments are required:
 * `workspace_id` - ID of the workspace. Change forces creation of a new resource.
 * `securable_name` - Name of securable. Change forces creation of a new resource.
 * `securable_type` - Type of securable. Default to `catalog`. Change forces creation of a new resource.
-* `binding_type` - Binding mode. Possible values are `BINDING_TYPE_READ_ONLY`, `BINDING_TYPE_READ_WRITE`
+* `binding_type` - Binding mode. Default to `BINDING_TYPE_READ_WRITE`. Possible values are `BINDING_TYPE_READ_ONLY`, `BINDING_TYPE_READ_WRITE`
 
 ## Import
 

--- a/internal/acceptance/catalog_workspace_binding_test.go
+++ b/internal/acceptance/catalog_workspace_binding_test.go
@@ -41,3 +41,21 @@ func TestUcAccCatalogWorkspaceBindingToSameWorkspace(t *testing.T) {
 		`,
 	})
 }
+
+func TestUcAccSecurableWorkspaceBindingToSameWorkspaceReadOnly(t *testing.T) {
+	unityWorkspaceLevel(t, step{
+		Template: `
+		resource "databricks_catalog" "dev" {
+			name           = "dev{var.RANDOM}"
+			isolation_mode = "ISOLATED"
+		}
+
+		resource "databricks_catalog_workspace_binding" "test" {
+			securable_name = databricks_catalog.dev.name
+			securable_type = "catalog"
+			workspace_id   = {env.THIS_WORKSPACE_ID}
+			binding_type   = "BINDING_TYPE_READ_ONLY"
+		}
+		`,
+	})
+}


### PR DESCRIPTION
## Changes
- Refactor to use new APIs. Per doc
>The original path (/api/2.1/unity-catalog/workspace-bindings/catalogs/{name}) is deprecated. Please use the new path (/api/2.1/unity-catalog/bindings/{securable_type}/{securable_name}) which introduces the ability to bind a securable in READ_ONLY mode (catalogs only)
- Close #2792 

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [x] covered with integration tests in `internal/acceptance`
- [x] relevant acceptance tests are passing
- [x] using Go SDK

