### PR TITLE
databricks_sql_permmissions: clarify that any_file also works for reading

### DIFF
--- a/docs/resources/sql_permissions.md
+++ b/docs/resources/sql_permissions.md
@@ -66,7 +66,7 @@ The following arguments are available to specify the data object you need to enf
 * `table` - Name of the table. Can be combined with `database`. 
 * `view` - Name of the view. Can be combined with `database`. 
 * `catalog` - (Boolean) If this access control for the entire catalog. Defaults to `false`.
-* `any_file` - (Boolean) If this access control for reading any file. Defaults to `false`.
+* `any_file` - (Boolean) If this access control for reading/writing any file. Defaults to `false`.
 * `anonymous_function` - (Boolean) If this access control for using anonymous function. Defaults to `false`.
 
 ### `privilege_assignments` blocks


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

- Clarify that `databricks_sql_permissions` `any_file` argument works also for writing files and not only reading them

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

