### PR TITLE
Migrate delete to use go-sdk for library resource

### DIFF
--- a/clusters/clusters_api_sdk.go
+++ b/clusters/clusters_api_sdk.go
@@ -5,22 +5,12 @@ import (
 	"log"
 	"time"
 
+	"github.com/databricks/databricks-sdk-go"
 	"github.com/databricks/databricks-sdk-go/service/compute"
-	"github.com/databricks/terraform-provider-databricks/common"
 )
 
-// Start a terminated Spark cluster given its ID and wait till it's running
-func StartCluster(ctx context.Context, c *common.DatabricksClient, clusterID string) error {
-	_, err := StartClusterAndGetInfo(ctx, c, clusterID)
-	return err
-}
-
 // StartAndGetInfo starts cluster and returns info
-func StartClusterAndGetInfo(ctx context.Context, c *common.DatabricksClient, clusterID string) (*compute.ClusterDetails, error) {
-	w, err := c.WorkspaceClient()
-	if err != nil {
-		return nil, err
-	}
+func StartClusterAndGetInfo(ctx context.Context, w *databricks.WorkspaceClient, clusterID string) (*compute.ClusterDetails, error) {
 	cluster, err := w.Clusters.GetByClusterId(ctx, clusterID)
 	if err != nil {
 		return cluster, err

--- a/clusters/clusters_api_sdk.go
+++ b/clusters/clusters_api_sdk.go
@@ -1,0 +1,47 @@
+package clusters
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/databricks/databricks-sdk-go/service/compute"
+	"github.com/databricks/terraform-provider-databricks/common"
+)
+
+// Start a terminated Spark cluster given its ID and wait till it's running
+func StartCluster(ctx context.Context, c *common.DatabricksClient, clusterID string) error {
+	_, err := StartClusterAndGetInfo(ctx, c, clusterID)
+	return err
+}
+
+// StartAndGetInfo starts cluster and returns info
+func StartClusterAndGetInfo(ctx context.Context, c *common.DatabricksClient, clusterID string) (*compute.ClusterDetails, error) {
+	w, err := c.WorkspaceClient()
+	if err != nil {
+		return nil, err
+	}
+	cluster, err := w.Clusters.GetByClusterId(ctx, clusterID)
+	if err != nil {
+		return cluster, err
+	}
+	switch cluster.State {
+	case compute.StateRunning:
+		// it's already running, so we're good to return
+		return cluster, nil
+	case compute.StatePending, compute.StateResizing, compute.StateRestarting:
+		// let's wait tiny bit, so we return RUNNING cluster info
+		return w.Clusters.WaitGetClusterRunning(ctx, clusterID, 20*time.Minute, nil)
+	case compute.StateTerminating:
+		// Let it finish terminating, so it's safe to start again.
+		// TERMINATED cluster info will be returned this way
+		info, err := w.Clusters.WaitGetClusterTerminated(ctx, clusterID, 20*time.Minute, nil)
+		if err != nil {
+			return info, err
+		}
+	case compute.StateError, compute.StateUnknown:
+		// most likely we can start error'ed cluster again...
+		log.Printf("[ERROR] Cluster %s: %s", cluster.State, cluster.StateMessage)
+	}
+	return w.Clusters.StartByClusterIdAndWait(ctx, clusterID)
+}

--- a/clusters/clusters_api_sdk_test.go
+++ b/clusters/clusters_api_sdk_test.go
@@ -33,7 +33,11 @@ func TestStartClusterAndGetInfo_Pending(t *testing.T) {
 	require.NoError(t, err)
 
 	ctx := context.Background()
-	clusterInfo, err := StartClusterAndGetInfo(ctx, client, "abc")
+	w, err := client.WorkspaceClient()
+	if err != nil {
+		panic(err)
+	}
+	clusterInfo, err := StartClusterAndGetInfo(ctx, w, "abc")
 	require.NoError(t, err)
 	assert.Equal(t, ClusterStateRunning, string(clusterInfo.State))
 }
@@ -80,7 +84,7 @@ func TestStartClusterAndGetInfo_Terminating(t *testing.T) {
 	if err != nil {
 		panic(err)
 	}
-	clusterInfo, err := StartClusterAndGetInfo(ctx, w), "abc")
+	clusterInfo, err := StartClusterAndGetInfo(ctx, w, "abc")
 	require.NoError(t, err)
 	assert.Equal(t, ClusterStateRunning, string(clusterInfo.State))
 }
@@ -152,7 +156,7 @@ func TestStartClusterAndGetInfo_StartingError(t *testing.T) {
 	ctx := context.Background()
 	w, err := client.WorkspaceClient()
 	if err != nil {
-		panic(err)m
+		panic(err)
 	}
 	_, err = StartClusterAndGetInfo(ctx, w, "abc")
 	require.Error(t, err)

--- a/clusters/clusters_api_sdk_test.go
+++ b/clusters/clusters_api_sdk_test.go
@@ -1,0 +1,148 @@
+package clusters
+
+import (
+	"context"
+	"testing"
+
+	"github.com/databricks/databricks-sdk-go/apierr"
+	"github.com/databricks/terraform-provider-databricks/qa"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStartClusterAndGetInfo_Pending(t *testing.T) {
+	client, server, err := qa.HttpFixtureClient(t, []qa.HTTPFixture{
+		{
+			Method:   "GET",
+			Resource: "/api/2.0/clusters/get?cluster_id=abc",
+			Response: ClusterInfo{
+				State:     ClusterStatePending,
+				ClusterID: "abc",
+			},
+		},
+		{
+			Method:   "GET",
+			Resource: "/api/2.0/clusters/get?cluster_id=abc",
+			Response: ClusterInfo{
+				State:     ClusterStateRunning,
+				ClusterID: "abc",
+			},
+		},
+	})
+	defer server.Close()
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	clusterInfo, err := StartClusterAndGetInfo(ctx, client, "abc")
+	require.NoError(t, err)
+	assert.Equal(t, ClusterStateRunning, string(clusterInfo.State))
+}
+
+func TestStartClusterAndGetInfo_Terminating(t *testing.T) {
+	client, server, err := qa.HttpFixtureClient(t, []qa.HTTPFixture{
+		{
+			Method:   "GET",
+			Resource: "/api/2.0/clusters/get?cluster_id=abc",
+			Response: ClusterInfo{
+				State:     ClusterStateTerminating,
+				ClusterID: "abc",
+			},
+		},
+		{
+			Method:   "GET",
+			Resource: "/api/2.0/clusters/get?cluster_id=abc",
+			Response: ClusterInfo{
+				State:     ClusterStateTerminated,
+				ClusterID: "abc",
+			},
+		},
+		{
+			Method:   "POST",
+			Resource: "/api/2.0/clusters/start",
+			ExpectedRequest: ClusterID{
+				ClusterID: "abc",
+			},
+		},
+		{
+			Method:   "GET",
+			Resource: "/api/2.0/clusters/get?cluster_id=abc",
+			Response: ClusterInfo{
+				State:     ClusterStateRunning,
+				ClusterID: "abc",
+			},
+		},
+	})
+	defer server.Close()
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	clusterInfo, err := StartClusterAndGetInfo(ctx, client, "abc")
+	require.NoError(t, err)
+	assert.Equal(t, ClusterStateRunning, string(clusterInfo.State))
+}
+
+func TestStartClusterAndGetInfo_Error(t *testing.T) {
+	client, server, err := qa.HttpFixtureClient(t, []qa.HTTPFixture{
+		{
+			Method:   "GET",
+			Resource: "/api/2.0/clusters/get?cluster_id=abc",
+			Response: ClusterInfo{
+				State:        ClusterStateError,
+				StateMessage: "I am a teapot",
+			},
+		},
+		{
+			Method:   "POST",
+			Resource: "/api/2.0/clusters/start",
+			ExpectedRequest: ClusterID{
+				ClusterID: "abc",
+			},
+		},
+		{
+			Method:   "GET",
+			Resource: "/api/2.0/clusters/get?cluster_id=abc",
+			Response: ClusterInfo{
+				State:     ClusterStateRunning,
+				ClusterID: "abc",
+			},
+		},
+	})
+	defer server.Close()
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	clusterInfo, err := StartClusterAndGetInfo(ctx, client, "abc")
+	require.NoError(t, err)
+	assert.Equal(t, ClusterStateRunning, string(clusterInfo.State))
+}
+
+func TestStartClusterAndGetInfo_StartingError(t *testing.T) {
+	client, server, err := qa.HttpFixtureClient(t, []qa.HTTPFixture{
+		{
+			Method:   "GET",
+			Resource: "/api/2.0/clusters/get?cluster_id=abc",
+			Response: ClusterInfo{
+				State:        ClusterStateError,
+				StateMessage: "I am a teapot",
+			},
+		},
+		{
+			Method:   "POST",
+			Resource: "/api/2.0/clusters/start",
+			ExpectedRequest: ClusterID{
+				ClusterID: "abc",
+			},
+			Response: apierr.APIErrorBody{
+				Message: "I am a teapot!",
+			},
+			Status: 418,
+		},
+	})
+	defer server.Close()
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	_, err = StartClusterAndGetInfo(ctx, client, "abc")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "I am a teapot")
+}

--- a/clusters/clusters_api_sdk_test.go
+++ b/clusters/clusters_api_sdk_test.go
@@ -76,7 +76,11 @@ func TestStartClusterAndGetInfo_Terminating(t *testing.T) {
 	require.NoError(t, err)
 
 	ctx := context.Background()
-	clusterInfo, err := StartClusterAndGetInfo(ctx, client, "abc")
+	w, err := client.WorkspaceClient()
+	if err != nil {
+		panic(err)
+	}
+	clusterInfo, err := StartClusterAndGetInfo(ctx, w), "abc")
 	require.NoError(t, err)
 	assert.Equal(t, ClusterStateRunning, string(clusterInfo.State))
 }
@@ -111,7 +115,11 @@ func TestStartClusterAndGetInfo_Error(t *testing.T) {
 	require.NoError(t, err)
 
 	ctx := context.Background()
-	clusterInfo, err := StartClusterAndGetInfo(ctx, client, "abc")
+	w, err := client.WorkspaceClient()
+	if err != nil {
+		panic(err)
+	}
+	clusterInfo, err := StartClusterAndGetInfo(ctx, w, "abc")
 	require.NoError(t, err)
 	assert.Equal(t, ClusterStateRunning, string(clusterInfo.State))
 }
@@ -142,7 +150,11 @@ func TestStartClusterAndGetInfo_StartingError(t *testing.T) {
 	require.NoError(t, err)
 
 	ctx := context.Background()
-	_, err = StartClusterAndGetInfo(ctx, client, "abc")
+	w, err := client.WorkspaceClient()
+	if err != nil {
+		panic(err)m
+	}
+	_, err = StartClusterAndGetInfo(ctx, w, "abc")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "I am a teapot")
 }

