### PR TITLE
fix two minor docs typos

### DIFF
--- a/docs/data-sources/node_type.md
+++ b/docs/data-sources/node_type.md
@@ -46,7 +46,7 @@ Data source allows you to pick groups by the following attributes
 * `min_gpus` - (Optional) Minimum number of GPU's attached to instance. Defaults to *0*.
 * `local_disk` - (Optional) Pick only nodes with local storage. Defaults to *false*.
 * `local_disk_min_size` - (Optional) Pick only nodes that have size local storage greater or equal to given value. Defaults to *0*.
-* `category` - (Optional, case insensitive string) Node category, which can be one of (depending on the cloud environment, could be checked with `databricks clusters list-node-types|jq '.node_types[]|.category'|sort |uniq`):
+* `category` - (Optional, case insensitive string) Node category, which can be one of (depending on the cloud environment, could be checked with `databricks clusters list-node-types -o json|jq '.node_types[]|.category'|sort |uniq`):
   * `General Purpose` (all clouds)
   * `General Purpose (HDD)` (Azure)
   * `Compute Optimized` (all clouds)

--- a/docs/resources/cluster_policy.md
+++ b/docs/resources/cluster_policy.md
@@ -55,7 +55,7 @@ resource "databricks_cluster_policy" "fair_use" {
   name       = "${var.team} cluster policy"
   definition = jsonencode(merge(local.default_policy, var.policy_overrides))
 
-  library {
+  libraries {
     pypi {
       package = "databricks-sdk==0.12.0"
       // repo can also be specified here


### PR DESCRIPTION
## Changes

Fix two typos in docs for readability:
- **cluster_policy** resource: change `library{}` block -> `libraries{}` in example to align with current arguments
- **node_type** data source: use `-o json` for jq input in example cli category dump

## Tests

- [ ] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

