### PR TITLE
Exporter: add emitting of libraries that are workspace files

### DIFF
--- a/docs/resources/repo.md
+++ b/docs/resources/repo.md
@@ -45,6 +45,7 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` -  Repo identifier
 * `commit_hash` - Hash of the HEAD commit at time of the last executed operation. It won't change if you manually perform pull operation via UI or API
+* `workspace_path` - path on Workspace File System (WSFS) in form of `/Workspace` + `path`
 
 ## Access Control
 

--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -897,8 +897,7 @@ func TestImportingClusters(t *testing.T) {
 			ic := newImportContext(client)
 			ic.Directory = tmpDir
 			ic.listing = "compute"
-			services, _ := ic.allServicesAndListing()
-			ic.services = services
+			ic.services = "access,users,policies,compute,secrets,groups,storage"
 
 			err := ic.Run()
 			assert.NoError(t, err)
@@ -989,6 +988,8 @@ func TestImportingJobs_JobList(t *testing.T) {
 						},
 						Libraries: []libraries.Library{
 							{Jar: "dbfs:/FileStore/jars/test.jar"},
+							{Whl: "/Workspace/Repos/user@domain.com/repo/test.whl"},
+							{Whl: "/Workspace/Users/user@domain.com/libs/test.whl"},
 						},
 						Name: "Dummy",
 						NewCluster: &clusters.Cluster{

--- a/exporter/importables.go
+++ b/exporter/importables.go
@@ -271,12 +271,16 @@ var resourcesMap map[string]importable = map[string]importable{
 			{Path: "driver_instance_pool_id", Resource: "databricks_instance_pool"},
 			{Path: "init_scripts.dbfs.destination", Resource: "databricks_dbfs_file", Match: "dbfs_path"},
 			{Path: "init_scripts.workspace.destination", Resource: "databricks_workspace_file"},
+			{Path: "init_scripts.workspace.destination", Resource: "databricks_repo", Match: "workspace_path", MatchType: MatchPrefix},
 			{Path: "library.jar", Resource: "databricks_dbfs_file", Match: "dbfs_path"},
 			{Path: "library.jar", Resource: "databricks_workspace_file", Match: "workspace_path"},
+			{Path: "library.jar", Resource: "databricks_repo", Match: "workspace_path", MatchType: MatchPrefix},
 			{Path: "library.whl", Resource: "databricks_dbfs_file", Match: "dbfs_path"},
 			{Path: "library.whl", Resource: "databricks_workspace_file", Match: "workspace_path"},
+			{Path: "library.whl", Resource: "databricks_repo", Match: "workspace_path", MatchType: MatchPrefix},
 			{Path: "library.egg", Resource: "databricks_dbfs_file", Match: "dbfs_path"},
 			{Path: "library.egg", Resource: "databricks_workspace_file", Match: "workspace_path"},
+			{Path: "library.egg", Resource: "databricks_repo", Match: "workspace_path", MatchType: MatchPrefix},
 			{Path: "policy_id", Resource: "databricks_cluster_policy"},
 			{Path: "single_user_name", Resource: "databricks_user", Match: "user_name", MatchType: MatchCaseInsensitive},
 			{Path: "single_user_name", Resource: "databricks_service_principal", Match: "application_id"},
@@ -367,6 +371,8 @@ var resourcesMap map[string]importable = map[string]importable{
 			{Path: "task.new_cluster.aws_attributes.instance_profile_arn", Resource: "databricks_instance_profile"},
 			{Path: "task.new_cluster.init_scripts.dbfs.destination", Resource: "databricks_dbfs_file", Match: "dbfs_path"},
 			{Path: "task.new_cluster.init_scripts.workspace.destination", Resource: "databricks_workspace_file"},
+			{Path: "task.new_cluster.init_scripts.workspace.destination", Resource: "databricks_repo",
+				Match: "workspace_path", MatchType: MatchPrefix},
 			{Path: "task.new_cluster.instance_pool_id", Resource: "databricks_instance_pool"},
 			{Path: "task.new_cluster.driver_instance_pool_id", Resource: "databricks_instance_pool"},
 			{Path: "task.new_cluster.policy_id", Resource: "databricks_cluster_policy"},
@@ -374,6 +380,8 @@ var resourcesMap map[string]importable = map[string]importable{
 			{Path: "job_cluster.new_cluster.aws_attributes.instance_profile_arn", Resource: "databricks_instance_profile"},
 			{Path: "job_cluster.new_cluster.init_scripts.dbfs.destination", Resource: "databricks_dbfs_file", Match: "dbfs_path"},
 			{Path: "job_cluster.new_cluster.init_scripts.workspace.destination", Resource: "databricks_workspace_file"},
+			{Path: "job_cluster.new_cluster.init_scripts.workspace.destination", Resource: "databricks_repo",
+				Match: "workspace_path", MatchType: MatchPrefix},
 			{Path: "job_cluster.new_cluster.instance_pool_id", Resource: "databricks_instance_pool"},
 			{Path: "job_cluster.new_cluster.driver_instance_pool_id", Resource: "databricks_instance_pool"},
 			{Path: "job_cluster.new_cluster.policy_id", Resource: "databricks_cluster_policy"},
@@ -634,7 +642,7 @@ var resourcesMap map[string]importable = map[string]importable{
 				}
 				if typ == "fixed" && strings.HasPrefix(k, "init_scripts.") &&
 					strings.HasSuffix(k, ".workspace.destination") {
-					ic.maybeEmitWorkspaceObject("databricks_workspace_file", eitherString(value, defaultValue))
+					ic.emitWorkspaceFileOrRepo(eitherString(value, defaultValue))
 				}
 				if typ == "fixed" && (strings.HasPrefix(k, "spark_conf.") || strings.HasPrefix(k, "spark_env_vars.")) {
 					either := eitherString(value, defaultValue)
@@ -673,10 +681,13 @@ var resourcesMap map[string]importable = map[string]importable{
 		Depends: []reference{
 			{Path: "libraries.jar", Resource: "databricks_dbfs_file", Match: "dbfs_path"},
 			{Path: "libraries.jar", Resource: "databricks_workspace_file", Match: "workspace_path"},
+			{Path: "libraries.jar", Resource: "databricks_repo", Match: "workspace_path", MatchType: MatchPrefix},
 			{Path: "libraries.whl", Resource: "databricks_dbfs_file", Match: "dbfs_path"},
 			{Path: "libraries.whl", Resource: "databricks_workspace_file", Match: "workspace_path"},
+			{Path: "libraries.whl", Resource: "databricks_repo", Match: "workspace_path", MatchType: MatchPrefix},
 			{Path: "libraries.egg", Resource: "databricks_dbfs_file", Match: "dbfs_path"},
 			{Path: "libraries.egg", Resource: "databricks_workspace_file", Match: "workspace_path"},
+			{Path: "libraries.egg", Resource: "databricks_repo", Match: "workspace_path", MatchType: MatchPrefix},
 		},
 		// TODO: special formatting required, where JSON is written line by line
 		// so that we're able to do the references
@@ -1908,6 +1919,8 @@ var resourcesMap map[string]importable = map[string]importable{
 			{Path: "cluster.aws_attributes.instance_profile_arn", Resource: "databricks_instance_profile"},
 			{Path: "new_cluster.init_scripts.dbfs.destination", Resource: "databricks_dbfs_file", Match: "dbfs_path"},
 			{Path: "new_cluster.init_scripts.workspace.destination", Resource: "databricks_workspace_file"},
+			{Path: "new_cluster.init_scripts.workspace.destination", Resource: "databricks_repo",
+				Match: "workspace_path", MatchType: MatchPrefix},
 			{Path: "cluster.instance_pool_id", Resource: "databricks_instance_pool"},
 			{Path: "cluster.driver_instance_pool_id", Resource: "databricks_instance_pool"},
 			{Path: "library.notebook.path", Resource: "databricks_notebook"},

--- a/exporter/test-data/get-cluster-policy.json
+++ b/exporter/test-data/get-cluster-policy.json
@@ -1,6 +1,11 @@
 {
   "created_at_timestamp": 1606308550000,
-  "definition": "{\"aws_attributes.instance_profile_arn\":{\"hidden\":true,\"type\":\"fixed\",\"value\":\"arn:aws:iam::12345:instance-profile/shard-s3-access\"},\"instance_pool_id\":{\"hidden\":true,\"type\":\"fixed\",\"value\":\"pool1\"},\"spark_conf.abc\":{\"hidden\":true,\"type\":\"fixed\",\"value\":\"{{secrets/some-kv-scope/secret}}\"},\"autoscale.max_workers\":{\"defaultValue\":2,\"maxValue\":5,\"type\":\"range\"}}",
+  "definition": "{\"aws_attributes.instance_profile_arn\":{\"hidden\":true,\"type\":\"fixed\",\"value\":\"arn:aws:iam::12345:instance-profile/shard-s3-access\"},\"instance_pool_id\":{\"hidden\":true,\"type\":\"fixed\",\"value\":\"pool1\"},\"spark_conf.abc\":{\"hidden\":true,\"type\":\"fixed\",\"value\":\"{{secrets/some-kv-scope/secret}}\"},\"autoscale.max_workers\":{\"defaultValue\":2,\"maxValue\":5,\"type\":\"range\"},\"init_scripts.0.workspace.destination\":{\"type\":\"fixed\",\"value\": \"/Workspace/Repos/user@domain.com/repo/test.sh\",\"hidden\": true},\"init_scripts.1.workspace.destination\":{\"type\": \"fixed\",\"value\": \"/Workspace/Users/user@domain.com/repo/test.sh\",\"hidden\": true},\"init_scripts.1.dbfs.destination\":{\"type\": \"fixed\",\"value\": \"dbfs:/FileStore/jars/test.jar\",\"hidden\": true}}",
   "name": "users cluster policy",
-  "policy_id": "123"
+  "policy_id": "123",
+  "libraries":[
+      {"jar":"dbfs:/FileStore/jars/test.jar"},
+      {"whl":"/Workspace/Repos/user@domain.com/repo/test.whl"},
+      {"whl":"/Workspace/Users/user@domain.com/libs/test.whl"}
+  ]
 }

--- a/exporter/util.go
+++ b/exporter/util.go
@@ -168,7 +168,6 @@ func (ic *importContext) emitRepoByPath(path string) {
 	})
 }
 
-// TODO: workspace init scripts also could be from Repos, so we need to handle them correctly...
 func (ic *importContext) emitWorkspaceFileOrRepo(path string) {
 	if strings.HasPrefix(path, "/Repos") {
 		ic.emitRepoByPath(path)

--- a/repos/resource_repo.go
+++ b/repos/resource_repo.go
@@ -181,6 +181,10 @@ func ResourceRepo() *schema.Resource {
 			ConflictsWith: []string{"branch"},
 			ValidateFunc:  validation.StringIsNotWhiteSpace,
 		}
+		s["workspace_path"] = &schema.Schema{
+			Type:     schema.TypeString,
+			Computed: true,
+		}
 
 		delete(s, "id")
 		return s
@@ -217,7 +221,12 @@ func ResourceRepo() *schema.Resource {
 			if err != nil {
 				return err
 			}
-			return common.StructToData(resp, s, d)
+			err = common.StructToData(resp, s, d)
+			if err != nil {
+				return err
+			}
+			d.Set("workspace_path", "/Workspace"+resp.Path)
+			return nil
 		},
 		Update: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
 			var repo ReposInformation

--- a/repos/resource_repo_test.go
+++ b/repos/resource_repo_test.go
@@ -50,7 +50,8 @@ func TestResourceRepoRead(t *testing.T) {
 		ID:       repoIDStr,
 	}.ApplyAndExpectData(t,
 		map[string]any{"id": repoIDStr, "path": path, "branch": branch, "git_provider": provider,
-			"url": url, "commit_hash": "7e0847ede61f07adede22e2bcce6050216489171"})
+			"url": url, "commit_hash": "7e0847ede61f07adede22e2bcce6050216489171",
+			"workspace_path": "/Workspace" + path})
 }
 
 func TestResourceRepoRead_NotFound(t *testing.T) {

--- a/workspace/resource_directory.go
+++ b/workspace/resource_directory.go
@@ -32,6 +32,10 @@ func ResourceDirectory() *schema.Resource {
 			Default:  false,
 			Optional: true,
 		},
+		"workspace_path": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
 	}
 
 	directoryRead := func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
@@ -44,7 +48,12 @@ func ResourceDirectory() *schema.Resource {
 			d.SetId("")
 			return fmt.Errorf("different object type, %s, on this path other than a directory", objectStatus.ObjectType)
 		}
-		return common.StructToData(objectStatus, s, d)
+		err = common.StructToData(objectStatus, s, d)
+		if err != nil {
+			return err
+		}
+		d.Set("workspace_path", "/Workspace"+d.Id())
+		return nil
 	}
 
 	return common.Resource{

--- a/workspace/resource_directory_test.go
+++ b/workspace/resource_directory_test.go
@@ -16,7 +16,7 @@ import (
 func TestResourceDirectoryRead(t *testing.T) {
 	path := "/test/path"
 	objectID := 12345
-	d, err := qa.ResourceFixture{
+	qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   http.MethodGet,
@@ -32,10 +32,9 @@ func TestResourceDirectoryRead(t *testing.T) {
 		Read:     true,
 		New:      true,
 		ID:       path,
-	}.Apply(t)
-	assert.NoError(t, err)
-	assert.Equal(t, path, d.Id())
-	assert.Equal(t, path, d.Get("path"))
+	}.ApplyAndExpectData(t, map[string]any{
+		"id": path, "path": path, "workspace_path": "/Workspace" + path, "object_id": objectID,
+	})
 }
 
 func TestResourceDirectoryDelete(t *testing.T) {


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

We now support libraries that are uploaded into the Databricks workspace as files (`databricks_workspace_file` resource). We now support emitting them in jobs, clusters & cluster policies.

Also added the `workspace_path` attribute to the `databricks_repo` and `databricks_directory` resources.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] tested manually
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

