### PR TITLE
Exporter: adjust generation & normalization of `databricks_job` names

### DIFF
--- a/exporter/context.go
+++ b/exporter/context.go
@@ -139,7 +139,7 @@ var nameFixes = []regexFix{
 	{regexp.MustCompile(`[0-9a-f]{8}[_-][0-9a-f]{4}[_-][0-9a-f]{4}` +
 		`[_-][0-9a-f]{4}[_-][0-9a-f]{12}[_-]`), ""},
 	//	{regexp.MustCompile(`[_-][0-9]+[\._-][0-9]+[\._-].*\.([a-z0-9]{1,4})`), "_$1"},
-	{regexp.MustCompile(`@.*$`), ""},
+	// {regexp.MustCompile(`@.*$`), ""},
 	{regexp.MustCompile(`[-\s\.\|]`), "_"},
 	{regexp.MustCompile(`\W+`), "_"},
 	{regexp.MustCompile(`[_]{2,}`), "_"},

--- a/exporter/importables.go
+++ b/exporter/importables.go
@@ -337,7 +337,12 @@ var resourcesMap map[string]importable = map[string]importable{
 		ApiVersion: common.API_2_1,
 		Service:    "jobs",
 		Name: func(ic *importContext, d *schema.ResourceData) string {
-			return fmt.Sprintf("%s_%s", d.Get("name").(string), d.Id())
+			name := d.Get("name").(string)
+			if name == "" {
+				name = "job"
+			}
+			return nameNormalizationRegex.ReplaceAllString(
+				fmt.Sprintf("%s_%s", name, d.Id()), "_")
 		},
 		Depends: []reference{
 			{Path: "email_notifications.on_failure", Resource: "databricks_user", Match: "user_name"},

--- a/exporter/importables_test.go
+++ b/exporter/importables_test.go
@@ -222,6 +222,17 @@ func TestClusterNameFromID(t *testing.T) {
 	assert.Equal(t, "c", resourcesMap["databricks_cluster"].Name(ic, d))
 }
 
+func TestJobName(t *testing.T) {
+	ic := importContextForTest()
+	d := jobs.ResourceJob().TestResourceData()
+	d.SetId("12345")
+	// job without name
+	assert.Equal(t, "job_12345", resourcesMap["databricks_job"].Name(ic, d))
+	// job with name
+	d.Set("name", "test@1pm")
+	assert.Equal(t, "test_1pm_12345", resourcesMap["databricks_job"].Name(ic, d))
+}
+
 func TestClusterLibrary(t *testing.T) {
 	ic := importContextForTest()
 	d := clusters.ResourceLibrary().TestResourceData()


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

In `context.go` we had a very aggressive name normalization rule `@.*$` that did not necessarily strip parts of the job name. Also added handling of the empty job name.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

