### PR TITLE
Fix Read method of the `databricks_mlflow_model` resource

### DIFF
--- a/mlflow/resource_mlflow_model.go
+++ b/mlflow/resource_mlflow_model.go
@@ -10,14 +10,9 @@ import (
 
 func ResourceMlflowModel() *schema.Resource {
 	s := common.StructToSchema(
-		ml.Model{},
+		ml.CreateModelRequest{},
 		func(s map[string]*schema.Schema) map[string]*schema.Schema {
-			delete(s, "latest_versions")
-			s["name"] = &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			}
+			s["name"].ForceNew = true
 			s["registered_model_id"] = &schema.Schema{
 				Computed: true,
 				Type:     schema.TypeString,
@@ -37,13 +32,7 @@ func ResourceMlflowModel() *schema.Resource {
 			if err != nil {
 				return err
 			}
-			model, err := w.ModelRegistry.GetModel(ctx, ml.GetModelRequest{
-				Name: res.RegisteredModel.Name,
-			})
-			if err != nil {
-				return err
-			}
-			d.SetId(model.RegisteredModelDatabricks.Name)
+			d.SetId(res.RegisteredModel.Name)
 			return nil
 		},
 		Read: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
@@ -58,7 +47,7 @@ func ResourceMlflowModel() *schema.Resource {
 			if err != nil {
 				return err
 			}
-			err = common.StructToData(res, s, d)
+			err = common.StructToData(res.RegisteredModelDatabricks, s, d)
 			if err != nil {
 				return err
 			}

--- a/mlflow/resource_mlflow_model_test.go
+++ b/mlflow/resource_mlflow_model_test.go
@@ -1,6 +1,7 @@
 package mlflow
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/databricks/databricks-sdk-go/service/ml"
@@ -205,6 +206,7 @@ func TestModelReadGetError(t *testing.T) {
 func TestModelUpdate(t *testing.T) {
 	pm := m()
 	pm.Description = "thedescription"
+	newDescription := "updatedddescription"
 	d, err := qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
 			{
@@ -218,7 +220,7 @@ func TestModelUpdate(t *testing.T) {
 				Response: ml.GetModelResponse{
 					RegisteredModelDatabricks: &ml.ModelDatabricks{
 						Name:        "xyz",
-						Description: "updatedddescription",
+						Description: newDescription,
 					},
 				},
 			},
@@ -230,15 +232,15 @@ func TestModelUpdate(t *testing.T) {
 		State: map[string]any{
 			"name": "xyz",
 		},
-		HCL: `
+		HCL: fmt.Sprintf(`
 		name = "xyz"
-		description = "updateddescription"
-		`,
+		description = "%s"
+		`, newDescription),
 	}.Apply(t)
 
 	assert.NoError(t, err)
 	assert.Equal(t, "xyz", d.Id(), "Resource ID should not be empty")
-	assert.Equal(t, "updateddescription", d.Get("description"), "Description should be updated")
+	assert.Equal(t, newDescription, d.Get("description"), "Description should be updated")
 }
 
 func TestModelUpdatePatchError(t *testing.T) {


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

`StructToData` did use wrong structure to deserialize data, so struct was empty after read. Also, changed to use `CreateModelRequest` as a base struct because we don't use all fields of the `Model` anyway.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [x] relevant acceptance tests are passing
- [ ] using Go SDK

