### PR TITLE
Added search by `display_name` to `databricks_service_principal` data source

### DIFF
--- a/docs/data-sources/service_principal.md
+++ b/docs/data-sources/service_principal.md
@@ -29,7 +29,7 @@ resource "databricks_group_member" "my_member_a" {
 
 ## Argument Reference
 
-Data source allows you to pick service principals by one of the following attributes:
+Data source allows you to pick service principals by one of the following attributes (only one of them):
 
 - `application_id` - (Required if `display_name` isn't used) ID of the service principal. The service principal must exist before this resource can be retrieved.
 - `display_name` - (Required if `application_id` isn't used) Exact display name of the service principal. The service principal must exist before this resource can be retrieved.  In case if there are several service principals with the same name, an error is thrown.

--- a/docs/data-sources/service_principal.md
+++ b/docs/data-sources/service_principal.md
@@ -29,9 +29,10 @@ resource "databricks_group_member" "my_member_a" {
 
 ## Argument Reference
 
-Data source allows you to pick service principals by the following attributes
+Data source allows you to pick service principals by one of the following attributes:
 
-- `application_id` - (Required) ID of the service principal. The service principal must exist before this resource can be retrieved.
+- `application_id` - (Required if `display_name` isn't used) ID of the service principal. The service principal must exist before this resource can be retrieved.
+- `display_name` - (Required if `application_id` isn't used) Exact display name of the service principal. The service principal must exist before this resource can be retrieved.  In case if there are several service principals with the same name, an error is thrown.
 
 ## Attribute Reference
 

--- a/scim/data_service_principal.go
+++ b/scim/data_service_principal.go
@@ -37,7 +37,11 @@ func DataSourceServicePrincipal() *schema.Resource {
 			return err
 		}
 		if len(spList) == 0 {
-			return fmt.Errorf("cannot find SP with ID %s", response.ApplicationID)
+			if response.ApplicationID != "" {
+				return fmt.Errorf("cannot find SP with ID %s", response.ApplicationID)
+			} else {
+				return fmt.Errorf("cannot find SP with name %s", response.DisplayName)
+			}
 		} else if len(spList) > 1 {
 			return fmt.Errorf("there are more than 1 service principal with name %s", response.DisplayName)
 		}

--- a/scim/data_service_principal.go
+++ b/scim/data_service_principal.go
@@ -24,15 +24,27 @@ func DataSourceServicePrincipal() *schema.Resource {
 	return common.DataResource(spnData{}, func(ctx context.Context, e any, c *common.DatabricksClient) error {
 		response := e.(*spnData)
 		spnAPI := NewServicePrincipalsAPI(ctx, c)
-		spList, err := spnAPI.Filter(fmt.Sprintf("applicationId eq '%s'", response.ApplicationID), true)
+		var spList []User
+		var err error
+		if response.ApplicationID != "" {
+			spList, err = spnAPI.Filter(fmt.Sprintf("applicationId eq '%s'", response.ApplicationID), true)
+		} else if response.DisplayName != "" {
+			spList, err = spnAPI.Filter(fmt.Sprintf("displayName eq '%s'", response.DisplayName), true)
+		} else {
+			return fmt.Errorf("please specify either application_id or display_name")
+		}
 		if err != nil {
 			return err
 		}
 		if len(spList) == 0 {
 			return fmt.Errorf("cannot find SP with ID %s", response.ApplicationID)
+		} else if len(spList) > 1 {
+			return fmt.Errorf("there are more than 1 service principal with name %s", response.DisplayName)
 		}
+
 		sp := spList[0]
 		response.DisplayName = sp.DisplayName
+		response.ApplicationID = sp.ApplicationID
 		response.Home = fmt.Sprintf("/Users/%s", sp.ApplicationID)
 		response.Repos = fmt.Sprintf("/Repos/%s", sp.ApplicationID)
 		response.AclPrincipalID = fmt.Sprintf("servicePrincipals/%s", sp.ApplicationID)

--- a/scim/data_service_principal.go
+++ b/scim/data_service_principal.go
@@ -26,6 +26,9 @@ func DataSourceServicePrincipal() *schema.Resource {
 		spnAPI := NewServicePrincipalsAPI(ctx, c)
 		var spList []User
 		var err error
+		if response.ApplicationID != "" && response.DisplayName != "" {
+			return fmt.Errorf("please specify only one of application_id or display_name")
+		}
 		if response.ApplicationID != "" {
 			spList, err = spnAPI.Filter(fmt.Sprintf("applicationId eq '%s'", response.ApplicationID), true)
 		} else if response.DisplayName != "" {

--- a/scim/data_service_principal_test.go
+++ b/scim/data_service_principal_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/databricks/terraform-provider-databricks/qa"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestDataServicePrincipalReadByAppId(t *testing.T) {
@@ -86,7 +87,7 @@ func TestDataServicePrincipalReadByNameNotFound(t *testing.T) {
 }
 
 func TestDataServicePrincipalReadError(t *testing.T) {
-	qa.ResourceFixture{
+	_, err := qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   "GET",
@@ -99,7 +100,8 @@ func TestDataServicePrincipalReadError(t *testing.T) {
 		Read:        true,
 		NonWritable: true,
 		ID:          "_",
-	}.ExpectError(t, "Response from server (500 Internal Server Error) : unexpected end of JSON input")
+	}.Apply(t)
+	assert.ErrorContains(t, err, "unexpected error handling request: unexpected end of JSON input")
 }
 
 func TestDataServicePrincipalReadByNameDuplicates(t *testing.T) {
@@ -142,4 +144,15 @@ func TestDataServicePrincipalReadNoParams(t *testing.T) {
 		NonWritable: true,
 		ID:          "_",
 	}.ExpectError(t, "please specify either application_id or display_name")
+}
+
+func TestDataServicePrincipalReadBothParams(t *testing.T) {
+	qa.ResourceFixture{
+		Resource: DataSourceServicePrincipal(),
+		HCL: `display_name = "abc"
+		application_id = "abc"`,
+		Read:        true,
+		NonWritable: true,
+		ID:          "_",
+	}.ExpectError(t, "please specify only one of application_id or display_name")
 }

--- a/scim/data_service_principal_test.go
+++ b/scim/data_service_principal_test.go
@@ -51,7 +51,7 @@ func TestDataServicePrincipalReadByAppId(t *testing.T) {
 	})
 }
 
-func TestDataServicePrincipalReadNotFound(t *testing.T) {
+func TestDataServicePrincipalReadByIdNotFound(t *testing.T) {
 	qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
 			{
@@ -66,6 +66,23 @@ func TestDataServicePrincipalReadNotFound(t *testing.T) {
 		NonWritable: true,
 		ID:          "_",
 	}.ExpectError(t, "cannot find SP with ID abc")
+}
+
+func TestDataServicePrincipalReadByNameNotFound(t *testing.T) {
+	qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "GET",
+				Resource: "/api/2.0/preview/scim/v2/ServicePrincipals?excludedAttributes=roles&filter=displayName%20eq%20%27abc%27",
+				Response: UserList{},
+			},
+		},
+		Resource:    DataSourceServicePrincipal(),
+		HCL:         `display_name = "abc"`,
+		Read:        true,
+		NonWritable: true,
+		ID:          "_",
+	}.ExpectError(t, "cannot find SP with name abc")
 }
 
 func TestDataServicePrincipalReadError(t *testing.T) {


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

Allow searching not only by `application_id`, but also by the exact `display_name`.

This fixes #2959

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

