### PR TITLE
Fixed `databricks_catalog` `isolation_mode`

### DIFF
--- a/catalog/resource_catalog.go
+++ b/catalog/resource_catalog.go
@@ -93,15 +93,17 @@ func ResourceCatalog() *schema.Resource {
 			if err != nil {
 				return err
 			}
-			_, err = w.WorkspaceBindings.Update(ctx, catalog.UpdateWorkspaceBindings{
-				Name:             ci.Name,
-				AssignWorkspaces: []int64{currentMetastoreAssignment.WorkspaceId},
+			_, err = w.WorkspaceBindings.UpdateBindings(ctx, catalog.UpdateWorkspaceBindingsParameters{
+				SecurableName: ci.Name,
+				SecurableType: "catalog",
+				Add: []catalog.WorkspaceBinding{
+					{
+						BindingType: catalog.WorkspaceBindingBindingTypeBindingTypeReadWrite,
+						WorkspaceId: currentMetastoreAssignment.WorkspaceId,
+					},
+				},
 			})
-			if err != nil {
-				return err
-			}
-
-			return nil
+			return err
 		},
 		Read: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
 			w, err := c.WorkspaceClient()
@@ -139,11 +141,16 @@ func ResourceCatalog() *schema.Resource {
 			if err != nil {
 				return err
 			}
-			_, err = w.WorkspaceBindings.Update(ctx, catalog.UpdateWorkspaceBindings{
-				Name:             ci.Name,
-				AssignWorkspaces: []int64{currentMetastoreAssignment.WorkspaceId},
+			_, err = w.WorkspaceBindings.UpdateBindings(ctx, catalog.UpdateWorkspaceBindingsParameters{
+				SecurableName: ci.Name,
+				SecurableType: "catalog",
+				Add: []catalog.WorkspaceBinding{
+					{
+						BindingType: catalog.WorkspaceBindingBindingTypeBindingTypeReadWrite,
+						WorkspaceId: currentMetastoreAssignment.WorkspaceId,
+					},
+				},
 			})
-
 			return err
 		},
 		Delete: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {

--- a/catalog/resource_catalog_test.go
+++ b/catalog/resource_catalog_test.go
@@ -518,14 +518,24 @@ func TestCatalogCreateIsolated(t *testing.T) {
 			},
 			{
 				Method:   "PATCH",
-				Resource: "/api/2.1/unity-catalog/workspace-bindings/catalogs/a",
-				ExpectedRequest: catalog.UpdateWorkspaceBindings{
-					Name:             "a",
-					AssignWorkspaces: []int64{123456789101112},
+				Resource: "/api/2.1/unity-catalog/bindings/catalog/a",
+				ExpectedRequest: catalog.UpdateWorkspaceBindingsParameters{
+					SecurableName: "a",
+					SecurableType: "catalog",
+					Add: []catalog.WorkspaceBinding{
+						{
+							WorkspaceId: int64(123456789101112),
+							BindingType: catalog.WorkspaceBindingBindingTypeBindingTypeReadWrite,
+						},
+					},
 				},
-
-				Response: catalog.CurrentWorkspaceBindings{
-					Workspaces: []int64{123456789101112},
+				Response: catalog.WorkspaceBindingsResponse{
+					Bindings: []catalog.WorkspaceBinding{
+						{
+							WorkspaceId: int64(123456789101112),
+							BindingType: catalog.WorkspaceBindingBindingTypeBindingTypeReadWrite,
+						},
+					},
 				},
 			},
 			{

--- a/internal/acceptance/catalog_test.go
+++ b/internal/acceptance/catalog_test.go
@@ -1,0 +1,51 @@
+package acceptance
+
+import (
+	"testing"
+)
+
+func TestUcAccCatalog(t *testing.T) {
+	unityWorkspaceLevel(t, step{
+		Template: `
+		resource "databricks_catalog" "sandbox" {
+			name         = "sandbox{var.RANDOM}"
+			comment      = "this catalog is managed by terraform"
+			properties = {
+				purpose = "testing"
+			}
+		}`,
+	})
+}
+
+func TestUcAccCatalogIsolated(t *testing.T) {
+	unityWorkspaceLevel(t, step{
+		Template: `
+		resource "databricks_catalog" "sandbox" {
+			name           = "sandbox{var.RANDOM}"
+			comment        = "this catalog is managed by terraform"
+			properties     = {
+				purpose = "testing"
+			}
+		}`,
+	}, step{
+		Template: `
+		resource "databricks_catalog" "sandbox" {
+			name           = "sandbox{var.RANDOM}"
+			isolation_mode = "ISOLATED"
+			comment        = "this catalog is managed by terraform"
+			properties     = {
+				purpose = "testing"
+			}
+		}`,
+	}, step{
+		Template: `
+		resource "databricks_catalog" "sandbox" {
+			name           = "sandbox{var.RANDOM}"
+			isolation_mode = "OPEN"
+			comment        = "this catalog is managed by terraform"
+			properties     = {
+				purpose = "testing"
+			}
+		}`,
+	})
+}

--- a/internal/acceptance/catalog_test.go
+++ b/internal/acceptance/catalog_test.go
@@ -21,7 +21,7 @@ func TestUcAccCatalogIsolated(t *testing.T) {
 	unityWorkspaceLevel(t, step{
 		Template: `
 		resource "databricks_catalog" "sandbox" {
-			name           = "sandbox{var.RANDOM}"
+			name           = "sandbox{var.STICKY_RANDOM}"
 			comment        = "this catalog is managed by terraform"
 			properties     = {
 				purpose = "testing"
@@ -30,7 +30,7 @@ func TestUcAccCatalogIsolated(t *testing.T) {
 	}, step{
 		Template: `
 		resource "databricks_catalog" "sandbox" {
-			name           = "sandbox{var.RANDOM}"
+			name           = "sandbox{var.STICKY_RANDOM}"
 			isolation_mode = "ISOLATED"
 			comment        = "this catalog is managed by terraform"
 			properties     = {
@@ -40,7 +40,7 @@ func TestUcAccCatalogIsolated(t *testing.T) {
 	}, step{
 		Template: `
 		resource "databricks_catalog" "sandbox" {
-			name           = "sandbox{var.RANDOM}"
+			name           = "sandbox{var.STICKY_RANDOM}"
 			isolation_mode = "OPEN"
 			comment        = "this catalog is managed by terraform"
 			properties     = {


### PR DESCRIPTION
## Changes
Fix a bug where it is not possible to update `databricks_catalog` `isolation_mode`
Close #2455

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [x] covered with integration tests in `internal/acceptance`
- [x] relevant acceptance tests are passing
- [x] using Go SDK

