### PR TITLE
Remove requirement to provide accountId in mws_credentials resource

### DIFF
--- a/common/client.go
+++ b/common/client.go
@@ -67,6 +67,20 @@ func (c *DatabricksClient) WorkspaceClient() (*databricks.WorkspaceClient, error
 	return w, nil
 }
 
+func (c *DatabricksClient) SetAccountId(accountId string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if accountId == "" {
+		return nil
+	}
+	oldAccountID := c.DatabricksClient.Config.AccountID
+	if oldAccountID != "" && oldAccountID != accountId {
+		return fmt.Errorf("account ID is already set to %s", oldAccountID)
+	}
+	c.DatabricksClient.Config.AccountID = accountId
+	return nil
+}
+
 func (c *DatabricksClient) AccountClient() (*databricks.AccountClient, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()

--- a/mws/resource_mws_credentials.go
+++ b/mws/resource_mws_credentials.go
@@ -49,6 +49,10 @@ func ResourceMwsCredentials() *schema.Resource {
 	p := common.NewPairSeparatedID("account_id", "credentials_id", "/")
 	return common.Resource{
 		Create: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
+			err := c.SetAccountId(d.Get("account_id").(string))
+			if err != nil {
+				return err
+			}
 			acc, err := c.AccountClient()
 			if err != nil {
 				return err
@@ -105,6 +109,10 @@ func ResourceMwsCredentials() *schema.Resource {
 			}
 			return acc.Credentials.DeleteByCredentialsId(ctx, credsId)
 		},
-		Schema: common.StructToSchema(CredentialInfo{}, common.NoCustomize),
+		Schema: common.StructToSchema(CredentialInfo{}, func(s map[string]*schema.Schema) map[string]*schema.Schema {
+			// nolint
+			s["account_id"].Deprecated = "`account_id` should be set as part of the Databricks Config, not in the resource."
+			return s
+		}),
 	}.ToResource()
 }


### PR DESCRIPTION
## Changes
Remove requirement to provide accountId in mws_credentials resource

## Tests

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [x] relevant acceptance tests are passing
- [ ] using Go SDK

