### PR TITLE
Make default_namespace_setting resource name singular

### DIFF
--- a/docs/resources/default_namespace_settings.md
+++ b/docs/resources/default_namespace_settings.md
@@ -4,7 +4,7 @@ subcategory: "Settings"
 
 # databricks_namespace_settings Resource
 
-The `databricks_default_namespace_settings` resource allows you to operate the setting configuration for the default namespace in the Databricks workspace.
+The `databricks_default_namespace_setting` resource allows you to operate the setting configuration for the default namespace in the Databricks workspace.
 Setting the default catalog for the workspace determines the catalog that is used when queries do not reference
 a fully qualified 3 level name. For example, if the default catalog is set to 'retail_prod' then a query
 'SELECT * FROM myTable' would reference the object 'retail_prod.default.myTable'
@@ -13,7 +13,7 @@ This setting requires a restart of clusters and SQL warehouses to take effect. A
 ## Example Usage
 
 ```hcl
-resource "databricks_default_namespace_settings" "this" {
+resource "databricks_default_namespace_setting" "this" {
 		namespace {
 			value = "namespace_value"
 		}

--- a/docs/resources/default_namespace_settings.md
+++ b/docs/resources/default_namespace_settings.md
@@ -2,7 +2,7 @@
 subcategory: "Settings"
 ---
 
-# databricks_namespace_settings Resource
+# databricks_namespace_setting Resource
 
 The `databricks_default_namespace_setting` resource allows you to operate the setting configuration for the default namespace in the Databricks workspace.
 Setting the default catalog for the workspace determines the catalog that is used when queries do not reference

--- a/internal/acceptance/default_namespace_test.go
+++ b/internal/acceptance/default_namespace_test.go
@@ -14,13 +14,13 @@ import (
 func TestAccDefaultNamespaceSetting(t *testing.T) {
 	workspaceLevel(t, step{
 		Template: `
-		resource "databricks_default_namespace_settings" "this" {
+		resource "databricks_default_namespace_setting" "this" {
 			namespace {
 				value = "namespace_value"
 			}
 		}
 		`,
-		Check: resourceCheck("databricks_default_namespace_settings.this", func(ctx context.Context, client *common.DatabricksClient, id string) error {
+		Check: resourceCheck("databricks_default_namespace_setting.this", func(ctx context.Context, client *common.DatabricksClient, id string) error {
 			ctx = context.WithValue(ctx, common.Api, common.API_2_1)
 			w, err := client.WorkspaceClient()
 			assert.NoError(t, err)
@@ -34,13 +34,13 @@ func TestAccDefaultNamespaceSetting(t *testing.T) {
 		}),
 	},
 		step{
-			Template: `resource "databricks_default_namespace_settings" "this" {
+			Template: `resource "databricks_default_namespace_setting" "this" {
 				namespace {
 					value = "namespace_value"
 				}
 			}`,
 			Destroy: true,
-			Check: resourceCheck("databricks_default_namespace_settings.this", func(ctx context.Context, client *common.DatabricksClient, id string) error {
+			Check: resourceCheck("databricks_default_namespace_setting.this", func(ctx context.Context, client *common.DatabricksClient, id string) error {
 				ctx = context.WithValue(ctx, common.Api, common.API_2_1)
 				w, err := client.WorkspaceClient()
 				assert.NoError(t, err)

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -104,7 +104,7 @@ func DatabricksProvider() *schema.Provider {
 			"databricks_cluster":                     clusters.ResourceCluster(),
 			"databricks_cluster_policy":              policies.ResourceClusterPolicy(),
 			"databricks_dbfs_file":                   storage.ResourceDbfsFile(),
-			"databricks_default_namespace_settings":  settings.ResourceDefaultNamespaceSettings(),
+			"databricks_default_namespace_setting":   settings.ResourceDefaultNamespaceSetting(),
 			"databricks_directory":                   workspace.ResourceDirectory(),
 			"databricks_entitlements":                scim.ResourceEntitlements(),
 			"databricks_external_location":           catalog.ResourceExternalLocation(),

--- a/settings/resource_default_namespace_setting.go
+++ b/settings/resource_default_namespace_setting.go
@@ -107,7 +107,7 @@ var resourceSchema = common.StructToSchema(settings.DefaultNamespaceSetting{},
 		return s
 	})
 
-func ResourceDefaultNamespaceSettings() *schema.Resource {
+func ResourceDefaultNamespaceSetting() *schema.Resource {
 	return common.Resource{
 		Schema: resourceSchema,
 		Create: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {

--- a/settings/resource_default_namespace_setting_test.go
+++ b/settings/resource_default_namespace_setting_test.go
@@ -74,7 +74,7 @@ func TestQueryCreateDefaultNameSetting(t *testing.T) {
 				},
 			},
 		},
-		Resource: ResourceDefaultNamespaceSettings(),
+		Resource: ResourceDefaultNamespaceSetting(),
 		Create:   true,
 		HCL: `
 			namespace {
@@ -106,7 +106,7 @@ func TestQueryReadDefaultNameSetting(t *testing.T) {
 				},
 			},
 		},
-		Resource: ResourceDefaultNamespaceSettings(),
+		Resource: ResourceDefaultNamespaceSetting(),
 		Read:     true,
 		HCL: `
 			namespace {
@@ -162,7 +162,7 @@ func TestQueryUpdateDefaultNameSetting(t *testing.T) {
 				},
 			},
 		},
-		Resource: ResourceDefaultNamespaceSettings(),
+		Resource: ResourceDefaultNamespaceSetting(),
 		Update:   true,
 		HCL: `
 			namespace {
@@ -244,7 +244,7 @@ func TestQueryUpdateDefaultNameSettingWithConflict(t *testing.T) {
 				},
 			},
 		},
-		Resource: ResourceDefaultNamespaceSettings(),
+		Resource: ResourceDefaultNamespaceSetting(),
 		Update:   true,
 		HCL: `
 			namespace {
@@ -273,7 +273,7 @@ func TestQueryDeleteDefaultNameSetting(t *testing.T) {
 				},
 			},
 		},
-		Resource: ResourceDefaultNamespaceSettings(),
+		Resource: ResourceDefaultNamespaceSetting(),
 		Delete:   true,
 		ID:       "etag1",
 	}.Apply(t)
@@ -309,7 +309,7 @@ func TestQueryDeleteDefaultNameSettingWithConflict(t *testing.T) {
 				},
 			},
 		},
-		Resource: ResourceDefaultNamespaceSettings(),
+		Resource: ResourceDefaultNamespaceSetting(),
 		Delete:   true,
 		ID:       "etag1",
 	}.Apply(t)


### PR DESCRIPTION
## Changes
Make default_namespace_setting resource name singular

## Tests
Run existing tests

- [X] `make test` run locally
- [X] relevant change in `docs/` folder
- [X] covered with integration tests in `internal/acceptance`
- [X] relevant acceptance tests are passing
- [X] using Go SDK

