### PR TITLE
Generate correct `url` attribute for `databricks_group` resource on account level

### DIFF
--- a/scim/resource_group.go
+++ b/scim/resource_group.go
@@ -58,7 +58,11 @@ func ResourceGroup() *schema.Resource {
 			d.Set("display_name", group.DisplayName)
 			d.Set("external_id", group.ExternalID)
 			d.Set("acl_principal_id", fmt.Sprintf("groups/%s", group.DisplayName))
-			d.Set("url", c.FormatURL("#setting/accounts/groups/", d.Id()))
+			if c.Config.IsAccountClient() {
+				d.Set("url", c.FormatURL("users/groups/", d.Id(), "/information"))
+			} else {
+				d.Set("url", c.FormatURL("#setting/accounts/groups/", d.Id()))
+			}
 			return group.Entitlements.readIntoData(d)
 		},
 		Update: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

The `databricks_group` resource exposes the `url` attribute that is generated during the read operation. It had incorrect value for groups on account level. This PR fixes this

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

