### PR TITLE
Migrate library read to use go-sdk

### DIFF
--- a/clusters/resource_library.go
+++ b/clusters/resource_library.go
@@ -35,7 +35,7 @@ func ResourceLibrary() *schema.Resource {
 		return split[0], split[1]
 	}
 	return common.Resource{
-		Schema: s,
+		Schema: libraySdkSchema,
 		Create: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
 			clusterID := d.Get("cluster_id").(string)
 			err := NewClustersAPI(ctx, c).Start(clusterID)

--- a/libraries/libraries_api_sdk.go
+++ b/libraries/libraries_api_sdk.go
@@ -14,7 +14,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-// clusterID string, timeout time.Duration, isActive bool, refresh bool
 func WaitForLibrariesInstalledSdk(ctx context.Context, w *databricks.WorkspaceClient, wait compute.Wait, timeout time.Duration) (result *compute.ClusterLibraryStatuses, err error) {
 	err = resource.RetryContext(ctx, timeout, func() *resource.RetryError {
 		libsClusterStatus, err := w.Libraries.ClusterStatusByClusterId(ctx, wait.ClusterID)
@@ -31,8 +30,8 @@ func WaitForLibrariesInstalledSdk(ctx context.Context, w *databricks.WorkspaceCl
 		}
 		if !wait.IsRunning {
 			log.Printf("[INFO] Cluster %s is currently not running, so just returning list of %d libraries",
-				wait.ClusterID, len(libsClusterStatus.LibraryStatuses)) // Check pointers
-			result = libsClusterStatus // Might not work, need to check
+				wait.ClusterID, len(libsClusterStatus.LibraryStatuses))
+			result = libsClusterStatus
 			return nil
 		}
 		retry, err := libsClusterStatus.IsRetryNeeded(wait)

--- a/libraries/libraries_api_sdk.go
+++ b/libraries/libraries_api_sdk.go
@@ -1,0 +1,76 @@
+package libraries
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/databricks/databricks-sdk-go"
+	"github.com/databricks/databricks-sdk-go/apierr"
+	"github.com/databricks/databricks-sdk-go/service/compute"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+// clusterID string, timeout time.Duration, isActive bool, refresh bool
+func WaitForLibrariesInstalledSdk(ctx context.Context, w *databricks.WorkspaceClient, wait compute.Wait, timeout time.Duration) (result *compute.ClusterLibraryStatuses, err error) {
+	err = resource.RetryContext(ctx, timeout, func() *resource.RetryError {
+		libsClusterStatus, err := w.Libraries.ClusterStatusByClusterId(ctx, wait.ClusterID)
+		if err != nil {
+			var apiErr *apierr.APIError
+			if !errors.As(err, &apiErr) {
+				return resource.NonRetryableError(err)
+			}
+			if apiErr.StatusCode != 404 && strings.Contains(apiErr.Message,
+				fmt.Sprintf("Cluster %s does not exist", wait.ClusterID)) {
+				apiErr.StatusCode = 404
+			}
+			return resource.NonRetryableError(apiErr)
+		}
+		if !wait.IsRunning {
+			log.Printf("[INFO] Cluster %s is currently not running, so just returning list of %d libraries",
+				wait.ClusterID, len(libsClusterStatus.LibraryStatuses)) // Check pointers
+			result = libsClusterStatus // Might not work, need to check
+			return nil
+		}
+		retry, err := libsClusterStatus.IsRetryNeeded(wait)
+		if retry {
+			return resource.RetryableError(err)
+		}
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+		result = libsClusterStatus
+		return nil
+	})
+	if err != nil {
+		return
+	}
+	if wait.IsRunning {
+		installed := []compute.LibraryFullStatus{}
+		cleanup := compute.UninstallLibraries{
+			ClusterId: wait.ClusterID,
+			Libraries: []compute.Library{},
+		}
+		// cleanup libraries that failed to install
+		for _, v := range result.LibraryStatuses {
+			if v.Status == "FAILED" {
+				log.Printf("[WARN] Removing failed library %s from %s", v.Library, wait.ClusterID)
+				cleanup.Libraries = append(cleanup.Libraries, *v.Library)
+				continue
+			}
+			installed = append(installed, v)
+		}
+		// and result contains only the libraries that were successfully installed
+		result.LibraryStatuses = installed
+		if len(cleanup.Libraries) > 0 {
+			w.Libraries.Uninstall(ctx, cleanup)
+			if err != nil {
+				err = fmt.Errorf("cannot cleanup libraries: %w", err)
+			}
+		}
+	}
+	return
+}

--- a/libraries/libraries_api_sdk.go
+++ b/libraries/libraries_api_sdk.go
@@ -14,6 +14,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
+// Given a compute.Wait struct, returns library statuses based on the input parameter.
+// If wait.IsRunning is set to true, this function will wait until all of the libraries are installed to return. Otherwise, it will directly return the list of libraries.
 func WaitForLibrariesInstalledSdk(ctx context.Context, w *databricks.WorkspaceClient, wait compute.Wait, timeout time.Duration) (result *compute.ClusterLibraryStatuses, err error) {
 	err = resource.RetryContext(ctx, timeout, func() *resource.RetryError {
 		libsClusterStatus, err := w.Libraries.ClusterStatusByClusterId(ctx, wait.ClusterID)
@@ -29,8 +31,8 @@ func WaitForLibrariesInstalledSdk(ctx context.Context, w *databricks.WorkspaceCl
 			return resource.NonRetryableError(apiErr)
 		}
 		if !wait.IsRunning {
-			log.Printf("[INFO] Cluster %s is currently not running, so just returning list of %d libraries",
-				wait.ClusterID, len(libsClusterStatus.LibraryStatuses))
+			log.Printf("[INFO] We don't have to wait until the libraries are installed, so just returning list of %d libraries",
+				len(libsClusterStatus.LibraryStatuses))
 			result = libsClusterStatus
 			return nil
 		}

--- a/libraries/libraries_api_sdk_test.go
+++ b/libraries/libraries_api_sdk_test.go
@@ -1,0 +1,142 @@
+package libraries
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/databricks/databricks-sdk-go/apierr"
+	"github.com/databricks/databricks-sdk-go/service/compute"
+	"github.com/databricks/terraform-provider-databricks/common"
+	"github.com/databricks/terraform-provider-databricks/qa"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWaitForLibrariesInstalledSdk(t *testing.T) {
+	qa.HTTPFixturesApply(t, []qa.HTTPFixture{
+		{
+			Method:       "GET",
+			Resource:     "/api/2.0/libraries/cluster-status?cluster_id=missing",
+			ReuseRequest: true,
+			Status:       404,
+			Response:     apierr.NotFound("missing"),
+		},
+		{
+			Method:       "GET",
+			Resource:     "/api/2.0/libraries/cluster-status?cluster_id=error",
+			ReuseRequest: true,
+			Status:       500,
+			Response: apierr.APIError{
+				Message: "internal error",
+			},
+		},
+		{
+			Method:       "GET",
+			Resource:     "/api/2.0/libraries/cluster-status?cluster_id=1005-abcd",
+			ReuseRequest: true,
+			Status:       400,
+			Response: apierr.APIError{
+				Message: "Cluster 1005-abcd does not exist",
+			},
+		},
+		{
+			Method:       "GET",
+			Resource:     "/api/2.0/libraries/cluster-status?cluster_id=still-installing",
+			ReuseRequest: true,
+			Response: ClusterLibraryStatuses{
+				ClusterID: "still-installing",
+				LibraryStatuses: []LibraryStatus{
+					{
+						Status: "PENDING",
+						Library: &Library{
+							Jar: "a.jar",
+						},
+					},
+				},
+			},
+		},
+		{
+			Method:       "GET",
+			Resource:     "/api/2.0/libraries/cluster-status?cluster_id=failed-wheel",
+			ReuseRequest: true,
+			Response: ClusterLibraryStatuses{
+				ClusterID: "still-installing",
+				LibraryStatuses: []LibraryStatus{
+					{
+						Status:   "FAILED",
+						Messages: []string{"does not compute"},
+						Library: &Library{
+							Whl: "b.whl",
+						},
+					},
+					{
+						Status: "INSTALLED",
+						Library: &Library{
+							Jar: "a.jar",
+						},
+					},
+				},
+			},
+		},
+		{
+			Method:   "POST",
+			Resource: "/api/2.0/libraries/uninstall",
+			ExpectedRequest: ClusterLibraryList{
+				ClusterID: "failed-wheel",
+				Libraries: []Library{
+					{
+						Whl: "b.whl",
+					},
+				},
+			},
+		},
+	}, func(ctx context.Context, client *common.DatabricksClient) {
+		w, err := client.WorkspaceClient()
+		if err != nil {
+			panic(err)
+		}
+		_, err = WaitForLibrariesInstalledSdk(ctx, w, compute.Wait{
+			ClusterID: "missing", Libraries: []compute.Library{}, IsRunning: true, IsRefresh: false,
+		}, 50*time.Millisecond)
+		assert.EqualError(t, err, "missing")
+
+		_, err = WaitForLibrariesInstalledSdk(ctx, w, compute.Wait{
+			ClusterID: "error", Libraries: []compute.Library{}, IsRunning: true, IsRefresh: false,
+		}, 50*time.Millisecond)
+		assert.EqualError(t, err, "internal error")
+
+		// cluster is not running
+		_, err = WaitForLibrariesInstalledSdk(ctx, w, compute.Wait{
+			ClusterID: "still-installing", Libraries: []compute.Library{}, IsRunning: false, IsRefresh: false,
+		}, 50*time.Millisecond)
+		assert.NoError(t, err)
+
+		// cluster is running
+		_, err = WaitForLibrariesInstalledSdk(ctx, w, compute.Wait{
+			ClusterID: "still-installing", Libraries: []compute.Library{}, IsRunning: true, IsRefresh: false,
+		}, 50*time.Millisecond)
+		assert.EqualError(t, err, "0 libraries are ready, but there are still 1 pending")
+
+		_, err = WaitForLibrariesInstalledSdk(ctx, w, compute.Wait{
+			ClusterID: "failed-wheel", Libraries: []compute.Library{}, IsRunning: true, IsRefresh: false,
+		}, 50*time.Millisecond)
+		assert.EqualError(t, err, "whl:b.whl failed: does not compute")
+
+		// uninstall b.whl and continue executing
+		_, err = WaitForLibrariesInstalledSdk(ctx, w, compute.Wait{
+			ClusterID: "failed-wheel", Libraries: []compute.Library{}, IsRunning: true, IsRefresh: true,
+		}, 50*time.Millisecond)
+		assert.NoError(t, err, "library should have been uninstalled and work proceeded")
+
+		// Cluster not available or doesn't exist
+		_, err = WaitForLibrariesInstalledSdk(ctx, w, compute.Wait{
+			ClusterID: "1005-abcd", Libraries: []compute.Library{}, IsRunning: false, IsRefresh: false,
+		}, 50*time.Millisecond)
+
+		var ae *apierr.APIError
+		assert.True(t, errors.As(err, &ae))
+		assert.Equal(t, 404, ae.StatusCode)
+		assert.Equal(t, "Cluster 1005-abcd does not exist", ae.Message)
+	})
+}


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
- Migrate library read method to use the go-sdk
- Added a `WaitForLibrariesInstalledSdk` method to mirror the one currently used, but implemented with the go-sdk

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

