### PR TITLE
Add `account_id` parameter to provider blocks in the guides where it was missing

### DIFF
--- a/docs/guides/aws-e2-firewall-hub-and-spoke.md
+++ b/docs/guides/aws-e2-firewall-hub-and-spoke.md
@@ -108,6 +108,7 @@ provider "aws" {
 provider "databricks" {
   alias         = "mws"
   host          = "https://accounts.cloud.databricks.com"
+  account_id    = var.databricks_account_id
   client_id     = var.client_id
   client_secret = var.client_secret
 }

--- a/docs/guides/aws-e2-firewall-workspace.md
+++ b/docs/guides/aws-e2-firewall-workspace.md
@@ -106,6 +106,7 @@ provider "aws" {
 provider "databricks" {
   alias         = "mws"
   host          = "https://accounts.cloud.databricks.com"
+  account_id    = var.databricks_account_id
   client_id     = var.client_id
   client_secret = var.client_secret
 }

--- a/docs/guides/aws-private-link-workspace.md
+++ b/docs/guides/aws-private-link-workspace.md
@@ -59,6 +59,7 @@ provider "aws" {
 provider "databricks" {
   alias         = "mws"
   host          = "https://accounts.cloud.databricks.com"
+  account_id    = var.databricks_account_id
   client_id     = var.client_id
   client_secret = var.client_secret
 }

--- a/docs/guides/aws-workspace.md
+++ b/docs/guides/aws-workspace.md
@@ -71,6 +71,7 @@ provider "aws" {
 provider "databricks" {
   alias         = "mws"
   host          = "https://accounts.cloud.databricks.com"
+  account_id    = var.databricks_account_id
   client_id     = var.client_id
   client_secret = var.client_secret
 }

--- a/docs/guides/unity-catalog-azure.md
+++ b/docs/guides/unity-catalog-azure.md
@@ -79,8 +79,9 @@ provider "databricks" {
 }
 
 provider "databricks" {
-  alias = "accounts"
-  host  = "https://accounts.azuredatabricks.net"
+  alias      = "accounts"
+  host       = "https://accounts.azuredatabricks.net"
+  account_id = var.databricks_account_id
 }
 ```
 

--- a/docs/guides/unity-catalog-gcp.md
+++ b/docs/guides/unity-catalog-gcp.md
@@ -76,8 +76,9 @@ provider "databricks" {
 }
 
 provider "databricks" {
-  alias = "accounts"
-  host  = "https://accounts.gcp.databricks.com"
+  alias      = "accounts"
+  host       = "https://accounts.gcp.databricks.com"
+  account_id = var.databricks_account_id
 }
 ```
 


### PR DESCRIPTION
This fixes #2809

## Changes
<!-- Summary of your changes that are easy to understand -->

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

