### PR TITLE
Exporter: generate cluster libraries blocks directly in `databricks_cluster`, don't generate `databricks_library` resources

### DIFF
--- a/clusters/data_clusters_test.go
+++ b/clusters/data_clusters_test.go
@@ -1,8 +1,12 @@
 package clusters
 
 import (
+	"context"
 	"testing"
 
+	"github.com/databricks/databricks-sdk-go/client"
+	"github.com/databricks/databricks-sdk-go/config"
+	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/databricks/terraform-provider-databricks/qa"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/stretchr/testify/assert"
@@ -67,14 +71,14 @@ func TestClustersDataSourceContainsName(t *testing.T) {
 	assert.Equal(t, 1, ids.Len())
 }
 
-// func TestClustersDataSourceErrorsOut(t *testing.T) {
-// 	client, _ := client.New(&config.Config{
-// 		Host:  ".",
-// 		Token: ".",
-// 	})
-// 	diag := DataSourceClusters().ReadContext(context.Background(), nil, &common.DatabricksClient{
-// 		DatabricksClient: client,
-// 	})
-// 	assert.NotNil(t, diag)
-// 	assert.True(t, diag.HasError())
-// }
+func TestClustersDataSourceErrorsOut(t *testing.T) {
+	client, _ := client.New(&config.Config{
+		Host:  ".",
+		Token: ".",
+	})
+	diag := DataSourceClusters().ReadContext(context.Background(), nil, &common.DatabricksClient{
+		DatabricksClient: client,
+	})
+	assert.NotNil(t, diag)
+	assert.True(t, diag.HasError())
+}

--- a/clusters/data_clusters_test.go
+++ b/clusters/data_clusters_test.go
@@ -1,12 +1,8 @@
 package clusters
 
 import (
-	"context"
 	"testing"
 
-	"github.com/databricks/databricks-sdk-go/client"
-	"github.com/databricks/databricks-sdk-go/config"
-	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/databricks/terraform-provider-databricks/qa"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/stretchr/testify/assert"
@@ -71,14 +67,14 @@ func TestClustersDataSourceContainsName(t *testing.T) {
 	assert.Equal(t, 1, ids.Len())
 }
 
-func TestClustersDataSourceErrorsOut(t *testing.T) {
-	client, _ := client.New(&config.Config{
-		Host:  ".",
-		Token: ".",
-	})
-	diag := DataSourceClusters().ReadContext(context.Background(), nil, &common.DatabricksClient{
-		DatabricksClient: client,
-	})
-	assert.NotNil(t, diag)
-	assert.True(t, diag.HasError())
-}
+// func TestClustersDataSourceErrorsOut(t *testing.T) {
+// 	client, _ := client.New(&config.Config{
+// 		Host:  ".",
+// 		Token: ".",
+// 	})
+// 	diag := DataSourceClusters().ReadContext(context.Background(), nil, &common.DatabricksClient{
+// 		DatabricksClient: client,
+// 	})
+// 	assert.NotNil(t, diag)
+// 	assert.True(t, diag.HasError())
+// }

--- a/clusters/resource_cluster.go
+++ b/clusters/resource_cluster.go
@@ -199,7 +199,7 @@ func resourceClusterRead(ctx context.Context, d *schema.ResourceData, c *common.
 		return err
 	}
 	d.Set("url", c.FormatURL("#setting/clusters/", d.Id(), "/configuration"))
-	shouldSkipLibrariesRead := common.IsExporter(ctx)
+	shouldSkipLibrariesRead := !common.IsExporter(ctx)
 	if d.Get("library.#").(int) == 0 && shouldSkipLibrariesRead {
 		// don't add externally added libraries, if config has no `library {}` blocks
 		// TODO: check if it still works fine with importing. Perhaps os.Setenv will do the trick

--- a/clusters/resource_cluster.go
+++ b/clusters/resource_cluster.go
@@ -199,7 +199,14 @@ func resourceClusterRead(ctx context.Context, d *schema.ResourceData, c *common.
 		return err
 	}
 	d.Set("url", c.FormatURL("#setting/clusters/", d.Id(), "/configuration"))
-	if d.Get("library.#").(int) == 0 {
+	var isExporter bool
+	p, ok := ctx.Value(common.Provider).(*schema.Provider)
+	if !ok {
+		isExporter = false
+	} else {
+		isExporter = p.TerraformVersion == "exporter"
+	}
+	if d.Get("library.#").(int) == 0 && !isExporter {
 		// don't add externally added libraries, if config has no `library {}` blocks
 		// TODO: check if it still works fine with importing. Perhaps os.Setenv will do the trick
 		return nil

--- a/clusters/resource_cluster.go
+++ b/clusters/resource_cluster.go
@@ -199,8 +199,8 @@ func resourceClusterRead(ctx context.Context, d *schema.ResourceData, c *common.
 		return err
 	}
 	d.Set("url", c.FormatURL("#setting/clusters/", d.Id(), "/configuration"))
-	shouldSkipLibsRead := common.GetTerraformVersionFromContext(ctx) != "exporter"
-	if d.Get("library.#").(int) == 0 && shouldSkipLibsRead {
+	shouldSkipLibrariesRead := common.IsExporter(ctx)
+	if d.Get("library.#").(int) == 0 && shouldSkipLibrariesRead {
 		// don't add externally added libraries, if config has no `library {}` blocks
 		// TODO: check if it still works fine with importing. Perhaps os.Setenv will do the trick
 		return nil

--- a/clusters/resource_cluster.go
+++ b/clusters/resource_cluster.go
@@ -199,14 +199,8 @@ func resourceClusterRead(ctx context.Context, d *schema.ResourceData, c *common.
 		return err
 	}
 	d.Set("url", c.FormatURL("#setting/clusters/", d.Id(), "/configuration"))
-	var isExporter bool
-	p, ok := ctx.Value(common.Provider).(*schema.Provider)
-	if !ok {
-		isExporter = false
-	} else {
-		isExporter = p.TerraformVersion == "exporter"
-	}
-	if d.Get("library.#").(int) == 0 && !isExporter {
+	shouldSkipLibsRead := common.GetTerraformVersionFromContext(ctx) != "exporter"
+	if d.Get("library.#").(int) == 0 && shouldSkipLibsRead {
 		// don't add externally added libraries, if config has no `library {}` blocks
 		// TODO: check if it still works fine with importing. Perhaps os.Setenv will do the trick
 		return nil

--- a/common/util.go
+++ b/common/util.go
@@ -23,3 +23,7 @@ func GetTerraformVersionFromContext(ctx context.Context) string {
 	}
 	return tfVersion
 }
+
+func IsExporter(ctx context.Context) bool {
+	return GetTerraformVersionFromContext(ctx) == "exporter"
+}

--- a/common/util.go
+++ b/common/util.go
@@ -1,7 +1,10 @@
 package common
 
 import (
+	"context"
 	"regexp"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 var (
@@ -10,4 +13,13 @@ var (
 
 func StringIsUUID(s string) bool {
 	return uuidRegex.MatchString(s)
+}
+
+func GetTerraformVersionFromContext(ctx context.Context) string {
+	tfVersion := "unknown"
+	p, ok := ctx.Value(Provider).(*schema.Provider)
+	if ok {
+		tfVersion = p.TerraformVersion
+	}
+	return tfVersion
 }

--- a/common/util_test.go
+++ b/common/util_test.go
@@ -21,4 +21,7 @@ func TestGetTerraformVersionFromContext(t *testing.T) {
 	p.TerraformVersion = "exporter"
 	ctx := context.WithValue(context.Background(), Provider, p)
 	assert.Equal(t, "exporter", GetTerraformVersionFromContext(ctx))
+
+	//
+	assert.True(t, IsExporter(ctx))
 }

--- a/common/util_test.go
+++ b/common/util_test.go
@@ -1,12 +1,24 @@
 package common
 
 import (
+	"context"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestStringIsUUID(t *testing.T) {
 	assert.True(t, StringIsUUID("3f670caf-9a4b-4479-8143-1a0878da8f57"))
 	assert.False(t, StringIsUUID("abc"))
+}
+
+func TestGetTerraformVersionFromContext(t *testing.T) {
+	assert.Equal(t, "unknown", GetTerraformVersionFromContext(context.Background()))
+
+	//
+	p := &schema.Provider{}
+	p.TerraformVersion = "exporter"
+	ctx := context.WithValue(context.Background(), Provider, p)
+	assert.Equal(t, "exporter", GetTerraformVersionFromContext(ctx))
 }

--- a/docs/guides/experimental-exporter.md
+++ b/docs/guides/experimental-exporter.md
@@ -53,7 +53,7 @@ All arguments are optional, and they tune what code is being generated.
 
 ## Services
 
-Services are just logical groups of resources used for filtering and organization in files written in `-directory`. All resources are globally sorted by their resource name, which allows you to use generated files for compliance purposes. Nevertheless, managing the entire Databricks workspace with Terraform is the preferred way. Except for notebooks and possibly libraries, which may have their own CI/CD processes.  
+Services are just logical groups of resources used for filtering and organization in files written in `-directory`. All resources are globally sorted by their resource name, which allows you to use generated files for compliance purposes. Nevertheless, managing the entire Databricks workspace with Terraform is the preferred way. Except for notebooks and possibly libraries, which may have their own CI/CD processes.
 
 -> **Note**
   Please note that for services not marked with **listing**, we'll export resources only if they are referenced from other resources.
@@ -112,7 +112,7 @@ Exporter aims to generate HCL code for most of the resources within the Databric
 | [databricks_instance_profile](../resources/instance_profile.md) | Yes | No |
 | [databricks_ip_access_list](../resources/ip_access_list.md) | Yes | Yes |
 | [databricks_job](../resources/job.md) | Yes | No |
-| [databricks_library](../resources/library.md) | Yes | No |
+| [databricks_library](../resources/library.md) | Yes\* | No |
 | [databricks_mlflow_model](../resources/mlflow_model.md) | No | No |
 | [databricks_mlflow_experiment](../resources/mlflow_experiment.md) | No | No |
 | [databricks_mlflow_webhook](../resources/mlflow_webhook.md) | Yes | Yes |
@@ -141,3 +141,7 @@ Exporter aims to generate HCL code for most of the resources within the Databric
 | [databricks_user_role](../resources/user_role.md) | Yes | No |
 | [databricks_workspace_conf](../resources/workspace_conf.md) | Yes (partial) | No |
 | [databricks_workspace_file](../resources/workspace_file.md) | Yes | Yes |
+
+Notes:
+
+- \* - libraries are exported as blocks inside the cluster definition instead of generating `databricks_library` resources.  This is done to decrease the number of generated resources.

--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -872,6 +872,22 @@ func TestImportingClusters(t *testing.T) {
 				ReuseRequest: true,
 				Response:     getJSONObject("test-data/secret-scopes-response.json"),
 			},
+			{
+				Method:   "GET",
+				Resource: "/api/2.0/libraries/cluster-status?cluster_id=test2",
+				Response: libraries.ClusterLibraryStatuses{
+					ClusterID: "test2",
+					LibraryStatuses: []libraries.LibraryStatus{
+						{
+							Library: &libraries.Library{
+								Pypi: &libraries.PyPi{
+									Package: "chispa",
+								},
+							},
+						},
+					},
+				},
+			},
 		},
 		func(ctx context.Context, client *common.DatabricksClient) {
 			os.Setenv("EXPORTER_PARALLELISM_databricks_cluster", "1")

--- a/exporter/importables.go
+++ b/exporter/importables.go
@@ -255,20 +255,6 @@ var resourcesMap map[string]importable = map[string]importable{
 			{Path: "role", Resource: "databricks_instance_profile", Match: "instance_profile_arn"},
 		},
 	},
-	"databricks_library": {
-		WorkspaceLevel: true,
-		Service:        "compute",
-		Depends: []reference{
-			{Path: "cluster_id", Resource: "databricks_cluster"},
-			{Path: "jar", Resource: "databricks_dbfs_file", Match: "dbfs_path"},
-			{Path: "whl", Resource: "databricks_dbfs_file", Match: "dbfs_path"},
-			{Path: "egg", Resource: "databricks_dbfs_file", Match: "dbfs_path"},
-		},
-		Name: func(ic *importContext, d *schema.ResourceData) string {
-			id := d.Id()
-			return "lib_" + id + fmt.Sprintf("_%x", md5.Sum([]byte(id)))[:9]
-		},
-	},
 	"databricks_cluster": {
 		WorkspaceLevel: true,
 		Service:        "compute",

--- a/exporter/importables_test.go
+++ b/exporter/importables_test.go
@@ -261,13 +261,6 @@ func TestJobName(t *testing.T) {
 	assert.Equal(t, "test_1pm_12345", resourcesMap["databricks_job"].Name(ic, d))
 }
 
-func TestClusterLibrary(t *testing.T) {
-	ic := importContextForTest()
-	d := clusters.ResourceLibrary().TestResourceData()
-	d.SetId("a-b-c")
-	assert.Equal(t, "lib_a-b-c_7b193b3d", resourcesMap["databricks_library"].Name(ic, d))
-}
-
 func TestImportClusterLibraries(t *testing.T) {
 	qa.HTTPFixturesApply(t, []qa.HTTPFixture{
 		{

--- a/exporter/util.go
+++ b/exporter/util.go
@@ -259,6 +259,8 @@ func (ic *importContext) importLibraries(d *schema.ResourceData, s map[string]*s
 	var cll libraries.ClusterLibraryList
 	common.DataToStructPointer(d, s, &cll)
 	for _, lib := range cll.Libraries {
+		// Emit workspace file libraries if necessary
+		// Emit Volume libraries when resource is available
 		ic.emitIfDbfsFile(lib.Whl)
 		ic.emitIfDbfsFile(lib.Jar)
 		ic.emitIfDbfsFile(lib.Egg)
@@ -271,16 +273,12 @@ func (ic *importContext) importClusterLibraries(d *schema.ResourceData, s map[st
 	if err != nil {
 		return err
 	}
-	if cll.LibraryStatuses != nil {
-		for _, lib := range cll.LibraryStatuses {
-			ic.Emit(&resource{
-				Resource: "databricks_library",
-				ID:       lib.Library.GetID(d.Id()),
-			})
-			ic.emitIfDbfsFile(lib.Library.Egg)
-			ic.emitIfDbfsFile(lib.Library.Jar)
-			ic.emitIfDbfsFile(lib.Library.Whl)
-		}
+	for _, lib := range cll.LibraryStatuses {
+		// Emit workspace file libraries if necessary
+		// Emit Volume libraries when resource is available
+		ic.emitIfDbfsFile(lib.Library.Egg)
+		ic.emitIfDbfsFile(lib.Library.Jar)
+		ic.emitIfDbfsFile(lib.Library.Whl)
 	}
 	return nil
 }


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

Instead of generating separate `databricks_library` resources, cluster libraries are now generated inside of the `databricks_cluster` definition.  This decreases the number of the generated resources that is important for big workspaces as it decreases the state size.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

