### PR TITLE
Modify github issue template to identify regressions faster

### DIFF
--- a/.github/ISSUE_TEMPLATE/provider-issue.md
+++ b/.github/ISSUE_TEMPLATE/provider-issue.md
@@ -11,6 +11,7 @@ Thank you for opening an issue. Please note that we try to keep the Databricks P
 -->
 
 ### Configuration
+<!-- Please provide a minimal reproducible configuration for the issue -->
 ```hcl
 # Copy-paste your Terraform configuration here
 ```
@@ -27,6 +28,9 @@ Thank you for opening an issue. Please note that we try to keep the Databricks P
 
 ### Terraform and provider versions
 <!-- Please paste the output of `terraform version`. If version of `databricks` provider is not the latest (https://github.com/databricks/terraform-provider-databricks/releases), please make sure to use the latest one. -->
+
+### Is it a regression?
+<!-- Did this work in a previous version of the provider? If so, which versions did you try? -->
 
 ### Debug Output
 <!-- Please add turn on logging, e.g. `TF_LOG=DEBUG terraform apply -no-color` and run command again, paste it to gist & provide the link to gist. If you're still willing to paste in log output, make sure you provide only relevant log lines with requests. It would make it more readable, if you pipe the log through `| grep databricks | sed -E 's/^.* plugin[^:]+: (.*)$/\1/'`, e.g.: `TF_LOG=DEBUG terraform apply -no-color 2>&1 | grep databricks | sed -E 's/^.* plugin[^:]+: (.*)$/\1/' 2>&1 |tee tf-debug.log`. If Terraform produced a panic, please provide a link to a GitHub Gist containing the output of the `crash.log`. -->


### PR DESCRIPTION
## Changes
Changes issue template, allows us to:
1. Potentially cut down on time to reproduction.
2. Identiy regressions early.

