### PR TITLE
Exporter: generate references also for integer attributes

### DIFF
--- a/exporter/importables.go
+++ b/exporter/importables.go
@@ -383,6 +383,7 @@ var resourcesMap map[string]importable = map[string]importable{
 			{Path: "task.spark_python_task.parameters", Resource: "databricks_dbfs_file", Match: "dbfs_path"},
 			{Path: "task.spark_jar_task.jar_uri", Resource: "databricks_dbfs_file", Match: "dbfs_path"},
 			{Path: "task.notebook_task.notebook_path", Resource: "databricks_notebook"},
+			{Path: "task.run_job_task.job_id", Resource: "databricks_job"},
 			{Path: "task.notebook_task.notebook_path", Resource: "databricks_repo", Match: "path", MatchType: MatchPrefix},
 			{Path: "task.pipeline_task.pipeline_id", Resource: "databricks_pipeline"},
 			{Path: "task.sql_task.query.query_id", Resource: "databricks_sql_query"},

--- a/exporter/test-data/run-job-child.json
+++ b/exporter/test-data/run-job-child.json
@@ -1,0 +1,27 @@
+{
+  "created_time":1678702840675,
+  "job_id":932035899730845,
+  "settings": {
+    "format":"MULTI_TASK",
+    "max_concurrent_runs":1,
+    "name":"JarTask",
+    "tasks": [
+      {
+        "existing_cluster_id":"1234",
+        "libraries": [
+          {
+            "jar":"dbfs:/FileStore/jars/tests-0.0.1.jar"
+          }
+        ],
+        "spark_jar_task": {
+          "main_class_name":"tests.JarTask1",
+          "parameters": [
+            "param1",
+            "param2"
+          ]
+        },
+        "task_key":"JarTask"
+      }
+    ]
+  }
+}

--- a/exporter/test-data/run-job-main.json
+++ b/exporter/test-data/run-job-main.json
@@ -1,0 +1,17 @@
+{
+  "created_time":1700654567867,
+  "job_id":1047501313827425,
+  "settings": {
+    "format":"MULTI_TASK",
+    "max_concurrent_runs":1,
+    "name":"RunJobTask",
+    "tasks": [
+      {
+        "run_job_task": {
+          "job_id":932035899730845
+        },
+        "task_key":"run_job"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

Originally exporter generated references only for strings. With introduction of `run_job_task` in `databricks_job` that uses integer type for `job_id` attribute, we need to generate references for integer fields as well, otherwise generated HCL code had a hardcoded Job ID value, and we couldn't use the generated code to apply to other environments.

This fixes #2933

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

