### PR TITLE
Add `workspace_path` attribute to `databricks_workspace_file` resource

### DIFF
--- a/docs/resources/workspace_file.md
+++ b/docs/resources/workspace_file.md
@@ -49,6 +49,7 @@ In addition to all arguments above, the following attributes are exported:
 * `id` -  Path of workspace file
 * `url` - Routable URL of the workspace file
 * `object_id` -  Unique identifier for a workspace file
+* `workspace_path` - path on Workspace File System (WSFS) in form of `/Workspace` + `path`
 
 ## Access Control
 

--- a/workspace/resource_workspace_file.go
+++ b/workspace/resource_workspace_file.go
@@ -24,6 +24,10 @@ func ResourceWorkspaceFile() *schema.Resource {
 			Optional: true,
 			Computed: true,
 		},
+		"workspace_path": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
 	})
 	return common.Resource{
 		Schema:        s,
@@ -73,6 +77,7 @@ func ResourceWorkspaceFile() *schema.Resource {
 				return err
 			}
 			d.Set("url", c.FormatURL("#workspace", d.Id()))
+			d.Set("workspace_path", "/Workspace"+objectStatus.Path)
 			return common.StructToData(objectStatus, s, d)
 		},
 		Update: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {

--- a/workspace/resource_workspace_file_test.go
+++ b/workspace/resource_workspace_file_test.go
@@ -11,35 +11,41 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+var (
+	dummyWorkspaceFilePath    = "/foo/path.py"
+	dummyWorkspaceFilePathUrl = "path=%2Ffoo%2Fpath.py"
+	dummyWorkspaceFilePayload = "YWJjCg=="
+)
+
 func TestResourceWorkspaceFileRead(t *testing.T) {
-	path := "/test/path.py"
 	objectID := 12345
-	d, err := qa.ResourceFixture{
+	qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   http.MethodGet,
-				Resource: "/api/2.0/workspace/get-status?path=%2Ftest%2Fpath.py",
+				Resource: "/api/2.0/workspace/get-status?" + dummyWorkspaceFilePathUrl,
 				Response: ObjectStatus{
 					ObjectID:   int64(objectID),
 					ObjectType: File,
-					Path:       path,
+					Path:       dummyWorkspaceFilePath,
 				},
 			},
 		},
 		Resource: ResourceWorkspaceFile(),
 		Read:     true,
 		New:      true,
-		ID:       path,
-	}.Apply(t)
-	assert.NoError(t, err)
-	assert.Equal(t, path, d.Id())
-	assert.Equal(t, path, d.Get("path"))
-	assert.Equal(t, objectID, d.Get("object_id"))
+		ID:       dummyWorkspaceFilePath,
+	}.ApplyAndExpectData(t, map[string]any{
+		"id":             dummyWorkspaceFilePath,
+		"path":           dummyWorkspaceFilePath,
+		"workspace_path": "/Workspace" + dummyWorkspaceFilePath,
+		"object_id":      objectID,
+	})
 }
 
 func TestResourceWorkspaceFileDelete(t *testing.T) {
 	path := "/test/path.py"
-	d, err := qa.ResourceFixture{
+	qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:          http.MethodPost,
@@ -51,9 +57,9 @@ func TestResourceWorkspaceFileDelete(t *testing.T) {
 		Resource: ResourceWorkspaceFile(),
 		Delete:   true,
 		ID:       path,
-	}.Apply(t)
-	assert.NoError(t, err)
-	assert.Equal(t, path, d.Id())
+	}.ApplyAndExpectData(t, map[string]any{
+		"id": path,
+	})
 }
 
 func TestResourceWorkspaceFileRead_NotFound(t *testing.T) {
@@ -98,7 +104,7 @@ func TestResourceWorkspaceFileRead_Error(t *testing.T) {
 }
 
 func TestResourceWorkspaceFileCreate_DirectoryExist(t *testing.T) {
-	d, err := qa.ResourceFixture{
+	qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   "POST",
@@ -111,38 +117,38 @@ func TestResourceWorkspaceFileCreate_DirectoryExist(t *testing.T) {
 				Method:   http.MethodPost,
 				Resource: "/api/2.0/workspace/import",
 				ExpectedRequest: ws_api.Import{
-					Content:   "YWJjCg==",
-					Path:      "/foo/path.py",
+					Content:   dummyWorkspaceFilePayload,
+					Path:      dummyWorkspaceFilePath,
 					Overwrite: true,
 					Format:    "AUTO",
 				},
 			},
 			{
 				Method:   http.MethodGet,
-				Resource: "/api/2.0/workspace/export?format=SOURCE&path=%2Ffoo%2Fpath.py",
+				Resource: "/api/2.0/workspace/export?format=SOURCE&" + dummyWorkspaceFilePathUrl,
 				Response: ExportPath{
-					Content: "YWJjCg==",
+					Content: dummyWorkspaceFilePayload,
 				},
 			},
 			{
 				Method:   http.MethodGet,
-				Resource: "/api/2.0/workspace/get-status?path=%2Ffoo%2Fpath.py",
+				Resource: "/api/2.0/workspace/get-status?" + dummyWorkspaceFilePathUrl,
 				Response: ObjectStatus{
 					ObjectID:   4567,
 					ObjectType: File,
-					Path:       "/foo/path.py",
+					Path:       dummyWorkspaceFilePath,
 				},
 			},
 		},
 		Resource: ResourceWorkspaceFile(),
 		State: map[string]any{
-			"content_base64": "YWJjCg==",
-			"path":           "/foo/path.py",
+			"content_base64": dummyWorkspaceFilePayload,
+			"path":           dummyWorkspaceFilePath,
 		},
 		Create: true,
-	}.Apply(t)
-	assert.NoError(t, err)
-	assert.Equal(t, "/foo/path.py", d.Id())
+	}.ApplyAndExpectData(t, map[string]any{
+		"id": dummyWorkspaceFilePath,
+	})
 }
 
 func TestResourceWorkspaceFileCreate_DirectoryDoesntExist(t *testing.T) {
@@ -159,8 +165,8 @@ func TestResourceWorkspaceFileCreate_DirectoryDoesntExist(t *testing.T) {
 				Method:   http.MethodPost,
 				Resource: "/api/2.0/workspace/import",
 				ExpectedRequest: ws_api.Import{
-					Content:   "YWJjCg==",
-					Path:      "/foo/path.py",
+					Content:   dummyWorkspaceFilePayload,
+					Path:      dummyWorkspaceFilePath,
 					Overwrite: true,
 					Format:    "AUTO",
 				},
@@ -174,38 +180,38 @@ func TestResourceWorkspaceFileCreate_DirectoryDoesntExist(t *testing.T) {
 				Method:   http.MethodPost,
 				Resource: "/api/2.0/workspace/import",
 				ExpectedRequest: ws_api.Import{
-					Content:   "YWJjCg==",
-					Path:      "/foo/path.py",
+					Content:   dummyWorkspaceFilePayload,
+					Path:      dummyWorkspaceFilePath,
 					Overwrite: true,
 					Format:    "AUTO",
 				},
 			},
 			{
 				Method:   http.MethodGet,
-				Resource: "/api/2.0/workspace/export?format=SOURCE&path=%2Ffoo%2Fpath.py",
+				Resource: "/api/2.0/workspace/export?format=SOURCE&" + dummyWorkspaceFilePathUrl,
 				Response: ExportPath{
-					Content: "YWJjCg==",
+					Content: dummyWorkspaceFilePayload,
 				},
 			},
 			{
 				Method:   http.MethodGet,
-				Resource: "/api/2.0/workspace/get-status?path=%2Ffoo%2Fpath.py",
+				Resource: "/api/2.0/workspace/get-status?" + dummyWorkspaceFilePathUrl,
 				Response: ObjectStatus{
 					ObjectID:   4567,
 					ObjectType: File,
-					Path:       "/foo/path.py",
+					Path:       dummyWorkspaceFilePath,
 				},
 			},
 		},
 		Resource: ResourceWorkspaceFile(),
 		State: map[string]any{
-			"content_base64": "YWJjCg==",
-			"path":           "/foo/path.py",
+			"content_base64": dummyWorkspaceFilePayload,
+			"path":           dummyWorkspaceFilePath,
 		},
 		Create: true,
 	}.Apply(t)
 	assert.NoError(t, err)
