### PR TITLE
Changed CREATE_TABLE to CREATE_EXTERNAL_TABLE in docs for external storage locations

### DIFF
--- a/docs/guides/unity-catalog-azure.md
+++ b/docs/guides/unity-catalog-azure.md
@@ -263,7 +263,7 @@ resource "databricks_grants" "external_creds" {
   storage_credential = databricks_storage_credential.external.id
   grant {
     principal  = "Data Engineers"
-    privileges = ["CREATE_TABLE"]
+    privileges = ["CREATE_EXTERNAL_TABLE"]
   }
 }
 
@@ -284,7 +284,7 @@ resource "databricks_grants" "some" {
   external_location = databricks_external_location.some.id
   grant {
     principal  = "Data Engineers"
-    privileges = ["CREATE_TABLE", "READ_FILES"]
+    privileges = ["CREATE_EXTERNAL_TABLE", "READ_FILES"]
   }
 }
 ```

--- a/docs/guides/unity-catalog-gcp.md
+++ b/docs/guides/unity-catalog-gcp.md
@@ -222,7 +222,7 @@ resource "databricks_grants" "external_creds" {
   storage_credential = databricks_storage_credential.external.id
   grant {
     principal  = "Data Engineers"
-    privileges = ["CREATE_TABLE"]
+    privileges = ["CREATE_EXTERNAL_TABLE"]
   }
 }
 
@@ -243,7 +243,7 @@ resource "databricks_grants" "some" {
   external_location = databricks_external_location.some.id
   grant {
     principal  = "Data Engineers"
-    privileges = ["CREATE_TABLE", "READ_FILES"]
+    privileges = ["CREATE_EXTERNAL_TABLE", "READ_FILES"]
   }
 }
 ```

--- a/docs/guides/unity-catalog.md
+++ b/docs/guides/unity-catalog.md
@@ -490,7 +490,7 @@ resource "databricks_grants" "some" {
   external_location = databricks_external_location.some.id
   grant {
     principal  = "Data Engineers"
-    privileges = ["CREATE_TABLE", "READ_FILES"]
+    privileges = ["CREATE_EXTERNAL_TABLE", "READ_FILES"]
   }
 }
 ```

--- a/docs/resources/grants.md
+++ b/docs/resources/grants.md
@@ -229,7 +229,7 @@ resource "databricks_grants" "external_creds" {
   storage_credential = databricks_storage_credential.external.id
   grant {
     principal  = "Data Engineers"
-    privileges = ["CREATE_TABLE"]
+    privileges = ["CREATE_EXTERNAL_TABLE"]
   }
 }
 ```
@@ -250,7 +250,7 @@ resource "databricks_grants" "some" {
   external_location = databricks_external_location.some.id
   grant {
     principal  = "Data Engineers"
-    privileges = ["CREATE_TABLE", "READ_FILES"]
+    privileges = ["CREATE_EXTERNAL_TABLE", "READ_FILES"]
   }
   grant {
     principal  = databricks_service_principal.my_sp.application_id

--- a/docs/resources/storage_credential.md
+++ b/docs/resources/storage_credential.md
@@ -25,7 +25,7 @@ resource "databricks_grants" "external_creds" {
   storage_credential = databricks_storage_credential.external.id
   grant {
     principal  = "Data Engineers"
-    privileges = ["CREATE_TABLE"]
+    privileges = ["CREATE_EXTERNAL_TABLE"]
   }
 }
 ```
@@ -45,7 +45,7 @@ resource "databricks_grants" "external_creds" {
   storage_credential = databricks_storage_credential.external.id
   grant {
     principal  = "Data Engineers"
-    privileges = ["CREATE_TABLE"]
+    privileges = ["CREATE_EXTERNAL_TABLE"]
   }
 }
 ```
@@ -62,7 +62,7 @@ resource "databricks_grants" "external_creds" {
   storage_credential = databricks_storage_credential.external.id
   grant {
     principal  = "Data Engineers"
-    privileges = ["CREATE_TABLE"]
+    privileges = ["CREATE_EXTERNAL_TABLE"]
   }
 }
 ```


### PR DESCRIPTION
## Changes
In the documentation, there is `CREATE_TABLE` permissions documented for every `databricks_grants` resource linked to a storage location. This is wrong. Only `CREATE_EXTERNAL_TABLE` exists for the `storage_credential` property. 

![image](https://github.com/databricks/terraform-provider-databricks/assets/72300830/88d42734-afca-4aea-b23a-a311d87392fc)

I must add, `CREATE_TABLE` does work, but it will set it to `CREATE_EXTERNAL_TABLE` in the UI. The next `terraform apply` will notice a difference, that will not go away until you change it to to the right value: `CREATE_EXTERNAL_TABLE`.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

Manual tests:

1. Set it to `CREATE_TABLE` and run `terraform apply`

```hcl
resource "databricks_grants" "external_location_grants_enriched" {
  provider          = databricks.workspace
  external_location = databricks_external_location.enriched.id
  grant {
    principal  = var.ad_group_principal_name
    privileges = ["CREATE_TABLE"]
  }

  depends_on = [ databricks_external_location.default_location ]
}
```

![image](https://github.com/databricks/terraform-provider-databricks/assets/72300830/af93b0ba-d694-4bb6-b029-5e1e3448e9cb)

2. Find out it is actually translates to `CREATE_EXTERNAL_TABLE`:

![image](https://github.com/databricks/terraform-provider-databricks/assets/72300830/756ec700-3817-416d-af83-c1724f45766b)

3. Run `terraform apply` again without changing anything & find out it wants to change the value:

![image](https://github.com/databricks/terraform-provider-databricks/assets/72300830/a202a892-ea9e-474b-9456-a0f6f73dce07)


4. Now add the right value (`CREATE_EXTERNAL_TABLE`): 
```hcl
resource "databricks_grants" "external_location_grants_enriched" {
  provider          = databricks.workspace
  external_location = databricks_external_location.enriched.id
  grant {
    principal  = var.ad_group_principal_name
    privileges = ["CREATE_EXTERNAL_TABLE"]
  }

  depends_on = [ databricks_external_location.default_location ]
}
```

Result:
![image](https://github.com/databricks/terraform-provider-databricks/assets/72300830/40b09da4-7bb2-41ff-a104-c33a05eed6d3)

