### PR TITLE
Remove diff suppression for a job's `run_as` block

### DIFF
--- a/internal/acceptance/job_test.go
+++ b/internal/acceptance/job_test.go
@@ -279,3 +279,23 @@ func TestAccJobRunAsServicePrincipal(t *testing.T) {
 		Template: runAsTemplate(`service_principal_name = "` + spId + `"`),
 	})
 }
+
+func TestAccJobRunAsMutations(t *testing.T) {
+	loadDebugEnvIfRunsFromIDE(t, "ucws")
+	spId := GetEnvOrSkipTest(t, "ACCOUNT_LEVEL_SERVICE_PRINCIPAL_ID")
+	unityWorkspaceLevel(
+		t,
+		// Provision job with service principal `run_as`
+		step{
+			Template: runAsTemplate(`service_principal_name = "` + spId + `"`),
+		},
+		// Update job to a user `run_as`
+		step{
+			Template: runAsTemplate(`user_name = data.databricks_current_user.me.user_name`),
+		},
+		// Update job back to a service principal `run_as`
+		step{
+			Template: runAsTemplate(`service_principal_name = "` + spId + `"`),
+		},
+	)
+}

--- a/jobs/data_job_test.go
+++ b/jobs/data_job_test.go
@@ -138,10 +138,10 @@ func TestDataSourceQueryableJobRunAsSameUser(t *testing.T) {
 		HCL:         `job_id = "234"`,
 		ID:          "234",
 	}.ApplyAndExpectData(t, map[string]any{
-		"job_id":                             "234",
-		"id":                                 "234",
-		"job_settings.0.settings.0.name":     "Second",
-		"job_settings.0.settings.0.run_as.0": map[string]any{},
+		"job_id":                         "234",
+		"id":                             "234",
+		"job_settings.0.settings.0.name": "Second",
+		"job_settings.0.settings.0.run_as.0.user_name": "user@domain.com",
 	})
 }
 

--- a/jobs/resource_job.go
+++ b/jobs/resource_job.go
@@ -290,7 +290,7 @@ type JobSettings struct {
 	NotificationSettings *jobs.JobNotificationSettings `json:"notification_settings,omitempty"`
 	Tags                 map[string]string             `json:"tags,omitempty"`
 	Queue                *jobs.QueueSettings           `json:"queue,omitempty"`
-	RunAs                *JobRunAs                     `json:"run_as,omitempty" tf:"suppress_diff"`
+	RunAs                *JobRunAs                     `json:"run_as,omitempty"`
 	Health               *JobHealth                    `json:"health,omitempty"`
 	Parameters           []JobParameterDefinition      `json:"parameters,omitempty" tf:"alias:parameter"`
 	Deployment           *jobs.JobDeployment           `json:"deployment,omitempty"`

--- a/jobs/resource_job.go
+++ b/jobs/resource_job.go
@@ -290,7 +290,7 @@ type JobSettings struct {
 	NotificationSettings *jobs.JobNotificationSettings `json:"notification_settings,omitempty"`
 	Tags                 map[string]string             `json:"tags,omitempty"`
 	Queue                *jobs.QueueSettings           `json:"queue,omitempty"`
-	RunAs                *JobRunAs                     `json:"run_as,omitempty"`
+	RunAs                *JobRunAs                     `json:"run_as,omitempty" tf:"computed"`
 	Health               *JobHealth                    `json:"health,omitempty"`
 	Parameters           []JobParameterDefinition      `json:"parameters,omitempty" tf:"alias:parameter"`
 	Deployment           *jobs.JobDeployment           `json:"deployment,omitempty"`
@@ -579,7 +579,10 @@ func (a JobsAPI) Read(id string) (job Job, err error) {
 		job.Settings.sortWebhooksByID()
 	}
 
-	if job.Settings != nil && job.RunAsUserName != "" && job.RunAsUserName != job.CreatorUserName {
+	// Populate the `run_as` field. In the settings struct it can only be set on write and is not
+	// returned on read. Therefore, we populate it from the top-level `run_as_user_name` field so
+	// that Terraform can still diff it with the intended state.
+	if job.Settings != nil && job.RunAsUserName != "" {
 		if common.StringIsUUID(job.RunAsUserName) {
 			job.Settings.RunAs = &JobRunAs{
 				ServicePrincipalName: job.RunAsUserName,


### PR DESCRIPTION
## Changes

Diff suppression meant that once a nested key was set (either `user_name` or `service_principal_name`), it was unable to unset it.  If both are specified, they are ignored. This meant that once a job was configured with a `run_as` user, it was not possible to configure it with a service principal, and vice versa.

Related PRs:
* #2388
* #2626
* #2765

## Tests

The new integration test passes.

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [x] covered with integration tests in `internal/acceptance`
- [x] relevant acceptance tests are passing
- [ ] using Go SDK

