### PR TITLE
Do not persist state from failed updates in  databricks_workspace_conf 

### DIFF
--- a/internal/acceptance/init_test.go
+++ b/internal/acceptance/init_test.go
@@ -207,6 +207,7 @@ func run(t *testing.T, steps []step) {
 			PreventPostDestroyRefresh: s.PreventPostDestroyRefresh,
 			ImportState:               s.ImportState,
 			ImportStateVerify:         s.ImportStateVerify,
+			ExpectError:               s.ExpectError,
 			Check: func(state *terraform.State) error {
 				// get configured client from provider
 				client := provider.Meta().(*common.DatabricksClient)

--- a/internal/acceptance/workspace_conf_test.go
+++ b/internal/acceptance/workspace_conf_test.go
@@ -2,12 +2,26 @@ package acceptance
 
 import (
 	"context"
+	"regexp"
 	"testing"
 
+	"github.com/databricks/databricks-sdk-go"
 	"github.com/databricks/databricks-sdk-go/service/settings"
-	"github.com/databricks/terraform-provider-databricks/common"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func assertEnableIpAccessList(t *testing.T, expected string) {
+	w, err := databricks.NewWorkspaceClient(&databricks.Config{})
+	require.NoError(t, err)
+	conf, err := w.WorkspaceConf.GetStatus(context.Background(), settings.GetStatusRequest{
+		Keys: "enableIpAccessLists",
+	})
+	require.NoError(t, err)
+	assert.Len(t, *conf, 1)
+	assert.Equal(t, (*conf)["enableIpAccessLists"], expected)
+}
 
 func TestAccWorkspaceConfFullLifecycle(t *testing.T) {
 	workspaceLevel(t, step{
@@ -16,21 +30,58 @@ func TestAccWorkspaceConfFullLifecycle(t *testing.T) {
 				"enableIpAccessLists": true
 			}
 		}`,
-		Check: resourceCheck("databricks_workspace_conf.this",
-			func(ctx context.Context, client *common.DatabricksClient, id string) error {
-				w, err := client.WorkspaceClient()
-				if err != nil {
-					return err
-				}
-				conf, err := w.WorkspaceConf.GetStatus(ctx, settings.GetStatusRequest{
-					Keys: "enableIpAccessLists",
-				})
-				if err != nil {
-					return err
-				}
-				assert.Len(t, *conf, 1)
-				assert.Equal(t, (*conf)["enableIpAccessLists"], "true")
-				return nil
-			}),
+		Check: func(s *terraform.State) error {
+			assertEnableIpAccessList(t, "true")
+			return nil
+		},
 	})
+}
+
+func TestAccInvalidWorkspaceConfAreIgnored(t *testing.T) {
+	workspaceLevel(t,
+		// Set enableIpAccessLists to false
+		step{
+			Template: `resource "databricks_workspace_conf" "this" {
+				custom_config = {
+					"enableIpAccessLists": "false"
+				}
+			}`,
+			Check: func(s *terraform.State) error {
+				// Assert server side configuration is updated
+				assertEnableIpAccessList(t, "false")
+
+				// Assert state is persisted
+				conf := s.RootModule().Resources["databricks_workspace_conf.this"]
+				assert.Equal(t, "false", conf.Primary.Attributes["custom_config.enableIpAccessLists"])
+				return nil
+			},
+		},
+		// Set invalid configuration
+		step{
+			Template: `resource "databricks_workspace_conf" "this" {
+				custom_config = {
+					"enableIpAccessLissss": "invalid"
+				}
+			}`,
+			// Assert on server side error returned
+			ExpectError: regexp.MustCompile(`cannot update workspace conf: Invalid keys`),
+		},
+		// Set enableIpAccessLists to true
+		step{
+			Template: `resource "databricks_workspace_conf" "this" {
+				custom_config = {
+					"enableIpAccessLists": "true"
+				}
+			}`,
+			Check: func(s *terraform.State) error {
+				// Assert server side configuration is updated
+				assertEnableIpAccessList(t, "true")
+
+				// Assert state is persisted
+				conf := s.RootModule().Resources["databricks_workspace_conf.this"]
+				assert.Equal(t, "true", conf.Primary.Attributes["custom_config.enableIpAccessLists"])
+				return nil
+			},
+		},
+	)
 }

--- a/workspace/resource_workspace_conf.go
+++ b/workspace/resource_workspace_conf.go
@@ -16,58 +16,80 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-// ResourceWorkspaceConf maintains workspace configuration for specified keys
-func ResourceWorkspaceConf() *schema.Resource {
-	create := func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
-		o, n := d.GetChange("custom_config")
-		old, okOld := o.(map[string]any)
-		new, okNew := n.(map[string]any)
-		if !okNew || !okOld {
-			return fmt.Errorf("internal type casting error")
+// This function applies configuration defined in the resource data to the workspace.
+func applyWorkspaceConf(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
+	o, n := d.GetChange("custom_config")
+	old, okOld := o.(map[string]any)
+	new, okNew := n.(map[string]any)
+	if !okNew || !okOld {
+		return fmt.Errorf("internal type casting error")
+	}
+	log.Printf("[DEBUG] Old workspace config: %v, new: %v", old, new)
+	patch := settings.WorkspaceConf{}
+
+	// Add new configuration keys
+	for k, v := range new {
+		patch[k] = fmt.Sprint(v)
+	}
+
+	// Remove old configuration keys, that are no longer present in the new configuration
+	for k, v := range old {
+		_, keep := new[k]
+		if keep {
+			continue
 		}
-		log.Printf("[DEBUG] Old workspace config: %v, new: %v", old, new)
-		patch := settings.WorkspaceConf{}
-		for k, v := range new {
-			patch[k] = fmt.Sprint(v)
-		}
-		for k, v := range old {
-			_, keep := new[k]
-			if keep {
-				continue
-			}
-			log.Printf("[DEBUG] Erasing configuration of %s", k)
-			switch r := v.(type) {
-			default:
+		log.Printf("[DEBUG] Erasing configuration of %s", k)
+		switch r := v.(type) {
+		default:
+			patch[k] = ""
+		case string:
+			_, err := strconv.ParseBool(r)
+			if err != nil {
 				patch[k] = ""
-			case string:
-				_, err := strconv.ParseBool(r)
-				if err != nil {
-					patch[k] = ""
-				} else {
-					patch[k] = "false"
-				}
-			case bool:
+			} else {
 				patch[k] = "false"
 			}
+		case bool:
+			patch[k] = "false"
 		}
-		w, err := c.WorkspaceClient()
-		if err != nil {
-			return err
-		}
-		err = w.WorkspaceConf.SetStatus(ctx, patch)
-		if err != nil {
-			return err
-		}
-		newConfig := map[string]any{}
-		for k, v := range patch {
-			newConfig[k] = v
-		}
-		d.SetId("_")
-		return nil
 	}
+
+	w, err := c.WorkspaceClient()
+	if err != nil {
+		return err
+	}
+	err = w.WorkspaceConf.SetStatus(ctx, patch)
+	if err != nil {
+		return err
+	}
+	newConfig := map[string]any{}
+	for k, v := range patch {
+		newConfig[k] = v
+	}
+	d.SetId("_")
+	return nil
+
+}
+
+func updateWorkspaceConf(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
+	err := applyWorkspaceConf(ctx, d, c)
+	if err != nil {
+		// Update methods from the Terraform SDK persist terraform configuration
+		// changes to the state by default, even if update fails.
+		// We revert back to the previous version of the configuration to prevent an
+		// invalid workspace configuration from being persisted in the terraform state.
+		prevConf, _ := d.GetChange("custom_config")
+		d.Set("custom_config", prevConf)
+		return err
+	}
+	return nil
+}
+
+// ResourceWorkspaceConf maintains workspace configuration for specified keys
+func ResourceWorkspaceConf() *schema.Resource {
 	return common.Resource{
-		Create: create,
-		Update: create,
+		Create: applyWorkspaceConf,
+		Update: updateWorkspaceConf,
 		Read: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
 			config := d.Get("custom_config").(map[string]any)
 			log.Printf("[DEBUG] Config available in state: %v", config)


### PR DESCRIPTION
## Changes
The Terraform SDK by default persists the state, even if apply fails. This PR sets the config back to it's previous value to prevent values not applied being persisted in state. 

This also solves the issue where entering typos for key values would brick the terraform state. 

## Tests
Manually and new integration test

