### PR TITLE
Fixed `TestWorkspace_WaitForResolve_Failure` by checking the unwrapped `*net.DNSError`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/databricks/terraform-provider-databricks
 go 1.20
 
 require (
-	github.com/databricks/databricks-sdk-go v0.25.1-0.20231123150617-fe6b76828faa
+	github.com/databricks/databricks-sdk-go v0.25.1-0.20231124124904-c3188f42c191
 	github.com/golang-jwt/jwt/v4 v4.5.0
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/hcl v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/databricks/terraform-provider-databricks
 go 1.20
 
 require (
-	github.com/databricks/databricks-sdk-go v0.25.1-0.20231124124904-c3188f42c191
+	github.com/databricks/databricks-sdk-go v0.25.1-0.20231124164407-b0f3c83d9f5e
 	github.com/golang-jwt/jwt/v4 v4.5.0
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/hcl v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -27,6 +27,8 @@ github.com/databricks/databricks-sdk-go v0.25.0 h1:qEpYHQ18HHqLIsIXXHhixakTtt6Q0
 github.com/databricks/databricks-sdk-go v0.25.0/go.mod h1:s3/f2T8UGyKkcMywIyporj/Kb/lsiWkiksT/C84Swrs=
 github.com/databricks/databricks-sdk-go v0.25.1-0.20231123150617-fe6b76828faa h1:dw813khCMgrSRH1RMOcQSO7QW/WtdWu7PfL389V1ww8=
 github.com/databricks/databricks-sdk-go v0.25.1-0.20231123150617-fe6b76828faa/go.mod h1:Ts4/j+CNHrgzAgP7mlJjjy3+k9zu2EXuObVw6+o+6RQ=
+github.com/databricks/databricks-sdk-go v0.25.1-0.20231124124904-c3188f42c191 h1:tCTCI16MWo1usP+5r3jiPKYcg01JT/lXItPFcr99UlI=
+github.com/databricks/databricks-sdk-go v0.25.1-0.20231124124904-c3188f42c191/go.mod h1:Ts4/j+CNHrgzAgP7mlJjjy3+k9zu2EXuObVw6+o+6RQ=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/go.sum
+++ b/go.sum
@@ -29,6 +29,8 @@ github.com/databricks/databricks-sdk-go v0.25.1-0.20231123150617-fe6b76828faa h1
 github.com/databricks/databricks-sdk-go v0.25.1-0.20231123150617-fe6b76828faa/go.mod h1:Ts4/j+CNHrgzAgP7mlJjjy3+k9zu2EXuObVw6+o+6RQ=
 github.com/databricks/databricks-sdk-go v0.25.1-0.20231124124904-c3188f42c191 h1:tCTCI16MWo1usP+5r3jiPKYcg01JT/lXItPFcr99UlI=
 github.com/databricks/databricks-sdk-go v0.25.1-0.20231124124904-c3188f42c191/go.mod h1:Ts4/j+CNHrgzAgP7mlJjjy3+k9zu2EXuObVw6+o+6RQ=
+github.com/databricks/databricks-sdk-go v0.25.1-0.20231124164407-b0f3c83d9f5e h1:esWvvF5TGkEK5UsHqAcodlpUjZposku6++eiKUkRvPo=
+github.com/databricks/databricks-sdk-go v0.25.1-0.20231124164407-b0f3c83d9f5e/go.mod h1:Ts4/j+CNHrgzAgP7mlJjjy3+k9zu2EXuObVw6+o+6RQ=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/mws/resource_mws_workspaces.go
+++ b/mws/resource_mws_workspaces.go
@@ -201,10 +201,10 @@ func (a WorkspacesAPI) verifyWorkspaceReachable(ws Workspace) *resource.RetryErr
 	// make a request to SCIM API, just to verify there are no errors
 	var response map[string]any
 	err = wsClient.Get(ctx, "/preview/scim/v2/Me", nil, &response)
-	var apiError *apierr.APIError
-	if errors.As(err, &apiError) {
+	var dnsError *net.DNSError
+	if errors.As(err, &dnsError) {
 		err = fmt.Errorf("workspace %s is not yet reachable: %s",
-			ws.WorkspaceURL, apiError)
+			ws.WorkspaceURL, dnsError.Err)
 		log.Printf("[INFO] %s", err)
 		// expected to retry on: dial tcp: lookup XXX: no such host
 		return resource.RetryableError(err)


### PR DESCRIPTION
This PR fixes the test failure by properly depending on the error from Go's networking stack, which is now propagated by https://github.com/databricks/databricks-sdk-go/pull/699
