### PR TITLE
Use token-based pagination for Jobs List operations

### DIFF
--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -473,7 +473,7 @@ func TestImportingUsersGroupsSecretScopes(t *testing.T) {
 			},
 			{
 				Method:   "GET",
-				Resource: "/api/2.1/jobs/list?expand_tasks=false&limit=25&offset=0",
+				Resource: "/api/2.1/jobs/list?expand_tasks=false&limit=25",
 				Response: jobs.JobListResponse{},
 			},
 			{
@@ -588,7 +588,7 @@ func TestImportingNoResourcesError(t *testing.T) {
 			},
 			{
 				Method:   "GET",
-				Resource: "/api/2.1/jobs/list?expand_tasks=false&limit=25&offset=0",
+				Resource: "/api/2.1/jobs/list?expand_tasks=false&limit=25",
 				Response: jobs.JobListResponse{},
 			},
 			{
@@ -632,7 +632,7 @@ func TestImportingClusters(t *testing.T) {
 			},
 			{
 				Method:   "GET",
-				Resource: "/api/2.1/jobs/list?expand_tasks=false&limit=25&offset=0",
+				Resource: "/api/2.1/jobs/list?expand_tasks=false&limit=25",
 				Response: jobs.JobListResponse{},
 			},
 			{
@@ -816,7 +816,7 @@ func TestImportingJobs_JobList(t *testing.T) {
 			emptyRepos,
 			{
 				Method:   "GET",
-				Resource: "/api/2.1/jobs/list?expand_tasks=false&limit=25&offset=0",
+				Resource: "/api/2.1/jobs/list?expand_tasks=false&limit=25",
 				Response: jobs.JobListResponse{
 					Jobs: []jobs.Job{
 						{
@@ -1035,7 +1035,7 @@ func TestImportingJobs_JobListMultiTask(t *testing.T) {
 			emptyRepos,
 			{
 				Method:   "GET",
-				Resource: "/api/2.1/jobs/list?expand_tasks=false&limit=25&offset=0",
+				Resource: "/api/2.1/jobs/list?expand_tasks=false&limit=25",
 				Response: jobs.JobListResponse{
 					Jobs: []jobs.Job{
 						{
@@ -1290,7 +1290,7 @@ func TestImportingSecrets(t *testing.T) {
 			},
 			{
 				Method:   "GET",
-				Resource: "/api/2.1/jobs/list?expand_tasks=false&limit=25&offset=0",
+				Resource: "/api/2.1/jobs/list?expand_tasks=false&limit=25",
 				Response: jobs.JobListResponse{},
 			},
 			{

--- a/jobs/data_job_test.go
+++ b/jobs/data_job_test.go
@@ -9,9 +9,9 @@ import (
 )
 
 func commonFixtures(name string) []qa.HTTPFixture {
-	resource := "/api/2.1/jobs/list?expand_tasks=false&limit=25&offset=0"
+	resource := "/api/2.1/jobs/list?expand_tasks=false&limit=25"
 	if name != "" {
-		resource = fmt.Sprintf("/api/2.1/jobs/list?expand_tasks=true&limit=25&name=%s&offset=0", name)
+		resource = fmt.Sprintf("/api/2.1/jobs/list?expand_tasks=true&limit=25&name=%s", name)
 	}
 	return []qa.HTTPFixture{
 		{
@@ -195,7 +195,7 @@ func TestDataSourceQueryableJobNoMatchName(t *testing.T) {
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   "GET",
-				Resource: "/api/2.1/jobs/list?expand_tasks=true&limit=25&name=Third&offset=0",
+				Resource: "/api/2.1/jobs/list?expand_tasks=true&limit=25&name=Third",
 				Response: JobListResponse{
 					Jobs: []Job{},
 				},

--- a/jobs/data_jobs_test.go
+++ b/jobs/data_jobs_test.go
@@ -11,7 +11,7 @@ func TestJobsData(t *testing.T) {
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   "GET",
-				Resource: "/api/2.1/jobs/list?expand_tasks=false&limit=25&offset=0",
+				Resource: "/api/2.1/jobs/list?expand_tasks=false&limit=25",
 				Response: JobListResponse{
 					Jobs: []Job{
 						{

--- a/jobs/resource_job.go
+++ b/jobs/resource_job.go
@@ -310,8 +310,10 @@ func (js *JobSettings) sortWebhooksByID() {
 
 // JobListResponse returns a list of all jobs
 type JobListResponse struct {
-	Jobs    []Job `json:"jobs"`
-	HasMore bool  `json:"has_more,omitempty"`
+	Jobs          []Job  `json:"jobs"`
+	HasMore       bool   `json:"has_more,omitempty"`
+	NextPageToken string `json:"next_page_token,omitempty"`
+	PrevPageToken string `json:"prev_page_token,omitempty"`
 }
 
 // Job contains the information when using a GET request from the Databricks Jobs api
@@ -416,12 +418,14 @@ func (a JobsAPI) ListByName(name string, expandTasks bool) ([]Job, error) {
 	if name != "" {
 		params["name"] = name
 	}
-	offset := 0
 
+	nextPageToken := ""
 	ctx := context.WithValue(a.context, common.Api, common.API_2_1)
 	for {
 		var resp JobListResponse
-		params["offset"] = offset
+		if nextPageToken != "" {
+			params["page_token"] = nextPageToken
+		}
 		err := a.client.Get(ctx, "/jobs/list", params, &resp)
 		if err != nil {
 			return nil, err
@@ -430,7 +434,7 @@ func (a JobsAPI) ListByName(name string, expandTasks bool) ([]Job, error) {
 		if !resp.HasMore {
 			break
 		}
-		offset += len(resp.Jobs)
+		nextPageToken = resp.NextPageToken
 	}
 	return jobs, nil
 }

--- a/jobs/resource_job_test.go
+++ b/jobs/resource_job_test.go
@@ -2184,7 +2184,7 @@ func TestJobsAPIList(t *testing.T) {
 	qa.HTTPFixturesApply(t, []qa.HTTPFixture{
 		{
 			Method:   "GET",
-			Resource: "/api/2.1/jobs/list?expand_tasks=false&limit=25&offset=0",
+			Resource: "/api/2.1/jobs/list?expand_tasks=false&limit=25",
 			Response: JobListResponse{
 				Jobs: []Job{
 					{
@@ -2205,26 +2205,26 @@ func TestJobsAPIListMultiplePages(t *testing.T) {
 	qa.HTTPFixturesApply(t, []qa.HTTPFixture{
 		{
 			Method:   "GET",
-			Resource: "/api/2.1/jobs/list?expand_tasks=false&limit=25&offset=0",
+			Resource: "/api/2.1/jobs/list?expand_tasks=false&limit=25",
 			Response: JobListResponse{
 				Jobs: []Job{
 					{
 						JobID: 1,
 					},
 				},
-				HasMore: true,
+				HasMore:       true,
+				NextPageToken: "aaaa",
 			},
 		},
 		{
 			Method:   "GET",
-			Resource: "/api/2.1/jobs/list?expand_tasks=false&limit=25&offset=1",
+			Resource: "/api/2.1/jobs/list?expand_tasks=false&limit=25&page_token=aaaa",
 			Response: JobListResponse{
 				Jobs: []Job{
 					{
 						JobID: 2,
 					},
 				},
-				HasMore: false,
 			},
 		},
 	}, func(ctx context.Context, client *common.DatabricksClient) {
@@ -2239,7 +2239,7 @@ func TestJobsAPIListByName(t *testing.T) {
 	qa.HTTPFixturesApply(t, []qa.HTTPFixture{
 		{
 			Method:   "GET",
-			Resource: "/api/2.1/jobs/list?expand_tasks=false&limit=25&name=test&offset=0",
+			Resource: "/api/2.1/jobs/list?expand_tasks=false&limit=25&name=test",
 			Response: JobListResponse{
 				Jobs: []Job{
 					{


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

As we couldn't easily switch `databricks_job` resource to use Go SDK, we were still using offset-based pagination that has a significant load onto the control plane.  This PR changes list operation to use recommended token-based approach until we switch to Go SDK.

This fixes #2807

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] ~relevant change in `docs/` folder~
- [ ] covered with integration tests in `internal/acceptance`
- [x] relevant acceptance tests are passing
- [ ] using Go SDK

