### PR TITLE
Documentation: consistent header levels and same doc structure

### DIFF
--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -80,7 +80,7 @@ resource "databricks_cluster" "shared_autoscaling" {
 }
 ```
 
-## Fixed size or autoscaling cluster
+### Fixed size or autoscaling cluster
 
 When you [create a Databricks cluster](https://docs.databricks.com/clusters/configure.html#cluster-size-and-autoscaling), you can either provide a `num_workers` for the fixed-size cluster or provide `min_workers` and/or `max_workers` for the cluster within the `autoscale` group. When you give a fixed-sized cluster, Databricks ensures that your cluster has a specified number of workers. When you provide a range for the number of workers, Databricks chooses the appropriate number of workers required to run your job - also known as "autoscaling." With autoscaling, Databricks dynamically reallocates workers to account for the characteristics of your job. Certain parts of your pipeline may be more computationally demanding than others, and Databricks automatically adds additional workers during these phases of your job (and removes them when they’re no longer needed).
 
@@ -221,7 +221,7 @@ library {
 }
 ```
 
-## cluster_log_conf
+### cluster_log_conf
 
 Example of pushing all cluster logs to DBFS:
 
@@ -254,7 +254,7 @@ There are a few more advanced attributes for S3 log delivery:
 * `kms_key` - (Optional) KMS key used if encryption is enabled and encryption type is set to `sse-kms`.
 * `canned_acl` - (Optional) Set canned access control list, e.g. `bucket-owner-full-control`. If `canned_cal` is set, the cluster instance profile must have `s3:PutObjectAcl` permission on the destination bucket and prefix. The full list of possible canned ACLs can be found [here](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl). By default, only the object owner gets full control. If you are using a cross-account role for writing data, you may want to set `bucket-owner-full-control` to make bucket owners able to read the logs.
 
-## init_scripts
+### init_scripts
 
 To run a particular init script on all clusters within the same workspace, both automated/job and interactive/all-purpose cluster types, please consider the [databricks_global_init_script](global_init_script.md) resource.
 
@@ -333,7 +333,7 @@ init_scripts {
 }
 ```
 
-## aws_attributes
+### aws_attributes
 
 `aws_attributes` optional configuration block contains attributes related to [clusters running on Amazon Web Services](https://docs.databricks.com/clusters/configure.html#aws-configurations).
 
@@ -373,7 +373,7 @@ The following options are available:
 * `ebs_volume_count` - (Optional) The number of volumes launched for each instance. You can choose up to 10 volumes. This feature is only enabled for supported node types. Legacy node types cannot specify custom EBS volumes. For node types with no instance store, at least one EBS volume needs to be specified; otherwise, cluster creation will fail. These EBS volumes will be mounted at /ebs0, /ebs1, and etc. Instance store volumes will be mounted at /local_disk0, /local_disk1, and etc. If EBS volumes are attached, Databricks will configure Spark to use only the EBS volumes for scratch storage because heterogeneously sized scratch devices can lead to inefficient disk utilization. If no EBS volumes are attached, Databricks will configure Spark to use instance store volumes. If EBS volumes are specified, then the Spark configuration spark.local.dir will be overridden.
 * `ebs_volume_size` - (Optional) The size of each EBS volume (in GiB) launched for each instance. For general purpose SSD, this value must be within the range 100 - 4096. For throughput optimized HDD, this value must be within the range 500 - 4096. Custom EBS volumes cannot be specified for the legacy node types (memory-optimized and compute-optimized).
 
-## azure_attributes
+### azure_attributes
 
 `azure_attributes` optional configuration block contains attributes related to [clusters running on Azure](https://docs.microsoft.com/en-us/azure/databricks/dev-tools/api/latest/clusters#--azureattributes).
 
@@ -407,7 +407,7 @@ The following options are [available](https://docs.microsoft.com/en-us/azure/dat
 * `first_on_demand` - (Optional) The first `first_on_demand` nodes of the cluster will be placed on on-demand instances. If this value is greater than 0, the cluster driver node will be placed on an on-demand instance. If this value is greater than or equal to the current cluster size, all nodes will be placed on on-demand instances. If this value is less than the current cluster size, `first_on_demand` nodes will be placed on on-demand instances, and the remainder will be placed on availability instances. This value does not affect cluster size and cannot be mutated over the lifetime of a cluster.
 * `spot_bid_max_price` - (Optional) The max price for Azure spot instances.  Use `-1` to specify the lowest price.
 
-## gcp_attributes
+### gcp_attributes
 
 `gcp_attributes` optional configuration block contains attributes related to [clusters running on GCP](https://docs.gcp.databricks.com/dev-tools/api/latest/clusters.html#clustergcpattributes).
 
@@ -442,7 +442,7 @@ The following options are available:
   * `AUTO`: Databricks picks an availability zone to schedule the cluster on.
   * name of a GCP availability zone: pick one of the available zones from the [list of available availability zones](https://cloud.google.com/compute/docs/regions-zones#available).
 
-## docker_image
+### docker_image
 
 [Databricks Container Services](https://docs.databricks.com/clusters/custom-containers.html) lets you specify a Docker image when you create a cluster. You need to enable Container Services in *Admin Console /  Advanced* page in the user interface. By enabling this feature, you acknowledge and agree that your usage of this feature is subject to the [applicable additional terms](http://www.databricks.com/product-specific-terms).
 
@@ -473,7 +473,7 @@ resource "databricks_cluster" "this" {
 }
 ```
 
