### PR TITLE
Add NumWorkers to ForceSendFields in `databricks_pipeline` if `spark_conf` contains config for single-node cluster

### DIFF
--- a/pipelines/resource_pipeline.go
+++ b/pipelines/resource_pipeline.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/databricks/databricks-sdk-go/apierr"
+	"github.com/databricks/databricks-sdk-go/marshal"
 	"github.com/databricks/terraform-provider-databricks/clusters"
 	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/databricks/terraform-provider-databricks/libraries"
@@ -57,6 +58,16 @@ type pipelineCluster struct {
 	SSHPublicKeys  []string                         `json:"ssh_public_keys,omitempty" tf:"max_items:10"`
 	InitScripts    []clusters.InitScriptStorageInfo `json:"init_scripts,omitempty" tf:"max_items:10"` // TODO: tf:alias
 	ClusterLogConf *clusters.StorageInfo            `json:"cluster_log_conf,omitempty"`
+
+	ForceSendFields []string `json:"-"`
+}
+
+func (s *pipelineCluster) UnmarshalJSON(b []byte) error {
+	return marshal.Unmarshal(b, s)
+}
+
+func (s pipelineCluster) MarshalJSON() ([]byte, error) {
+	return marshal.Marshal(s)
 }
 
 type NotebookLibrary struct {
@@ -179,6 +190,8 @@ func NewPipelinesAPI(ctx context.Context, m any) PipelinesAPI {
 }
 
 func (a PipelinesAPI) Create(s PipelineSpec, timeout time.Duration) (string, error) {
+	adjustForceSendFields(&s)
+
 	var resp createPipelineResponse
 	err := a.client.Post(a.ctx, "/pipelines", s, &resp)
 	if err != nil {
@@ -199,12 +212,22 @@ func (a PipelinesAPI) Create(s PipelineSpec, timeout time.Duration) (string, err
 	return id, nil
 }
 
+func adjustForceSendFields(s *PipelineSpec) {
+	for i := range s.Clusters {
+		cluster := &s.Clusters[i]
+		if cluster.Autoscale == nil {
+			cluster.ForceSendFields = append(cluster.ForceSendFields, "NumWorkers")
+		}
+	}
+}
+
 func (a PipelinesAPI) Read(id string) (p PipelineInfo, err error) {
 	err = a.client.Get(a.ctx, "/pipelines/"+id, nil, &p)
 	return
 }
 
 func (a PipelinesAPI) Update(id string, s PipelineSpec, timeout time.Duration) error {
+	adjustForceSendFields(&s)
 	err := a.client.Put(a.ctx, "/pipelines/"+id, s)
 	if err != nil {
 		return err

--- a/pipelines/resource_pipeline.go
+++ b/pipelines/resource_pipeline.go
@@ -215,7 +215,7 @@ func (a PipelinesAPI) Create(s PipelineSpec, timeout time.Duration) (string, err
 func adjustForceSendFields(s *PipelineSpec) {
 	for i := range s.Clusters {
 		cluster := &s.Clusters[i]
-		if cluster.Autoscale == nil {
+		if cluster.SparkConf["spark.databricks.cluster.profile"] == "singleNode" {
 			cluster.ForceSendFields = append(cluster.ForceSendFields, "NumWorkers")
 		}
 	}

--- a/pipelines/resource_pipeline.go
+++ b/pipelines/resource_pipeline.go
@@ -215,6 +215,11 @@ func (a PipelinesAPI) Create(s PipelineSpec, timeout time.Duration) (string, err
 func adjustForceSendFields(s *PipelineSpec) {
 	for i := range s.Clusters {
 		cluster := &s.Clusters[i]
+		// TF Go SDK doesn't differentiate between the default and not set values.
+		// If nothing is specified, DLT creates a cluster with enhanced autoscaling
+		// from 1 to 5 nodes, which is different than sending a request for zero workers.
+		// The solution here is to look for the Spark configuration to determine
+		// if the user only wants a single node cluster (only master, no workers).
 		if cluster.SparkConf["spark.databricks.cluster.profile"] == "singleNode" {
 			cluster.ForceSendFields = append(cluster.ForceSendFields, "NumWorkers")
 		}

--- a/pipelines/resource_pipeline_test.go
+++ b/pipelines/resource_pipeline_test.go
@@ -698,3 +698,122 @@ func TestResourcePipelineCreateServerless(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "serverless", d.Id())
 }
+
+func TestZeroWorkers(t *testing.T) {
+	d, err := qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "POST",
+				Resource: "/api/2.0/pipelines",
+				ExpectedRequest: PipelineSpec{
+					Name:    "test-pipeline",
+					Channel: "CURRENT",
+					Edition: "ADVANCED",
+					Clusters: []pipelineCluster{
+						{
+							Label: "default",
+
+							NumWorkers:      0,
+							ForceSendFields: []string{"NumWorkers"},
+						},
+					},
+				},
+				Response: createPipelineResponse{
+					PipelineID: "abcd",
+				},
+			},
+			{
+				Method:   "GET",
+				Resource: "/api/2.0/pipelines/abcd",
+				Response: map[string]any{
+					"id":    "abcd",
+					"name":  "test-pipeline",
+					"state": "RUNNING",
+					"spec":  basicPipelineSpec,
+				},
+			},
+			{
+				Method:   "GET",
+				Resource: "/api/2.0/pipelines/abcd",
+				Response: map[string]any{
+					"id":    "abcd",
+					"name":  "test-pipeline",
+					"state": "RUNNING",
+					"spec":  basicPipelineSpec,
+				},
+			},
+		},
+		Create:   true,
+		Resource: ResourcePipeline(),
+		HCL: `name = "test-pipeline"
+		cluster {
+		  label = "default"
+		  num_workers = 0
+		}
+		`,
+	}.Apply(t)
+	assert.NoError(t, err)
+	assert.Equal(t, "abcd", d.Id())
+}
+
+func TestAutoscaling(t *testing.T) {
+	d, err := qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "POST",
+				Resource: "/api/2.0/pipelines",
+				ExpectedRequest: PipelineSpec{
+					Name:    "test-pipeline",
+					Channel: "CURRENT",
+					Edition: "ADVANCED",
+					Clusters: []pipelineCluster{
+						{
+							Label: "default",
+
+							Autoscale: &dltAutoScale{
+								MinWorkers: 2,
+								MaxWorkers: 10,
+							},
+						},
+					},
+				},
+				Response: createPipelineResponse{
+					PipelineID: "abcd",
+				},
+			},
+			{
+				Method:   "GET",
+				Resource: "/api/2.0/pipelines/abcd",
+				Response: map[string]any{
+					"id":    "abcd",
+					"name":  "test-pipeline",
+					"state": "RUNNING",
+					"spec":  basicPipelineSpec,
+				},
+			},
+			{
+				Method:   "GET",
+				Resource: "/api/2.0/pipelines/abcd",
+				Response: map[string]any{
+					"id":    "abcd",
+					"name":  "test-pipeline",
+					"state": "RUNNING",
+					"spec":  basicPipelineSpec,
+				},
+			},
+		},
+		Create:   true,
+		Resource: ResourcePipeline(),
+		HCL: `name = "test-pipeline"
+		cluster {
+		  label = "default"
+		  autoscale {
+			min_workers = 2
+			max_workers = 10
+		  }
+		}
+		`,
+	}.Apply(t)
+	assert.NoError(t, err)
+	assert.Equal(t, "abcd", d.Id())
+}


### PR DESCRIPTION
## Changes
Add NumWorkers to ForceSendFields in Pipelines if AutoScaling is null

This fixes #1875

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [X] `make test` run locally
- [X] relevant change in `docs/` folder
- [x] covered with integration tests in `internal/acceptance`
- [X] relevant acceptance tests are passing
- [ ] using Go SDK

