### PR TITLE
Make notebook extensions more obvious

### DIFF
--- a/docs/resources/notebook.md
+++ b/docs/resources/notebook.md
@@ -42,6 +42,25 @@ resource "databricks_notebook" "lesson" {
 }
 ```
 
+## Trim Extensions
+
+```hcl
+data "databricks_current_user" "me" {
+}
+
+resource "databricks_notebook" "example.py" {
+  source = "${path.module}/example.py"
+  path   = "${data.databricks_current_user.me.home}/AA/BB/example.py"
+  trim_export_extension = true
+}
+```
+
+This will create a notebook named `example` on databricks workspace; when exporting as `source` in the GUI, it will be renamed `example.py`.
+
+You can run the notebook with `%run example`.
+
+If you do not specify `trim_export_extension` argument and include the a extension in the `path` argument, the notebook will be created as `example.py`, but when exporting as `source` in GUI, it will be renamed `example.py.py`.
+
 ## Argument Reference
 
 -> **Note** Notebook on Databricks workspace would only be changed, if Terraform stage did change. This means that any manual changes to managed notebook won't be overwritten by Terraform, if there's no local change to notebook sources. Notebooks are identified by their path, so changing notebook's name manually on the workspace and then applying Terraform state would result in creation of notebook from Terraform state.
@@ -52,6 +71,7 @@ The size of a notebook source code must not exceed a few megabytes. The followin
 * `source` - Path to notebook in source code format on local filesystem. Conflicts with `content_base64`.
 * `content_base64` - The base64-encoded notebook source code. Conflicts with `source`. Use of `content_base64` is discouraged, as it's increasing memory footprint of Terraform state and should only be used in exceptional circumstances, like creating a notebook with configuration properties for a data pipeline.
 * `language` -  (required with `content_base64`) One of `SCALA`, `PYTHON`, `SQL`, `R`.
+* `trim_export_extension` (optional) - defaults to `false`; setting this to `true` will create notebooks without extensions even when `path` specifies an extension. This functionality exists to prevent exports of notebooks with duplicate extensions by databricks workspace GUI.
 
 ## Attribute Reference
 

--- a/workspace/resource_notebook.go
+++ b/workspace/resource_notebook.go
@@ -368,11 +368,13 @@ func ResourceNotebook() *schema.Resource {
 			}
 			notebooksAPI := NewNotebooksAPI(ctx, c)
 			path := d.Get("path").(string)
+			pathNoExtension := path[0 : len(path)-len(filepath.Ext(path))]
+
 			createNotebook := ImportPath{
 				Content:   base64.StdEncoding.EncodeToString(content),
 				Language:  d.Get("language").(string),
 				Format:    d.Get("format").(string),
-				Path:      path,
+				Path:      pathNoExtension,
 				Overwrite: true,
 			}
 			if createNotebook.Language == "" {
@@ -400,7 +402,7 @@ func ResourceNotebook() *schema.Resource {
 					return err
 				}
 			}
-			d.SetId(path)
+			d.SetId(pathNoExtension)
 			return nil
 		},
 		Read: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {

--- a/workspace/resource_notebook_test.go
+++ b/workspace/resource_notebook_test.go
@@ -116,7 +116,7 @@ func TestResourceNotebookCreate_DirectoryExist(t *testing.T) {
 				Resource: "/api/2.0/workspace/import",
 				ExpectedRequest: ImportPath{
 					Content:   "YWJjCg==",
-					Path:      "/foo/path",
+					Path:      "/foo/path.py",
 					Language:  "PYTHON",
 					Overwrite: true,
 					Format:    "SOURCE",
@@ -124,55 +124,18 @@ func TestResourceNotebookCreate_DirectoryExist(t *testing.T) {
 			},
 			{
 				Method:   http.MethodGet,
-				Resource: "/api/2.0/workspace/export?format=SOURCE&path=%2Ffoo%2Fpath",
+				Resource: "/api/2.0/workspace/export?format=SOURCE&path=%2Ffoo%2Fpath.py",
 				Response: ExportPath{
 					Content: "YWJjCg==",
 				},
 			},
 			{
 				Method:   http.MethodGet,
-				Resource: "/api/2.0/workspace/get-status?path=%2Ffoo%2Fpath",
+				Resource: "/api/2.0/workspace/get-status?path=%2Ffoo%2Fpath.py",
 				Response: ObjectStatus{
 					ObjectID:   4567,
 					ObjectType: "NOTEBOOK",
-					Path:       "/foo/path",
-					Language:   "PYTHON",
-				},
-			},
-		},
-		Resource: ResourceNotebook(),
-		State: map[string]any{
-			"content_base64": "YWJjCg==",
-			"language":       "PYTHON",
-			"path":           "/foo/path",
-		},
-		Create: true,
-	}.Apply(t)
-	assert.NoError(t, err)
-	assert.Equal(t, "/foo/path", d.Id())
-}
-
-func TestResourceNotebookCreate_TrimExtension(t *testing.T) {
-	d, err := qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:   http.MethodPost,
-				Resource: "/api/2.0/workspace/import",
-				ExpectedRequest: ImportPath{
-					Content:   "YWJjCg==",
-					Path:      "/foo/path",
-					Language:  "PYTHON",
-					Overwrite: true,
-					Format:    "SOURCE",
-				},
-			},
-			{
-				Method:   http.MethodGet,
-				Resource: "/api/2.0/workspace/get-status?path=%2Ffoo%2Fpath",
-				Response: ObjectStatus{
-					ObjectID:   4567,
-					ObjectType: "NOTEBOOK",
-					Path:       "/foo/path",
+					Path:       "/foo/path.py",
 					Language:   "PYTHON",
 				},
 			},
@@ -186,7 +149,7 @@ func TestResourceNotebookCreate_TrimExtension(t *testing.T) {
 		Create: true,
 	}.Apply(t)
 	assert.NoError(t, err)
-	assert.Equal(t, "/foo/path", d.Id())
+	assert.Equal(t, "/foo/path.py", d.Id())
 }
 
 func TestResourceNotebookCreate_DirectoryDoesntExist(t *testing.T) {
@@ -204,7 +167,7 @@ func TestResourceNotebookCreate_DirectoryDoesntExist(t *testing.T) {
 				Resource: "/api/2.0/workspace/import",
 				ExpectedRequest: ImportPath{
 					Content:   "YWJjCg==",
-					Path:      "/foo/path",
+					Path:      "/foo/path.py",
 					Language:  "PYTHON",
 					Overwrite: true,
 					Format:    "SOURCE",
@@ -220,7 +183,7 @@ func TestResourceNotebookCreate_DirectoryDoesntExist(t *testing.T) {
 				Resource: "/api/2.0/workspace/import",
 				ExpectedRequest: ImportPath{
 					Content:   "YWJjCg==",
-					Path:      "/foo/path",
+					Path:      "/foo/path.py",
 					Language:  "PYTHON",
 					Overwrite: true,
 					Format:    "SOURCE",
@@ -228,18 +191,18 @@ func TestResourceNotebookCreate_DirectoryDoesntExist(t *testing.T) {
 			},
 			{
 				Method:   http.MethodGet,
-				Resource: "/api/2.0/workspace/export?format=SOURCE&path=%2Ffoo%2Fpath",
+				Resource: "/api/2.0/workspace/export?format=SOURCE&path=%2Ffoo%2Fpath.py",
 				Response: ExportPath{
 					Content: "YWJjCg==",
 				},
 			},
 			{
 				Method:   http.MethodGet,
-				Resource: "/api/2.0/workspace/get-status?path=%2Ffoo%2Fpath",
+				Resource: "/api/2.0/workspace/get-status?path=%2Ffoo%2Fpath.py",
 				Response: ObjectStatus{
 					ObjectID:   4567,
 					ObjectType: "NOTEBOOK",
-					Path:       "/foo/path",
+					Path:       "/foo/path.py",
 					Language:   "PYTHON",
 				},
 			},
@@ -248,12 +211,12 @@ func TestResourceNotebookCreate_DirectoryDoesntExist(t *testing.T) {
 		State: map[string]any{
 			"content_base64": "YWJjCg==",
 			"language":       "PYTHON",
-			"path":           "/foo/path",
+			"path":           "/foo/path.py",
 		},
 		Create: true,
 	}.Apply(t)
 	assert.NoError(t, err)
-	assert.Equal(t, "/foo/path", d.Id())
+	assert.Equal(t, "/foo/path.py", d.Id())
 }
 
 func TestResourceNotebookCreate_DirectoryCreateError(t *testing.T) {
@@ -276,7 +239,7 @@ func TestResourceNotebookCreate_DirectoryCreateError(t *testing.T) {
 				Resource: "/api/2.0/workspace/import",
 				ExpectedRequest: ImportPath{
 					Content:   "YWJjCg==",
-					Path:      "/foo/path",
+					Path:      "/foo/path.py",
 					Language:  "PYTHON",
 					Overwrite: true,
 					Format:    "SOURCE",
@@ -292,7 +255,7 @@ func TestResourceNotebookCreate_DirectoryCreateError(t *testing.T) {
 		State: map[string]any{
 			"content_base64": "YWJjCg==",
 			"language":       "PYTHON",
-			"path":           "/foo/path",
+			"path":           "/foo/path.py",
 		},
 		Create: true,
 	}.Apply(t)
@@ -588,4 +551,80 @@ func TestParallelListing(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 4, len(objects))
 
+}
+
+func TestResourceNotebookCreate_TrimExtension(t *testing.T) {
+	d, err := qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   http.MethodPost,
+				Resource: "/api/2.0/workspace/import",
+				ExpectedRequest: ImportPath{
+					Content:   "YWJjCg==",
+					Path:      "/foo/path",
+					Language:  "PYTHON",
+					Overwrite: true,
+					Format:    "SOURCE",
+				},
+			},
+			{
+				Method:   http.MethodGet,
+				Resource: "/api/2.0/workspace/get-status?path=%2Ffoo%2Fpath",
+				Response: ObjectStatus{
+					ObjectID:   4567,
+					ObjectType: "NOTEBOOK",
+					Path:       "/foo/path",
+					Language:   "PYTHON",
+				},
+			},
+		},
+		Resource: ResourceNotebook(),
+		State: map[string]any{
+			"content_base64":        "YWJjCg==",
+			"language":              "PYTHON",
+			"path":                  "/foo/path.py",
+			"trim_export_extension": true,
+		},
+		Create: true,
+	}.Apply(t)
+	assert.NoError(t, err)
+	assert.Equal(t, "/foo/path", d.Id())
+}
+
+func TestResourceNotebookCreate_TrimExtension_NoOpWhenFalse(t *testing.T) {
+	d, err := qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   http.MethodPost,
+				Resource: "/api/2.0/workspace/import",
+				ExpectedRequest: ImportPath{
+					Content:   "YWJjCg==",
+					Path:      "/foo/path.py",
+					Language:  "PYTHON",
+					Overwrite: true,
+					Format:    "SOURCE",
+				},
+			},
+			{
+				Method:   http.MethodGet,
+				Resource: "/api/2.0/workspace/get-status?path=%2Ffoo%2Fpath.py",
+				Response: ObjectStatus{
+					ObjectID:   4567,
+					ObjectType: "NOTEBOOK",
+					Path:       "/foo/path.py",
+					Language:   "PYTHON",
+				},
+			},
+		},
+		Resource: ResourceNotebook(),
+		State: map[string]any{
+			"content_base64":        "YWJjCg==",
+			"language":              "PYTHON",
+			"path":                  "/foo/path.py",
+			"trim_export_extension": false,
+		},
+		Create: true,
+	}.Apply(t)
+	assert.NoError(t, err)
+	assert.Equal(t, "/foo/path.py", d.Id())
 }

--- a/workspace/resource_notebook_test.go
+++ b/workspace/resource_notebook_test.go
@@ -152,6 +152,43 @@ func TestResourceNotebookCreate_DirectoryExist(t *testing.T) {
 	assert.Equal(t, "/foo/path", d.Id())
 }
 
+func TestResourceNotebookCreate_TrimExtension(t *testing.T) {
+	d, err := qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   http.MethodPost,
+				Resource: "/api/2.0/workspace/import",
+				ExpectedRequest: ImportPath{
+					Content:   "YWJjCg==",
+					Path:      "/foo/path",
+					Language:  "PYTHON",
+					Overwrite: true,
+					Format:    "SOURCE",
+				},
+			},
+			{
+				Method:   http.MethodGet,
+				Resource: "/api/2.0/workspace/get-status?path=%2Ffoo%2Fpath",
+				Response: ObjectStatus{
+					ObjectID:   4567,
+					ObjectType: "NOTEBOOK",
+					Path:       "/foo/path",
+					Language:   "PYTHON",
+				},
+			},
+		},
+		Resource: ResourceNotebook(),
+		State: map[string]any{
+			"content_base64": "YWJjCg==",
+			"language":       "PYTHON",
+			"path":           "/foo/path.py",
+		},
+		Create: true,
+	}.Apply(t)
+	assert.NoError(t, err)
+	assert.Equal(t, "/foo/path", d.Id())
+}
+
 func TestResourceNotebookCreate_DirectoryDoesntExist(t *testing.T) {
 	d, err := qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{

--- a/workspace/resource_notebook_test.go
+++ b/workspace/resource_notebook_test.go
@@ -116,7 +116,7 @@ func TestResourceNotebookCreate_DirectoryExist(t *testing.T) {
 				Resource: "/api/2.0/workspace/import",
 				ExpectedRequest: ImportPath{
 					Content:   "YWJjCg==",
-					Path:      "/foo/path.py",
+					Path:      "/foo/path",
 					Language:  "PYTHON",
 					Overwrite: true,
 					Format:    "SOURCE",
@@ -124,18 +124,18 @@ func TestResourceNotebookCreate_DirectoryExist(t *testing.T) {
 			},
 			{
 				Method:   http.MethodGet,
-				Resource: "/api/2.0/workspace/export?format=SOURCE&path=%2Ffoo%2Fpath.py",
+				Resource: "/api/2.0/workspace/export?format=SOURCE&path=%2Ffoo%2Fpath",
 				Response: ExportPath{
 					Content: "YWJjCg==",
 				},
 			},
 			{
 				Method:   http.MethodGet,
-				Resource: "/api/2.0/workspace/get-status?path=%2Ffoo%2Fpath.py",
+				Resource: "/api/2.0/workspace/get-status?path=%2Ffoo%2Fpath",
 				Response: ObjectStatus{
 					ObjectID:   4567,
 					ObjectType: "NOTEBOOK",
-					Path:       "/foo/path.py",
+					Path:       "/foo/path",
 					Language:   "PYTHON",
 				},
 			},
@@ -144,12 +144,12 @@ func TestResourceNotebookCreate_DirectoryExist(t *testing.T) {
 		State: map[string]any{
 			"content_base64": "YWJjCg==",
 			"language":       "PYTHON",
-			"path":           "/foo/path.py",
+			"path":           "/foo/path",
 		},
 		Create: true,
 	}.Apply(t)
 	assert.NoError(t, err)
-	assert.Equal(t, "/foo/path.py", d.Id())
+	assert.Equal(t, "/foo/path", d.Id())
 }
 
 func TestResourceNotebookCreate_DirectoryDoesntExist(t *testing.T) {
@@ -167,7 +167,7 @@ func TestResourceNotebookCreate_DirectoryDoesntExist(t *testing.T) {
 				Resource: "/api/2.0/workspace/import",
 				ExpectedRequest: ImportPath{
 					Content:   "YWJjCg==",
-					Path:      "/foo/path.py",
+					Path:      "/foo/path",
 					Language:  "PYTHON",
 					Overwrite: true,
 					Format:    "SOURCE",
@@ -183,7 +183,7 @@ func TestResourceNotebookCreate_DirectoryDoesntExist(t *testing.T) {
 				Resource: "/api/2.0/workspace/import",
 				ExpectedRequest: ImportPath{
 					Content:   "YWJjCg==",
-					Path:      "/foo/path.py",
+					Path:      "/foo/path",
 					Language:  "PYTHON",
 					Overwrite: true,
 					Format:    "SOURCE",
@@ -191,18 +191,18 @@ func TestResourceNotebookCreate_DirectoryDoesntExist(t *testing.T) {
 			},
 			{
 				Method:   http.MethodGet,
-				Resource: "/api/2.0/workspace/export?format=SOURCE&path=%2Ffoo%2Fpath.py",
+				Resource: "/api/2.0/workspace/export?format=SOURCE&path=%2Ffoo%2Fpath",
 				Response: ExportPath{
 					Content: "YWJjCg==",
 				},
 			},
 			{
 				Method:   http.MethodGet,
-				Resource: "/api/2.0/workspace/get-status?path=%2Ffoo%2Fpath.py",
+				Resource: "/api/2.0/workspace/get-status?path=%2Ffoo%2Fpath",
 				Response: ObjectStatus{
 					ObjectID:   4567,
 					ObjectType: "NOTEBOOK",
-					Path:       "/foo/path.py",
+					Path:       "/foo/path",
 					Language:   "PYTHON",
 				},
 			},
@@ -211,12 +211,12 @@ func TestResourceNotebookCreate_DirectoryDoesntExist(t *testing.T) {
 		State: map[string]any{
 			"content_base64": "YWJjCg==",
 			"language":       "PYTHON",
-			"path":           "/foo/path.py",
+			"path":           "/foo/path",
 		},
 		Create: true,
 	}.Apply(t)
 	assert.NoError(t, err)
-	assert.Equal(t, "/foo/path.py", d.Id())
+	assert.Equal(t, "/foo/path", d.Id())
 }
 
 func TestResourceNotebookCreate_DirectoryCreateError(t *testing.T) {
@@ -239,7 +239,7 @@ func TestResourceNotebookCreate_DirectoryCreateError(t *testing.T) {
 				Resource: "/api/2.0/workspace/import",
 				ExpectedRequest: ImportPath{
 					Content:   "YWJjCg==",
-					Path:      "/foo/path.py",
+					Path:      "/foo/path",
 					Language:  "PYTHON",
 					Overwrite: true,
 					Format:    "SOURCE",
@@ -255,7 +255,7 @@ func TestResourceNotebookCreate_DirectoryCreateError(t *testing.T) {
 		State: map[string]any{
 			"content_base64": "YWJjCg==",
 			"language":       "PYTHON",
-			"path":           "/foo/path.py",
+			"path":           "/foo/path",
 		},
 		Create: true,
 	}.Apply(t)


### PR DESCRIPTION
## Changes

databricks workspace notebook resource modified to allow inclusion of extension in module call.

**Previous behaviour:**

Following resource config would create `notebook.py.py` on the workspace, but databricks UI masks the extension for notebooks so it's not apparent.

```HCL

resource "databricks_notebook" "some_notebook" {
source =  "./notebook.py"
path = "/notebook.py"
}
```

**New behaviour**

Both of these configurations will now create only `notebook.py` on the workspace

```HCL

resource "databricks_notebook" "some_notebook" {
source =  "./notebook.py"
path = "/notebook.py"
}
```

```HCL

resource "databricks_notebook" "some_notebook" {
source =  "./notebook.py"
path = "/notebook"
}
```

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] covered with integration tests in `internal/acceptance`
- [x] relevant acceptance tests are passing
- [x] using Go SDK
- [x] confirmed behaviour and no regression with delv terraform apply
- [x] added additional unit test