-## cluster_mount_info blocks (experimental)
+### cluster_mount_info blocks (experimental)
 
 -> **Note** The underlying API is experimental and may change in the future.
 
@@ -506,7 +506,7 @@ resource "databricks_cluster" "with_nfs" {
 }
 ```
 
-## workload_type block
+### workload_type block
 
 It's possible to restrict which workloads may run on the given cluster - notebooks and/or jobs. It's done by defining a `workload_type` block that consists of a single block `clients` with following attributes:
 

--- a/docs/resources/instance_pool.md
+++ b/docs/resources/instance_pool.md
@@ -55,7 +55,7 @@ The following options are [available](https://docs.databricks.com/dev-tools/api/
 * `spot_bid_price_percent` - (Optional) (Integer) The max price for AWS spot instances, as a percentage of the corresponding instance type’s on-demand price. For example, if this field is set to 50, and the instance pool needs a new i3.xlarge spot instance, then the max price is half of the price of on-demand i3.xlarge instances. Similarly, if this field is set to 200, the max price is twice the price of on-demand i3.xlarge instances. If not specified, the *default value is 100*. When spot instances are requested for this instance pool, only spot instances whose max price percentage matches this field are considered. *For safety, this field cannot be greater than 10000.*
 * `availability` - (Optional) (String) Availability type used for all instances in the pool. Only `ON_DEMAND` and `SPOT` are supported.
 
-## azure_attributes Configuration Block
+### azure_attributes Configuration Block
 
 `azure_attributes` optional configuration block contains attributes related to [instance pools on Azure](https://docs.microsoft.com/en-us/azure/databricks/dev-tools/api/latest/instance-pools#--instancepoolazureattributes).
 
@@ -64,7 +64,7 @@ The following options are [available](https://docs.microsoft.com/en-us/azure/dat
 * `availability` - (Optional) Availability type used for all nodes. Valid values are `SPOT_AZURE` and `ON_DEMAND_AZURE`.
 * `spot_bid_max_price` - (Optional) The max price for Azure spot instances.  Use `-1` to specify the lowest price.
 
-## gcp_attributes Configuration Block
+### gcp_attributes Configuration Block
 
 `gcp_attributes` optional configuration block contains attributes related to [instance pools on GCP](https://docs.gcp.databricks.com/dev-tools/api/latest/instance-pools.html#clusterinstancepoolgcpattributes).
 
@@ -92,7 +92,7 @@ For disk_spec make sure to use **ebs_volume_type** only on AWS deployment of Dat
   * Premium LRS (SSD): `1 - 1023` GiB
   * Standard LRS (HDD): `1- 1023` GiB
 
-## preloaded_docker_image sub_block
+### preloaded_docker_image sub_block
 
 [Databricks Container Services](https://docs.databricks.com/clusters/custom-containers.html) lets you specify a Docker image when you create a cluster.  You need to enable Container Services in *Admin Console /  Advanced* page in the user interface. By enabling this feature, you acknowledge and agree that your usage of this feature is subject to the [applicable additional terms](http://www.databricks.com/product-specific-terms). You can instruct the instance pool to pre-download the Docker image onto the instances so when node is acquired for a cluster that requires a custom Docker image the setup process will be faster.
 

--- a/docs/resources/job.md
+++ b/docs/resources/job.md
@@ -405,7 +405,7 @@ resource "databricks_job" "sql_aggregation_job" {
 }
 ```
 
-### Exported attributes
+## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
 

