### PR TITLE
Exporter: don't omit `display_name` in `databricks_user` if it's not equal to `user_name`

### DIFF
--- a/exporter/importables.go
+++ b/exporter/importables.go
@@ -858,6 +858,14 @@ var resourcesMap map[string]importable = map[string]importable{
 			ic.emitRoles("user", u.ID, u.Roles)
 			return nil
 		},
+		ShouldOmitField: func(ic *importContext, pathString string, as *schema.Schema, d *schema.ResourceData) bool {
+			if pathString == "display_name" {
+				userName := d.Get("user_name").(string)
+				displayName := d.Get("display_name").(string)
+				return displayName == "" || userName == displayName
+			}
+			return defaultShouldOmitFieldFunc(ic, pathString, as, d)
+		},
 	},
 	"databricks_service_principal": {
 		Service:        "users",

--- a/exporter/importables_test.go
+++ b/exporter/importables_test.go
@@ -575,6 +575,21 @@ func TestSpnSearchSuccess(t *testing.T) {
 	})
 }
 
+func TestShouldOmitForUsers(t *testing.T) {
+	d := scim.ResourceUser().TestResourceData()
+	d.SetId("user1")
+	d.Set("user_name", "user@domain.com")
+	d.Set("display_name", "")
+	assert.True(t, resourcesMap["databricks_user"].ShouldOmitField(nil, "display_name",
+		scim.ResourceUser().Schema["application_id"], d))
+	d.Set("display_name", "user@domain.com")
+	assert.True(t, resourcesMap["databricks_user"].ShouldOmitField(nil, "display_name",
+		scim.ResourceUser().Schema["application_id"], d))
+	d.Set("display_name", "Some user")
+	assert.False(t, resourcesMap["databricks_user"].ShouldOmitField(nil, "display_name",
+		scim.ResourceUser().Schema["application_id"], d))
+}
+
 func TestUserImportSkipNonDirectGroups(t *testing.T) {
 	qa.HTTPFixturesApply(t, []qa.HTTPFixture{
 		{


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

It wasn't put into the generated code because `display_name` is marked as `computed` and we didn't have a dedicated `ShouldOmitField` function in `databricks_user` definition.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

