### PR TITLE
[NOT MERGED] Migrate library delete to use go-sdk

### DIFF
--- a/clusters/resource_library.go
+++ b/clusters/resource_library.go
@@ -82,9 +82,7 @@ func ResourceLibrary() *schema.Resource {
 			if err != nil {
 				return err
 			}
-			_, err = w.Clusters.Start(ctx, compute.StartCluster{
-				ClusterId: clusterID,
-			})
+			_, err = w.Clusters.StartByClusterIdAndWait(ctx, clusterID)
 			if err != nil {
 				return err
 			}

--- a/clusters/resource_library.go
+++ b/clusters/resource_library.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/databricks/databricks-sdk-go/apierr"
+	"github.com/databricks/databricks-sdk-go/service/compute"
 	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/databricks/terraform-provider-databricks/libraries"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -77,12 +78,18 @@ func ResourceLibrary() *schema.Resource {
 		},
 		Delete: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
 			clusterID, libraryRep := parseId(d.Id())
-			err := NewClustersAPI(ctx, c).Start(clusterID)
+			w, err := c.WorkspaceClient()
 			if err != nil {
 				return err
 			}
-			librariesAPI := libraries.NewLibrariesAPI(ctx, c)
-			cll, err := librariesAPI.ClusterStatus(clusterID)
+			_, err = w.Clusters.Start(ctx, compute.StartCluster{
+				ClusterId: clusterID,
+			})
+			if err != nil {
+				return err
+			}
+			// cll, err := librariesAPI.ClusterStatus(clusterID)
+			cll, err := w.Libraries.ClusterStatusByClusterId(ctx, clusterID)
 			if err != nil {
 				return err
 			}
