### PR TITLE
Exporter: Ignore workspace assets of deleted users and service principals

### DIFF
--- a/docs/guides/experimental-exporter.md
+++ b/docs/guides/experimental-exporter.md
@@ -45,6 +45,7 @@ All arguments are optional, and they tune what code is being generated.
 * `-skip-interactive` - optionally run in a non-interactive mode.
 * `-includeUserDomains` - optionally include domain name into generated resource name for `databricks_user` resource.
 * `-importAllUsers` - optionally include all users and service principals even if they are only part of the `users` group.
+* `-exportDeletedUsersAssets` - optionally include assets of deleted users and service principals.
 * `-incremental` - experimental option for incremental export of modified resources and merging with existing resources. *Please note that only a limited set of resources (notebooks, SQL queries/dashboards/alerts, ...) provides information about the last modified date - all other resources will be re-exported again! Also, it's impossible to detect the deletion of the resources, so you must do periodic full export if resources are deleted!*   **Requires** `-updated-since` option if no `exporter-run-stats.json` file exists in the output directory.
 * `-updated-since` - timestamp (in ISO8601 format supported by Go language) for exporting of resources modified since a given timestamp. I.e., `2023-07-24T00:00:00Z`. If not specified, the exporter will try to load the last run timestamp from the `exporter-run-stats.json` file generated during the export and use it.
 * `-notebooksFormat` - optional format for exporting of notebooks. Supported values are `SOURCE` (default), `DBC`, `JUPYTER`.  This option could be used to export notebooks with embedded dashboards.

