### PR TITLE
Add integration test coverage for delta sharing parameters

### DIFF
--- a/internal/acceptance/metastore_test.go
+++ b/internal/acceptance/metastore_test.go
@@ -1,73 +1,90 @@
 package acceptance
 
 import (
+	"encoding/json"
+	"fmt"
 	"os"
+	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
-func TestUcAccMetastore(t *testing.T) {
-	cloudEnv := os.Getenv("CLOUD_ENV")
+func getStorageRoot(cloudEnv string) string {
 	switch cloudEnv {
 	case "ucacct":
-		unityAccountLevel(t, step{
-			Template: `resource "databricks_metastore" "this" {
-				name = "{var.RANDOM}"
-				storage_root = "s3://{env.TEST_BUCKET}/test{var.RANDOM}"
-				region = "us-east-1"
-				force_destroy = true
-			}`,
-		})
+		return "s3://{env.TEST_BUCKET}/test{var.RANDOM}"
 	case "azure-ucacct":
-		unityAccountLevel(t, step{
-			Template: `resource "databricks_metastore" "this" {
-				name = "{var.RANDOM}"
-				storage_root = "abfss://{var.RANDOM}@{var.RANDOM}.dfs.core.windows.net/"
-				region = "eastus"
-				force_destroy = true
-			}`,
-		})
+		return "abfss://{var.RANDOM}@{var.RANDOM}/"
 	case "gcp-accounts":
-		unityAccountLevel(t, step{
-			Template: `resource "databricks_metastore" "this" {
-				name = "{var.RANDOM}"
-				storage_root = "gs://{var.RANDOM}/metastore"
-				region = "us-east1"
-				force_destroy = true
-			}`,
-		})
+		return "gs://{var.RANDOM}/metastore"
 	default:
-		t.Skipf("not available on %s", cloudEnv)
+		return ""
+	}
+}
+
+func getRegion(cloudEnv string) string {
+	switch cloudEnv {
+	case "ucacct":
+		return "us-east-1"
+	case "azure-ucacct":
+		return "eastus"
+	case "gcp-accounts":
+		return "us-east1"
+	default:
+		return ""
 	}
 }
 
 func TestUcAccRootlessMetastore(t *testing.T) {
-	cloudEnv := os.Getenv("CLOUD_ENV")
-	switch cloudEnv {
-	case "ucacct":
-		unityAccountLevel(t, step{
-			Template: `resource "databricks_metastore" "this" {
-				name = "{var.RANDOM}"
-				region = "us-east-1"
-				force_destroy = true
-			}`,
-		})
-	case "azure-ucacct":
-		unityAccountLevel(t, step{
-			Template: `resource "databricks_metastore" "this" {
-				name = "{var.RANDOM}"
-				region = "eastus"
-				force_destroy = true
-			}`,
-		})
-	case "gcp-accounts":
-		unityAccountLevel(t, step{
-			Template: `resource "databricks_metastore" "this" {
-				name = "{var.RANDOM}"
-				region = "us-east1"
-				force_destroy = true
-			}`,
-		})
-	default:
-		t.Skipf("not available on %s", cloudEnv)
+	loadDebugEnvIfRunsFromIDE(t, "ucacct")
+	runMetastoreTest(t, map[string]any{
+		"region": getRegion(os.Getenv("CLOUD_ENV")),
+	})
+}
+
+func TestUcAccMetastore(t *testing.T) {
+	loadDebugEnvIfRunsFromIDE(t, "ucacct")
+	runMetastoreTest(t, map[string]any{
+		"storage_root": getStorageRoot(os.Getenv("CLOUD_ENV")),
+		"region":       getRegion(os.Getenv("CLOUD_ENV")),
+	})
+}
+
+func TestUcAccMetastoreDeltaSharing(t *testing.T) {
+	loadDebugEnvIfRunsFromIDE(t, "ucacct")
+	runMetastoreTest(t, map[string]any{
+		"storage_root":        getStorageRoot(os.Getenv("CLOUD_ENV")),
+		"region":              getRegion(os.Getenv("CLOUD_ENV")),
+		"delta_sharing_scope": "INTERNAL",
+		"delta_sharing_recipient_token_lifetime_in_seconds": 3600,
+		"delta_sharing_organization_name":                   "databricks-tf-provider-test",
+	})
+}
+
+func TestUcAccMetastoreDeltaSharingInfiniteLifetime(t *testing.T) {
+	loadDebugEnvIfRunsFromIDE(t, "ucacct")
+	runMetastoreTest(t, map[string]any{
+		"storage_root":        getStorageRoot(os.Getenv("CLOUD_ENV")),
+		"region":              getRegion(os.Getenv("CLOUD_ENV")),
+		"delta_sharing_scope": "INTERNAL",
+		"delta_sharing_recipient_token_lifetime_in_seconds": 0,
+	})
+}
+
+func runMetastoreTest(t *testing.T, extraAttributes map[string]any) {
+	params := make([]string, len(extraAttributes))
+	for k, v := range extraAttributes {
+		jsonValue, err := json.Marshal(v)
+		require.NoError(t, err)
+		params = append(params, k+" = "+string(jsonValue))
 	}
+	template := strings.Join(params, "\n\t\t\t")
+	unityAccountLevel(t, step{
+		Template: fmt.Sprintf(`resource "databricks_metastore" "this" {
+			name = "{var.RANDOM}"
+			force_destroy = true
+			%s
+		}`, template),
+	})
 }


### PR DESCRIPTION
## Changes
As a follow up to a regression with delta sharing parameters in the Terraform provider, this PR adds more integration test coverage to the metastore resource to ensure that we submit `0` as a parameter explicitly for `delta_sharing_recipient_token_lifetime_in_seconds`.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

