### PR TITLE
Exporter: fix generation of `branch` & `tag` attributes in `databricks_repo`

### DIFF
--- a/exporter/importables.go
+++ b/exporter/importables.go
@@ -1265,8 +1265,13 @@ var resourcesMap map[string]importable = map[string]importable{
 			return nil
 		},
 		ShouldOmitField: func(ic *importContext, pathString string, as *schema.Schema, d *schema.ResourceData) bool {
-			if pathString == "path" {
+			switch pathString {
+			case "path":
 				return false
+			case "branch":
+				return d.Get("branch").(string) == ""
+			case "tag":
+				return d.Get("tag").(string) == ""
 			}
 			return defaultShouldOmitFieldFunc(ic, pathString, as, d)
 		},

--- a/exporter/importables_test.go
+++ b/exporter/importables_test.go
@@ -594,6 +594,24 @@ func TestShouldOmitForUsers(t *testing.T) {
 		scim.ResourceUser().Schema["application_id"], d))
 }
 
+func TestShouldOmitFoRepos(t *testing.T) {
+	d := repos.ResourceRepo().TestResourceData()
+	d.SetId("1234")
+	d.Set("path", "/Repos/Test/repo")
+	assert.False(t, resourcesMap["databricks_repo"].ShouldOmitField(nil, "path",
+		repos.ResourceRepo().Schema["path"], d))
+	assert.True(t, resourcesMap["databricks_repo"].ShouldOmitField(nil, "branch",
+		repos.ResourceRepo().Schema["branch"], d))
+	assert.True(t, resourcesMap["databricks_repo"].ShouldOmitField(nil, "tag",
+		repos.ResourceRepo().Schema["tag"], d))
+	d.Set("branch", "test")
+	assert.False(t, resourcesMap["databricks_repo"].ShouldOmitField(nil, "branch",
+		repos.ResourceRepo().Schema["branch"], d))
+	d.Set("tag", "v123")
+	assert.False(t, resourcesMap["databricks_repo"].ShouldOmitField(nil, "tag",
+		repos.ResourceRepo().Schema["tag"], d))
+}
+
 func TestUserImportSkipNonDirectGroups(t *testing.T) {
 	qa.HTTPFixturesApply(t, []qa.HTTPFixture{
 		{


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

These attributes were omitted from the generated code because they are marked as `computed` in the resource.  This PR fixes this.

This fixes #2927


## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

