### PR TITLE
Allow to override built-in `databricks_cluster_policy` resources

### DIFF
--- a/docs/resources/cluster_policy.md
+++ b/docs/resources/cluster_policy.md
@@ -100,6 +100,38 @@ module "engineering_compute_policy" {
 }
 ```
 
+### Overriding the built-in cluster policies
+
+You can override built-in cluster policies by creating a `databricks_cluster_policy` resource with following attributes:
+
+* `name` - the name of the built-in cluster policy.
+* `policy_family_id` - the ID of the cluster policy family used for built-in cluster policy.
+* `policy_family_definition_overrides` - settings to override in the built-in cluster policy.
+
+You can obtain the list of defined cluster policies families using the `databricks policy-families list` command of the new [Databricks CLI](https://docs.databricks.com/en/dev-tools/cli/index.html), or via [list policy families](https://docs.databricks.com/api/workspace/policyfamilies/list) REST API.
+
+```hcl
+locals {
+  personal_vm_override = {
+    "autotermination_minutes" : {
+      "type" : "fixed",
+      "value" : 220,
+      "hidden" : true
+    },
+    "custom_tags.Team" : {
+      "type" : "fixed",
+      "value" : var.team
+    }
+  }
+}
+
+resource "databricks_cluster_policy" "personal_vm" {
+  policy_family_id                   = "personal-vm"
+  policy_family_definition_overrides = jsonencode(personal_vm_override)
+  name                               = "Personal Compute"
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:

--- a/docs/resources/default_namespace_settings.md
+++ b/docs/resources/default_namespace_settings.md
@@ -14,9 +14,9 @@ This setting requires a restart of clusters and SQL warehouses to take effect. A
 
 ```hcl
 resource "databricks_default_namespace_setting" "this" {
-		namespace {
-			value = "namespace_value"
-		}
+  namespace {
+    value = "namespace_value"
+  }
 }
 ```
 

--- a/exporter/context.go
+++ b/exporter/context.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/databricks/databricks-sdk-go"
+	"github.com/databricks/databricks-sdk-go/service/compute"
 
 	"github.com/databricks/terraform-provider-databricks/commands"
 	"github.com/databricks/terraform-provider-databricks/common"
@@ -134,6 +135,9 @@ type importContext struct {
 	allDirectories      []workspace.ObjectStatus
 	allWorkspaceObjects []workspace.ObjectStatus
 	wsObjectsMutex      sync.RWMutex
+
+	builtInPolicies      map[string]compute.PolicyFamily
+	builtInPoliciesMutex sync.Mutex
 }
 
 type mount struct {

--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -253,6 +253,15 @@ var emptyClusterPolicies = qa.HTTPFixture{
 	Response:     compute.ListPoliciesResponse{},
 }
 
+var emptyPolicyFamilies = qa.HTTPFixture{
+	Method:   "GET",
+	Resource: "/api/2.0/policy-families?",
+	Response: compute.ListPolicyFamiliesResponse{
+		PolicyFamilies: []compute.PolicyFamily{},
+	},
+	ReuseRequest: true,
+}
+
 var emptyMlflowWebhooks = qa.HTTPFixture{
 	Method:       "GET",
 	ReuseRequest: true,
@@ -392,6 +401,7 @@ func TestImportingUsersGroupsSecretScopes(t *testing.T) {
 			emptySqlAlerts,
 			emptyPipelines,
 			emptyClusterPolicies,
+			emptyPolicyFamilies,
 			emptyWorkspaceConf,
 			allKnownWorkspaceConfs,
 			dummyWorkspaceConf,
@@ -649,6 +659,7 @@ func TestImportingNoResourcesError(t *testing.T) {
 			emptySqlDashboards,
 			emptySqlAlerts,
 			emptyPipelines,
+			emptyPolicyFamilies,
 			{
 				Method:       "GET",
 				Resource:     "/api/2.0/global-init-scripts",

--- a/internal/acceptance/cluster_policy_test.go
+++ b/internal/acceptance/cluster_policy_test.go
@@ -28,3 +28,29 @@ func TestAccClusterPolicyResourceFullLifecycle(t *testing.T) {
 		}`,
 	})
 }
+
+func TestAccClusterPolicyResourceOverrideBuiltIn(t *testing.T) {
+	workspaceLevel(t, step{
+		Template: `resource "databricks_cluster_policy" "personal_vm" {
+			name = "Personal Compute"
+			policy_family_id = "personal-vm"
+			policy_family_definition_overrides = jsonencode({
+				"node_type_id": {
+				  "type": "fixed",
+				  "value": "Standard_DS3_v2"
+				}
+			  })
+		}
+		`,
+	})
+}
+
+func TestAccClusterPolicyResourceOverrideNew(t *testing.T) {
+	workspaceLevel(t, step{
+		Template: `resource "databricks_cluster_policy" "policyoverrideempty" {
+			policy_family_id = "personal-vm"
+			name             = "Policy Override {var.RANDOM}"
+		  }
+		  `,
+	})
+}

--- a/policies/resource_cluster_policy.go
+++ b/policies/resource_cluster_policy.go
@@ -3,11 +3,26 @@ package policies
 import (
 	"context"
 
+	"github.com/databricks/databricks-sdk-go"
 	"github.com/databricks/databricks-sdk-go/service/compute"
 	"github.com/databricks/terraform-provider-databricks/common"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
+
+func isBuiltinPolicyFamily(ctx context.Context, w *databricks.WorkspaceClient, familyId, familyName string) (bool, error) {
+	// Fetch supported policy families, and check against it
+	families, err2 := w.PolicyFamilies.ListAll(ctx, compute.ListPolicyFamiliesRequest{})
+	if err2 != nil {
+		return false, err2
+	}
+	for _, family := range families {
+		if familyId == family.PolicyFamilyId && familyName == family.Name {
+			return true, nil
+		}
+	}
+	return false, nil
+}
 
 // ResourceClusterPolicy ...
 func ResourceClusterPolicy() *schema.Resource {
@@ -19,6 +34,7 @@ func ResourceClusterPolicy() *schema.Resource {
 				Computed: true,
 			}
 			m["definition"].ConflictsWith = []string{"policy_family_definition_overrides", "policy_family_id"}
+			m["definition"].Computed = true
 			m["policy_family_definition_overrides"].ConflictsWith = []string{"definition"}
 			m["policy_family_id"].ConflictsWith = []string{"definition"}
 			m["policy_family_definition_overrides"].RequiredWith = []string{"policy_family_id"}
@@ -37,11 +53,31 @@ func ResourceClusterPolicy() *schema.Resource {
 			var request compute.CreatePolicy
 			common.DataToStructPointer(d, s, &request)
 
-			clusterPolicy, err := w.ClusterPolicies.Create(ctx, request)
+			var clusterPolicy *compute.CreatePolicyResponse
+			if request.PolicyFamilyId != "" {
+				isBuiltin, err2 := isBuiltinPolicyFamily(ctx, w, request.PolicyFamilyId, request.Name)
+				if err2 != nil {
+					return err2
+				}
+				if isBuiltin {
+					resp, err2 := w.ClusterPolicies.GetByName(ctx, request.Name)
+					if err2 != nil {
+						return err2
+					}
+					clusterPolicy = &compute.CreatePolicyResponse{PolicyId: resp.PolicyId}
+					var editRequest compute.EditPolicy
+					common.DataToStructPointer(d, s, &editRequest)
+					editRequest.PolicyId = resp.PolicyId
+					err = w.ClusterPolicies.Edit(ctx, editRequest)
+				} else {
+					clusterPolicy, err = w.ClusterPolicies.Create(ctx, request)
+				}
+			} else {
+				clusterPolicy, err = w.ClusterPolicies.Create(ctx, request)
+			}
 			if err != nil {
 				return err
 			}
-
 			d.SetId(clusterPolicy.PolicyId)
 			return nil
 		},
@@ -50,7 +86,6 @@ func ResourceClusterPolicy() *schema.Resource {
 			if err != nil {
 				return err
 			}
-
 			resp, err := w.ClusterPolicies.GetByPolicyId(ctx, d.Id())
 			if err != nil {
 				return err
@@ -66,6 +101,9 @@ func ResourceClusterPolicy() *schema.Resource {
 			var request compute.EditPolicy
 			common.DataToStructPointer(d, s, &request)
 			request.PolicyId = d.Id()
+			if request.PolicyFamilyId != "" {
+				request.Definition = ""
+			}
 
 			return w.ClusterPolicies.Edit(ctx, request)
 		},
@@ -73,6 +111,20 @@ func ResourceClusterPolicy() *schema.Resource {
 			w, err := c.WorkspaceClient()
 			if err != nil {
 				return err
+			}
+			var request compute.EditPolicy
+			common.DataToStructPointer(d, s, &request)
+			if request.PolicyFamilyId != "" {
+				isBuiltin, err := isBuiltinPolicyFamily(ctx, w, request.PolicyFamilyId, request.Name)
+				if err != nil {
+					return err
+				}
+				if isBuiltin {
+					request.PolicyId = d.Id()
+					request.PolicyFamilyDefinitionOverrides = ""
+					request.Definition = ""
+					return w.ClusterPolicies.Edit(ctx, request)
+				}
 			}
 			return w.ClusterPolicies.DeleteByPolicyId(ctx, d.Id())
 		},


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

Databricks is shipped with a number of built-in cluster policies that are inherited from the cluster policy families.  For built-in cluster policies we need to provide an override, not the `definition`.  We also need to handle deletes for them differently - just remove the overrides because we can't remove built-in policies.  We also need to distinguish cases when we override built-in policy from cases when we create a new policy based on the cluster policy family.

This PR makes following changes:

* Discovers a list of cluster policies families dynamically instead of relying on hardcoded list of policies
* When creating a new `databricks_cluster_policy`, check if it's built-in policy or not, and if it's built-in, then update it with policy override instead of trying to create.
* When deleting a created `databricks_cluster_policy`, check if it's built-in policy or not, and if it's built-in, then reset policy overrides to empty string to return back to the original state.

This fixes #2935

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [x] covered with integration tests in `internal/acceptance`
- [x] relevant acceptance tests are passing
- [x] using Go SDK

