### PR TITLE
fix: resolved issue with run_as_role not being applied on databricks_sql_query resource

### DIFF
--- a/sql/api/query.go
+++ b/sql/api/query.go
@@ -14,6 +14,7 @@ type Query struct {
 	Query        string `json:"query"`
 	// Deprecated: Use databricks_job resource to schedule a Query
 	Schedule       *QuerySchedule    `json:"schedule"`
+	RunAsRole      string            `json:"run_as_role,omitempty"`
 	Options        *QueryOptions     `json:"options,omitempty"`
 	Tags           []string          `json:"tags,omitempty"`
 	Visualizations []json.RawMessage `json:"visualizations,omitempty"`
@@ -46,8 +47,6 @@ type QuerySchedule struct {
 type QueryOptions struct {
 	Parameters    []any             `json:"-"`
 	RawParameters []json.RawMessage `json:"parameters,omitempty"`
-
-	RunAsRole string `json:"run_as_role,omitempty"`
 }
 
 // MarshalJSON ...

--- a/sql/resource_sql_query.go
+++ b/sql/resource_sql_query.go
@@ -290,10 +290,7 @@ func (q *QueryEntity) toAPIObject(schema map[string]*schema.Schema, data *schema
 	}
 
 	if q.RunAsRole != "" {
-		if aq.Options == nil {
-			aq.Options = &api.QueryOptions{}
-		}
-		aq.Options.RunAsRole = q.RunAsRole
+		aq.RunAsRole = q.RunAsRole
 	}
 
 	return &aq, nil
@@ -449,7 +446,7 @@ func (q *QueryEntity) fromAPIObject(aq *api.Query, schema map[string]*schema.Sch
 			q.Parameter = append(q.Parameter, p)
 		}
 
-		q.RunAsRole = aq.Options.RunAsRole
+		q.RunAsRole = aq.RunAsRole
 	}
 
 	// Transform to ResourceData.

--- a/sql/resource_sql_query_test.go
+++ b/sql/resource_sql_query_test.go
@@ -20,9 +20,7 @@ func TestQueryCreate(t *testing.T) {
 					Name:         "Query name",
 					Description:  "Query description",
 					Query:        "SELECT 1",
-					Options: &api.QueryOptions{
-						RunAsRole: "viewer",
-					},
+					RunAsRole:    "viewer",
 				},
 				Response: api.Query{
 					ID:           "foo",
@@ -30,9 +28,7 @@ func TestQueryCreate(t *testing.T) {
 					Name:         "Query name",
 					Description:  "Query description",
 					Query:        "SELECT 1",
-					Options: &api.QueryOptions{
-						RunAsRole: "viewer",
-					},
+					RunAsRole:    "viewer",
 				},
 			},
 			{
@@ -44,9 +40,7 @@ func TestQueryCreate(t *testing.T) {
 					Name:         "Query name",
 					Description:  "Query description",
 					Query:        "SELECT 1",
-					Options: &api.QueryOptions{
-						RunAsRole: "viewer",
-					},
+					RunAsRole:    "viewer",
 				},
 			},
 		},


### PR DESCRIPTION
Fix for: https://github.com/databricks/terraform-provider-databricks/issues/2939

## Changes
The `run_as_role` property wasn't being applied correctly on a databricks_sql_query resource, as documented in https://github.com/databricks/terraform-provider-databricks/issues/2939. This PR tries to solve this issue by aligning the TF code with the [Databricks Query API](https://docs.databricks.com/api/workspace/queries/create), so that run_as_role is only specified and queried from the top-level object, and not from the `options` block anymore.

## Tests
Specifically, the `sql/resource_sql_query_test.go` was updated and run to verify this fix. A proper integration test run is still required to validate the fix.

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

