### PR TITLE
Add edit_mode field to resource_job

### DIFF
--- a/jobs/resource_job.go
+++ b/jobs/resource_job.go
@@ -293,6 +293,7 @@ type JobSettings struct {
 	Health               *JobHealth                    `json:"health,omitempty"`
 	Parameters           []JobParameterDefinition      `json:"parameters,omitempty" tf:"alias:parameter"`
 	Deployment           *jobs.JobDeployment           `json:"deployment,omitempty"`
+	EditMode             jobs.CreateJobEditMode        `json:"edit_mode,omitempty"`
 }
 
 func (js *JobSettings) isMultiTask() bool {

--- a/jobs/resource_job_test.go
+++ b/jobs/resource_job_test.go
@@ -58,6 +58,7 @@ func TestResourceJobCreate(t *testing.T) {
 						Kind:             "BUNDLE",
 						MetadataFilePath: "/a/b/c",
 					},
+					EditMode: "UI_LOCKED",
 				},
 				Response: Job{
 					JobID: 789,
@@ -102,6 +103,7 @@ func TestResourceJobCreate(t *testing.T) {
 							Kind:             "BUNDLE",
 							MetadataFilePath: "/a/b/c",
 						},
+						EditMode: "UI_LOCKED",
 					},
 				},
 			},
@@ -137,7 +139,8 @@ func TestResourceJobCreate(t *testing.T) {
 		deployment {
 			kind = "BUNDLE"
 			metadata_file_path = "/a/b/c"
-		}`,
+		}
+		edit_mode = "UI_LOCKED"`,
 	}.Apply(t)
 	assert.NoError(t, err)
 	assert.Equal(t, "789", d.Id())


### PR DESCRIPTION
## Changes
This is required to support break-glass UI for DABs. We don't need to document this since the feature is in private-preview and is only meant to be used internally from the CLI for now.

## Tests
Existing unit test

