### PR TITLE
Migrate clusters delete to Go SDK

### DIFF
--- a/clusters/resource_cluster.go
+++ b/clusters/resource_cluster.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
+	"github.com/databricks/databricks-sdk-go/service/compute"
 	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/databricks/terraform-provider-databricks/libraries"
 )
@@ -27,7 +28,11 @@ func ResourceCluster() *schema.Resource {
 		Update: resourceClusterUpdate,
 		Delete: func(ctx context.Context,
 			d *schema.ResourceData, c *common.DatabricksClient) error {
-			return NewClustersAPI(ctx, c).PermanentDelete(d.Id())
+			w, err := c.WorkspaceClient()
+			if err != nil {
+				return err
+			}
+			return w.Clusters.PermanentDelete(ctx, compute.PermanentDeleteCluster{ClusterId: d.Id()})
 		},
 		Schema:        clusterSchema,
 		SchemaVersion: 2,

--- a/clusters/resource_cluster_test.go
+++ b/clusters/resource_cluster_test.go
@@ -1345,7 +1345,7 @@ func TestResourceClusterDelete(t *testing.T) {
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   "POST",
-				Resource: "/api/2.0/clusters/delete",
+				Resource: "/api/2.0/clusters/permanent-delete",
 				ExpectedRequest: map[string]string{
 					"cluster_id": "abc",
 				},
@@ -1378,7 +1378,7 @@ func TestResourceClusterDelete_Error(t *testing.T) {
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   "POST",
-				Resource: "/api/2.0/clusters/delete",
+				Resource: "/api/2.0/clusters/permanent-delete",
 				Response: apierr.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
Migrating clusters delete to use Go SDK 

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->
Nightly Passed
 
- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

