### PR TITLE
Migrate jobs delete to go-sdk

### DIFF
--- a/jobs/resource_job.go
+++ b/jobs/resource_job.go
@@ -920,7 +920,12 @@ func ResourceJob() *schema.Resource {
 		},
 		Delete: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
 			ctx = getReadCtx(ctx, d)
-			return NewJobsAPI(ctx, c).Delete(d.Id())
+			w, err := c.WorkspaceClient()
+			if err != nil {
+				return err
+			}
+			jobID, err := parseJobId(d.Id())
+			return w.Jobs.DeleteByJobId(ctx, jobID)
 		},
 	}.ToResource()
 }

--- a/jobs/resource_job.go
+++ b/jobs/resource_job.go
@@ -925,6 +925,9 @@ func ResourceJob() *schema.Resource {
 				return err
 			}
 			jobID, err := parseJobId(d.Id())
+			if err != nil {
+				return err
+			}
 			return w.Jobs.DeleteByJobId(ctx, jobID)
 		},
 	}.ToResource()

--- a/jobs/resource_job_test.go
+++ b/jobs/resource_job_test.go
@@ -2217,7 +2217,7 @@ func TestResourceJobDelete(t *testing.T) {
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   "POST",
-				Resource: "/api/2.0/jobs/delete",
+				Resource: "/api/2.1/jobs/delete",
 				ExpectedRequest: map[string]int{
 					"job_id": 789,
 				},


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
- Migrate jobs delete to use go-sdk
- Updated test fixture because the go-sdk uses 2.1 api

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