--- a/exporter/command.go
+++ b/exporter/command.go
@@ -100,6 +100,8 @@ func Run(args ...string) error {
 	flags.BoolVar(&ic.includeUserDomains, "includeUserDomains", false, "Include domain portion in `databricks_user` resource name")
 	flags.BoolVar(&ic.importAllUsers, "importAllUsers", false,
 		"Import all users and service principals, even if they aren't referenced in any resource")
+	flags.BoolVar(&ic.exportDeletedUsersAssets, "exportDeletedUsersAssets", false,
+		"Export assets (notebooks, etc.) of deleted users & service principals")
 	flags.StringVar(&ic.Directory, "directory", cwd,
 		"Directory to generate sources in. Defaults to current directory.")
 	flags.Int64Var(&ic.lastActiveDays, "last-active-days", 3650,

--- a/exporter/context.go
+++ b/exporter/context.go
@@ -80,25 +80,26 @@ type importContext struct {
 	Scope importedResources
 
 	// command-line resources (immutable, or set by the single thread)
-	includeUserDomains  bool
-	importAllUsers      bool
-	debug               bool
-	incremental         bool
-	mounts              bool
-	noFormat            bool
-	services            string
-	listing             string
-	match               string
-	lastActiveDays      int64
-	lastActiveMs        int64
-	generateDeclaration bool
-	meAdmin             bool
-	prefix              string
-	accountLevel        bool
-	shImports           map[string]bool
-	notebooksFormat     string
-	updatedSinceStr     string
-	updatedSinceMs      int64
+	includeUserDomains       bool
+	importAllUsers           bool
+	exportDeletedUsersAssets bool
+	debug                    bool
+	incremental              bool
+	mounts                   bool
+	noFormat                 bool
+	services                 string
+	listing                  string
+	match                    string
+	lastActiveDays           int64
+	lastActiveMs             int64
+	generateDeclaration      bool
+	meAdmin                  bool
+	prefix                   string
+	accountLevel             bool
+	shImports                map[string]bool
+	notebooksFormat          string
+	updatedSinceStr          string
+	updatedSinceMs           int64
 
 	waitGroup *sync.WaitGroup
 

--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -1559,6 +1559,9 @@ func TestImportingRepos(t *testing.T) {
 	qa.HTTPFixturesApply(t,
 		[]qa.HTTPFixture{
 			meAdminFixture,
+			userListIdUsernameFixture,
+			userListFixture,
+			userReadFixture,
 			{
 				Method:   "GET",
 				Resource: "/api/2.0/repos?",
@@ -1902,6 +1905,18 @@ func TestImportingDLTPipelines(t *testing.T) {
 			},
 			{
 				Method:   "GET",
+				Resource: "/api/2.0/preview/scim/v2/Users?attributes=userName%2Cid",
+				Response: scim.UserList{
+					Resources: []scim.User{
+						{
+							ID:       "id",
+							UserName: "id",
+						},
+					},
+				},
+			},
+			{
+				Method:   "GET",
 				Resource: "/api/2.0/instance-profiles/list",
 				Response: getJSONObject("test-data/list-instance-profiles.json"),
 			},
@@ -1971,10 +1986,12 @@ func TestImportingDLTPipelinesMatchingOnly(t *testing.T) {
 			meAdminFixture,
 			emptyRepos,
 			emptyIpAccessLIst,
+			userListIdUsernameFixture,
+			userListFixture,
+			userReadFixture,
 			{
 				Method:   "GET",
 				Resource: "/api/2.0/pipelines?max_results=50",
-
 				Response: pipelines.PipelineListResponse{
 					Statuses: []pipelines.PipelineStateInfo{
 						{

--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -1560,6 +1560,7 @@ func TestImportingRepos(t *testing.T) {
 		[]qa.HTTPFixture{
 			meAdminFixture,
 			userListIdUsernameFixture,
+			userListIdUsernameFixture2,
 			userListFixture,
 			userReadFixture,
 			{
@@ -1987,6 +1988,7 @@ func TestImportingDLTPipelinesMatchingOnly(t *testing.T) {
 			emptyRepos,
 			emptyIpAccessLIst,
 			userListIdUsernameFixture,
+			userListIdUsernameFixture2,
 			userListFixture,
 			userReadFixture,
 			{

--- a/exporter/importables.go
+++ b/exporter/importables.go
@@ -45,7 +45,7 @@ var (
 	fileNameNormalizationRegex   = regexp.MustCompile(`[^-_\w/.@]`)
 	jobClustersRegex             = regexp.MustCompile(`^((job_cluster|task)\.[0-9]+\.new_cluster\.[0-9]+\.)`)
 	dltClusterRegex              = regexp.MustCompile(`^(cluster\.[0-9]+\.)`)
-	userDirRegex               = regexp.MustCompile(`^(/Users/[^/]+)(/.*)?$`)
+	userDirRegex                 = regexp.MustCompile(`^(/Users/[^/]+)(/.*)?$`)
 	secretPathRegex              = regexp.MustCompile(`^\{\{secrets\/([^\/]+)\/([^}]+)\}\}$`)
 	sqlParentRegexp              = regexp.MustCompile(`^folders/(\d+)$`)
 	dltDefaultStorageRegex       = regexp.MustCompile(`^dbfs:/pipelines/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)

--- a/exporter/importables.go
+++ b/exporter/importables.go
@@ -45,6 +45,7 @@ var (
 	fileNameNormalizationRegex   = regexp.MustCompile(`[^-_\w/.@]`)
 	jobClustersRegex             = regexp.MustCompile(`^((job_cluster|task)\.[0-9]+\.new_cluster\.[0-9]+\.)`)
 	dltClusterRegex              = regexp.MustCompile(`^(cluster\.[0-9]+\.)`)
+	userDirRegex               = regexp.MustCompile(`^(/Users/[^/]+)(/.*)?$`)
 	secretPathRegex              = regexp.MustCompile(`^\{\{secrets\/([^\/]+)\/([^}]+)\}\}$`)
 	sqlParentRegexp              = regexp.MustCompile(`^folders/(\d+)$`)
 	dltDefaultStorageRegex       = regexp.MustCompile(`^dbfs:/pipelines/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
@@ -642,10 +643,7 @@ var resourcesMap map[string]importable = map[string]importable{
 				}
 				if typ == "fixed" && strings.HasPrefix(k, "init_scripts.") &&
 					strings.HasSuffix(k, ".workspace.destination") {
-					ic.Emit(&resource{
-						Resource: "databricks_workspace_file",
-						ID:       eitherString(value, defaultValue),
-					})
+					ic.maybeEmitWorkspaceObject("databricks_workspace_file", eitherString(value, defaultValue))
 				}
 				if typ == "fixed" && (strings.HasPrefix(k, "spark_conf.") || strings.HasPrefix(k, "spark_env_vars.")) {
 					either := eitherString(value, defaultValue)
@@ -1941,14 +1939,10 @@ var resourcesMap map[string]importable = map[string]importable{
 				if res := ignoreIdeFolderRegex.FindStringSubmatch(directory.Path); res != nil {
 					continue
 				}
-				// TODO: don't emit directories for deleted users/SPs (how to identify them?)
-				ic.Emit(&resource{
-					Resource: "databricks_directory",
-					ID:       directory.Path,
-				})
+				ic.maybeEmitWorkspaceObject("databricks_directory", directory.Path)
+
 				if offset%50 == 0 {
-					log.Printf("[INFO] Scanned %d of %d directories",
-						offset+1, len(directoryList))
+					log.Printf("[INFO] Scanned %d of %d directories", offset+1, len(directoryList))
 				}
 			}
 			return nil

--- a/exporter/importables_test.go
+++ b/exporter/importables_test.go
@@ -34,15 +34,15 @@ import (
 func importContextForTest() *importContext {
 	p := provider.DatabricksProvider()
 	return &importContext{
-		Importables: resourcesMap,
-		Resources:   p.ResourcesMap,
-		Files:       map[string]*hclwrite.File{},
-		testEmits:   map[string]bool{},
-		nameFixes:   nameFixes,
-		waitGroup:   &sync.WaitGroup{},
-		allUsers:    map[string]scim.User{},
-		allSps:      map[string]scim.User{},
-		channels:    makeResourcesChannels(p),
+		Importables:              resourcesMap,
+		Resources:                p.ResourcesMap,
+		Files:                    map[string]*hclwrite.File{},
+		testEmits:                map[string]bool{},
+		nameFixes:                nameFixes,
+		waitGroup:                &sync.WaitGroup{},
+		allUsers:                 map[string]scim.User{},
+		allSps:                   map[string]scim.User{},
+		channels:                 makeResourcesChannels(p),
 		exportDeletedUsersAssets: false,
 	}
 }

--- a/exporter/importables_test.go
+++ b/exporter/importables_test.go
@@ -43,6 +43,7 @@ func importContextForTest() *importContext {
 		allUsers:    map[string]scim.User{},
 		allSps:      map[string]scim.User{},
 		channels:    makeResourcesChannels(p),
+		exportDeletedUsersAssets: false,
 	}
 }
 

--- a/exporter/util.go
+++ b/exporter/util.go
@@ -135,7 +135,7 @@ func (ic *importContext) emitUserOrServicePrincipal(userOrSPName string) {
 func (ic *importContext) emitUserOrServicePrincipalForPath(path, prefix string) {
 	if strings.HasPrefix(path, prefix) {
 		parts := strings.SplitN(path, "/", 4)
-		if len(parts) >= 3 {
+		if len(parts) >= 3 && parts[2] != "" {
 			ic.emitUserOrServicePrincipal(parts[2])
 		}
 	}
@@ -146,7 +146,7 @@ func (ic *importContext) IsUserOrServicePrincipalDirectory(path, prefix string) 
 		return false
 	}
 	parts := strings.SplitN(path, "/", 4)
-	if len(parts) == 3 || (len(parts) == 4 && parts[3] == "") {
+	if (len(parts) == 3 || (len(parts) == 4 && parts[3] == "")) && parts[2] != "" {
 		userOrSPName := parts[2]
 		var err error
 		if common.StringIsUUID(userOrSPName) {

--- a/exporter/util.go
+++ b/exporter/util.go
@@ -155,6 +155,7 @@ func (ic *importContext) IsUserOrServicePrincipalDirectory(path, prefix string) 
 			_, err = ic.findUserByName(strings.ToLower(userOrSPName))
 		}
 		return err == nil
+
 	}
 	return false
 }
@@ -800,7 +801,7 @@ func wsObjectGetModifiedAt(obs workspace.ObjectStatus) int64 {
 }
 
 func (ic *importContext) shouldEmitForPath(path string) bool {
-	if strings.HasPrefix(path, "/Users/") {
+	if !ic.exportDeletedUsersAssets && strings.HasPrefix(path, "/Users/") {
 		userDir := userDirRegex.ReplaceAllString(path, "$1")
 		return ic.IsUserOrServicePrincipalDirectory(userDir, "/Users")
 	}

--- a/exporter/util_test.go
+++ b/exporter/util_test.go
@@ -42,7 +42,7 @@ func TestAddAwsMounts(t *testing.T) {
 var (
 	userListIdUsernameFixture = qa.HTTPFixture{
 		Method:   "GET",
-		Resource: "/api/2.0/preview/scim/v2/Users?attributes=userName%2Cid",
+		Resource: "/api/2.0/preview/scim/v2/Users?attributes=id%2CuserName&count=100&startIndex=1",
 		Response: iam.ListUsersResponse{
 			Resources: []iam.User{
 				{
@@ -50,7 +50,20 @@ var (
 					UserName: "user@domain.com",
 				},
 			},
+			TotalResults: 1,
+			StartIndex:   1,
 		},
+		ReuseRequest: true,
+	}
+	userListIdUsernameFixture2 = qa.HTTPFixture{
+		Method:   "GET",
+		Resource: "/api/2.0/preview/scim/v2/Users?attributes=id%2CuserName&count=100&startIndex=2",
+		Response: iam.ListUsersResponse{
+			Resources:    []iam.User{},
+			TotalResults: 1,
+			StartIndex:   2,
+		},
+		ReuseRequest: true,
 	}
 	userListFixture = qa.HTTPFixture{
 		Method:   "GET",
@@ -70,7 +83,7 @@ var (
 	}
 	spListIdUsernameFixture = qa.HTTPFixture{
 		Method:   "GET",
-		Resource: "/api/2.0/preview/scim/v2/ServicePrincipals?attributes=id%2CuserName",
+		Resource: "/api/2.0/preview/scim/v2/ServicePrincipals?attributes=id%2CuserName&count=100&startIndex=1",
 		Response: iam.ListServicePrincipalResponse{
 			Resources: []iam.ServicePrincipal{
 				{
@@ -78,6 +91,17 @@ var (
 					ApplicationId: "21aab5a7-ee70-4385-34d4-a77278be5cb6",
 				},
 			},
+			TotalResults: 1,
+			StartIndex:   1,
+		},
+	}
+	spListIdUsernameFixture2 = qa.HTTPFixture{
+		Method:   "GET",
+		Resource: "/api/2.0/preview/scim/v2/ServicePrincipals?attributes=id%2CuserName&count=100&startIndex=2",
+		Response: iam.ListServicePrincipalResponse{
+			Resources:    []iam.ServicePrincipal{},
+			TotalResults: 1,
+			StartIndex:   2,
 		},
 	}
 	spListFixture = qa.HTTPFixture{
@@ -105,6 +129,7 @@ var (
 func TestEmitUser(t *testing.T) {
 	qa.HTTPFixturesApply(t, []qa.HTTPFixture{
 		userListIdUsernameFixture,
+		userListIdUsernameFixture2,
 		userListFixture,
 		userReadFixture,
 	}, func(ctx context.Context, client *common.DatabricksClient) {
@@ -119,6 +144,7 @@ func TestEmitUser(t *testing.T) {
 func TestEmitServicePrincipal(t *testing.T) {
 	qa.HTTPFixturesApply(t, []qa.HTTPFixture{
 		spListIdUsernameFixture,
+		spListIdUsernameFixture2,
 		spListFixture,
 		spReadFixture,
 	}, func(ctx context.Context, client *common.DatabricksClient) {
@@ -133,7 +159,7 @@ func TestEmitUserError(t *testing.T) {
 	qa.HTTPFixturesApply(t, []qa.HTTPFixture{
 		{
 			Method:   "GET",
-			Resource: "/api/2.0/preview/scim/v2/Users?attributes=userName%2Cid",
+			Resource: "/api/2.0/preview/scim/v2/Users?attributes=id%2CuserName&count=100&startIndex=1",
 			Response: iam.ListUsersResponse{
 				Resources: []iam.User{},
 			},
@@ -148,6 +174,7 @@ func TestEmitUserError(t *testing.T) {
 func TestEmitUserOrServicePrincipalForPath(t *testing.T) {
 	qa.HTTPFixturesApply(t, []qa.HTTPFixture{
 		userListIdUsernameFixture,
+		userListIdUsernameFixture2,
 		userListFixture,
 		userReadFixture,
 	}, func(ctx context.Context, client *common.DatabricksClient) {
@@ -172,6 +199,7 @@ func TestEmitUserOrServicePrincipalForPath_NoEmit(t *testing.T) {
 func TestEmitNotebookOrRepo(t *testing.T) {
 	qa.HTTPFixturesApply(t, []qa.HTTPFixture{
 		userListIdUsernameFixture,
+		userListIdUsernameFixture2,
 		userListFixture,
 		userReadFixture,
 	}, func(ctx context.Context, client *common.DatabricksClient) {
@@ -197,6 +225,7 @@ func TestEmitNotebookOrRepo(t *testing.T) {
 func TestIsUserOrServicePrincipalDirectory(t *testing.T) {
 	qa.HTTPFixturesApply(t, []qa.HTTPFixture{
 		userListIdUsernameFixture,
+		userListIdUsernameFixture2,
 		userListFixture,
 		userReadFixture,
 	}, func(ctx context.Context, client *common.DatabricksClient) {
@@ -219,6 +248,7 @@ func TestIsUserOrServicePrincipalDirectory(t *testing.T) {
 
 	qa.HTTPFixturesApply(t, []qa.HTTPFixture{
 		userListIdUsernameFixture,
+		userListIdUsernameFixture2,
 		userListFixture,
 		userReadFixture,
 	}, func(ctx context.Context, client *common.DatabricksClient) {
@@ -229,6 +259,7 @@ func TestIsUserOrServicePrincipalDirectory(t *testing.T) {
 
 	qa.HTTPFixturesApply(t, []qa.HTTPFixture{
 		userListIdUsernameFixture,
+		userListIdUsernameFixture2,
 		userListFixture,
 		userReadFixture,
 	}, func(ctx context.Context, client *common.DatabricksClient) {
@@ -239,6 +270,7 @@ func TestIsUserOrServicePrincipalDirectory(t *testing.T) {
 
 	qa.HTTPFixturesApply(t, []qa.HTTPFixture{
 		spListIdUsernameFixture,
+		spListIdUsernameFixture2,
 		spListFixture,
 		spReadFixture,
 	}, func(ctx context.Context, client *common.DatabricksClient) {

--- a/exporter/util_test.go
+++ b/exporter/util_test.go
@@ -1,10 +1,15 @@
 package exporter
 
 import (
+	"context"
 	"os"
 	"testing"
 
+	"github.com/databricks/databricks-sdk-go/service/iam"
 	"github.com/databricks/terraform-provider-databricks/clusters"
+	"github.com/databricks/terraform-provider-databricks/common"
+	"github.com/databricks/terraform-provider-databricks/qa"
+	"github.com/databricks/terraform-provider-databricks/scim"
 	"github.com/databricks/terraform-provider-databricks/workspace"
 	"github.com/stretchr/testify/assert"
 )
@@ -34,65 +39,173 @@ func TestAddAwsMounts(t *testing.T) {
 	assert.Equal(t, 2, len(ic.mountMap))
 }
 
-func TestEmitUserOrServicePrincipal(t *testing.T) {
-	ic := importContextForTest()
-	assert.True(t, len(ic.testEmits) == 0)
+var (
+	userListIdUsernameFixture = qa.HTTPFixture{
+		Method:   "GET",
+		Resource: "/api/2.0/preview/scim/v2/Users?attributes=userName%2Cid",
+		Response: iam.ListUsersResponse{
+			Resources: []iam.User{
+				{
+					Id:       "id",
+					UserName: "user@domain.com",
+				},
+			},
+		},
+	}
+	userListFixture = qa.HTTPFixture{
+		Method:   "GET",
+		Resource: "/api/2.0/preview/scim/v2/Users?attributes=userName%2Cid&startIndex=1",
+		Response: scim.User{
+			ID:       "id",
+			UserName: "user@domain.com",
+		},
+	}
+	userReadFixture = qa.HTTPFixture{
+		Method:   "GET",
+		Resource: "/api/2.0/preview/scim/v2/Users/id?attributes=id,userName,displayName,active,externalId,entitlements,groups,roles",
+		Response: iam.User{
+			Id:       "id",
+			UserName: "user@domain.com",
+		},
+	}
+	spListIdUsernameFixture = qa.HTTPFixture{
+		Method:   "GET",
+		Resource: "/api/2.0/preview/scim/v2/ServicePrincipals?attributes=id%2CuserName",
+		Response: iam.ListServicePrincipalResponse{
+			Resources: []iam.ServicePrincipal{
+				{
+					Id:            "id",
+					ApplicationId: "21aab5a7-ee70-4385-34d4-a77278be5cb6",
+				},
+			},
+		},
+	}
+	spListFixture = qa.HTTPFixture{
+		Method:   "GET",
+		Resource: "/api/2.0/preview/scim/v2/ServicePrincipals?attributes=id%2CuserName&startIndex=1",
+		Response: scim.UserList{
+			Resources: []scim.User{
+				{
+					ID:            "id",
+					ApplicationID: "21aab5a7-ee70-4385-34d4-a77278be5cb6",
+				},
+			},
+		},
+	}
+	spReadFixture = qa.HTTPFixture{
+		Method:   "GET",
+		Resource: "/api/2.0/preview/scim/v2/ServicePrincipals/id?attributes=userName,displayName,active,externalId,entitlements,groups,roles",
+		Response: iam.ServicePrincipal{
+			Id:            "id",
+			ApplicationId: "21aab5a7-ee70-4385-34d4-a77278be5cb6",
+		},
+	}
+)
 
-	ic.emitUserOrServicePrincipal("user@domain.com")
-	assert.True(t, len(ic.testEmits) == 1)
-	assert.True(t, ic.testEmits["databricks_user[<unknown>] (user_name: user@domain.com)"])
+func TestEmitUser(t *testing.T) {
+	qa.HTTPFixturesApply(t, []qa.HTTPFixture{
+		userListIdUsernameFixture,
+		userListFixture,
+		userReadFixture,
+	}, func(ctx context.Context, client *common.DatabricksClient) {
+		ic := importContextForTestWithClient(ctx, client)
+		assert.True(t, len(ic.testEmits) == 0)
+		ic.emitUserOrServicePrincipal("user@domain.com")
+		assert.True(t, len(ic.testEmits) == 1)
+		assert.True(t, ic.testEmits["databricks_user[<unknown>] (id: id)"])
+	})
+}
 
-	//
-	ic = importContextForTest()
-	ic.emitUserOrServicePrincipal("21aab5a7-ee70-4385-34d4-a77278be5cb6")
-	assert.True(t, len(ic.testEmits) == 1)
-	assert.True(t, ic.testEmits["databricks_service_principal[<unknown>] (application_id: 21aab5a7-ee70-4385-34d4-a77278be5cb6)"])
+func TestEmitServicePrincipal(t *testing.T) {
+	qa.HTTPFixturesApply(t, []qa.HTTPFixture{
+		spListIdUsernameFixture,
+		spListFixture,
+		spReadFixture,
+	}, func(ctx context.Context, client *common.DatabricksClient) {
+		ic := importContextForTestWithClient(ctx, client)
+		ic.emitUserOrServicePrincipal("21aab5a7-ee70-4385-34d4-a77278be5cb6")
+		assert.True(t, len(ic.testEmits) == 1)
+		assert.True(t, ic.testEmits["databricks_service_principal[<unknown>] (id: id)"])
+	})
+}
 
-	// unsuccessfull test
-	ic = importContextForTest()
-	ic.emitUserOrServicePrincipal("abc")
-	assert.True(t, len(ic.testEmits) == 0)
+func TestEmitUserError(t *testing.T) {
+	qa.HTTPFixturesApply(t, []qa.HTTPFixture{
+		{
+			Method:   "GET",
+			Resource: "/api/2.0/preview/scim/v2/Users?attributes=userName%2Cid",
+			Response: iam.ListUsersResponse{
+				Resources: []iam.User{},
+			},
+		},
+	}, func(ctx context.Context, client *common.DatabricksClient) {
+		ic := importContextForTestWithClient(ctx, client)
+		ic.emitUserOrServicePrincipal("abc")
+		assert.True(t, len(ic.testEmits) == 0)
+	})
 }
 
 func TestEmitUserOrServicePrincipalForPath(t *testing.T) {
-	ic := importContextForTest()
+	qa.HTTPFixturesApply(t, []qa.HTTPFixture{
+		userListIdUsernameFixture,
+		userListFixture,
+		userReadFixture,
+	}, func(ctx context.Context, client *common.DatabricksClient) {
+		ic := importContextForTestWithClient(ctx, client)
+		ic.emitUserOrServicePrincipalForPath("/Users/user@domain.com/abc", "/Users")
+		assert.True(t, len(ic.testEmits) == 1)
+		assert.True(t, ic.testEmits["databricks_user[<unknown>] (id: id)"])
+	})
+}
 
-	ic.emitUserOrServicePrincipalForPath("/Users/user@domain.com/abc", "/Users")
-	assert.True(t, len(ic.testEmits) == 1)
-	assert.True(t, ic.testEmits["databricks_user[<unknown>] (user_name: user@domain.com)"])
-
+func TestEmitUserOrServicePrincipalForPath_NoEmit(t *testing.T) {
 	// Negative cases
-	ic = importContextForTest()
+	ic := importContextForTest()
 	ic.emitUserOrServicePrincipalForPath("/Shared/abc", "/Users")
 	assert.True(t, len(ic.testEmits) == 0)
 
-	ic = importContextForTest()
-	ic.emitUserOrServicePrincipalForPath("/Users/abc", "/Users")
-	assert.True(t, len(ic.testEmits) == 0)
 	ic = importContextForTest()
 	ic.emitUserOrServicePrincipalForPath("/Users/", "/Users")
 	assert.True(t, len(ic.testEmits) == 0)
 }
 
 func TestEmitNotebookOrRepo(t *testing.T) {
-	ic := importContextForTest()
-	ic.emitNotebookOrRepo("/Users/user@domain.com/abc")
-	assert.True(t, len(ic.testEmits) == 1)
-	assert.True(t, ic.testEmits["databricks_notebook[<unknown>] (id: /Users/user@domain.com/abc)"])
+	qa.HTTPFixturesApply(t, []qa.HTTPFixture{
+		userListIdUsernameFixture,
+		userListFixture,
+		userReadFixture,
+	}, func(ctx context.Context, client *common.DatabricksClient) {
+		ic := importContextForTestWithClient(ctx, client)
+		ic.emitNotebookOrRepo("/Users/user@domain.com/abc")
+		assert.True(t, len(ic.testEmits) == 1)
+		assert.True(t, ic.testEmits["databricks_notebook[<unknown>] (id: /Users/user@domain.com/abc)"])
+	})
 
 	// test for repository
-	ic = importContextForTest()
-	ic.emitNotebookOrRepo("/Repos/user@domain.com/repo/abc")
-	assert.True(t, len(ic.testEmits) == 1)
-	assert.True(t, ic.testEmits["databricks_repo[<unknown>] (path: /Repos/user@domain.com/repo)"])
+	qa.HTTPFixturesApply(t, []qa.HTTPFixture{
+		userListIdUsernameFixture,
+		userListFixture,
+		userReadFixture,
+	}, func(ctx context.Context, client *common.DatabricksClient) {
+		ic := importContextForTestWithClient(ctx, client)
+		ic.emitNotebookOrRepo("/Repos/user@domain.com/repo/abc")
+		assert.True(t, len(ic.testEmits) == 1)
+		assert.True(t, ic.testEmits["databricks_repo[<unknown>] (path: /Repos/user@domain.com/repo)"])
+	})
 }
 
 func TestIsUserOrServicePrincipalDirectory(t *testing.T) {
-	ic := importContextForTest()
-	result_false_partslength_more_than_3 := ic.IsUserOrServicePrincipalDirectory("/Users/user@domain.com/abc", "/Users")
-	assert.False(t, result_false_partslength_more_than_3)
+	qa.HTTPFixturesApply(t, []qa.HTTPFixture{
+		userListIdUsernameFixture,
+		userListFixture,
+		userReadFixture,
+	}, func(ctx context.Context, client *common.DatabricksClient) {
+		ic := importContextForTestWithClient(ctx, client)
+		result_false_partslength_more_than_3 := ic.IsUserOrServicePrincipalDirectory("/Users/user@domain.com/abc", "/Users")
+		assert.False(t, result_false_partslength_more_than_3)
+	})
 
-	ic = importContextForTest()
+	ic := importContextForTest()
 	result_false_partslength_less_than_3 := ic.IsUserOrServicePrincipalDirectory("/Users", "/Users")
 	assert.False(t, result_false_partslength_less_than_3)
 
@@ -104,17 +217,35 @@ func TestIsUserOrServicePrincipalDirectory(t *testing.T) {
 	result_false_notprefix_with_user := ic.IsUserOrServicePrincipalDirectory("/Shared", "/Users")
 	assert.False(t, result_false_notprefix_with_user)
 
-	ic = importContextForTest()
-	result_true_user_directory := ic.IsUserOrServicePrincipalDirectory("/Users/user@domain.com", "/Users")
-	assert.True(t, result_true_user_directory)
+	qa.HTTPFixturesApply(t, []qa.HTTPFixture{
+		userListIdUsernameFixture,
+		userListFixture,
+		userReadFixture,
+	}, func(ctx context.Context, client *common.DatabricksClient) {
+		ic := importContextForTestWithClient(ctx, client)
+		result_true_user_directory := ic.IsUserOrServicePrincipalDirectory("/Users/user@domain.com", "/Users")
+		assert.True(t, result_true_user_directory)
+	})
 
-	ic = importContextForTest()
-	result_true_user_directory = ic.IsUserOrServicePrincipalDirectory("/Users/user@domain.com/", "/Users")
-	assert.True(t, result_true_user_directory)
+	qa.HTTPFixturesApply(t, []qa.HTTPFixture{
+		userListIdUsernameFixture,
+		userListFixture,
+		userReadFixture,
+	}, func(ctx context.Context, client *common.DatabricksClient) {
+		ic := importContextForTestWithClient(ctx, client)
+		result_true_user_directory := ic.IsUserOrServicePrincipalDirectory("/Users/user@domain.com/", "/Users")
+		assert.True(t, result_true_user_directory)
+	})
 
-	ic = importContextForTest()
-	result_true_sp_directory := ic.IsUserOrServicePrincipalDirectory("/Users/0e561119-c5a0-4f29-b246-5a953adb9575", "/Users")
-	assert.True(t, result_true_sp_directory)
+	qa.HTTPFixturesApply(t, []qa.HTTPFixture{
+		spListIdUsernameFixture,
+		spListFixture,
+		spReadFixture,
+	}, func(ctx context.Context, client *common.DatabricksClient) {
+		ic := importContextForTestWithClient(ctx, client)
+		result_true_sp_directory := ic.IsUserOrServicePrincipalDirectory("/Users/21aab5a7-ee70-4385-34d4-a77278be5cb6", "/Users")
+		assert.True(t, result_true_sp_directory)
+	})
 }
 
 func TestGetEnvAsInt(t *testing.T) {


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

Don't export workspace objects (notebooks, workspace files, and directories) of deleted users and service principals.  Otherwise, when importing into another workspace it will be attempted to create them, and the apply step will fail as we can't create folders under the `/Users` folder.

It doesn't cover other objects of deleted users, like SQL queries/alerts/dashboards - this may come in the next PRs.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

