### PR TITLE
Release v1.30.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,51 @@
 # Version changelog
 
+## 1.30.0
+
+New Features and Improvements:
+ * Added DeltaSharingRecipientTokenLifetimeInSeconds to ForceSendFields if DeltaSharingScope is set in [databricks_metastore](https://registry.terraform.io/providers/databricks/databricks/latest/docs/resources/metastore) ([#2846](https://github.com/databricks/terraform-provider-databricks/pull/2846)).
+ * Added NumWorkers to ForceSendFields in [databricks_pipeline](https://registry.terraform.io/providers/databricks/databricks/latest/docs/resources/pipeline) if `spark_conf` contains config for single-node cluster ([#2852](https://github.com/databricks/terraform-provider-databricks/pull/2852)).
+ * Added Terraform Provider for DefaultNamespaceSettings ([#2710](https://github.com/databricks/terraform-provider-databricks/pull/2710)).
+ * Added `binding_type` attribute to [databricks_catalog_workspace_binding](https://registry.terraform.io/providers/databricks/databricks/latest/docs/resources/catalog_workspace_binding) resource ([#2803](https://github.com/databricks/terraform-provider-databricks/pull/2803)).
+ * Added `run_job_task` into the list of supported tasks of [databricks_job](https://registry.terraform.io/providers/databricks/databricks/latest/docs/resources/job) resource ([#2889](https://github.com/databricks/terraform-provider-databricks/pull/2889)).
+ * Added support for `run_as_role` in [databricks_sql_dashboard](https://registry.terraform.io/providers/databricks/databricks/latest/docs/resources/sql_dashboard) resource ([#2756](https://github.com/databricks/terraform-provider-databricks/pull/2756)).
+resource ([#2495](https://github.com/databricks/terraform-provider-databricks/pull/2495)).
+ * Added [databricks_mlflow_model](https://registry.terraform.io/providers/databricks/databricks/latest/docs/data-sources/mlflow_model) data source ([#2456](https://github.com/databricks/terraform-provider-databricks/pull/2456)).
+ * Allow authentication during configure to fail ([#2892](https://github.com/databricks/terraform-provider-databricks/pull/2892)).
+ * Authenticate client during configuration ([#2885](https://github.com/databricks/terraform-provider-databricks/pull/2885)).
+ * Improve performance of [databricks_notebook](https://registry.terraform.io/providers/databricks/databricks/latest/docs/resources/notebook) and [databricks_workspace_file](https://registry.terraform.io/providers/databricks/databricks/latest/docs/resources/workspace_file) resources ([#2902](https://github.com/databricks/terraform-provider-databricks/pull/2902)).
+ * Make `aws_key_info.key_alias` optional for [databricks_mws_customer_managed_keys](https://registry.terraform.io/providers/databricks/databricks/latest/docs/resources/mws_customer_managed_keys) ([#2791](https://github.com/databricks/terraform-provider-databricks/pull/2791)).
+ * Make `prefix` & `suffix` optional in `multiple` block of [databricks_sql_query](https://registry.terraform.io/providers/databricks/databricks/latest/docs/resources/sql_query) ([#2905](https://github.com/databricks/terraform-provider-databricks/pull/2905)).
+ * Recreate metastore assignment when changing workspace id ([#2899](https://github.com/databricks/terraform-provider-databricks/pull/2899)).
+ * Update connection types ([#2897](https://github.com/databricks/terraform-provider-databricks/pull/2897)).
+ * Mark `storage_root` optional for [databricks_metastore](https://registry.terraform.io/providers/databricks/databricks/latest/docs/resources/metastore) resource ([#2873](https://github.com/databricks/terraform-provider-databricks/pull/2873)).
+ * Refactor [databricks_recipient](https://registry.terraform.io/providers/databricks/databricks/latest/docs/resources/recipient) to Go SDK ([#2858](https://github.com/databricks/terraform-provider-databricks/pull/2858)).
+
+Bugfixes:
+ * Fixed `Update` method of [databricks_user](https://registry.terraform.io/providers/databricks/databricks/latest/docs/resources/user) ([#2878](https://github.com/databricks/terraform-provider-databricks/pull/2878)).
+ * Fixed `Read` method of the [databricks_mlflow_model](https://registry.terraform.io/providers/databricks/databricks/latest/docs/resources/mlflow_model) resource ([#2853](https://github.com/databricks/terraform-provider-databricks/pull/2853)).
+
+Exporter:
+ * Fix emitting of group membership ([#2868](https://github.com/databricks/terraform-provider-databricks/pull/2868)).
+ * Don't omit `display_name` in [databricks_user](https://registry.terraform.io/providers/databricks/databricks/latest/docs/resources/user) if it's not equal to `user_name` ([#2851](https://github.com/databricks/terraform-provider-databricks/pull/2851)).
+ * Follow recommendations of identity team on decreasing load on SCIM API ([#2773](https://github.com/databricks/terraform-provider-databricks/pull/2773)).
+ * Add case-insensitive match type for dependencies ([#2854](https://github.com/databricks/terraform-provider-databricks/pull/2854)).
+ * Disable generation of empty or default blocks for [databricks_job](https://registry.terraform.io/providers/databricks/databricks/latest/docs/resources/job) and [databricks_cluster](https://registry.terraform.io/providers/databricks/databricks/latest/docs/resources/cluster) ([#2857](https://github.com/databricks/terraform-provider-databricks/pull/2857)).
+
+Documentation Changes:
+ * Update [databricks_job](https://registry.terraform.io/providers/databricks/databricks/latest/docs/resources/job) documentation with `queue` block ([#2872](https://github.com/databricks/terraform-provider-databricks/pull/2872)).
+ * Use correct label in the issue template for documentation ([#2850](https://github.com/databricks/terraform-provider-databricks/pull/2850)).
+ * Modified github issue template to identify regressions faster ([#2847](https://github.com/databricks/terraform-provider-databricks/pull/2847)).
+ * Fixed documented default value for data_security_mode ([#2866](https://github.com/databricks/terraform-provider-databricks/pull/2866)).
+ * Add a note about setting entitlements with [databricks_entitlements](https://registry.terraform.io/providers/databricks/databricks/latest/docs/resources/entitlements) for account-level identities ([#2910](https://github.com/databricks/terraform-provider-databricks/pull/2910)).
+ * Add the missing `region` field to [databricks_metastore](https://registry.terraform.io/providers/databricks/databricks/latest/docs/resources/metastore) resource block ([#2859](https://github.com/databricks/terraform-provider-databricks/pull/2859)).
+
+Internal Changes:
+ * Skiped GCP for UC integration tests using system schemas or statement execution API ([#2877](https://github.com/databricks/terraform-provider-databricks/pull/2877)).
+ * Added integration test for SQL warehouse permissions in [databricks_permissions](https://registry.terraform.io/providers/databricks/databricks/latest/docs/resources/permissions) ([#2845](https://github.com/databricks/terraform-provider-databricks/pull/2845)).
+ * Bumped github.com/databricks/databricks-sdk-go from 0.24.0 to 0.25.0 ([#2909](https://github.com/databricks/terraform-provider-databricks/pull/2909)).
+ * Enabled and fix tests ([#2901](https://github.com/databricks/terraform-provider-databricks/pull/2901)).
+
 ## 1.29.0
 
 New Features and Improvements:

--- a/common/version.go
+++ b/common/version.go
@@ -3,7 +3,7 @@ package common
 import "context"
 
 var (
-	version = "1.29.0"
+	version = "1.30.0"
 	// ResourceName is resource name without databricks_ prefix
 	ResourceName contextKey = 1
 	// Provider is the current instance of provider


### PR DESCRIPTION
New Features and Improvements:
 * Added DeltaSharingRecipientTokenLifetimeInSeconds to ForceSendFields if DeltaSharingScope is set in [databricks_metastore](https://registry.terraform.io/providers/databricks/databricks/latest/docs/resources/metastore) ([#2846](https://github.com/databricks/terraform-provider-databricks/pull/2846)).
 * Added NumWorkers to ForceSendFields in [databricks_pipeline](https://registry.terraform.io/providers/databricks/databricks/latest/docs/resources/pipeline) if `spark_conf` contains config for single-node cluster ([#2852](https://github.com/databricks/terraform-provider-databricks/pull/2852)).
 * Added Terraform Provider for DefaultNamespaceSettings ([#2710](https://github.com/databricks/terraform-provider-databricks/pull/2710)).
 * Added `binding_type` attribute to [databricks_catalog_workspace_binding](https://registry.terraform.io/providers/databricks/databricks/latest/docs/resources/catalog_workspace_binding) resource ([#2803](https://github.com/databricks/terraform-provider-databricks/pull/2803)).
 * Added `run_job_task` into the list of supported tasks of [databricks_job](https://registry.terraform.io/providers/databricks/databricks/latest/docs/resources/job) resource ([#2889](https://github.com/databricks/terraform-provider-databricks/pull/2889)).
 * Added support for `run_as_role` in [databricks_sql_dashboard](https://registry.terraform.io/providers/databricks/databricks/latest/docs/resources/sql_dashboard) resource ([#2756](https://github.com/databricks/terraform-provider-databricks/pull/2756)).
resource ([#2495](https://github.com/databricks/terraform-provider-databricks/pull/2495)).
 * Added [databricks_mlflow_model](https://registry.terraform.io/providers/databricks/databricks/latest/docs/data-sources/mlflow_model) data source ([#2456](https://github.com/databricks/terraform-provider-databricks/pull/2456)).
 * Allow authentication during configure to fail ([#2892](https://github.com/databricks/terraform-provider-databricks/pull/2892)).
 * Authenticate client during configuration ([#2885](https://github.com/databricks/terraform-provider-databricks/pull/2885)).
 * Improve performance of [databricks_notebook](https://registry.terraform.io/providers/databricks/databricks/latest/docs/resources/notebook) and [databricks_workspace_file](https://registry.terraform.io/providers/databricks/databricks/latest/docs/resources/workspace_file) resources ([#2902](https://github.com/databricks/terraform-provider-databricks/pull/2902)).
 * Make `aws_key_info.key_alias` optional for [databricks_mws_customer_managed_keys](https://registry.terraform.io/providers/databricks/databricks/latest/docs/resources/mws_customer_managed_keys) ([#2791](https://github.com/databricks/terraform-provider-databricks/pull/2791)).
 * Make `prefix` & `suffix` optional in `multiple` block of [databricks_sql_query](https://registry.terraform.io/providers/databricks/databricks/latest/docs/resources/sql_query) ([#2905](https://github.com/databricks/terraform-provider-databricks/pull/2905)).
 * Recreate metastore assignment when changing workspace id ([#2899](https://github.com/databricks/terraform-provider-databricks/pull/2899)).
 * Update connection types ([#2897](https://github.com/databricks/terraform-provider-databricks/pull/2897)).
 * Mark `storage_root` optional for [databricks_metastore](https://registry.terraform.io/providers/databricks/databricks/latest/docs/resources/metastore) resource ([#2873](https://github.com/databricks/terraform-provider-databricks/pull/2873)).
 * Refactor [databricks_recipient](https://registry.terraform.io/providers/databricks/databricks/latest/docs/resources/recipient) to Go SDK ([#2858](https://github.com/databricks/terraform-provider-databricks/pull/2858)).

Bugfixes:
 * Fixed `Update` method of [databricks_user](https://registry.terraform.io/providers/databricks/databricks/latest/docs/resources/user) ([#2878](https://github.com/databricks/terraform-provider-databricks/pull/2878)).
 * Fixed `Read` method of the [databricks_mlflow_model](https://registry.terraform.io/providers/databricks/databricks/latest/docs/resources/mlflow_model) resource ([#2853](https://github.com/databricks/terraform-provider-databricks/pull/2853)).

Exporter:
 * Fix emitting of group membership ([#2868](https://github.com/databricks/terraform-provider-databricks/pull/2868)).
 * Don't omit `display_name` in [databricks_user](https://registry.terraform.io/providers/databricks/databricks/latest/docs/resources/user) if it's not equal to `user_name` ([#2851](https://github.com/databricks/terraform-provider-databricks/pull/2851)).
 * Follow recommendations of identity team on decreasing load on SCIM API ([#2773](https://github.com/databricks/terraform-provider-databricks/pull/2773)).
 * Add case-insensitive match type for dependencies ([#2854](https://github.com/databricks/terraform-provider-databricks/pull/2854)).
 * Disable generation of empty or default blocks for [databricks_job](https://registry.terraform.io/providers/databricks/databricks/latest/docs/resources/job) and [databricks_cluster](https://registry.terraform.io/providers/databricks/databricks/latest/docs/resources/cluster) ([#2857](https://github.com/databricks/terraform-provider-databricks/pull/2857)).

Documentation Changes:
 * Update [databricks_job](https://registry.terraform.io/providers/databricks/databricks/latest/docs/resources/job) documentation with `queue` block ([#2872](https://github.com/databricks/terraform-provider-databricks/pull/2872)).
 * Use correct label in the issue template for documentation ([#2850](https://github.com/databricks/terraform-provider-databricks/pull/2850)).
 * Modified github issue template to identify regressions faster ([#2847](https://github.com/databricks/terraform-provider-databricks/pull/2847)).
 * Fixed documented default value for data_security_mode ([#2866](https://github.com/databricks/terraform-provider-databricks/pull/2866)).
 * Add a note about setting entitlements with [databricks_entitlements](https://registry.terraform.io/providers/databricks/databricks/latest/docs/resources/entitlements) for account-level identities ([#2910](https://github.com/databricks/terraform-provider-databricks/pull/2910)).
 * Add the missing `region` field to [databricks_metastore](https://registry.terraform.io/providers/databricks/databricks/latest/docs/resources/metastore) resource block ([#2859](https://github.com/databricks/terraform-provider-databricks/pull/2859)).

Internal Changes:
 * Skiped GCP for UC integration tests using system schemas or statement execution API ([#2877](https://github.com/databricks/terraform-provider-databricks/pull/2877)).
 * Added integration test for SQL warehouse permissions in [databricks_permissions](https://registry.terraform.io/providers/databricks/databricks/latest/docs/resources/permissions) ([#2845](https://github.com/databricks/terraform-provider-databricks/pull/2845)).
 * Bumped github.com/databricks/databricks-sdk-go from 0.24.0 to 0.25.0 ([#2909](https://github.com/databricks/terraform-provider-databricks/pull/2909)).
 * Enabled and fix tests ([#2901](https://github.com/databricks/terraform-provider-databricks/pull/2901)).