### PR TITLE
allow creating single node pools

### DIFF
--- a/clusters/clusters_api.go
+++ b/clusters/clusters_api.go
@@ -444,6 +444,9 @@ func (cluster Cluster) Validate() error {
 	if profile == "singleNode" && strings.HasPrefix(master, "local") && resourceClass == "SingleNode" {
 		return nil
 	}
+	if cluster.InstancePoolID != "" && strings.HasPrefix(master, "local") {
+		return nil
+	}
 	return fmt.Errorf("NumWorkers could be 0 only for SingleNode clusters. See https://docs.databricks.com/clusters/single-node.html for more details")
 }
 

--- a/clusters/resource_cluster_test.go
+++ b/clusters/resource_cluster_test.go
@@ -1483,6 +1483,85 @@ func TestResourceClusterCreate_SingleNode(t *testing.T) {
 	assert.Equal(t, 0, d.Get("num_workers"))
 }
 
+func TestResourceClusterCreate_SingleNodePool(t *testing.T) {
+	d, err := qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "POST",
+				Resource: "/api/2.0/clusters/create",
+				ExpectedRequest: Cluster{
+					AutoterminationMinutes: 60,
+					NumWorkers:             0,
+					ClusterName:            "Single Node Cluster Pool",
+					SparkVersion:           "7.3.x-scala12",
+					InstancePoolID:         "Standard_F4s",
+					SparkConf: map[string]string{
+						"spark.master": "local[*]",
+					},
+				},
+				Response: ClusterInfo{
+					ClusterID: "abc",
+					State:     ClusterStateRunning,
+				},
+			},
+			{
+				Method:   "POST",
+				Resource: "/api/2.0/clusters/events",
+				ExpectedRequest: EventsRequest{
+					ClusterID:  "abc",
+					Limit:      1,
+					Order:      SortDescending,
+					EventTypes: []ClusterEventType{EvTypePinned, EvTypeUnpinned},
+				},
+				Response: EventsResponse{
+					Events:     []ClusterEvent{},
+					TotalCount: 0,
+				},
+			},
+			{
+				Method:       "GET",
+				ReuseRequest: true,
+				Resource:     "/api/2.0/clusters/get?cluster_id=abc",
+				Response: ClusterInfo{
+					ClusterID:              "abc",
+					ClusterName:            "Single Node Cluster",
+					SparkVersion:           "7.3.x-scala12",
+					NodeTypeID:             "Standard_F4s",
+					AutoterminationMinutes: 120,
+					State:                  ClusterStateRunning,
+					SparkConf: map[string]string{
+						"spark.master":                     "local[*]",
+						"spark.databricks.cluster.profile": "singleNode",
+					},
+					CustomTags: map[string]string{
+						"ResourceClass": "SingleNode",
+					},
+				},
+			},
+			{
+				Method:   "GET",
+				Resource: "/api/2.0/libraries/cluster-status?cluster_id=abc",
+				Response: libraries.ClusterLibraryStatuses{
+					LibraryStatuses: []libraries.LibraryStatus{},
+				},
+			},
+		},
+		Create:   true,
+		Resource: ResourceCluster(),
+		State: map[string]any{
+			"cluster_name":     "Single Node Cluster Pool",
+			"spark_version":    "7.3.x-scala12",
+			"instance_pool_id": "Standard_F4s",
+			"is_pinned":        false,
+			"spark_conf": map[string]any{
+				"spark.master": "local[*]",
+			},
+		},
+	}.Apply(t)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, d.Get("num_workers"))
+}
+
 func TestResourceClusterCreate_SingleNodeFail(t *testing.T) {
 	_, err := qa.ResourceFixture{
 		Create:   true,

--- a/internal/acceptance/cluster_test.go
+++ b/internal/acceptance/cluster_test.go
@@ -48,7 +48,7 @@ func TestAccClusterResource_CreateClusterWithLibraries(t *testing.T) {
 	})
 }
 
-func TestAccClusterResource_CreateSingleNodeCluster(t *testing.T) {
+func TestAccClusterResource_CreateSingleNodePoolCluster(t *testing.T) {
 	workspaceLevel(t, step{
 		Template: `
 		data "databricks_spark_version" "latest" {
@@ -57,6 +57,24 @@ func TestAccClusterResource_CreateSingleNodeCluster(t *testing.T) {
 			cluster_name = "singlenode-{var.RANDOM}"
 			spark_version = data.databricks_spark_version.latest.id
 			instance_pool_id = "{env.TEST_INSTANCE_POOL_ID}"
+			num_workers = 0
+			autotermination_minutes = 10
+			spark_conf = {
+				"spark.master" = "local[*]"
+			}
+		}`,
+	})
+}
+
+func TestAccClusterResource_CreateSingleNodeCluster(t *testing.T) {
+	workspaceLevel(t, step{
+		Template: `
+		data "databricks_spark_version" "latest" {
+		}
+		resource "databricks_cluster" "this" {
+			cluster_name = "singlenode-{var.RANDOM}"
+			spark_version = data.databricks_spark_version.latest.id
+			node_type_id = "{env.TEST_INSTANCE_POOL_ID}"
 			num_workers = 0
 			autotermination_minutes = 10
 			spark_conf = {

--- a/internal/acceptance/cluster_test.go
+++ b/internal/acceptance/cluster_test.go
@@ -71,10 +71,13 @@ func TestAccClusterResource_CreateSingleNodeCluster(t *testing.T) {
 		Template: `
 		data "databricks_spark_version" "latest" {
 		}
+                 data "databricks_node_type" "smallest" {
+                     local_disk = true
+                 }
 		resource "databricks_cluster" "this" {
 			cluster_name = "singlenode-{var.RANDOM}"
 			spark_version = data.databricks_spark_version.latest.id
-			node_type_id = "{env.TEST_INSTANCE_POOL_ID}"
+			node_type_id = data.databricks_node_type.smallest.id
 			num_workers = 0
 			autotermination_minutes = 10
 			spark_conf = {


### PR DESCRIPTION
## Changes
Creating a single node pool.
Setting num_worker = 0, instance_pool_id and driver_instance_pool_id to the same pool creates a single node pool.
However, the UI explicitly says that `spark.databricks.cluster.profile` should not be set to `singleNode`.

<img width="1131" alt="image" src="https://github.com/databricks/terraform-provider-databricks/assets/116642/9e4e6a14-0193-4512-b010-1c5061c3c39b">

## Tests
Currently trying to publish into the terraform registry to verify it by hand.

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [x] covered with integration tests in `internal/acceptance`
- [x] relevant acceptance tests are passing
- [x] using Go SDK
