### PR TITLE
Make `prefix` & `suffix` optional in `multiple` block of `databricks_sql_query`

### DIFF
--- a/sql/resource_sql_query.go
+++ b/sql/resource_sql_query.go
@@ -126,8 +126,8 @@ type QueryParameterDateRangeLike struct {
 
 // QueryParameterAllowMultiple ...
 type QueryParameterAllowMultiple struct {
-	Prefix    string `json:"prefix"`
-	Suffix    string `json:"suffix"`
+	Prefix    string `json:"prefix,omitempty"`
+	Suffix    string `json:"suffix,omitempty"`
 	Separator string `json:"separator"`
 }
 


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

SQL Queries API doesn't return those fields if the corresponding option isn't configured, so these fields need to be optional in Terraform, otherwise code generated by the exporter won't include them.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

