### PR TITLE
Fixed read method for `databricks_storage_credential` resource

### DIFF
--- a/catalog/resource_metastore_data_access.go
+++ b/catalog/resource_metastore_data_access.go
@@ -42,6 +42,8 @@ func adjustDataAccessSchema(m map[string]*schema.Schema) map[string]*schema.Sche
 	m["gcp_service_account_key"].DiffSuppressFunc = SuppressGcpSAKeyDiff
 
 	common.MustSchemaPath(m, "azure_managed_identity", "credential_id").Computed = true
+	common.MustSchemaPath(m, "databricks_gcp_service_account", "email").Computed = true
+	common.MustSchemaPath(m, "databricks_gcp_service_account", "credential_id").Computed = true
 
 	m["force_destroy"] = &schema.Schema{
 		Type:     schema.TypeBool,
@@ -155,7 +157,7 @@ func ResourceMetastoreDataAccess() *schema.Resource {
 				}
 				isDefault := metastore.StorageRootCredentialName == dacName
 				d.Set("is_default", isDefault)
-				return common.StructToData(storageCredential, dacSchema, d)
+				return common.StructToData(storageCredential.CredentialInfo, dacSchema, d)
 			}, func(w *databricks.WorkspaceClient) error {
 				var storageCredential *catalog.StorageCredentialInfo
 				storageCredential, err = w.StorageCredentials.GetByName(ctx, dacName)

--- a/catalog/resource_metastore_data_access_test.go
+++ b/catalog/resource_metastore_data_access_test.go
@@ -210,10 +210,12 @@ func TestCreateAccountDacWithAws(t *testing.T) {
 			{
 				Method:   "GET",
 				Resource: "/api/2.0/accounts/100/metastores/abc/storage-credentials/bcd?",
-				Response: catalog.StorageCredentialInfo{
-					Name: "bcd",
-					AwsIamRole: &catalog.AwsIamRole{
-						RoleArn: "def",
+				Response: catalog.AccountsStorageCredentialInfo{
+					CredentialInfo: &catalog.StorageCredentialInfo{
+						Name: "bcd",
+						AwsIamRole: &catalog.AwsIamRole{
+							RoleArn: "def",
+						},
 					},
 				},
 			},
@@ -275,10 +277,12 @@ func TestCreateAccountDacWithAzMI(t *testing.T) {
 			{
 				Method:   "GET",
 				Resource: "/api/2.0/accounts/100/metastores/abc/storage-credentials/bcd?",
-				Response: catalog.StorageCredentialInfo{
-					Name: "bcd",
-					AzureManagedIdentity: &catalog.AzureManagedIdentity{
-						AccessConnectorId: "def",
+				Response: catalog.AccountsStorageCredentialInfo{
+					CredentialInfo: &catalog.StorageCredentialInfo{
+						Name: "bcd",
+						AzureManagedIdentity: &catalog.AzureManagedIdentity{
+							AccessConnectorId: "def",
+						},
 					},
 				},
 			},
@@ -341,10 +345,12 @@ func TestCreateAccountDacWithDbGcpSA(t *testing.T) {
 			{
 				Method:   "GET",
 				Resource: "/api/2.0/accounts/100/metastores/abc/storage-credentials/bcd?",
-				Response: catalog.StorageCredentialInfo{
-					Name: "bcd",
-					DatabricksGcpServiceAccount: &catalog.DatabricksGcpServiceAccountResponse{
-						Email: "a@example.com",
+				Response: catalog.AccountsStorageCredentialInfo{
+					CredentialInfo: &catalog.StorageCredentialInfo{
+						Name: "bcd",
+						DatabricksGcpServiceAccount: &catalog.DatabricksGcpServiceAccountResponse{
+							Email: "a@example.com",
+						},
 					},
 				},
 			},
@@ -367,5 +373,9 @@ func TestCreateAccountDacWithDbGcpSA(t *testing.T) {
 		is_default = true
 		databricks_gcp_service_account {}
 		`,
-	}.ApplyNoError(t)
+	}.ApplyAndExpectData(t,
+		map[string]any{
+			"databricks_gcp_service_account.#":       1,
+			"databricks_gcp_service_account.0.email": "a@example.com",
+		})
 }

--- a/catalog/resource_storage_credential.go
+++ b/catalog/resource_storage_credential.go
@@ -107,7 +107,7 @@ func ResourceStorageCredential() *schema.Resource {
 				if err != nil {
 					return err
 				}
-				return common.StructToData(storageCredential, storageCredentialSchema, d)
+				return common.StructToData(storageCredential.CredentialInfo, storageCredentialSchema, d)
 			}, func(w *databricks.WorkspaceClient) error {
 				storageCredential, err := w.StorageCredentials.GetByName(ctx, d.Id())
 				if err != nil {


### PR DESCRIPTION
## Changes
- Fix storage credential read method
- Close #2766, #2697, #2749

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [x] relevant acceptance tests are passing (test locally)
- [x] using Go SDK

