### PR TITLE
Improve performance of `databricks_notebook` and `databricks_workspace_file` resources

### DIFF
--- a/workspace/resource_notebook.go
+++ b/workspace/resource_notebook.go
@@ -300,7 +300,7 @@ func (a NotebooksAPI) list(path string) ([]ObjectStatus, error) {
 // Delete will delete folders given a path and recursive flag
 func (a NotebooksAPI) Delete(path string, recursive bool) error {
 	if recursive {
-		log.Printf("[DEBUG] Doing recursive delete...")
+		log.Printf("[DEBUG] Doing recursive delete of path '%s'", path)
 		mtx.Lock()
 		defer mtx.Unlock()
 	}
@@ -389,12 +389,10 @@ func ResourceNotebook() *schema.Resource {
 			if err != nil {
 				if isParentDoesntExistError(err) {
 					parent := filepath.ToSlash(filepath.Dir(path))
-					if parent != "/" {
-						log.Printf("[DEBUG] Parent folder '%s' doesn't exist, creating...", parent)
-						err = notebooksAPI.Mkdirs(parent)
-						if err != nil {
-							return err
-						}
+					log.Printf("[DEBUG] Parent folder '%s' doesn't exist, creating...", parent)
+					err = notebooksAPI.Mkdirs(parent)
+					if err != nil {
+						return err
 					}
 					err = notebooksAPI.Create(createNotebook)
 				}

--- a/workspace/resource_notebook.go
+++ b/workspace/resource_notebook.go
@@ -101,8 +101,10 @@ var mtx = &sync.Mutex{}
 
 // Create creates a notebook given the content and path
 func (a NotebooksAPI) Create(r ImportPath) error {
-	mtx.Lock()
-	defer mtx.Unlock()
+	if r.Format == "DBC" {
+		mtx.Lock()
+		defer mtx.Unlock()
+	}
 	return a.client.Post(a.context, "/workspace/import", r, nil)
 }
 
@@ -297,8 +299,11 @@ func (a NotebooksAPI) list(path string) ([]ObjectStatus, error) {
 
 // Delete will delete folders given a path and recursive flag
 func (a NotebooksAPI) Delete(path string, recursive bool) error {
-	mtx.Lock()
-	defer mtx.Unlock()
+	if recursive {
+		log.Printf("[DEBUG] Doing recursive delete...")
+		mtx.Lock()
+		defer mtx.Unlock()
+	}
 	return a.client.Post(a.context, "/workspace/delete", DeletePath{
 		Path:      path,
 		Recursive: recursive,
@@ -363,13 +368,6 @@ func ResourceNotebook() *schema.Resource {
 			}
 			notebooksAPI := NewNotebooksAPI(ctx, c)
 			path := d.Get("path").(string)
-			parent := filepath.ToSlash(filepath.Dir(path))
-			if parent != "/" {
-				err = notebooksAPI.Mkdirs(parent)
-				if err != nil {
-					return err
-				}
-			}
 			createNotebook := ImportPath{
 				Content:   base64.StdEncoding.EncodeToString(content),
 				Language:  d.Get("language").(string),
@@ -389,7 +387,20 @@ func ResourceNotebook() *schema.Resource {
 			}
 			err = notebooksAPI.Create(createNotebook)
 			if err != nil {
-				return err
+				if isParentDoesntExistError(err) {
+					parent := filepath.ToSlash(filepath.Dir(path))
+					if parent != "/" {
+						log.Printf("[DEBUG] Parent folder '%s' doesn't exist, creating...", parent)
+						err = notebooksAPI.Mkdirs(parent)
+						if err != nil {
+							return err
+						}
+					}
+					err = notebooksAPI.Create(createNotebook)
+				}
+				if err != nil {
+					return err
+				}
 			}
 			d.SetId(path)
 			return nil
@@ -431,7 +442,13 @@ func ResourceNotebook() *schema.Resource {
 			})
 		},
 		Delete: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
-			return NewNotebooksAPI(ctx, c).Delete(d.Id(), true)
+			objType := d.Get("object_type")
+			return NewNotebooksAPI(ctx, c).Delete(d.Id(), !(objType == Notebook || objType == File))
 		},
 	}.ToResource()
+}
+
+func isParentDoesntExistError(err error) bool {
+	errStr := err.Error()
+	return strings.HasPrefix(errStr, "The parent folder ") && strings.HasSuffix(errStr, " does not exist.")
 }

--- a/workspace/resource_workspace_file.go
+++ b/workspace/resource_workspace_file.go
@@ -48,12 +48,10 @@ func ResourceWorkspaceFile() *schema.Resource {
 			if err != nil {
 				if isParentDoesntExistError(err) {
 					parent := filepath.ToSlash(filepath.Dir(path))
-					if parent != "/" {
-						log.Printf("[DEBUG] Parent folder '%s' doesn't exist, creating...", parent)
-						err = client.Workspace.MkdirsByPath(ctx, parent)
-						if err != nil {
-							return err
-						}
+					log.Printf("[DEBUG] Parent folder '%s' doesn't exist, creating...", parent)
+					err = client.Workspace.MkdirsByPath(ctx, parent)
+					if err != nil {
+						return err
 					}
 					err = client.Workspace.Import(ctx, importReq)
 				}

--- a/workspace/resource_workspace_file.go
+++ b/workspace/resource_workspace_file.go
@@ -3,6 +3,7 @@ package workspace
 import (
 	"context"
 	"encoding/base64"
+	"log"
 	"path/filepath"
 
 	ws_api "github.com/databricks/databricks-sdk-go/service/workspace"
@@ -37,21 +38,28 @@ func ResourceWorkspaceFile() *schema.Resource {
 				return err
 			}
 			path := d.Get("path").(string)
-			parent := filepath.ToSlash(filepath.Dir(path))
-			if parent != "/" {
-				err = client.Workspace.MkdirsByPath(ctx, parent)
-				if err != nil {
-					return err
-				}
-			}
-			err = client.Workspace.Import(ctx, ws_api.Import{
+			importReq := ws_api.Import{
 				Content:   base64.StdEncoding.EncodeToString(content),
 				Format:    ws_api.ImportFormatAuto,
 				Path:      path,
 				Overwrite: true,
-			})
+			}
+			err = client.Workspace.Import(ctx, importReq)
 			if err != nil {
-				return err
+				if isParentDoesntExistError(err) {
+					parent := filepath.ToSlash(filepath.Dir(path))
+					if parent != "/" {
+						log.Printf("[DEBUG] Parent folder '%s' doesn't exist, creating...", parent)
+						err = client.Workspace.MkdirsByPath(ctx, parent)
+						if err != nil {
+							return err
+						}
+					}
+					err = client.Workspace.Import(ctx, importReq)
+				}
+				if err != nil {
+					return err
+				}
 			}
 			d.SetId(path)
 			return nil
@@ -89,7 +97,7 @@ func ResourceWorkspaceFile() *schema.Resource {
 			if err != nil {
 				return err
 			}
-			return client.Workspace.Delete(ctx, ws_api.Delete{Path: d.Id(), Recursive: true})
+			return client.Workspace.Delete(ctx, ws_api.Delete{Path: d.Id(), Recursive: false})
 		},
 	}.ToResource()
 }


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

There were problems with the performance of `databricks_notebook` resource:

* There is an explicit Mutex there to coordinate the creation & deletion of directories - use of it led to the situation when notebooks were created sequentially even with high parallelism.
* Both `databricks_notebook` and `databricks_workspace_file` are always called `mkdirs` API to make sure that the parent directory exists.

This PR includes the following changes:

* In both `databricks_notebook` and `databricks_workspace_file`, the `mkdirs` API is called only when the error about "Parent folder doesn't exist". This should decrease the number of API calls.
* Decrease the use of locks in `databricks_notebook`

This fixes #2898

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

