### PR TITLE
Point master to main everywhere in TF

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,9 +2,9 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, main ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, main ]
   schedule:
     - cron: '41 1 * * 0'
       

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,6 +1,8 @@
 name: build
 
 on:
+  push:
+    branches: [ master, main ]
   pull_request:
     types: [opened, synchronize]
   merge_group:

--- a/.github/workflows/schema.yml
+++ b/.github/workflows/schema.yml
@@ -8,11 +8,11 @@ on:
     inputs:
       base:
         description: 'Base ref'
-        default: 'master'
+        default: 'main'
         required: true
       head:
         description: 'Head ref'
-        default: 'master'
+        default: 'main'
         required: true
 
 jobs:
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           # Checkout main branch to generate schema for current release
-          ref: master
+          ref: main
 
       - if: github.event_name == 'workflow_dispatch'
         name: Checkout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -809,7 +809,7 @@ The remote registry returned warnings for registry.terraform.io/databrickslabs/d
 
 After you replace `databrickslabs/databricks` with `databricks/databricks` in the `required_providers` block, the warning will disappear. Do a global "search and replace" in `*.tf` files. Alternatively you can run `python3 -c "$(curl -Ls https://dbricks.co/updtfns)"` from the command-line, that would do all the boring work for you.
 
-If you didn't check-in [`.terraform.lock.hcl`](https://www.terraform.io/language/files/dependency-lock#lock-file-location) to the source code version control, you may you may see `Failed to install provider` error. Please follow the simple steps described in the [troubleshooting guide](https://github.com/databrickslabs/terraform-provider-databricks/blob/master/docs/guides/troubleshooting.md).
+If you didn't check-in [`.terraform.lock.hcl`](https://www.terraform.io/language/files/dependency-lock#lock-file-location) to the source code version control, you may you may see `Failed to install provider` error. Please follow the simple steps described in the [troubleshooting guide](https://github.com/databrickslabs/terraform-provider-databricks/blob/main/docs/guides/troubleshooting.md).
 
 ## 0.6.2
 
