### PR TITLE
Exporter: generate correct code for inherited `databricks_cluster_policy`

### DIFF
--- a/exporter/importables_test.go
+++ b/exporter/importables_test.go
@@ -113,7 +113,7 @@ func TestClusterPolicy(t *testing.T) {
 
 func TestPredefinedClusterPolicy(t *testing.T) {
 	d := policies.ResourceClusterPolicy().TestResourceData()
-	d.Set("name", "Job Compute")
+	d.Set("policy_family_id", "job-cluster")
 	policy, _ := json.Marshal(map[string]map[string]string{})
 	d.Set("definition", string(policy))
 	ic := importContextForTest()
@@ -689,8 +689,9 @@ func TestPoliciesListing(t *testing.T) {
 			Response: compute.ListPoliciesResponse{
 				Policies: []compute.Policy{
 					{
-						Name:     "Personal Compute",
-						PolicyId: "123",
+						Name:           "Personal Compute",
+						PolicyFamilyId: "personal-vm",
+						PolicyId:       "123",
 					},
 					{
 						Name:     "abcd",


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

Cluster policy could be inherited from the cluster policy family - in this case, the `definition` attribute should be ignored as it's coming from the cluster policy family. Also, switch to detection of built-in cluster policies by ID, instead of name.

It should be done together with the fix for #2935

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

