### PR TITLE
Exporter: fix generation of names for `databricks_library` resources

### DIFF
--- a/exporter/context.go
+++ b/exporter/context.go
@@ -764,14 +764,15 @@ func (ic *importContext) ResourceName(r *resource) string {
 		name = r.ID
 	}
 	name = ic.prefix + name
+	origCaseName := name
 	name = strings.ToLower(name)
 	name = ic.regexFix(name, ic.nameFixes)
 	// this is either numeric id or all-non-ascii
 	if regexp.MustCompile(`^\d`).MatchString(name) || name == "" {
 		if name == "" {
-			name = r.ID
+			origCaseName = r.ID
 		}
-		name = fmt.Sprintf("r%x", md5.Sum([]byte(name)))[0:12]
+		name = fmt.Sprintf("r%x", md5.Sum([]byte(origCaseName)))[0:12]
 	}
 	return name
 }

--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -1348,7 +1348,12 @@ func TestResourceName(t *testing.T) {
 	norm = ic.ResourceName(&resource{
 		Name: "9721431b_bcd3_4526_b90f_f5de2befec8c|8737798193",
 	})
-	assert.Equal(t, "r7322b058678", norm)
+	assert.Equal(t, "r56cde0f5eda", norm)
+
+	assert.NotEqual(t, ic.ResourceName(&resource{
+		Name: "0A"}), ic.ResourceName(&resource{
+		Name: "0a",
+	}))
 
 	norm = ic.ResourceName(&resource{
 		Name: "General Policy - All Users",

--- a/exporter/importables.go
+++ b/exporter/importables.go
@@ -261,7 +261,8 @@ var resourcesMap map[string]importable = map[string]importable{
 			{Path: "egg", Resource: "databricks_dbfs_file", Match: "dbfs_path"},
 		},
 		Name: func(ic *importContext, d *schema.ResourceData) string {
-			return d.Id()
+			id := d.Id()
+			return "lib_" + id + fmt.Sprintf("_%x", md5.Sum([]byte(id)))[:9]
 		},
 	},
 	"databricks_cluster": {

--- a/exporter/importables_test.go
+++ b/exporter/importables_test.go
@@ -226,7 +226,7 @@ func TestClusterLibrary(t *testing.T) {
 	ic := importContextForTest()
 	d := clusters.ResourceLibrary().TestResourceData()
 	d.SetId("a-b-c")
-	assert.Equal(t, "a-b-c", resourcesMap["databricks_library"].Name(ic, d))
+	assert.Equal(t, "lib_a-b-c_7b193b3d", resourcesMap["databricks_library"].Name(ic, d))
 }
 
 func TestImportClusterLibraries(t *testing.T) {


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

Internally, the exporter uses the following resource ID for `databricks_library`: `<cluster_id>/<type>:coordinate` (i.e., `0426-122546-8xi8q5o3/pypi:chispa`).

When generating the final name of the resource, this name is normalized and checked if it's starting with a number, as Terraform doesn't allow identifiers to start with a number. If the final name starts with a number, then the artificial final name is generated consisting in the form of `r<first 12 digits of MD5 of the original name>`.  This leads to the generation of duplicate resources in case if cluster ID starts with a number, and the same library was attached to the cluster multiple times, having only differences in the character case, like, `Chispa` and `chispa` (our clusters UI allows that).

This PR fixes this issue with the following changes:

* add the `lib_` prefix to the library name together with the first 8 numbers of the MD5 of the library ID
* when generating resource name in the form of `r<first 12 digits of MD5 of the original name>`, calculate MD5 of the original string, not the lower-cased form

Please note that you will need to perform a full export because resource names has changed

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] tested manually
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

