### PR TITLE
Fix `Update` method of `databricks_user` to prevent removal of groups

### DIFF
--- a/scim/resource_user.go
+++ b/scim/resource_user.go
@@ -110,7 +110,7 @@ func ResourceUser() *schema.Resource {
 			if err != nil {
 				return err
 			}
-			return NewUsersAPI(ctx, c).Update(d.Id(), "userName,displayName,active,externalId,entitlements", u)
+			return NewUsersAPI(ctx, c).Update(d.Id(), u)
 		},
 		Delete: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
 			user := NewUsersAPI(ctx, c)
@@ -181,5 +181,5 @@ func createForceOverridesManuallyAddedUser(err error, d *schema.ResourceData, us
 	}
 	user := userList[0]
 	d.SetId(user.ID)
-	return usersAPI.Update(d.Id(), "userName,displayName,active,externalId,entitlements", u)
+	return usersAPI.Update(d.Id(), u)
 }

--- a/scim/resource_user_test.go
+++ b/scim/resource_user_test.go
@@ -272,7 +272,7 @@ func TestResourceUserUpdate(t *testing.T) {
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   "GET",
-				Resource: "/api/2.0/preview/scim/v2/Users/abc?attributes=userName,displayName,active,externalId,entitlements",
+				Resource: "/api/2.0/preview/scim/v2/Users/abc?attributes=groups,roles",
 				Response: User{
 					DisplayName: "Example user",
 					Active:      true,
@@ -659,7 +659,7 @@ func TestCreateForceOverwriteFindsAndSetsID(t *testing.T) {
 		},
 		{
 			Method:   "GET",
-			Resource: "/api/2.0/preview/scim/v2/Users/abc?attributes=userName,displayName,active,externalId,entitlements",
+			Resource: "/api/2.0/preview/scim/v2/Users/abc?attributes=groups,roles",
 			Response: User{
 				ID: "abc",
 			},
@@ -701,7 +701,7 @@ func TestCreateForceOverwriteFindsAndSetsAccID(t *testing.T) {
 		},
 		{
 			Method:   "GET",
-			Resource: "/api/2.0/preview/scim/v2/Users/abc?attributes=userName,displayName,active,externalId,entitlements",
+			Resource: "/api/2.0/preview/scim/v2/Users/abc?attributes=groups,roles",
 			Response: User{
 				ID: "abc",
 			},

--- a/scim/users.go
+++ b/scim/users.go
@@ -66,8 +66,8 @@ func (a UsersAPI) readByPath(userPath string) (user User, err error) {
 }
 
 // Update replaces user information for given ID
-func (a UsersAPI) Update(userID, attributes string, updateRequest User) error {
-	user, err := a.Read(userID, attributes)
+func (a UsersAPI) Update(userID string, updateRequest User) error {
+	user, err := a.Read(userID, "groups,roles")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The `Update` method wasn't reading the correct set of attributes when updating user (i.e. when having `force = true`) - this lead that groups were reset to empty state, and users were losing their groups association.

This fixes #2648 and #1639

## Changes
<!-- Summary of your changes that are easy to understand -->

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [x] relevant acceptance tests are passing
- [ ] using Go SDK

