### PR TITLE
Exporter: disable generation of empty or default blocks for `databricks_job` and `databricks_cluster`

### DIFF
--- a/exporter/importables.go
+++ b/exporter/importables.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"reflect"
 	"regexp"
 	"sort"
 	"strconv"
@@ -15,6 +16,7 @@ import (
 
 	"github.com/databricks/databricks-sdk-go/service/compute"
 	"github.com/databricks/databricks-sdk-go/service/iam"
+	sdk_jobs "github.com/databricks/databricks-sdk-go/service/jobs"
 	"github.com/databricks/databricks-sdk-go/service/ml"
 	"github.com/databricks/databricks-sdk-go/service/settings"
 	"github.com/databricks/terraform-provider-databricks/clusters"
@@ -560,6 +562,44 @@ var resourcesMap map[string]importable = map[string]importable{
 			switch pathString {
 			case "url", "format":
 				return true
+			}
+			var js jobs.JobSettings
+			common.DataToStructPointer(d, ic.Resources["databricks_job"].Schema, &js)
+			switch pathString {
+			case "email_notifications":
+				if js.EmailNotifications != nil {
+					return reflect.DeepEqual(*js.EmailNotifications, jobs.EmailNotifications{})
+				}
+			case "webhook_notifications":
+				if js.WebhookNotifications != nil {
+					return reflect.DeepEqual(*js.WebhookNotifications, jobs.WebhookNotifications{})
+				}
+			case "notification_settings":
+				if js.NotificationSettings != nil {
+					return reflect.DeepEqual(*js.NotificationSettings, sdk_jobs.JobNotificationSettings{})
+				}
+			}
+			if strings.HasPrefix(pathString, "task.") {
+				parts := strings.Split(pathString, ".")
+				if len(parts) > 2 {
+					taskIndex, err := strconv.Atoi(parts[1])
+					if err == nil && taskIndex >= 0 && taskIndex < len(js.Tasks) {
+						blockName := parts[len(parts)-1]
+						switch blockName {
+						case "notification_settings":
+							if js.Tasks[taskIndex].NotificationSettings != nil {
+								return reflect.DeepEqual(*js.Tasks[taskIndex].NotificationSettings, sdk_jobs.TaskNotificationSettings{})
+							}
+						case "email_notifications":
+							if js.Tasks[taskIndex].EmailNotifications != nil {
+								return reflect.DeepEqual(*js.Tasks[taskIndex].EmailNotifications, jobs.EmailNotifications{})
+							}
+						}
+					}
+				}
+				if strings.HasSuffix(pathString, ".notebook_task.0.source") && d.Get(pathString).(string) == "WORKSPACE" {
+					return true
+				}
 			}
 			if res := jobClustersRegex.FindStringSubmatch(pathString); res != nil { // analyze job clusters
 				return makeShouldOmitFieldForCluster(jobClustersRegex)(ic, pathString, as, d)

--- a/exporter/util.go
+++ b/exporter/util.go
@@ -627,6 +627,10 @@ func makeShouldOmitFieldForCluster(regex *regexp.Regexp) func(ic *importContext,
 			return workerInstPoolID != ""
 		case prefix + "enable_local_disk_encryption":
 			return false
+		case prefix + "spark_conf":
+			return fmt.Sprintf("%v", d.Get(prefix+"spark_conf")) == "map[spark.databricks.delta.preview.enabled:true]"
+		case prefix + "spark_env_vars":
+			return fmt.Sprintf("%v", d.Get(prefix+"spark_env_vars")) == "map[PYSPARK_PYTHON:/databricks/python3/bin/python3]"
 		}
 
 		return defaultShouldOmitFieldFunc(ic, pathString, as, d)


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

* Disable generation of empty blocks for `email_notifications`, `webhook_notifications`, and `notification_settings` in `databricks_job`
* Don't produce `spark_conf` & `spark_env_vars` in clusters if they are default values produced by the REST API backend

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] tested manually
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

