### PR TITLE
Allow authentication during configure to fail

### DIFF
--- a/internal/acceptance/tf_provider_test.go
+++ b/internal/acceptance/tf_provider_test.go
@@ -22,7 +22,9 @@ func NoOpResource() *schema.Resource {
 	return s
 }
 
-func TestAccProviderPlanShouldSucceedWithoutHost(t *testing.T) {
+// This test ensures that, within a single Terraform module, a workspace can be created and that
+// the Databricks provider can be configured to use that workspace.
+func TestAccProviderPlanShouldSucceedWithIncompleteConfiguration(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		IsUnitTest: true,
 		ProviderFactories: map[string]func() (*schema.Provider, error){
@@ -38,7 +40,7 @@ func TestAccProviderPlanShouldSucceedWithoutHost(t *testing.T) {
 
 				data "databricks_spark_version" "latest_lts" {
 					long_term_support = true
-					# depend on something so that this is known at apply
+					# depend on something so that we try to configure our provider but do not try to fetch this resource
 					depends_on = [noop_noop.this]
 				}
 				`,

--- a/internal/acceptance/tf_provider_test.go
+++ b/internal/acceptance/tf_provider_test.go
@@ -1,0 +1,50 @@
+package acceptance
+
+import (
+	"testing"
+
+	"github.com/databricks/terraform-provider-databricks/provider"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func noOpProvider() *schema.Provider {
+	s := &schema.Provider{
+		ResourcesMap: map[string]*schema.Resource{
+			"noop_noop": NoOpResource(),
+		},
+	}
+	return s
+}
+
+func NoOpResource() *schema.Resource {
+	s := &schema.Resource{}
+	return s
+}
+
+func TestAccProviderPlanShouldSucceedWithoutHost(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		IsUnitTest: true,
+		ProviderFactories: map[string]func() (*schema.Provider, error){
+			"databricks": func() (*schema.Provider, error) { return provider.DatabricksProvider(), nil },
+			"noop":       func() (*schema.Provider, error) { return noOpProvider(), nil },
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: `
+				provider "databricks" {}
+
+				resource "noop_noop" "this" { }
+
+				data "databricks_spark_version" "latest_lts" {
+					long_term_support = true
+					# depend on something so that this is known at apply
+					depends_on = [noop_noop.this]
+				}
+				`,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -2,12 +2,15 @@ package provider
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"log"
 	"net/http"
 	"reflect"
 	"sort"
 	"strings"
 
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
@@ -226,7 +229,7 @@ func configureDatabricksClient(ctx context.Context, d *schema.ResourceData) (any
 		}
 	}
 	sort.Strings(attrsUsed)
-	log.Printf("[INFO] Explicit and implicit attributes: %s", strings.Join(attrsUsed, ", "))
+	tflog.Info(ctx, fmt.Sprintf("Explicit and implicit attributes: %s", strings.Join(attrsUsed, ", ")))
 	if cfg.AuthType != "" {
 		// mapping from previous Google authentication types
 		// and current authentication types from Databricks Go SDK
@@ -247,8 +250,16 @@ func configureDatabricksClient(ctx context.Context, d *schema.ResourceData) (any
 	if err != nil {
 		return nil, diag.FromErr(err)
 	}
-	err = cfg.Authenticate(r.WithContext(context.Background()))
-	if err != nil {
+	err = cfg.Authenticate(r)
+	// When a user creates a workspace and then configures the Databricks provider in the same
+	// module for that workspace, the workspace does not exist at planning time, so computed
+	// attributes like the host are not included in the ConfigureProvider call. In this case,
+	// authentication will fail, but it is safe to continue: the client will not be used, as
+	// no resources yet exist in the as-yet-nonexisting workspace, so Terraform will not attempt
+	// to fetch any resources.
+	if errors.Is(err, config.ErrCannotConfigureAuth) {
+		tflog.Debug(ctx, "default authentication failed, continuing. During planning, this is expected when the configured workspace does not yet exist.")
+	} else if err != nil {
 		return nil, diag.FromErr(err)
 	}
 	client, err := client.New(cfg)

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -427,6 +427,7 @@ func TestConfig_OAuthFetchesToken(t *testing.T) {
 		assertAuth: "oauth-m2m",
 		assertHost: ts.URL,
 	}.apply(t)
+
 	ws, err := client.WorkspaceClient()
 	require.NoError(t, err)
 	bgCtx := context.Background()

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -75,7 +75,7 @@ func (tt providerFixture) rawConfig() map[string]any {
 }
 
 func (tc providerFixture) apply(t *testing.T) *common.DatabricksClient {
-	c, err := configureProviderAndReturnClient(t, tc)
+	c, err := configureProviderAndReturnClient(t, tc, true)
 	if tc.assertError != "" {
 		require.NotNilf(t, err, "Expected to have %s error", tc.assertError)
 		require.True(t, strings.HasPrefix(err.Error(), tc.assertError),
@@ -418,7 +418,7 @@ func TestConfig_OAuthFetchesToken(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(shortLivedOAuthHandler))
 	defer ts.Close()
 
-	client := providerFixture{
+	pf := providerFixture{
 		env: map[string]string{
 			"DATABRICKS_HOST":          ts.URL,
 			"DATABRICKS_CLIENT_ID":     "x",
@@ -426,8 +426,9 @@ func TestConfig_OAuthFetchesToken(t *testing.T) {
 		},
 		assertAuth: "oauth-m2m",
 		assertHost: ts.URL,
-	}.apply(t)
-
+	}
+	client, err := configureProviderAndReturnClient(t, pf, false)
+	require.NoError(t, err)
 	ws, err := client.WorkspaceClient()
 	require.NoError(t, err)
 	bgCtx := context.Background()
@@ -445,7 +446,7 @@ func TestConfig_OAuthFetchesToken(t *testing.T) {
 	}
 }
 
-func configureProviderAndReturnClient(t *testing.T, tt providerFixture) (*common.DatabricksClient, error) {
+func configureProviderAndReturnClient(t *testing.T, tt providerFixture, tryAuthenticate bool) (*common.DatabricksClient, error) {
 	for k, v := range tt.env {
 		t.Setenv(k, v)
 	}
@@ -460,6 +461,15 @@ func configureProviderAndReturnClient(t *testing.T, tt providerFixture) (*common
 		return nil, fmt.Errorf(strings.Join(issues, ", "))
 	}
 	client := p.Meta().(*common.DatabricksClient)
-
+	if tryAuthenticate {
+		r, err := http.NewRequest("GET", "", nil)
+		if err != nil {
+			return nil, err
+		}
+		err = client.Config.Authenticate(r)
+		if err != nil {
+			return nil, err
+		}
+	}
 	return client, nil
 }


### PR DESCRIPTION
## Changes
As a follow-up to https://github.com/databricks/terraform-provider-databricks/pull/2885, we should tolerate auth failures for dynamically configured providers during the planning phase. This allows users to create workspaces and then configure a provider to manage resources in that workspace as part of a single template. 

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [x] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

