### PR TITLE
Add deployment field to resource_job

### DIFF
--- a/jobs/resource_job.go
+++ b/jobs/resource_job.go
@@ -292,6 +292,7 @@ type JobSettings struct {
 	RunAs                *JobRunAs                     `json:"run_as,omitempty" tf:"suppress_diff"`
 	Health               *JobHealth                    `json:"health,omitempty"`
 	Parameters           []JobParameterDefinition      `json:"parameters,omitempty" tf:"alias:parameter"`
+	Deployment           *jobs.JobDeployment           `json:"deployment,omitempty"`
 }
 
 func (js *JobSettings) isMultiTask() bool {

--- a/jobs/resource_job_test.go
+++ b/jobs/resource_job_test.go
@@ -54,6 +54,10 @@ func TestResourceJobCreate(t *testing.T) {
 					RunAs: &JobRunAs{
 						UserName: "user@mail.com",
 					},
+					Deployment: &jobs.JobDeployment{
+						Kind:             "BUNDLE",
+						MetadataFilePath: "/a/b/c",
+					},
 				},
 				Response: Job{
 					JobID: 789,
@@ -94,6 +98,10 @@ func TestResourceJobCreate(t *testing.T) {
 						RunAs: &JobRunAs{
 							UserName: "user@mail.com",
 						},
+						Deployment: &jobs.JobDeployment{
+							Kind:             "BUNDLE",
+							MetadataFilePath: "/a/b/c",
+						},
 					},
 				},
 			},
@@ -125,6 +133,10 @@ func TestResourceJobCreate(t *testing.T) {
 		}
 		run_as {
 			user_name = "user@mail.com"
+		}
+		deployment {
+			kind = "BUNDLE"
+			metadata_file_path = "/a/b/c"
 		}`,
 	}.Apply(t)
 	assert.NoError(t, err)


### PR DESCRIPTION
## Changes
This PR adds the deployment field to the Job resource. This allows jobs created to be aware that they are a part of a bundle, as well as communicate bundle metadata with the job.

## Tests
Unit test
