### PR TITLE
Recreate `databricks_metastore_assignment` when changing workspace or metastore id

### DIFF
--- a/catalog/resource_metastore_assignment.go
+++ b/catalog/resource_metastore_assignment.go
@@ -14,6 +14,8 @@ func ResourceMetastoreAssignment() *schema.Resource {
 	s := common.StructToSchema(catalog.MetastoreAssignment{},
 		func(m map[string]*schema.Schema) map[string]*schema.Schema {
 			m["default_catalog_name"].Default = "hive_metastore"
+			m["workspace_id"].ForceNew = true
+			m["metastore_id"].ForceNew = true
 			return m
 		})
 	pi := common.NewPairID("workspace_id", "metastore_id").Schema(

--- a/catalog/resource_metastore_assignment_test.go
+++ b/catalog/resource_metastore_assignment_test.go
@@ -118,3 +118,44 @@ func TestMetastoreAssignmentAccount_Update(t *testing.T) {
 		`,
 	}.ApplyNoError(t)
 }
+
+func TestMetastoreAssignmentWorskpace_Update(t *testing.T) {
+	qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "PUT",
+				Resource: "/api/2.0/accounts/100/workspaces/124/metastores/a",
+				ExpectedRequest: catalog.AccountsCreateMetastoreAssignment{
+					MetastoreAssignment: &catalog.CreateMetastoreAssignment{
+						DefaultCatalogName: "hive_metastore",
+						MetastoreId:        "a",
+					},
+				},
+			},
+			{
+				Method:   "GET",
+				Resource: "/api/2.0/accounts/100/workspaces/123/metastore?",
+				Response: catalog.AccountsMetastoreAssignment{
+					MetastoreAssignment: &catalog.MetastoreAssignment{
+						MetastoreId:        "a",
+						WorkspaceId:        123,
+						DefaultCatalogName: "hive_metastore",
+					},
+				},
+			},
+		},
+		Resource:    ResourceMetastoreAssignment(),
+		AccountID:   "100",
+		ID:          "123|a",
+		Update:      true,
+		RequiresNew: true,
+		InstanceState: map[string]string{
+			"workspace_id": "123",
+			"metastore_id": "a",
+		},
+		HCL: `
+		workspace_id = 124
+		metastore_id = "a"
+		`,
+	}.ApplyNoError(t)
+}

--- a/internal/acceptance/metastore_assignment_test.go
+++ b/internal/acceptance/metastore_assignment_test.go
@@ -21,3 +21,17 @@ func TestUcAccAccountMetastoreAssignment(t *testing.T) {
 		}`,
 	})
 }
+
+func TestUcAccMetastoreReAssignment(t *testing.T) {
+	unityAccountLevel(t, step{
+		Template: `resource "databricks_metastore_assignment" "this" {
+			metastore_id = "{env.TEST_METASTORE_ID}"
+			workspace_id = {env.DUMMY_WORKSPACE_ID}
+		}`,
+	}, step{
+		Template: `resource "databricks_metastore_assignment" "this" {
+			metastore_id = "{env.TEST_METASTORE_ID}"
+			workspace_id = {env.DUMMY2_WORKSPACE_ID}
+		}`,
+	})
+}


### PR DESCRIPTION
## Changes
Recreate metastore assignment when changing workspace id.

This resolves https://github.com/databricks/terraform-provider-databricks/issues/2876.
## Tests

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [x] covered with integration tests in `internal/acceptance`
- [x] relevant acceptance tests are passing
- [x] using Go SDK