-	assert.Equal(t, "/foo/path.py", d.Id())
+	assert.Equal(t, dummyWorkspaceFilePath, d.Id())
 }
 
 func TestResourceWorkspaceFileCreate_DirectoryCreateError(t *testing.T) {
@@ -227,8 +233,8 @@ func TestResourceWorkspaceFileCreate_DirectoryCreateError(t *testing.T) {
 				Method:   http.MethodPost,
 				Resource: "/api/2.0/workspace/import",
 				ExpectedRequest: ws_api.Import{
-					Content:   "YWJjCg==",
-					Path:      "/foo/path.py",
+					Content:   dummyWorkspaceFilePayload,
+					Path:      dummyWorkspaceFilePath,
 					Overwrite: true,
 					Format:    "AUTO",
 				},
@@ -241,8 +247,8 @@ func TestResourceWorkspaceFileCreate_DirectoryCreateError(t *testing.T) {
 		},
 		Resource: ResourceWorkspaceFile(),
 		State: map[string]any{
-			"content_base64": "YWJjCg==",
-			"path":           "/foo/path.py",
+			"content_base64": dummyWorkspaceFilePayload,
+			"path":           dummyWorkspaceFilePath,
 		},
 		Create: true,
 	}.Apply(t)
@@ -327,7 +333,7 @@ func TestResourceWorkspaceFileCreate_Error(t *testing.T) {
 				Method:   http.MethodPost,
 				Resource: "/api/2.0/workspace/import",
 				ExpectedRequest: map[string]interface{}{
-					"content":   "YWJjCg==",
+					"content":   dummyWorkspaceFilePayload,
 					"format":    "AUTO",
 					"overwrite": true,
 					"path":      "/path.py",
@@ -341,7 +347,7 @@ func TestResourceWorkspaceFileCreate_Error(t *testing.T) {
 		},
 		Resource: ResourceWorkspaceFile(),
 		State: map[string]any{
-			"content_base64": "YWJjCg==",
+			"content_base64": dummyWorkspaceFilePayload,
 			"path":           "/path.py",
 		},
 		Create: true,
@@ -380,7 +386,7 @@ func TestResourceWorkspaceFileUpdate(t *testing.T) {
 				ExpectedRequest: ws_api.Import{
 					Format:    "AUTO",
 					Overwrite: true,
-					Content:   "YWJjCg==",
+					Content:   dummyWorkspaceFilePayload,
 					Path:      "abc",
 				},
 			},
@@ -396,7 +402,7 @@ func TestResourceWorkspaceFileUpdate(t *testing.T) {
 		},
 		Resource: ResourceWorkspaceFile(),
 		State: map[string]any{
-			"content_base64": "YWJjCg==",
+			"content_base64": dummyWorkspaceFilePayload,
 			"path":           "/path.py",
 		},
 		ID:          "abc",


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

This new attribute will help with references to files on WSFS, for example, when using exporter (will be added in a separate PR after testing).

Also, refactored tests a bit.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

