### PR TITLE
Documentation: add a note about setting entitlements with `databricks_entitlements` for account-level identities

### DIFF
--- a/docs/resources/group.md
+++ b/docs/resources/group.md
@@ -7,6 +7,8 @@ This resource allows you to manage both [account groups and workspace-local grou
 
 -> **Note** To assign an account level group to a workspace use [databricks_mws_permission_assignment](mws_permission_assignment.md).
 
+-> **Note** Entitlements, like, `allow_cluster_create`, `allow_instance_pool_create`, `databricks_sql_access`, `workspace_access` applicable only for workspace-level groups.  Use [databricks_entitlements](entitlements.md) resource to assign entitlements inside a workspace to account-level groups.
+
 To create account groups in the Databricks account, the provider must be configured accordingly. On AWS deployment with `host = "https://accounts.cloud.databricks.com"` and `account_id = "00000000-0000-0000-0000-000000000000"`. On Azure deployments `host = "https://accounts.azuredatabricks.net"`, `account_id = "00000000-0000-0000-0000-000000000000"` and using [AAD tokens](https://registry.terraform.io/providers/databricks/databricks/latest/docs#special-configurations-for-azure) as authentication.
 
 Recommended to use along with Identity Provider SCIM provisioning to populate users into those groups:

--- a/docs/resources/service_principal.md
+++ b/docs/resources/service_principal.md
@@ -7,6 +7,8 @@ Directly manage [Service Principals](https://docs.databricks.com/administration-
 
 -> **Note** To assign account level service principals to workspace use [databricks_mws_permission_assignment](mws_permission_assignment.md).
 
+-> **Note** Entitlements, like, `allow_cluster_create`, `allow_instance_pool_create`, `databricks_sql_access`, `workspace_access` applicable only for workspace-level service principals.  Use [databricks_entitlements](entitlements.md) resource to assign entitlements inside a workspace to account-level service principals.
+
 To create service principals in the Databricks account, the provider must be configured with `host = "https://accounts.cloud.databricks.com"` on AWS deployments or `host = "https://accounts.azuredatabricks.net"` and authenticate using [AAD tokens](https://registry.terraform.io/providers/databricks/databricks/latest/docs#special-configurations-for-azure) on Azure deployments
 
 ## Example Usage

--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -7,6 +7,8 @@ This resource allows you to manage [users in Databricks Workspace](https://docs.
 
 -> **Note** To assign account level users to workspace use [databricks_mws_permission_assignment](mws_permission_assignment.md).
 
+-> **Note** Entitlements, like, `allow_cluster_create`, `allow_instance_pool_create`, `databricks_sql_access`, `workspace_access` applicable only for workspace-level users.  Use [databricks_entitlements](entitlements.md) resource to assign entitlements inside a workspace to account-level users.
+
 To create users in the Databricks account, the provider must be configured with `host = "https://accounts.cloud.databricks.com"` on AWS deployments or `host = "https://accounts.azuredatabricks.net"` and authenticate using [AAD tokens](https://registry.terraform.io/providers/databricks/databricks/latest/docs#special-configurations-for-azure) on Azure deployments
 
 ## Example Usage


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

The built-in entitlements of `databricks_group`, `databricks_user`, and `databricks_service_principal` are assignable only to workspace-level identities, and for account-level identities we should use `databricks_entitlements`.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