--- a/docs/resources/metastore_assignment.md
+++ b/docs/resources/metastore_assignment.md
@@ -22,14 +22,6 @@ resource "databricks_metastore_assignment" "this" {
 }
 ```
 
-## Import
-
-This resource can be imported by combination of workspace id and metastore id:
-
-```bash
-terraform import databricks_metastore_assignment.this '<workspace_id>|<metastore_id>'
-```
-
 ## Argument Reference
 
 The following arguments are required:
@@ -43,3 +35,11 @@ The following arguments are required:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - ID of this metastore assignment in form of `<metastore_id>|<metastore_id>`.
+
+## Import
+
+This resource can be imported by combination of workspace id and metastore id:
+
+```bash
+terraform import databricks_metastore_assignment.this '<workspace_id>|<metastore_id>'
+```

--- a/docs/resources/mlflow_webhook.md
+++ b/docs/resources/mlflow_webhook.md
@@ -96,13 +96,13 @@ Configuration must include one of `http_url_spec` or `job_spec` blocks, but not 
 * `enable_ssl_verification` - (Optional) Enable/disable SSL certificate validation. Default is `true`. For self-signed certificates, this field must be `false` AND the destination server must disable certificate validation as well. For security purposes, it is encouraged to perform secret validation with the HMAC-encoded portion of the payload and acknowledge the risk associated with disabling hostname validation whereby it becomes more likely that requests can be maliciously routed to an unintended host.
 * `secret` - (Optional) Shared secret required for HMAC encoding payload. The HMAC-encoded payload will be sent in the header as `X-Databricks-Signature: encoded_payload`.
 
-## Import
-
--> **Note** Importing this resource is not currently supported.
-
 ## Access Control
 
 * MLflow webhooks could be configured only by workspace admins.
+
+## Import
+
+-> **Note** Importing this resource is not currently supported.
 
 ## Related Resources
 

--- a/docs/resources/mws_workspaces.md
+++ b/docs/resources/mws_workspaces.md
@@ -358,10 +358,6 @@ In addition to all arguments above, the following attributes are exported:
 * `creation_time` - (Integer) time when workspace was created
 * `workspace_url` - (String) URL of the workspace
 
-## Import
-
--> **Note** Importing this resource is not currently supported.
-
 ## Timeouts
 
 The `timeouts` block allows you to specify `create`, `read` and `update` timeouts. It usually takes 5-7 minutes to provision Databricks E2 Workspace and another couple of minutes for your local DNS caches to resolve. Please launch `TF_LOG=DEBUG terraform apply` whenever you observe timeout issues.
@@ -381,6 +377,10 @@ You can reset local DNS caches before provisioning new workspaces with one of th
 * Mac OS X Yosemite - `sudo discoveryutil udnsflushcaches`
 * Mac OS X Snow Leopard - `sudo dscacheutil -flushcache`
 * Mac OS X Leopard and below - `sudo lookupd -flushcache`
+
+## Import
+
+-> **Note** Importing this resource is not currently supported.
 
 ## Related Resources
 

--- a/docs/resources/repo.md
+++ b/docs/resources/repo.md
@@ -30,7 +30,7 @@ The following arguments are supported:
 * `branch` - (Optional) name of the branch for initial checkout. If not specified, the default branch of the repository will be used.  Conflicts with `tag`.  If `branch` is removed, and `tag` isn't specified, then the repository will stay at the previously checked out state.
 * `tag` - (Optional) name of the tag for initial checkout.  Conflicts with `branch`.
 
-## sparse_checkout
+### sparse_checkout
 
 Optional `sparse_checkout` configuration block contains attributes related to [sparse checkout feature](https://docs.databricks.com/repos/git-operations-with-repos.html#configure-sparse-checkout-mode) in Databricks Repos.  It supports following attributes:
 

--- a/docs/resources/secret_scope.md
+++ b/docs/resources/secret_scope.md
@@ -20,7 +20,7 @@ The following arguments are supported:
 * `name` - (Required) Scope name requested by the user. Must be unique within a workspace. Must consist of alphanumeric characters, dashes, underscores, and periods, and may not exceed 128 characters.
 * `initial_manage_principal` - (Optional) The principal with the only possible value `users` that is initially granted `MANAGE` permission to the created scope.  If it's omitted, then the [databricks_secret_acl](secret_acl.md) with `MANAGE` permission applied to the scope is assigned to the API request issuer's user identity (see [documentation](https://docs.databricks.com/dev-tools/api/latest/secrets.html#create-secret-scope)). This part of the state cannot be imported.
 
-## keyvault_metadata
+### keyvault_metadata
 
 On Azure, it is possible to create Azure Databricks secret scopes backed by Azure Key Vault. Secrets are stored in Azure Key Vault and can be accessed through the Azure Databricks secrets utilities, making use of Azure Databricks access control and secret redaction. A secret scope may be configured with at most one Key Vault. 
 


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

In a number of resources the header levels were inconsistent for documentation about blocks (some were on the 2nd level, some on the 3rd, while most of the resources use the 3rd level).  Also, changed the order of sections a bit to get a uniform order of sections.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