@@ -90,9 +97,9 @@ func ResourceLibrary() *schema.Resource {
 				if v.Library.String() != libraryRep {
 					continue
 				}
-				return librariesAPI.Uninstall(libraries.ClusterLibraryList{
-					ClusterID: clusterID,
-					Libraries: []libraries.Library{*v.Library},
+				return w.Libraries.Uninstall(ctx, compute.UninstallLibraries{
+					ClusterId: clusterID,
+					Libraries: []compute.Library{*v.Library},
 				})
 			}
 			return apierr.NotFound(fmt.Sprintf("cannot find %s on %s", libraryRep, clusterID))

--- a/clusters/resource_library.go
+++ b/clusters/resource_library.go
@@ -88,7 +88,6 @@ func ResourceLibrary() *schema.Resource {
 			if err != nil {
 				return err
 			}
-			// cll, err := librariesAPI.ClusterStatus(clusterID)
 			cll, err := w.Libraries.ClusterStatusByClusterId(ctx, clusterID)
 			if err != nil {
 				return err

--- a/clusters/resource_library_test.go
+++ b/clusters/resource_library_test.go
@@ -65,6 +65,14 @@ func TestLibraryDelete(t *testing.T) {
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:       "GET",
+				Resource:     "/api/2.0/clusters/get?cluster_id=abc",
+				ReuseRequest: true,
+				Response: ClusterInfo{
+					State: ClusterStateRunning,
+				},
+			},
+			{
+				Method:       "GET",
 				Resource:     "/api/2.1/clusters/get?cluster_id=abc",
 				ReuseRequest: true,
 				Response: ClusterInfo{

--- a/clusters/resource_library_test.go
+++ b/clusters/resource_library_test.go
@@ -3,6 +3,7 @@ package clusters
 import (
 	"testing"
 
+	"github.com/databricks/databricks-sdk-go/service/compute"
 	"github.com/databricks/terraform-provider-databricks/libraries"
 	"github.com/databricks/terraform-provider-databricks/qa"
 )
@@ -65,18 +66,17 @@ func TestLibraryDelete(t *testing.T) {
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:       "GET",
-				Resource:     "/api/2.0/clusters/get?cluster_id=abc",
+				Resource:     "/api/2.1/clusters/start?cluster_id=abc",
 				ReuseRequest: true,
 				Response: ClusterInfo{
 					State: ClusterStateRunning,
 				},
 			},
 			{
-				Method:       "GET",
-				Resource:     "/api/2.1/clusters/get?cluster_id=abc",
-				ReuseRequest: true,
-				Response: ClusterInfo{
-					State: ClusterStateRunning,
+				Method:   "POST",
+				Resource: "/api/2.1/clusters/start",
+				ExpectedRequest: compute.StartCluster{
+					ClusterId: "abc",
 				},
 			},
 			{

--- a/clusters/resource_library_test.go
+++ b/clusters/resource_library_test.go
@@ -66,7 +66,7 @@ func TestLibraryDelete(t *testing.T) {
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:       "GET",
-				Resource:     "/api/2.1/clusters/get?cluster_id=abc",
+				Resource:     "/api/2.0/clusters/get?cluster_id=abc",
 				ReuseRequest: true,
 				Response: ClusterInfo{
 					State: ClusterStateRunning,

--- a/clusters/resource_library_test.go
+++ b/clusters/resource_library_test.go
@@ -74,7 +74,7 @@ func TestLibraryDelete(t *testing.T) {
 			{
 				Method:       "GET",
 				ReuseRequest: true,
-				Resource:     "/api/2.1/libraries/cluster-status?cluster_id=abc",
+				Resource:     "/api/2.0/libraries/cluster-status?cluster_id=abc",
 				Response: libraries.ClusterLibraryStatuses{
 					LibraryStatuses: []libraries.LibraryStatus{
 						{
@@ -88,7 +88,7 @@ func TestLibraryDelete(t *testing.T) {
 			},
 			{
 				Method:   "POST",
-				Resource: "/api/2.1/libraries/uninstall",
+				Resource: "/api/2.0/libraries/uninstall",
 				ExpectedRequest: libraries.ClusterLibraryList{
 					Libraries: []libraries.Library{
 						{

--- a/clusters/resource_library_test.go
+++ b/clusters/resource_library_test.go
@@ -65,7 +65,7 @@ func TestLibraryDelete(t *testing.T) {
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:       "GET",
-				Resource:     "/api/2.0/clusters/get?cluster_id=abc",
+				Resource:     "/api/2.1/clusters/get?cluster_id=abc",
 				ReuseRequest: true,
 				Response: ClusterInfo{
 					State: ClusterStateRunning,
@@ -74,7 +74,7 @@ func TestLibraryDelete(t *testing.T) {
 			{
 				Method:       "GET",
 				ReuseRequest: true,
-				Resource:     "/api/2.0/libraries/cluster-status?cluster_id=abc",
+				Resource:     "/api/2.1/libraries/cluster-status?cluster_id=abc",
 				Response: libraries.ClusterLibraryStatuses{
 					LibraryStatuses: []libraries.LibraryStatus{
 						{
@@ -88,7 +88,7 @@ func TestLibraryDelete(t *testing.T) {
 			},
 			{
 				Method:   "POST",
-				Resource: "/api/2.0/libraries/uninstall",
+				Resource: "/api/2.1/libraries/uninstall",
 				ExpectedRequest: libraries.ClusterLibraryList{
 					Libraries: []libraries.Library{
 						{

--- a/clusters/resource_library_test.go
+++ b/clusters/resource_library_test.go
@@ -66,7 +66,7 @@ func TestLibraryDelete(t *testing.T) {
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:       "GET",
-				Resource:     "/api/2.1/clusters/start?cluster_id=abc",
+				Resource:     "/api/2.1/clusters/get?cluster_id=abc",
 				ReuseRequest: true,
 				Response: ClusterInfo{
 					State: ClusterStateRunning,

--- a/clusters/resource_library_test.go
+++ b/clusters/resource_library_test.go
@@ -74,7 +74,7 @@ func TestLibraryDelete(t *testing.T) {
 			},
 			{
 				Method:   "POST",
-				Resource: "/api/2.1/clusters/start",
+				Resource: "/api/2.0/clusters/start",
 				ExpectedRequest: compute.StartCluster{
 					ClusterId: "abc",
 				},


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
- Migrate delete handler of `resource_library` to use `go-sdk`

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

