### PR TITLE
Exporter: fix emitting of group membership

### DIFF
--- a/exporter/context.go
+++ b/exporter/context.go
@@ -138,8 +138,6 @@ type mount struct {
 var nameFixes = []regexFix{
 	{regexp.MustCompile(`[0-9a-f]{8}[_-][0-9a-f]{4}[_-][0-9a-f]{4}` +
 		`[_-][0-9a-f]{4}[_-][0-9a-f]{12}[_-]`), ""},
-	//	{regexp.MustCompile(`[_-][0-9]+[\._-][0-9]+[\._-].*\.([a-z0-9]{1,4})`), "_$1"},
-	// {regexp.MustCompile(`@.*$`), ""},
 	{regexp.MustCompile(`[-\s\.\|]`), "_"},
 	{regexp.MustCompile(`\W+`), "_"},
 	{regexp.MustCompile(`[_]{2,}`), "_"},

--- a/exporter/importables.go
+++ b/exporter/importables.go
@@ -623,7 +623,7 @@ var resourcesMap map[string]importable = map[string]importable{
 				return err
 			}
 			for offset, policy := range policies {
-				log.Printf("[INFO] Scanning %d:  %v", offset+1, policy)
+				log.Printf("[TRACE] Scanning %d:  %v", offset+1, policy)
 				if slices.Contains(predefinedClusterPolicies, policy.Name) {
 					continue
 				}
@@ -890,11 +890,7 @@ var resourcesMap map[string]importable = map[string]importable{
 			if err != nil {
 				return err
 			}
-			userName := u.DisplayName
-			if userName == "" {
-				userName = u.UserName
-			}
-			ic.emitGroups(u, userName)
+			ic.emitGroups(u)
 			ic.emitRoles("user", u.ID, u.Roles)
 			return nil
 		},
@@ -944,11 +940,7 @@ var resourcesMap map[string]importable = map[string]importable{
 			if err != nil {
 				return err
 			}
-			spnName := u.DisplayName
-			if spnName == "" {
-				spnName = u.ApplicationID
-			}
-			ic.emitGroups(u, spnName)
+			ic.emitGroups(u)
 			ic.emitRoles("service_principal", u.ID, u.Roles)
 			if ic.accountLevel {
 				ic.Emit(&resource{

--- a/exporter/util.go
+++ b/exporter/util.go
@@ -197,10 +197,10 @@ func (ic *importContext) getAllWorkspaceObjects() []workspace.ObjectStatus {
 	return ic.allWorkspaceObjects
 }
 
-func (ic *importContext) emitGroups(u scim.User, principal string) {
+func (ic *importContext) emitGroups(u scim.User) {
 	for _, g := range u.Groups {
 		if g.Type != "direct" {
-			log.Printf("[DEBUG] Skipping non-direct group %s/%s for %s", g.Value, g.Display, principal)
+			log.Printf("[DEBUG] Skipping non-direct group %s/%s for %s", g.Value, g.Display, u.DisplayName)
 			continue
 		}
 		ic.Emit(&resource{
@@ -210,7 +210,7 @@ func (ic *importContext) emitGroups(u scim.User, principal string) {
 		ic.Emit(&resource{
 			Resource: "databricks_group_member",
 			ID:       fmt.Sprintf("%s|%s", g.Value, u.ID),
-			Name:     fmt.Sprintf("%s_%s_%s", g.Display, g.Value, principal),
+			Name:     fmt.Sprintf("%s_%s_%s_%s", g.Display, g.Value, u.DisplayName, u.ID),
 		})
 	}
 }


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

There was an inconsistency in emitting the `databricks_group_member` - depending on where it was emitted - from a group, or from a user/service principal, the generated name was either with user/SP ID or without.  This behavior was always there, but it wasn't visible until we started to do a parallel processing of resources.

This PR fixes this behavior, and group membership is consistent now.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

