### PR TITLE
Added `databricks_instance_profiles` data source

### DIFF
--- a/aws/data_instance_profiles.go
+++ b/aws/data_instance_profiles.go
@@ -1,0 +1,38 @@
+package aws
+
+import (
+	"context"
+	"strings"
+
+	"github.com/databricks/databricks-sdk-go"
+	"github.com/databricks/terraform-provider-databricks/common"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func DataSourceInstanceProfiles() *schema.Resource {
+	type instanceProfileData struct {
+		Name    string `json:"name,omitempty" tf:"computed"`
+		Arn     string `json:"arn,omitempty" tf:"computed"`
+		RoleArn string `json:"role_arn,omitempty" tf:"computed"`
+		IsMeta  bool   `json:"is_meta,omitempty" tf:"computed"`
+	}
+	return common.WorkspaceData(func(ctx context.Context, data *struct {
+		InstanceProfiles []instanceProfileData `json:"instance_profiles,omitempty" tf:"computed"`
+	}, w *databricks.WorkspaceClient) error {
+		instanceProfiles, err := w.InstanceProfiles.ListAll(ctx)
+		if err != nil {
+			return err
+		}
+		for _, v := range instanceProfiles {
+			arnSlices := strings.Split(v.InstanceProfileArn, "/")
+			name := arnSlices[len(arnSlices)-1]
+			data.InstanceProfiles = append(data.InstanceProfiles, instanceProfileData{
+				Name:    name,
+				Arn:     v.InstanceProfileArn,
+				RoleArn: v.IamRoleArn,
+				IsMeta:  v.IsMetaInstanceProfile,
+			})
+		}
+		return nil
+	})
+}

--- a/aws/data_instance_profiles_test.go
+++ b/aws/data_instance_profiles_test.go
@@ -1,0 +1,127 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/databricks/databricks-sdk-go/service/compute"
+	"github.com/databricks/terraform-provider-databricks/qa"
+)
+
+func TestInstanceProfilesData(t *testing.T) {
+	qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "GET",
+				Resource: "/api/2.0/instance-profiles/list",
+				Response: compute.ListInstanceProfilesResponse{
+					InstanceProfiles: []compute.InstanceProfile{
+						{
+							IamRoleArn:            "arn:aws:iam::123456789012:role/S3Access",
+							InstanceProfileArn:    "arn:aws:iam::123456789012:instance-profile/S3Access",
+							IsMetaInstanceProfile: true,
+						},
+						{
+							IamRoleArn:            "arn:aws:iam::123456789098:role/KMSAccess",
+							InstanceProfileArn:    "arn:aws:iam::123456789098:instance-profile/KMSAccess",
+							IsMetaInstanceProfile: false,
+						},
+						{
+							InstanceProfileArn:    "arn:aws:iam::123456789098:instance-profile/different",
+							IamRoleArn:            "arn:aws:iam::123456789098:role/value",
+							IsMetaInstanceProfile: false,
+						},
+					},
+				},
+			},
+		},
+		Resource:    DataSourceInstanceProfiles(),
+		Read:        true,
+		NonWritable: true,
+		ID:          "_",
+	}.ApplyAndExpectData(t, map[string]any{
+		"instance_profiles": []interface{}{
+			map[string]interface{}{
+				"name":     "S3Access",
+				"arn":      "arn:aws:iam::123456789012:instance-profile/S3Access",
+				"role_arn": "arn:aws:iam::123456789012:role/S3Access",
+				"is_meta":  true,
+			},
+			map[string]interface{}{
+				"name":     "KMSAccess",
+				"arn":      "arn:aws:iam::123456789098:instance-profile/KMSAccess",
+				"role_arn": "arn:aws:iam::123456789098:role/KMSAccess",
+				"is_meta":  false,
+			},
+			map[string]interface{}{
+				"name":     "different",
+				"arn":      "arn:aws:iam::123456789098:instance-profile/different",
+				"role_arn": "arn:aws:iam::123456789098:role/value",
+				"is_meta":  false,
+			},
+		},
+	})
+}
+
+func TestInstanceProfilesDataEmpty(t *testing.T) {
+	qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "GET",
+				Resource: "/api/2.0/instance-profiles/list",
+				Response: compute.ListInstanceProfilesResponse{
+					InstanceProfiles: []compute.InstanceProfile{},
+				},
+			},
+		},
+		Resource:    DataSourceInstanceProfiles(),
+		Read:        true,
+		NonWritable: true,
+		ID:          "_",
+	}.ApplyAndExpectData(t, map[string]any{
+		"instance_profiles": []interface{}{},
+	})
+}
+
+func TestInstanceProfilesDataDuplicate(t *testing.T) {
+	qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "GET",
+				Resource: "/api/2.0/instance-profiles/list",
+				Response: compute.ListInstanceProfilesResponse{
+					InstanceProfiles: []compute.InstanceProfile{
+						{
+							IamRoleArn:            "arn:aws:iam::123456789012:role/S3Access",
+							InstanceProfileArn:    "arn:aws:iam::123456789012:instance-profile/S3Access",
+							IsMetaInstanceProfile: true,
+						},
+						{
+							IamRoleArn:            "arn:aws:iam::123456789012:role/S3Access",
+							InstanceProfileArn:    "arn:aws:iam::123456789012:instance-profile/S3Access",
+							IsMetaInstanceProfile: true,
+						},
+					},
+				},
+			},
+		},
+		Resource:    DataSourceInstanceProfiles(),
+		Read:        true,
+		NonWritable: true,
+		ID:          "_",
+	}.ApplyAndExpectData(t, map[string]any{
+		"instance_profiles": []interface{}{
+			map[string]interface{}{
+				"name":     "S3Access",
+				"arn":      "arn:aws:iam::123456789012:instance-profile/S3Access",
+				"role_arn": "arn:aws:iam::123456789012:role/S3Access",
+				"is_meta":  true,
+			},
+			map[string]interface{}{
+				"name":     "S3Access",
+				"arn":      "arn:aws:iam::123456789012:instance-profile/S3Access",
+				"role_arn": "arn:aws:iam::123456789012:role/S3Access",
+				"is_meta":  true,
+			},
+		},
+	})
+}