--- a/clusters/resource_library.go
+++ b/clusters/resource_library.go
@@ -78,11 +78,11 @@ func ResourceLibrary() *schema.Resource {
 		},
 		Delete: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
 			clusterID, libraryRep := parseId(d.Id())
-			err := StartCluster(ctx, c, clusterID)
+			w, err := c.WorkspaceClient()
 			if err != nil {
 				return err
 			}
-			w, err := c.WorkspaceClient()
+			_, err = StartClusterAndGetInfo(ctx, w, clusterID)
 			if err != nil {
 				return err
 			}

--- a/clusters/resource_library.go
+++ b/clusters/resource_library.go
@@ -82,7 +82,7 @@ func ResourceLibrary() *schema.Resource {
 			if err != nil {
 				return err
 			}
-			_, err = StartClusterAndGetInfo(ctx, w, clusterID)
+			_, err m= StartClusterAndGetInfo(ctx, w, clusterID)
 			if err != nil {
 				return err
 			}

--- a/clusters/resource_library.go
+++ b/clusters/resource_library.go
@@ -82,7 +82,7 @@ func ResourceLibrary() *schema.Resource {
 			if err != nil {
 				return err
 			}
-			_, err m= StartClusterAndGetInfo(ctx, w, clusterID)
+			_, err = StartClusterAndGetInfo(ctx, w, clusterID)
 			if err != nil {
 				return err
 			}

--- a/clusters/resource_library.go
+++ b/clusters/resource_library.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/databricks/databricks-sdk-go/apierr"
+	"github.com/databricks/databricks-sdk-go/service/compute"
 	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/databricks/terraform-provider-databricks/libraries"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -77,12 +78,15 @@ func ResourceLibrary() *schema.Resource {
 		},
 		Delete: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
 			clusterID, libraryRep := parseId(d.Id())
-			err := NewClustersAPI(ctx, c).Start(clusterID)
+			err := StartCluster(ctx, c, clusterID)
 			if err != nil {
 				return err
 			}
-			librariesAPI := libraries.NewLibrariesAPI(ctx, c)
-			cll, err := librariesAPI.ClusterStatus(clusterID)
+			w, err := c.WorkspaceClient()
+			if err != nil {
+				return err
+			}
+			cll, err := w.Libraries.ClusterStatusByClusterId(ctx, clusterID)
 			if err != nil {
 				return err
 			}
@@ -90,9 +94,9 @@ func ResourceLibrary() *schema.Resource {
 				if v.Library.String() != libraryRep {
 					continue
 				}
-				return librariesAPI.Uninstall(libraries.ClusterLibraryList{
-					ClusterID: clusterID,
-					Libraries: []libraries.Library{*v.Library},
+				return w.Libraries.Uninstall(ctx, compute.UninstallLibraries{
+					ClusterId: clusterID,
+					Libraries: []compute.Library{*v.Library},
 				})
 			}
 			return apierr.NotFound(fmt.Sprintf("cannot find %s on %s", libraryRep, clusterID))


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
- Add `clusters_api_sdk.go` to implement same functionalities as in `clusters_api.go` with the go-sdk
- Migrate library delete to use the go sdk implementation

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

