### PR TITLE
Exporter: Correctly handle not allowed characters in the notebooks/directories names

### DIFF
--- a/exporter/context.go
+++ b/exporter/context.go
@@ -828,6 +828,12 @@ func (ic *importContext) Emit(r *resource) {
 	}
 }
 
+func maybeAddQuoteCharacter(s string) string {
+	s = strings.ReplaceAll(s, "\\", "\\\\")
+	s = strings.ReplaceAll(s, "\"", "\\\"")
+	return s
+}
+
 func (ic *importContext) getTraversalTokens(ref reference, value string) hclwrite.Tokens {
 	matchType := ref.MatchTypeValue()
 	attr := ref.MatchAttribute()
@@ -848,18 +854,18 @@ func (ic *importContext) getTraversalTokens(ref reference, value string) hclwrit
 		tokens := hclwrite.Tokens{&hclwrite.Token{Type: hclsyntax.TokenOQuote, Bytes: []byte{'"', '$', '{'}}}
 		tokens = append(tokens, hclwrite.TokensForTraversal(traversal)...)
 		tokens = append(tokens, &hclwrite.Token{Type: hclsyntax.TokenCQuote, Bytes: []byte{'}'}})
-		tokens = append(tokens, &hclwrite.Token{Type: hclsyntax.TokenQuotedLit, Bytes: []byte(rest)})
+		tokens = append(tokens, &hclwrite.Token{Type: hclsyntax.TokenQuotedLit, Bytes: []byte(maybeAddQuoteCharacter(rest))})
 		tokens = append(tokens, &hclwrite.Token{Type: hclsyntax.TokenCQuote, Bytes: []byte{'"'}})
 		return tokens
 	case MatchRegexp:
 		indices := ref.Regexp.FindStringSubmatchIndex(value)
 		if len(indices) == 4 {
 			tokens := hclwrite.Tokens{&hclwrite.Token{Type: hclsyntax.TokenOQuote, Bytes: []byte{'"'}}}
-			tokens = append(tokens, &hclwrite.Token{Type: hclsyntax.TokenQuotedLit, Bytes: []byte(value[0:indices[2]])})
+			tokens = append(tokens, &hclwrite.Token{Type: hclsyntax.TokenQuotedLit, Bytes: []byte(maybeAddQuoteCharacter(value[0:indices[2]]))})
 			tokens = append(tokens, &hclwrite.Token{Type: hclsyntax.TokenOQuote, Bytes: []byte{'$', '{'}})
 			tokens = append(tokens, hclwrite.TokensForTraversal(traversal)...)
 			tokens = append(tokens, &hclwrite.Token{Type: hclsyntax.TokenCQuote, Bytes: []byte{'}'}})
-			tokens = append(tokens, &hclwrite.Token{Type: hclsyntax.TokenQuotedLit, Bytes: []byte(value[indices[3]:])})
+			tokens = append(tokens, &hclwrite.Token{Type: hclsyntax.TokenQuotedLit, Bytes: []byte(maybeAddQuoteCharacter(value[indices[3]:]))})
 			tokens = append(tokens, &hclwrite.Token{Type: hclsyntax.TokenCQuote, Bytes: []byte{'"'}})
 			return tokens
 		}

--- a/exporter/importables.go
+++ b/exporter/importables.go
@@ -41,6 +41,7 @@ var (
 	gsRegex                      = regexp.MustCompile(`^gs://([^/]+)(/.*)?$`)
 	globalWorkspaceConfName      = "global_workspace_conf"
 	nameNormalizationRegex       = regexp.MustCompile(`\W+`)
+	fileNameNormalizationRegex   = regexp.MustCompile(`[^-_\w/.@]`)
 	jobClustersRegex             = regexp.MustCompile(`^((job_cluster|task)\.[0-9]+\.new_cluster\.[0-9]+\.)`)
 	dltClusterRegex              = regexp.MustCompile(`^(cluster\.[0-9]+\.)`)
 	predefinedClusterPolicies    = []string{"Personal Compute", "Job Compute", "Power User Compute", "Shared Compute"}
@@ -1307,7 +1308,8 @@ var resourcesMap map[string]importable = map[string]importable{
 				fileExtension = fileExtensionFormatMapping[ic.notebooksFormat]
 			}
 			r.Data.Set("format", ic.notebooksFormat)
-			name := r.ID[1:] + fileExtension // todo: replace non-alphanum+/ with _
+			objectId := r.Data.Get("object_id").(int)
+			name := fileNameNormalizationRegex.ReplaceAllString(r.ID[1:], "_") + "_" + strconv.Itoa(objectId) + fileExtension
 			content, _ := base64.StdEncoding.DecodeString(contentB64)
 			fileName, err := ic.createFileIn("notebooks", name, []byte(content))
 			if err != nil {
@@ -1316,7 +1318,7 @@ var resourcesMap map[string]importable = map[string]importable{
 			if ic.meAdmin {
 				ic.Emit(&resource{
 					Resource: "databricks_permissions",
-					ID:       fmt.Sprintf("/notebooks/%d", r.Data.Get("object_id").(int)),
+					ID:       fmt.Sprintf("/notebooks/%d", objectId),
 					Name:     "notebook_" + ic.Importables["databricks_notebook"].Name(ic, r.Data),
 				})
 			}
@@ -1353,7 +1355,15 @@ var resourcesMap map[string]importable = map[string]importable{
 			if err != nil {
 				return err
 			}
-			name := r.ID[1:]
+			objectId := r.Data.Get("object_id").(int)
+			parts := strings.Split(r.ID, "/")
+			plen := len(parts)
+			if idx := strings.Index(parts[plen-1], "."); idx != -1 {
+				parts[plen-1] = parts[plen-1][:idx] + "_" + strconv.Itoa(objectId) + parts[plen-1][idx:]
+			} else {
+				parts[plen-1] = parts[plen-1] + "_" + strconv.Itoa(objectId)
+			}
+			name := fileNameNormalizationRegex.ReplaceAllString(strings.Join(parts, "/")[1:], "_")
 			content, _ := base64.StdEncoding.DecodeString(contentB64)
 			fileName, err := ic.createFileIn("workspace_files", name, []byte(content))
 			if err != nil {
@@ -1363,7 +1373,7 @@ var resourcesMap map[string]importable = map[string]importable{
 			if ic.meAdmin {
 				ic.Emit(&resource{
 					Resource: "databricks_permissions",
-					ID:       fmt.Sprintf("/files/%d", r.Data.Get("object_id").(int)),
+					ID:       fmt.Sprintf("/files/%d", objectId),
 					Name:     "ws_file_" + ic.Importables["databricks_workspace_file"].Name(ic, r.Data),
 				})
 			}

--- a/exporter/importables_test.go
+++ b/exporter/importables_test.go
@@ -788,7 +788,7 @@ func TestRepoListFails(t *testing.T) {
 	})
 }
 
-func testGenerate(t *testing.T, fixtures []qa.HTTPFixture, services string, cb func(*importContext)) {
+func testGenerate(t *testing.T, fixtures []qa.HTTPFixture, services string, asAdmin bool, cb func(*importContext)) {
 	qa.HTTPFixturesApply(t, fixtures, func(ctx context.Context, client *common.DatabricksClient) {
 		ic := importContextForTest()
 		ic.Directory = fmt.Sprintf("/tmp/tf-%s", qa.RandomName())
@@ -796,6 +796,7 @@ func testGenerate(t *testing.T, fixtures []qa.HTTPFixture, services string, cb f
 		ic.Client = client
 		ic.Context = ctx
 		ic.testEmits = nil
+		ic.meAdmin = asAdmin
 		ic.importing = map[string]bool{}
 		ic.variables = map[string]string{}
 		ic.services = services
@@ -839,7 +840,7 @@ func TestNotebookGeneration(t *testing.T) {
 				Content: "YWJj",
 			},
 		},
-	}, "notebooks", func(ic *importContext) {
+	}, "notebooks", false, func(ic *importContext) {
 		ic.notebooksFormat = "SOURCE"
 		err := resourcesMap["databricks_notebook"].List(ic)
 		assert.NoError(t, err)
@@ -848,7 +849,7 @@ func TestNotebookGeneration(t *testing.T) {
 		ic.generateHclForResources(nil)
 		assert.Equal(t, commands.TrimLeadingWhitespace(`
 		resource "databricks_notebook" "first_second_123" {
-		  source = "${path.module}/notebooks/First/Second.py"
+		  source = "${path.module}/notebooks/First/Second_123.py"
 		  path   = "/First/Second"
 		}`), string(ic.Files["notebooks"].Bytes()))
 	})
@@ -889,7 +890,7 @@ func TestNotebookGenerationJupyter(t *testing.T) {
 				Content: "YWJj",
 			},
 		},
-	}, "notebooks", func(ic *importContext) {
+	}, "notebooks", false, func(ic *importContext) {
 		ic.notebooksFormat = "JUPYTER"
 		err := resourcesMap["databricks_notebook"].List(ic)
 		assert.NoError(t, err)
@@ -898,10 +899,70 @@ func TestNotebookGenerationJupyter(t *testing.T) {
 		ic.generateHclForResources(nil)
 		assert.Equal(t, commands.TrimLeadingWhitespace(`
 		resource "databricks_notebook" "first_second_123" {
-		  source   = "${path.module}/notebooks/First/Second.ipynb"
+		  source   = "${path.module}/notebooks/First/Second_123.ipynb"
 		  path     = "/First/Second"
 		  language = "PYTHON"
 		  format   = "JUPYTER"
+		}`), string(ic.Files["notebooks"].Bytes()))
+	})
+}
+
+func TestNotebookGenerationBadCharacters(t *testing.T) {
+	testGenerate(t, []qa.HTTPFixture{
+		{
+			Method:   "GET",
+			Resource: "/api/2.0/workspace/list?path=%2F",
+			Response: workspace.ObjectList{
+				Objects: []workspace.ObjectStatus{
+					{
+						Path:       "/Repos/Foo/Bar",
+						ObjectType: "NOTEBOOK",
+					},
+					{
+						Path:       "/Fir\"st\\/Second",
+						ObjectType: "NOTEBOOK",
+					},
+				},
+			},
+		},
+		{
+			Method:   "GET",
+			Resource: "/api/2.0/workspace/get-status?path=%2FFir%22st%5C",
+
+			Response: workspace.ObjectStatus{
+				ObjectID:   124,
+				ObjectType: "DIRECTORY",
+				Path:       "/Fir\"st\\",
+			},
+		},
+		{
+			Method:   "GET",
+			Resource: "/api/2.0/workspace/get-status?path=%2FFir%22st%5C%2FSecond",
+			Response: workspace.ObjectStatus{
+				ObjectID:   123,
+				ObjectType: "NOTEBOOK",
+				Path:       "/Fir\"st\\/Second",
+				Language:   "PYTHON",
+			},
+		},
+		{
+			Method:   "GET",
+			Resource: "/api/2.0/workspace/export?format=SOURCE&path=%2FFir%22st%5C%2FSecond",
+			Response: workspace.ExportPath{
+				Content: "YWJj",
+			},
+		},
+	}, "notebooks,directories", true, func(ic *importContext) {
+		ic.notebooksFormat = "SOURCE"
+		err := resourcesMap["databricks_notebook"].List(ic)
+		assert.NoError(t, err)
+		ic.waitGroup.Wait()
+		ic.closeImportChannels()
+		ic.generateHclForResources(nil)
+		assert.Equal(t, commands.TrimLeadingWhitespace(`
+		resource "databricks_notebook" "fir_st_second_123" {
+		  source = "${path.module}/notebooks/Fir_st_/Second_123.py"
+		  path   = "/Fir\"st\\/Second"
 		}`), string(ic.Files["notebooks"].Bytes()))
 	})
 }
@@ -939,7 +1000,7 @@ func TestDirectoryGeneration(t *testing.T) {
 				Path:       "/first",
 			},
 		},
-	}, "directories", func(ic *importContext) {
+	}, "directories", false, func(ic *importContext) {
 		err := resourcesMap["databricks_directory"].List(ic)
 		assert.NoError(t, err)
 
@@ -965,7 +1026,7 @@ func TestGlobalInitScriptGen(t *testing.T) {
 				ContentBase64: "YWJj",
 			},
 		},
-	}, "workspace", func(ic *importContext) {
+	}, "workspace", false, func(ic *importContext) {
 		ic.Emit(&resource{
 			Resource: "databricks_global_init_script",
 			ID:       "a",
@@ -997,7 +1058,7 @@ func TestSecretGen(t *testing.T) {
 				},
 			},
 		},
-	}, "secrets", func(ic *importContext) {
+	}, "secrets", false, func(ic *importContext) {
 		ic.Emit(&resource{
 			Resource: "databricks_secret",
 			ID:       "a|||b",
@@ -1032,7 +1093,7 @@ func TestDbfsFileGen(t *testing.T) {
 				BytesRead: 3,
 			},
 		},
-	}, "storage", func(ic *importContext) {
+	}, "storage", false, func(ic *importContext) {
 		ic.Emit(&resource{
 			Resource: "databricks_dbfs_file",
 			ID:       "a",


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

Our UI & API allow the creation of directories and notebooks with characters like `\` and `"` in names, but they were incorrectly handled in the exporter.  This PR fixes that by doing the following:

* Correctly handle special characters when generating references
* Sanitizing file names for exported notebooks and workspace files and making them unique on disk by adding the object ID

It also should fix #2661 because we'll remove bad characters from file names

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] tested manually
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

