### PR TITLE
Force sending the `content` field when creating empty `databricks_workspace_file` resources

### DIFF
--- a/internal/acceptance/workspace_file_test.go
+++ b/internal/acceptance/workspace_file_test.go
@@ -18,6 +18,15 @@ func TestAccWorkspaceFile(t *testing.T) {
 	})
 }
 
+func TestAccWorkspaceFileEmptyFile(t *testing.T) {
+	workspaceLevel(t, step{
+		Template: `resource "databricks_workspace_file" "empty" {
+			source = "{var.CWD}/../../workspace/acceptance/testdata/empty_file"
+			path = "/Shared/provider-test/empty_{var.RANDOM}"
+		}`,
+	})
+}
+
 func TestAccWorkspaceFileBase64(t *testing.T) {
 	workspaceLevel(t, step{
 		Template: `resource "databricks_workspace_file" "this2" {

--- a/workspace/resource_workspace_file.go
+++ b/workspace/resource_workspace_file.go
@@ -39,10 +39,11 @@ func ResourceWorkspaceFile() *schema.Resource {
 			}
 			path := d.Get("path").(string)
 			importReq := ws_api.Import{
-				Content:   base64.StdEncoding.EncodeToString(content),
-				Format:    ws_api.ImportFormatAuto,
-				Path:      path,
-				Overwrite: true,
+				Content:         base64.StdEncoding.EncodeToString(content),
+				Format:          ws_api.ImportFormatAuto,
+				Path:            path,
+				Overwrite:       true,
+				ForceSendFields: []string{"Content"},
 			}
 			err = client.Workspace.Import(ctx, importReq)
 			if err != nil {
@@ -84,10 +85,11 @@ func ResourceWorkspaceFile() *schema.Resource {
 				return err
 			}
 			return client.Workspace.Import(ctx, ws_api.Import{
-				Content:   base64.StdEncoding.EncodeToString(content),
-				Format:    ws_api.ImportFormatAuto,
-				Overwrite: true,
-				Path:      d.Id(),
+				Content:         base64.StdEncoding.EncodeToString(content),
+				Format:          ws_api.ImportFormatAuto,
+				Overwrite:       true,
+				Path:            d.Id(),
+				ForceSendFields: []string{"Content"},
 			})
 		},
 		Delete: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {

--- a/workspace/resource_workspace_file_test.go
+++ b/workspace/resource_workspace_file_test.go
@@ -285,6 +285,41 @@ func TestResourceWorkspaceFileCreateSource(t *testing.T) {
 	assert.Equal(t, "/Dashboard", d.Id())
 }
 
+func TestResourceWorkspaceFileCreateEmptyFileSource(t *testing.T) {
+	d, err := qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   http.MethodPost,
+				Resource: "/api/2.0/workspace/import",
+				ExpectedRequest: ws_api.Import{
+					Content:         "",
+					Path:            "/__init__.py",
+					Overwrite:       true,
+					Format:          "AUTO",
+					ForceSendFields: []string{"Content"},
+				},
+			},
+			{
+				Method:   http.MethodGet,
+				Resource: "/api/2.0/workspace/get-status?path=%2F__init__.py",
+				Response: ObjectStatus{
+					ObjectID:   4567,
+					ObjectType: File,
+					Path:       "/__init__.py",
+				},
+			},
+		},
+		Resource: ResourceWorkspaceFile(),
+		State: map[string]any{
+			"source": "acceptance/testdata/empty_file",
+			"path":   "/__init__.py",
+		},
+		Create: true,
+	}.Apply(t)
+	assert.NoError(t, err)
+	assert.Equal(t, "/__init__.py", d.Id())
+}
+
 func TestResourceWorkspaceFileCreate_Error(t *testing.T) {
 	d, err := qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->


The issue was reported by the customer who used the exporter to migrate the Azure workspace that they exported many empty `__init__.py` files, but couldn't import them because Terraform gave them an error.  The reason for this error is that in API spec the `content` field is marked as `optional` and correspondingly the `omitempty` was generated in Go SDK, but in fact, this field is required by the API.

To work around this problem until the API spec is fixed, the `Content` field was explicitly added to the `ForceSendFields` array to send the empty content.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [x] covered with integration tests in `internal/acceptance`
- [x] relevant acceptance tests are passing
- [x] using Go SDK