--- a/docs/data-sources/instance_profiles.md
+++ b/docs/data-sources/instance_profiles.md
@@ -1,0 +1,33 @@
+---
+subcategory: "Deployment"
+---
+
+# databricks_instance_profiles Data Source
+
+Lists all available [databricks_instance_profiles](../resources/instance_profile.md).
+
+## Example Usage
+
+Get all instance profiles:
+
+```hcl
+data "databricks_instance_profiles" "all" {
+}
+
+output "all_instance_profiles" {
+  value = data.databricks_instance_profiles.all.instance_profiles
+}
+```
+
+## Argument Reference
+
+There are no arguments available for this data source.
+
+## Attribute Reference
+
+This data source exports the following attributes:
+* `instance_profiles` - Set of objects for a [databricks_instance_profile](../resources/instance_profile.md). This contains the following attributes:
+  * `name` - Name of the instance profile.
+  * `arn` - ARN of the instance profile.
+  * `role_arn` - ARN of the role attached to the instance profile.
+  * `is_meta` - Whether the instance profile is a meta instance profile or not.

--- a/internal/acceptance/data_instance_profiles_test.go
+++ b/internal/acceptance/data_instance_profiles_test.go
@@ -1,0 +1,26 @@
+package acceptance
+
+import (
+	"testing"
+)
+
+func TestAccDataSourceInstanceProfiles(t *testing.T) {
+	GetEnvOrSkipTest(t, "TEST_EC2_INSTANCE_PROFILE")
+	workspaceLevel(t, step{
+		Template: `
+		resource "databricks_instance_profile" "this" {
+			instance_profile_arn = "{env.TEST_EC2_INSTANCE_PROFILE}"
+		}
+
+		data "databricks_instance_profiles" "this" {
+		}
+		
+		output "instance_profiles" {
+			value = data.databricks_instance_profiles.this.instance_profiles
+		}
+
+		output "instance_profile" {
+			value = data.databricks_instance_profiles.this.instance_profiles[0]
+		}`,
+	})
+}

