### PR TITLE
Revert validation in metastore resource

### DIFF
--- a/catalog/resource_metastore.go
+++ b/catalog/resource_metastore.go
@@ -84,10 +84,6 @@ func ResourceMetastore() *schema.Resource {
 				}
 				return nil
 			}, func(w *databricks.WorkspaceClient) error {
-				err := validateMetastoreId(ctx, w, d.Get("metastore_id").(string))
-				if err != nil {
-					return err
-				}
 				mi, err := w.Metastores.Create(ctx, create)
 				if err != nil {
 					return err
@@ -131,12 +127,8 @@ func ResourceMetastore() *schema.Resource {
 				}
 				return nil
 			}, func(w *databricks.WorkspaceClient) error {
-				err := validateMetastoreId(ctx, w, d.Get("metastore_id").(string))
-				if err != nil {
-					return err
-				}
 				update.Id = d.Id()
-				_, err = w.Metastores.Update(ctx, update)
+				_, err := w.Metastores.Update(ctx, update)
 				if err != nil {
 					return err
 				}
@@ -148,10 +140,6 @@ func ResourceMetastore() *schema.Resource {
 			return c.AccountOrWorkspaceRequest(func(acc *databricks.AccountClient) error {
 				return acc.Metastores.Delete(ctx, catalog.DeleteAccountMetastoreRequest{Force: force, MetastoreId: d.Id()})
 			}, func(w *databricks.WorkspaceClient) error {
-				err := validateMetastoreId(ctx, w, d.Get("metastore_id").(string))
-				if err != nil {
-					return err
-				}
 				return w.Metastores.Delete(ctx, catalog.DeleteMetastoreRequest{Force: force, Id: d.Id()})
 			})
 		},


### PR DESCRIPTION
## Changes
Revert validation in metastore. 
Other UC APIs at the workspace level implicitly use the metastore assigned to the workspace. This validation is only needed for those resources, to ensure that a user isn't trying to update UC resources belonging to a different metastore than the one assigned to the workspace.

## Tests

- [X] `make test` run locally
- [ ] relevant change in `docs/` folder
- [X] covered with integration tests in `internal/acceptance`
- [X] relevant acceptance tests are passing
- [X] using Go SDK