@@ -1323,7 +1323,7 @@ Updated dependency versions:
 
 * Added `databricks_global_init_script` resource to configure global init scripts ([#487](https://github.com/databricks/terraform-provider-databricks/issues/487)).
 * Added `databricks_sql_endpoint` resource ([#498](https://github.com/databricks/terraform-provider-databricks/pull/498))
-* Added [experimental resource exporter](https://github.com/databricks/terraform-provider-databricks/blob/master/docs/guides/experimental-exporter.md) to generate configuration for entire workspace.
+* Added [experimental resource exporter](https://github.com/databricks/terraform-provider-databricks/blob/main/docs/guides/experimental-exporter.md) to generate configuration for entire workspace.
 * Improved user-facing documentaiton ([#508](https://github.com/databricks/terraform-provider-databricks/pull/508/files), [#516](https://github.com/databricks/terraform-provider-databricks/pull/516), [#511](https://github.com/databricks/terraform-provider-databricks/pull/511), [#504](https://github.com/databricks/terraform-provider-databricks/pull/504), [#492]([Update docs in various places](https://github.com/databricks/terraform-provider-databricks/pull/492)))
 * Simplified authentication issues debugging ([#490](https://github.com/databricks/terraform-provider-databricks/pull/490))
 * Made cleaner error message for no config profile ([#491](https://github.com/databricks/terraform-provider-databricks/pull/491))
@@ -1470,7 +1470,7 @@ Updated dependency versions:
 
 ## 0.2.4
 
-* Added [Azure CLI authentication](https://github.com/databricks/terraform-provider-databricks/blob/master/docs/index.md#authenticating-with-azure-cli) to bridge the gap of local development workflows and let more people use the provider.
+* Added [Azure CLI authentication](https://github.com/databricks/terraform-provider-databricks/blob/main/docs/index.md#authenticating-with-azure-cli) to bridge the gap of local development workflows and let more people use the provider.
 * All authentication is completely [lazy-initialized](https://github.com/databricks/terraform-provider-databricks/pull/270), which makes it provider overall more stable.
 * Significantly increased [unit test coverage](https://codecov.io/gh/databricks/terraform-provider-databricks), which runs before every merge of a pull request.
 * Introduced constantly running integration test suite environments: azsp, azcli & awsmt
@@ -1491,7 +1491,7 @@ Updated dependency versions:
 * gopkg.in/ini.v1 v1.60.2
 
 **Deprecations**
-* `library_*` is no longer receiving fixes and will be removed in `0.3`, please rewrite cluster & job resources to use [`library` configuration block](https://github.com/databricks/terraform-provider-databricks/blob/master/docs/resources/cluster.md#library-configuration-block).
+* `library_*` is no longer receiving fixes and will be removed in `0.3`, please rewrite cluster & job resources to use [`library` configuration block](https://github.com/databricks/terraform-provider-databricks/blob/main/docs/resources/cluster.md#library-configuration-block).
 * `basic_auth` provider block is no longer receiving fixesand will be removed in `0.3`, please use `username` and `password` options
 * `azure_auth` provider block is no longer receiving fixesand will be removed in `0.3`, please use `azure_*` options 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,7 +73,7 @@ Additional git and GitHub resources:
 If you use Terraform 0.12, please execute the following curl command in your shell:
 
 ```bash
-curl https://raw.githubusercontent.com/databricks/terraform-provider-databricks/master/godownloader-databricks-provider.sh | bash -s -- -b $HOME/.terraform.d/plugins
+curl https://raw.githubusercontent.com/databricks/terraform-provider-databricks/main/godownloader-databricks-provider.sh | bash -s -- -b $HOME/.terraform.d/plugins
 ```
 
 ## Installing from source

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@
 | [databricks_zones](docs/data-sources/zones.md)
 | [Contributing and Development Guidelines](CONTRIBUTING.md)
 
-[![build](https://github.com/databricks/terraform-provider-databricks/workflows/build/badge.svg?branch=master)](https://github.com/databricks/terraform-provider-databricks/actions?query=workflow%3Abuild+branch%3Amaster) [![codecov](https://codecov.io/gh/databricks/terraform-provider-databricks/branch/master/graph/badge.svg)](https://codecov.io/gh/databricks/terraform-provider-databricks) ![lines](https://img.shields.io/tokei/lines/github/databricks/terraform-provider-databricks) [![downloads](https://img.shields.io/github/downloads/databricks/terraform-provider-databricks/total.svg)](https://hanadigital.github.io/grev/?user=databricks&repo=terraform-provider-databricks)
+[![build](https://github.com/databricks/terraform-provider-databricks/workflows/build/badge.svg?branch=main)](https://github.com/databricks/terraform-provider-databricks/actions?query=workflow%3Abuild+branch%3Amain) [![codecov](https://codecov.io/gh/databricks/terraform-provider-databricks/branch/main/graph/badge.svg)](https://codecov.io/gh/databricks/terraform-provider-databricks) ![lines](https://img.shields.io/tokei/lines/github/databricks/terraform-provider-databricks) [![downloads](https://img.shields.io/github/downloads/databricks/terraform-provider-databricks/total.svg)](https://hanadigital.github.io/grev/?user=databricks&repo=terraform-provider-databricks)
 
 If you use Terraform 0.13 or newer, please refer to instructions specified at [registry page](https://registry.terraform.io/providers/databricks/databricks/latest). If you use older versions of Terraform or want to build it from sources, please refer to [contributing guidelines](CONTRIBUTING.md) page.
 

--- a/docs/guides/aws-e2-firewall-hub-and-spoke.md
+++ b/docs/guides/aws-e2-firewall-hub-and-spoke.md
@@ -6,7 +6,7 @@ page_title: "Provisioning AWS Databricks E2 with a Hub & Spoke firewall for data
 
 You can provision multiple Databricks workspaces with Terraform, and where many Databricks workspaces are deployed, we recommend a hub and spoke topology reference architecture powered by AWS Transit Gateway. The hub will consist of a central inspection and egress virtual private cloud (VPC), while the Spoke VPC houses federated Databricks workspaces for different business units or segregated teams. In this way, you create your version of a centralized deployment model for your egress architecture, as is recommended for large enterprises. For more information, please visit [Data Exfiltration Protection With Databricks on AWS](https://databricks.com/blog/2021/02/02/data-exfiltration-protection-with-databricks-on-aws.html).
 
-![Data Exfiltration](https://raw.githubusercontent.com/databricks/terraform-provider-databricks/master/docs/images/aws-exfiltration-replace-1.png)
+![Data Exfiltration](https://raw.githubusercontent.com/databricks/terraform-provider-databricks/main/docs/images/aws-exfiltration-replace-1.png)
 
 ## Provider initialization for E2 workspaces
 
@@ -122,7 +122,7 @@ The very first step is Hub & Spoke VPC creation. Please consult [main documentat
 
 The first step is to create a Spoke VPC, which houses federated Databricks workspaces for different business units or segregated teams.
 
-![SpokeVPC](https://raw.githubusercontent.com/databricks/terraform-provider-databricks/master/docs/images/aws-e2-firewall-spoke-vpc.png)
+![SpokeVPC](https://raw.githubusercontent.com/databricks/terraform-provider-databricks/main/docs/images/aws-e2-firewall-spoke-vpc.png)
 
 ```hcl
 data "aws_availability_zones" "available" {}
@@ -309,7 +309,7 @@ module "vpc_endpoints" {
 
 The hub will consist of a central inspection and egress virtual private cloud (VPC). We're going to create a central inspection/egress VPC, which, once we’ve finished, should look like this:
 
-![HubVPC](https://raw.githubusercontent.com/databricks/terraform-provider-databricks/master/docs/images/aws-e2-firewall-hub-vpc.png)
+![HubVPC](https://raw.githubusercontent.com/databricks/terraform-provider-databricks/main/docs/images/aws-e2-firewall-hub-vpc.png)
 
 ```hcl
 /* Create VPC */
@@ -470,7 +470,7 @@ Now that our spoke and inspection/egress VPCs are ready to go, all you need to d
 First, we will create a Transit Gateway and link our Databricks data plane via TGW subnets.
 All of the logic that determines what routes are going via a Transit Gateway is encapsulated within Transit Gateway Route Tables. We will create some TGW route tables for our Hub & Spoke networks.
 
-![TransitGateway](https://raw.githubusercontent.com/databricks/terraform-provider-databricks/master/docs/images/aws-e2-firewall-tgw.png)
+![TransitGateway](https://raw.githubusercontent.com/databricks/terraform-provider-databricks/main/docs/images/aws-e2-firewall-tgw.png)
 
 ```hcl
 //Create transit gateway
@@ -555,7 +555,7 @@ resource "aws_route" "hub_nat_to_tgw" {
 
 Once [VPC](#vpc) is ready, we're going to create AWS Network Firewall for your VPC that restricts outbound http/s traffic to an approved set of Fully Qualified Domain Names (FQDNs).
 
-![AWS Network Firewall](https://raw.githubusercontent.com/databricks/terraform-provider-databricks/master/docs/images/aws-e2-firewall-config.png)
+![AWS Network Firewall](https://raw.githubusercontent.com/databricks/terraform-provider-databricks/main/docs/images/aws-e2-firewall-config.png)
 
 ### AWS Firewall Rule Groups
 

--- a/docs/guides/aws-e2-firewall-workspace.md
+++ b/docs/guides/aws-e2-firewall-workspace.md
@@ -8,7 +8,7 @@ You can provision multiple Databricks workspaces with Terraform. This example sh
 
 For more information, please visit [Data Exfiltration Protection With Databricks on AWS](https://databricks.com/blog/2021/02/02/data-exfiltration-protection-with-databricks-on-aws.html).
 
-![Data Exfiltration_Workspace](https://raw.githubusercontent.com/databricks/terraform-provider-databricks/master/docs/images/aws-e2-firewall-workspace.png)
+![Data Exfiltration_Workspace](https://raw.githubusercontent.com/databricks/terraform-provider-databricks/main/docs/images/aws-e2-firewall-workspace.png)
 
 ## Provider initialization for E2 workspaces
 

--- a/docs/guides/aws-private-link-workspace.md
+++ b/docs/guides/aws-private-link-workspace.md
@@ -6,7 +6,7 @@ page_title: "Provisioning Databricks on AWS with PrivateLink"
 
 Databricks PrivateLink support enables private connectivity between users and their Databricks workspaces and between clusters on the data plane and core services on the control plane within the Databricks workspace infrastructure. You can use Terraform to deploy the underlying cloud resources and the private access settings resources automatically using a programmatic approach. This guide assumes you are deploying into an existing VPC and have set up credentials and storage configurations as per prior examples, notably here.
 
-![Private link backend](https://raw.githubusercontent.com/databricks/terraform-provider-databricks/master/docs/images/aws-e2-private-link-backend.png)
+![Private link backend](https://raw.githubusercontent.com/databricks/terraform-provider-databricks/main/docs/images/aws-e2-private-link-backend.png)
 
 This guide uses the following variables in configurations:
 

--- a/docs/guides/aws-workspace.md
+++ b/docs/guides/aws-workspace.md
@@ -6,7 +6,7 @@ page_title: "Provisioning AWS Databricks E2"
 
 You can provision multiple Databricks workspaces with Terraform.
 
-![Simplest multiworkspace](https://github.com/databricks/terraform-provider-databricks/raw/master/docs/simplest-multiworkspace.png)
+![Simplest multiworkspace](https://github.com/databricks/terraform-provider-databricks/raw/main/docs/simplest-multiworkspace.png)
 
 ## Provider initialization for E2 workspaces
 
@@ -341,8 +341,8 @@ Error: MALFORMED_REQUEST: Failed credentials validation checks: Spot Cancellatio
 
 - Try creating workspace from UI:
 
-![create_workspace_error](https://github.com/databricks/terraform-provider-databricks/raw/master/docs/images/create_workspace_error.png)
+![create_workspace_error](https://github.com/databricks/terraform-provider-databricks/raw/main/docs/images/create_workspace_error.png)
 
 - Verify if the role and policy exist (assume role should allow external ID)
 
-![iam_role_trust_error](https://github.com/databricks/terraform-provider-databricks/raw/master/docs/images/iam_role_trust_error.png)
+![iam_role_trust_error](https://github.com/databricks/terraform-provider-databricks/raw/main/docs/images/iam_role_trust_error.png)

--- a/docs/guides/azure-private-link-workspace-simplified.md
+++ b/docs/guides/azure-private-link-workspace-simplified.md
@@ -19,7 +19,7 @@ This guide covers a [simple deployment](https://learn.microsoft.com/en-us/azure/
 * A separate private endpoint is used for web authentication
 * The same Databricks workspace is used for web authentication traffic. Databricks still strongly recommends creating a separate workspace called a private web auth workspace for each region to host the web auth private network settings.
 
-![Azure Databricks with Private Link - Simple deployment](https://github.com/databricks/terraform-provider-databricks/raw/master/docs/images/azure-private-link-simplified.png)
+![Azure Databricks with Private Link - Simple deployment](https://github.com/databricks/terraform-provider-databricks/raw/main/docs/images/azure-private-link-simplified.png)
 
 This guide uses the following variables:
 

--- a/docs/guides/azure-private-link-workspace-standard.md
+++ b/docs/guides/azure-private-link-workspace-standard.md
@@ -27,7 +27,7 @@ This guide covers a [standard deployment](https://learn.microsoft.com/en-us/azur
 * A separate Web Auth workspace is not mandatory but recommended.
 * DNS mapping for SSO login callbacks to the Azure Databricks web application can be managed by the Web Auth workspace or another workspace associated with the **browser_authentication** private endpoint.
 
-![Azure Databricks with Private Link - Standard deployment](https://github.com/databricks/terraform-provider-databricks/raw/master/docs/images/azure-private-link-standard.png)
+![Azure Databricks with Private Link - Standard deployment](https://github.com/databricks/terraform-provider-databricks/raw/main/docs/images/azure-private-link-standard.png)
 
 This guide uses the following variables:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,57 +7,57 @@ description: Terraform provider for the Databricks Lakehouse platform
 
 # Databricks Provider
 
-Use the Databricks Terraform provider to interact with almost all of [Databricks](http://databricks.com/) resources. If you're new to Databricks, please follow guide to create a workspace on [Azure](guides/azure-workspace.md), [AWS](guides/aws-workspace.md) or [GCP](guides/gcp-workspace.md) and then this [workspace management](guides/workspace-management.md) tutorial.  Take advantage of [Terraform Modules](https://www.terraform.io/docs/modules/index.html) to make your code simpler and reuse [existing modules for Databricks resources](https://registry.terraform.io/search/modules?namespace=databricks).   Changelog is available [on GitHub](https://github.com/databricks/terraform-provider-databricks/blob/master/CHANGELOG.md).
+Use the Databricks Terraform provider to interact with almost all of [Databricks](http://databricks.com/) resources. If you're new to Databricks, please follow guide to create a workspace on [Azure](guides/azure-workspace.md), [AWS](guides/aws-workspace.md) or [GCP](guides/gcp-workspace.md) and then this [workspace management](guides/workspace-management.md) tutorial. Take advantage of [Terraform Modules](https://www.terraform.io/docs/modules/index.html) to make your code simpler and reuse [existing modules for Databricks resources](https://registry.terraform.io/search/modules?namespace=databricks). Changelog is available [on GitHub](https://github.com/databricks/terraform-provider-databricks/blob/main/CHANGELOG.md).
 
-![Resources](https://github.com/databricks/terraform-provider-databricks/raw/master/docs/resources.png)
+![Resources](https://raw.githubusercontent.com/databricks/terraform-provider-databricks/main/docs/resources.png)
 
 Compute resources
 
-* Deploy [databricks_cluster](resources/cluster.md) on selected [databricks_node_type](data-sources/node_type.md)
-* Schedule automated [databricks_job](resources/job.md)
-* Control cost and data access with [databricks_cluster_policy](resources/cluster_policy.md)
-* Speedup job & cluster startup with [databricks_instance_pool](resources/instance_pool.md)
-* Customize clusters with [databricks_global_init_script](resources/global_init_script.md)
-* Manage few [databricks_notebook](resources/notebook.md), and even [list them](data-sources/notebook_paths.md)
-* Manage [databricks_repo](resources/repo.md)
+- Deploy [databricks_cluster](resources/cluster.md) on selected [databricks_node_type](data-sources/node_type.md)
+- Schedule automated [databricks_job](resources/job.md)
+- Control cost and data access with [databricks_cluster_policy](resources/cluster_policy.md)
+- Speedup job & cluster startup with [databricks_instance_pool](resources/instance_pool.md)
+- Customize clusters with [databricks_global_init_script](resources/global_init_script.md)
+- Manage few [databricks_notebook](resources/notebook.md), and even [list them](data-sources/notebook_paths.md)
+- Manage [databricks_repo](resources/repo.md)
 
 Storage
 
-* Manage JAR, Wheel & Egg libraries through [databricks_dbfs_file](resources/dbfs_file.md)
-* List entries on DBFS with [databricks_dbfs_file_paths](data-sources/dbfs_file_paths.md) data source
-* Get contents of small files with [databricks_dbfs_file](data-sources/dbfs_file.md) data source
-* Mount storage with [databricks_mount](resources/mount.md) resource
+- Manage JAR, Wheel & Egg libraries through [databricks_dbfs_file](resources/dbfs_file.md)
+- List entries on DBFS with [databricks_dbfs_file_paths](data-sources/dbfs_file_paths.md) data source
+- Get contents of small files with [databricks_dbfs_file](data-sources/dbfs_file.md) data source
+- Mount storage with [databricks_mount](resources/mount.md) resource
 
 Security
 
-* Organize [databricks_user](resources/user.md) into [databricks_group](resources/group.md) through [databricks_group_member](resources/group_member.md), also reading [metadata](data-sources/group.md)
-* Create [databricks_service_principal](resources/service_principal.md) with [databricks_obo_token](resources/obo_token.md) to enable even more restricted access control.
-* Create [databricks_service_principal](resources/service_principal.md) with [databricks_service_principal_secret](resources/service_principal_secret.md) to authenticate with the service principal OAuth tokens (Only for AWS deployments)
-* Manage data access with [databricks_instance_profile](resources/instance_profile.md), which can be assigned through [databricks_group_instance_profile](resources/group_instance_profile.md) and [databricks_user_instance_profile](resources/user_instance_profile.md)
-* Control which networks can access workspace with [databricks_ip_access_list](resources/ip_access_list.md)
-* Generically manage [databricks_permissions](resources/permissions.md)
-* Manage data object access control lists with [databricks_sql_permissions](resources/sql_permissions.md)
-* Keep sensitive elements like passwords in [databricks_secret](resources/secret.md), grouped into [databricks_secret_scope](resources/secret_scope.md) and controlled by [databricks_secret_acl](resources/secret_acl.md)
+- Organize [databricks_user](resources/user.md) into [databricks_group](resources/group.md) through [databricks_group_member](resources/group_member.md), also reading [metadata](data-sources/group.md)
+- Create [databricks_service_principal](resources/service_principal.md) with [databricks_obo_token](resources/obo_token.md) to enable even more restricted access control.
+- Create [databricks_service_principal](resources/service_principal.md) with [databricks_service_principal_secret](resources/service_principal_secret.md) to authenticate with the service principal OAuth tokens (Only for AWS deployments)
+- Manage data access with [databricks_instance_profile](resources/instance_profile.md), which can be assigned through [databricks_group_instance_profile](resources/group_instance_profile.md) and [databricks_user_instance_profile](resources/user_instance_profile.md)
+- Control which networks can access workspace with [databricks_ip_access_list](resources/ip_access_list.md)
+- Generically manage [databricks_permissions](resources/permissions.md)
+- Manage data object access control lists with [databricks_sql_permissions](resources/sql_permissions.md)
+- Keep sensitive elements like passwords in [databricks_secret](resources/secret.md), grouped into [databricks_secret_scope](resources/secret_scope.md) and controlled by [databricks_secret_acl](resources/secret_acl.md)
 
 [E2 Architecture](../docs/guides/aws-workspace.md)
 
-* Create [workspaces](resources/mws_workspaces.md) in your [VPC](resources/mws_networks.md) with [DBFS](resources/mws_storage_configurations.md) using [cross-account IAM roles](resources/mws_credentials.md), having your notebooks encrypted with [CMK](resources/mws_customer_managed_keys.md).
-* Use predefined AWS IAM Policy Templates: [databricks_aws_assume_role_policy](data-sources/aws_assume_role_policy.md), [databricks_aws_crossaccount_policy](data-sources/aws_crossaccount_policy.md), [databricks_aws_bucket_policy](data-sources/aws_bucket_policy.md)
-* Configure billing and audit [databricks_mws_log_delivery](resources/mws_log_delivery.md)
+- Create [workspaces](resources/mws_workspaces.md) in your [VPC](resources/mws_networks.md) with [DBFS](resources/mws_storage_configurations.md) using [cross-account IAM roles](resources/mws_credentials.md), having your notebooks encrypted with [CMK](resources/mws_customer_managed_keys.md).
+- Use predefined AWS IAM Policy Templates: [databricks_aws_assume_role_policy](data-sources/aws_assume_role_policy.md), [databricks_aws_crossaccount_policy](data-sources/aws_crossaccount_policy.md), [databricks_aws_bucket_policy](data-sources/aws_bucket_policy.md)
+- Configure billing and audit [databricks_mws_log_delivery](resources/mws_log_delivery.md)
 
 Databricks SQL
 
-* Create [databricks_sql_endpoint](resources/sql_endpoint.md) controlled by [databricks_permissions](resources/permissions.md).
-* Manage [queries](resources/sql_query.md) and their [visualizations](resources/sql_visualization.md).
-* Manage [dashboards](resources/sql_dashboard.md) and their [widgets](resources/sql_widget.md).
-* Provide [global configuration for all SQL warehouses](docs/resources/sql_global_config.md)
+- Create [databricks_sql_endpoint](resources/sql_endpoint.md) controlled by [databricks_permissions](resources/permissions.md).
+- Manage [queries](resources/sql_query.md) and their [visualizations](resources/sql_visualization.md).
+- Manage [dashboards](resources/sql_dashboard.md) and their [widgets](resources/sql_widget.md).
+- Provide [global configuration for all SQL warehouses](docs/resources/sql_global_config.md)
 
 Machine Learning
 
-* Create [models in Unity Catalog](resources/registered_model.md).
-* Create [MLflow experiments](resources/mlflow_experiment.md).
-* Create [models in the workspace model registry](resources/mlflow_model.md).
-* Create [model serving endpoints](resources/model_serving.md).
+- Create [models in Unity Catalog](resources/registered_model.md).
+- Create [MLflow experiments](resources/mlflow_experiment.md).
+- Create [models in the workspace model registry](resources/mlflow_model.md).
+- Create [model serving endpoints](resources/model_serving.md).
 
 ## Example Usage
 
@@ -111,7 +111,7 @@ To make Databricks Terraform Provider generally available, we've moved it from [
 You should have [`.terraform.lock.hcl`](https://github.com/databrickslabs/terraform-provider-databricks/blob/v0.6.2/scripts/versions-lock.hcl) file in your state directory that is checked into source control. terraform init will give you the following warning.
 
 ```text
-Warning: Additional provider information from registry 
+Warning: Additional provider information from registry
 
 The remote registry returned warnings for registry.terraform.io/databrickslabs/databricks:
 - For users on Terraform 0.13 or greater, this provider has moved to databricks/databricks. Please update your source in required_providers.
@@ -131,11 +131,11 @@ In case of the problems using Databricks Terraform provider follow the steps out
 
 There are currently a number of supported methods to [authenticate](https://docs.databricks.com/dev-tools/api/latest/authentication.html) into the Databricks platform to create resources:
 
-* [PAT Tokens](#authenticating-with-hostname-and-token)
-* AWS via [Service Principals](#authenticating-with-service-principal)
-* GCP via [Google Cloud CLI](#special-configurations-for-gcp)
-* Azure Active Directory Tokens via [Azure CLI](#authenticating-with-azure-cli), [Service Principals](#authenticating-with-azure-service-principal), or [Managed Service Identities](#authenticating-with-azure-msi)
-* Username and password pair (legacy)
+- [PAT Tokens](#authenticating-with-hostname-and-token)
+- AWS via [Service Principals](#authenticating-with-service-principal)
+- GCP via [Google Cloud CLI](#special-configurations-for-gcp)
+- Azure Active Directory Tokens via [Azure CLI](#authenticating-with-azure-cli), [Service Principals](#authenticating-with-azure-service-principal), or [Managed Service Identities](#authenticating-with-azure-msi)
+- Username and password pair (legacy)
 
 ### Authenticating with Databricks CLI credentials
 
@@ -145,14 +145,14 @@ It is the recommended way to use Databricks Terraform provider, in case you're a
 [AWS Shared Credentials File](https://www.terraform.io/docs/providers/aws/index.html#shared-credentials-file)
 or [Azure CLI authentication](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/azure_cli).
 
-``` hcl
+```hcl
 provider "databricks" {
 }
 ```
 
 You can specify non-standard location of configuration file through `config_file` parameter or `DATABRICKS_CONFIG_FILE` environment variable:
 
-``` hcl
+```hcl
 provider "databricks" {
   config_file = "/opt/databricks/cli-config"
 }
@@ -160,7 +160,7 @@ provider "databricks" {
 
 You can specify a [CLI connection profile](https://docs.databricks.com/dev-tools/cli/index.html#connection-profiles) through `profile` parameter or `DATABRICKS_CONFIG_PROFILE` environment variable:
 
-``` hcl
+```hcl
 provider "databricks" {
   profile = "ML_WORKSPACE"
 }
@@ -170,7 +170,7 @@ provider "databricks" {
 
 You can use `host` and `token` parameters to supply credentials to the workspace. When environment variables are preferred, then you can specify `DATABRICKS_HOST` and `DATABRICKS_TOKEN` instead. Environment variables are the second most recommended way of configuring this provider.
 
-``` hcl
+```hcl
 provider "databricks" {
   host  = "https://abc-cdef-ghi.cloud.databricks.com"
   token = "dapitokenhere"
@@ -183,7 +183,7 @@ provider "databricks" {
 
 You can use the `username` + `password` attributes to authenticate the provider for E2 workspace setup. Respective `DATABRICKS_USERNAME` and `DATABRICKS_PASSWORD` environment variables are applicable as well.
 
-``` hcl
+```hcl
 provider "databricks" {
   host = "https://accounts.cloud.databricks.com"
   username = var.user
@@ -197,16 +197,16 @@ provider "databricks" {
 
 The provider block supports the following arguments:
 
-* `host` - (optional) This is the host of the Databricks workspace. It is a URL that you use to login to your workspace.
-Alternatively, you can provide this value as an environment variable `DATABRICKS_HOST`.
-* `token` - (optional) This is the API token to authenticate into the workspace. Alternatively, you can provide this value as an environment variable `DATABRICKS_TOKEN`.
-* `username` - (optional) This is the username of the user that can log into the workspace. Alternatively, you can provide this value as an environment variable `DATABRICKS_USERNAME`. Recommended only for [creating workspaces in AWS](resources/mws_workspaces.md).
-* `password` - (optional) This is the user's password that can log into the workspace. Alternatively, you can provide this value as an environment variable `DATABRICKS_PASSWORD`. Recommended only for [creating workspaces in AWS](resources/mws_workspaces.md).
-* `config_file` - (optional) Location of the Databricks CLI credentials file created by `databricks configure --token` command (~/.databrickscfg by default). Check [Databricks CLI documentation](https://docs.databricks.com/dev-tools/cli/index.html#set-up-authentication) for more details. The provider uses configuration file credentials when you don't specify host/token/username/password/azure attributes. Alternatively, you can provide this value as an environment variable `DATABRICKS_CONFIG_FILE`. This field defaults to `~/.databrickscfg`.
-* `profile` - (optional) Connection profile specified within ~/.databrickscfg. Please check [connection profiles section](https://docs.databricks.com/dev-tools/cli/index.html#connection-profiles) for more details. This field defaults to
-`DEFAULT`.
-* `account_id` - (optional) Account Id that could be found in the bottom left corner of [Accounts Console](https://accounts.cloud.databricks.com/). Alternatively, you can provide this value as an environment variable `DATABRICKS_ACCOUNT_ID`. Only has effect when `host = "https://accounts.cloud.databricks.com/"`, and is currently used to provision account admins via [databricks_user](resources/user.md). In the future releases of the provider this property will also be used specify account for `databricks_mws_*` resources as well.
-* `auth_type` - (optional) enforce specific auth type to be used in very rare cases, where a single Terraform state manages Databricks workspaces on more than one cloud and `more than one authorization method configured` error is a false positive. Valid values are `pat`, `basic`, `oauth-m2m`, `azure-client-secret`, `azure-msi`, `azure-cli`, `google-credentials`, and `google-id`.
+- `host` - (optional) This is the host of the Databricks workspace. It is a URL that you use to login to your workspace.
+  Alternatively, you can provide this value as an environment variable `DATABRICKS_HOST`.
+- `token` - (optional) This is the API token to authenticate into the workspace. Alternatively, you can provide this value as an environment variable `DATABRICKS_TOKEN`.
+- `username` - (optional) This is the username of the user that can log into the workspace. Alternatively, you can provide this value as an environment variable `DATABRICKS_USERNAME`. Recommended only for [creating workspaces in AWS](resources/mws_workspaces.md).
+- `password` - (optional) This is the user's password that can log into the workspace. Alternatively, you can provide this value as an environment variable `DATABRICKS_PASSWORD`. Recommended only for [creating workspaces in AWS](resources/mws_workspaces.md).
+- `config_file` - (optional) Location of the Databricks CLI credentials file created by `databricks configure --token` command (~/.databrickscfg by default). Check [Databricks CLI documentation](https://docs.databricks.com/dev-tools/cli/index.html#set-up-authentication) for more details. The provider uses configuration file credentials when you don't specify host/token/username/password/azure attributes. Alternatively, you can provide this value as an environment variable `DATABRICKS_CONFIG_FILE`. This field defaults to `~/.databrickscfg`.
+- `profile` - (optional) Connection profile specified within ~/.databrickscfg. Please check [connection profiles section](https://docs.databricks.com/dev-tools/cli/index.html#connection-profiles) for more details. This field defaults to
+  `DEFAULT`.
+- `account_id` - (optional) Account Id that could be found in the bottom left corner of [Accounts Console](https://accounts.cloud.databricks.com/). Alternatively, you can provide this value as an environment variable `DATABRICKS_ACCOUNT_ID`. Only has effect when `host = "https://accounts.cloud.databricks.com/"`, and is currently used to provision account admins via [databricks_user](resources/user.md). In the future releases of the provider this property will also be used specify account for `databricks_mws_*` resources as well.
+- `auth_type` - (optional) enforce specific auth type to be used in very rare cases, where a single Terraform state manages Databricks workspaces on more than one cloud and `more than one authorization method configured` error is a false positive. Valid values are `pat`, `basic`, `oauth-m2m`, `azure-client-secret`, `azure-msi`, `azure-cli`, `google-credentials`, and `google-id`.
 
 ## Special configurations for AWS
 
@@ -214,7 +214,7 @@ Alternatively, you can provide this value as an environment variable `DATABRICKS
 
 You can use the `client_id` + `client_secret` attributes to authenticate with a service principal at both the account and workspace levels. The `client_id` is the `application_id` of the [Service Principal](resources/service_principal.md) and `client_secret` is its secret. You can generate the secret from Databricks Accounts Console (see [instruction](https://docs.databricks.com/dev-tools/authentication-oauth.html#step-2-create-an-oauth-secret-for-a-service-principal)) or by using the Terraform resource [databricks_service_principal_secret](resources/service_principal_secret.md).
 
-``` hcl
+```hcl
 provider "databricks" {
   host          = "https://abc-cdef-ghi.cloud.databricks.com"
   client_id     = var.client_id
@@ -224,7 +224,7 @@ provider "databricks" {
 
 To create resources at both the account and workspace levels, you can create two providers as shown below
 
-``` hcl
+```hcl
 provider "databricks" {
   alias         = "accounts"
   host          = "https://accounts.cloud.databricks.com"
@@ -243,7 +243,7 @@ provider "databricks" {
 
 Next, you can specify the corresponding provider when creating the resource. For example, you can use the workspace provider to create a workspace group
 
-``` hcl
+```hcl
 resource "databricks_group" "cluster_admin" {
   provider                   = databricks.workspace
   display_name               = "cluster_admin"
@@ -252,8 +252,8 @@ resource "databricks_group" "cluster_admin" {
 }
 ```
 
-* `client_id` - The `application_id` of the [Service Principal](resources/service_principal.md). Alternatively, you can provide this value as an environment variable `DATABRICKS_CLIENT_ID`.
-* `client_secret` - Secret of the service principal. Alternatively, you can provide this value as an environment variable `DATABRICKS_CLIENT_SECRET`.
+- `client_id` - The `application_id` of the [Service Principal](resources/service_principal.md). Alternatively, you can provide this value as an environment variable `DATABRICKS_CLIENT_ID`.
+- `client_secret` - Secret of the service principal. Alternatively, you can provide this value as an environment variable `DATABRICKS_CLIENT_SECRET`.
 
 ## Special configurations for Azure
 
@@ -329,13 +329,13 @@ resource "databricks_user" "my-user" {
 }
 ```
 
-* `azure_workspace_resource_id` - (optional) `id` attribute of [azurerm_databricks_workspace](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/databricks_workspace) resource. Combination of subscription id, resource group name, and workspace name. Required with `auzre_use_msi` or `azure_client_secret`.
-* `azure_client_secret` - (optional) This is the Azure Enterprise Application (Service principal) client secret. This service principal requires contributor access to your Azure Databricks deployment. Alternatively, you can provide this value as an environment variable `ARM_CLIENT_SECRET`.
-* `azure_client_id` - (optional) This is the Azure Enterprise Application (Service principal) client id. This service principal requires contributor access to your Azure Databricks deployment. Alternatively, you can provide this value as an environment variable `ARM_CLIENT_ID`.
-* `azure_tenant_id` - (optional) This is the Azure Active Directory Tenant id in which the Enterprise Application (Service Principal)
-resides. Alternatively, you can provide this value as an environment variable `ARM_TENANT_ID`.
-* `azure_environment` - (optional) This is the Azure Environment which defaults to the `public` cloud. Other options are `german`, `china` and `usgovernment`. Alternatively, you can provide this value as an environment variable `ARM_ENVIRONMENT`.
-* `azure_use_msi` - (optional) Use [Azure Managed Service Identity](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/managed_service_identity) authentication. Alternatively, you can provide this value as an environment variable `ARM_USE_MSI`.
+- `azure_workspace_resource_id` - (optional) `id` attribute of [azurerm_databricks_workspace](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/databricks_workspace) resource. Combination of subscription id, resource group name, and workspace name. Required with `auzre_use_msi` or `azure_client_secret`.
+- `azure_client_secret` - (optional) This is the Azure Enterprise Application (Service principal) client secret. This service principal requires contributor access to your Azure Databricks deployment. Alternatively, you can provide this value as an environment variable `ARM_CLIENT_SECRET`.
+- `azure_client_id` - (optional) This is the Azure Enterprise Application (Service principal) client id. This service principal requires contributor access to your Azure Databricks deployment. Alternatively, you can provide this value as an environment variable `ARM_CLIENT_ID`.
+- `azure_tenant_id` - (optional) This is the Azure Active Directory Tenant id in which the Enterprise Application (Service Principal)
+  resides. Alternatively, you can provide this value as an environment variable `ARM_TENANT_ID`.
+- `azure_environment` - (optional) This is the Azure Environment which defaults to the `public` cloud. Other options are `german`, `china` and `usgovernment`. Alternatively, you can provide this value as an environment variable `ARM_ENVIRONMENT`.
+- `azure_use_msi` - (optional) Use [Azure Managed Service Identity](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/managed_service_identity) authentication. Alternatively, you can provide this value as an environment variable `ARM_USE_MSI`.
 
 There are `ARM_*` environment variables provide a way to share authentication configuration using the `databricks` provider alongside the [`azurerm` provider](https://registry.terraform.io/providers/hashicorp/azurerm/latest).
 
@@ -357,11 +357,11 @@ If you are configuring a new Databricks account for the first time, please creat
 
 This section covers configuration parameters not related to authentication. They could be used when debugging problems, or do an additional tuning of provider's behaviour:
 
-* `http_timeout_seconds` - the amount of time Terraform waits for a response from Databricks REST API. Default is *60*.
-* `rate_limit` - defines maximum number of requests per second made to Databricks REST API by Terraform. Default is *15*.
-* `debug_truncate_bytes` - Applicable only when `TF_LOG=DEBUG` is set. Truncate JSON fields in HTTP requests and responses above this limit. Default is *96*.
-* `debug_headers` - Applicable only when `TF_LOG=DEBUG` is set. Debug HTTP headers of requests made by the provider. Default is *false*. We recommend turning this flag on only under exceptional circumstances, when troubleshooting authentication issues. Turning this flag on will log first `debug_truncate_bytes` of any HTTP header value in cleartext.
-* `skip_verify` - skips SSL certificate verification for HTTP calls. *Use at your own risk.* Default is *false* (don't skip verification).
+- `http_timeout_seconds` - the amount of time Terraform waits for a response from Databricks REST API. Default is _60_.
+- `rate_limit` - defines maximum number of requests per second made to Databricks REST API by Terraform. Default is _15_.
+- `debug_truncate_bytes` - Applicable only when `TF_LOG=DEBUG` is set. Truncate JSON fields in HTTP requests and responses above this limit. Default is _96_.
+- `debug_headers` - Applicable only when `TF_LOG=DEBUG` is set. Debug HTTP headers of requests made by the provider. Default is _false_. We recommend turning this flag on only under exceptional circumstances, when troubleshooting authentication issues. Turning this flag on will log first `debug_truncate_bytes` of any HTTP header value in cleartext.
+- `skip_verify` - skips SSL certificate verification for HTTP calls. _Use at your own risk._ Default is _false_ (don't skip verification).
 
 ## Environment variables
 
@@ -389,7 +389,7 @@ The following configuration attributes can be passed via environment variables:
 |      `google_service_account` | `GOOGLE_SERVICE_ACCOUNT`          |
 |        `debug_truncate_bytes` | `DATABRICKS_DEBUG_TRUNCATE_BYTES` |
 |               `debug_headers` | `DATABRICKS_DEBUG_HEADERS`        |
-|               `rate_limit`    | `DATABRICKS_RATE_LIMIT`           |
+|                  `rate_limit` | `DATABRICKS_RATE_LIMIT`           |
 
 ## Empty provider block
 

--- a/docs/resources/mws_workspaces.md
+++ b/docs/resources/mws_workspaces.md
@@ -22,7 +22,7 @@ This resource allows you to set up [workspaces in E2 architecture on AWS](https:
 
 ### Creating a Databricks on AWS workspace
 
-![Simplest multiworkspace](https://github.com/databricks/terraform-provider-databricks/raw/master/docs/simplest-multiworkspace.png)
+![Simplest multiworkspace](https://github.com/databricks/terraform-provider-databricks/raw/main/docs/simplest-multiworkspace.png)
 
 To get workspace running, you have to configure a couple of things:
 

--- a/docs/resources/permissions.md
+++ b/docs/resources/permissions.md
@@ -8,7 +8,7 @@ This resource allows you to generically manage [access control](https://docs.dat
 
 -> **Note** Configuring this resource for an object will **OVERWRITE** any existing permissions of the same type unless imported, and changes made outside of Terraform will be reset unless the changes are also reflected in the configuration.
 
--> **Note** It is not possible to lower permissions for `admins` or your own user anywhere from `CAN_MANAGE` level, so Databricks Terraform Provider [removes](https://github.com/databricks/terraform-provider-databricks/blob/master/access/resource_permissions.go#L261-L271) those `access_control` blocks automatically.
+-> **Note** It is not possible to lower permissions for `admins` or your own user anywhere from `CAN_MANAGE` level, so Databricks Terraform Provider [removes](https://github.com/databricks/terraform-provider-databricks/blob/main/access/resource_permissions.go#L261-L271) those `access_control` blocks automatically.
 
 -> **Note** If multiple permission levels are specified for an identity (e.g. `CAN_RESTART` and `CAN_MANAGE` for a cluster), only the highest level permission is returned and will cause permanent drift.
 
@@ -801,7 +801,7 @@ access_control {
 
 Arguments for the `access_control` block are:
 
--> **Note** It is not possible to lower permissions for `admins` or your own user anywhere from `CAN_MANAGE` level, so Databricks Terraform Provider [removes](https://github.com/databricks/terraform-provider-databricks/blob/master/access/resource_permissions.go#L261-L271) those `access_control` blocks automatically.
+-> **Note** It is not possible to lower permissions for `admins` or your own user anywhere from `CAN_MANAGE` level, so Databricks Terraform Provider [removes](https://github.com/databricks/terraform-provider-databricks/blob/main/access/resource_permissions.go#L261-L271) those `access_control` blocks automatically.
 
 - `permission_level` - (Required) permission level according to specific resource. See examples above for the reference.
 


### PR DESCRIPTION
## Changes
Currently, `main` and `master` point to the same commit. This PR rewrites all references to branch `master` to `main` in the `main` branch. Once this is merged, I will change the default branch in the TF repo from master to main.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