--- a/internal/acceptance/data_instance_profiles_test.go
+++ b/internal/acceptance/data_instance_profiles_test.go
@@ -8,22 +8,7 @@ func TestAccDataSourceInstanceProfiles(t *testing.T) {
 	GetEnvOrSkipTest(t, "TEST_EC2_INSTANCE_PROFILE")
 	workspaceLevel(t, step{
 		Template: `
-		resource "databricks_instance_profile" "this" {
-			instance_profile_arn = "{env.TEST_EC2_INSTANCE_PROFILE}"
-		}
-
-  		# Delay the data call, otherwise it will return null
-  		resource "time_sleep" "wait" {
-  			depends_on = [databricks_instance_profile.this]
-
-  			create_duration = "10s"
-		}
-
 		data "databricks_instance_profiles" "this" {
-			depends_on = [
-				databricks_instance_profile.this,
-    				time_sleep.wait,
-			]
 		}
 		
 		output "instance_profiles" {

--- a/internal/acceptance/data_instance_profiles_test.go
+++ b/internal/acceptance/data_instance_profiles_test.go
@@ -12,9 +12,17 @@ func TestAccDataSourceInstanceProfiles(t *testing.T) {
 			instance_profile_arn = "{env.TEST_EC2_INSTANCE_PROFILE}"
 		}
 
+  		# Delay the data call, otherwise it will return null
+  		resource "time_sleep" "wait" {
+  			depends_on = [databricks_instance_profile.this]
+
+  			create_duration = "10s"
+		}
+
 		data "databricks_instance_profiles" "this" {
 			depends_on = [
-				databricks_instance_profile.this
+				databricks_instance_profile.this,
+    				time_sleep.wait,
 			]
 		}
 		

--- a/internal/acceptance/data_instance_profiles_test.go
+++ b/internal/acceptance/data_instance_profiles_test.go
@@ -13,6 +13,9 @@ func TestAccDataSourceInstanceProfiles(t *testing.T) {
 		}
 
 		data "databricks_instance_profiles" "this" {
+			depends_on = [
+				databricks_instance_profile.this
+			]
 		}
 		
 		output "instance_profiles" {

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -68,7 +68,7 @@ func DatabricksProvider() *schema.Provider {
 			"databricks_directory":               workspace.DataSourceDirectory(),
 			"databricks_group":                   scim.DataSourceGroup(),
 			"databricks_instance_pool":           pools.DataSourceInstancePool(),
-			"databricks_instance_profile":        aws.DataSourceInstanceProfiles(),
+			"databricks_instance_profiles":       aws.DataSourceInstanceProfiles(),
 			"databricks_jobs":                    jobs.DataSourceJobs(),
 			"databricks_job":                     jobs.DataSourceJob(),
 			"databricks_metastore":               catalog.DataSourceMetastore(),

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -68,6 +68,7 @@ func DatabricksProvider() *schema.Provider {
 			"databricks_directory":               workspace.DataSourceDirectory(),
 			"databricks_group":                   scim.DataSourceGroup(),
 			"databricks_instance_pool":           pools.DataSourceInstancePool(),
+			"databricks_instance_profile":        aws.DataSourceInstanceProfiles(),
 			"databricks_jobs":                    jobs.DataSourceJobs(),
 			"databricks_job":                     jobs.DataSourceJob(),
 			"databricks_metastore":               catalog.DataSourceMetastore(),


### PR DESCRIPTION
## Changes
Added a new data source `databricks_instance_profiles` to list all instance profiles and export their properties as a list of objects.

Fixes #2330

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [x] covered with integration tests in `internal/acceptance`
- [x] relevant acceptance tests are passing
- [x] using Go SDK
