### PR TITLE
Revert "Add support for Databricks Account Console IP Access Lists"

### DIFF
--- a/access/resource_ip_access_list.go
+++ b/access/resource_ip_access_list.go
@@ -3,7 +3,6 @@ package access
 import (
 	"context"
 
-	"github.com/databricks/databricks-sdk-go"
 	"github.com/databricks/databricks-sdk-go/service/settings"
 	"github.com/databricks/terraform-provider-databricks/common"
 
@@ -11,15 +10,17 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
+type ipAccessListUpdateRequest struct {
+	Label       string            `json:"label"`
+	ListType    settings.ListType `json:"list_type"`
+	IpAddresses []string          `json:"ip_addresses"`
+	Enabled     bool              `json:"enabled,omitempty" tf:"default:true"`
+}
+
 // ResourceIPAccessList manages IP access lists
 func ResourceIPAccessList() *schema.Resource {
-	s := common.StructToSchema(settings.CreateIpAccessList{}, func(s map[string]*schema.Schema) map[string]*schema.Schema {
+	s := common.StructToSchema(ipAccessListUpdateRequest{}, func(s map[string]*schema.Schema) map[string]*schema.Schema {
 		// nolint
-		s["enabled"] = &schema.Schema{
-			Type:     schema.TypeBool,
-			Optional: true,
-			Default:  true,
-		}
 		s["list_type"].ValidateFunc = validation.StringInSlice([]string{"ALLOW", "BLOCK"}, false)
 		s["ip_addresses"].Elem = &schema.Schema{
 			Type:         schema.TypeString,
@@ -30,67 +31,47 @@ func ResourceIPAccessList() *schema.Resource {
 	return common.Resource{
 		Schema: s,
 		Create: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
+			w, err := c.WorkspaceClient()
+			if err != nil {
+				return err
+			}
 			var iacl settings.CreateIpAccessList
-			var updateIacl settings.UpdateIpAccessList
 			common.DataToStructPointer(d, s, &iacl)
-			common.DataToStructPointer(d, s, &updateIacl)
-			return c.AccountOrWorkspaceRequest(func(acc *databricks.AccountClient) error {
-				status, err := acc.IpAccessLists.Create(ctx, iacl)
-				if err != nil {
-					return err
-				}
-				//need to enable the IP Access List with update
-				if d.Get("enabled").(bool) {
-					updateIacl.IpAccessListId = status.IpAccessList.ListId
-					err = acc.IpAccessLists.Update(ctx, updateIacl)
-					if err != nil {
-						return err
-					}
-				}
-				d.SetId(status.IpAccessList.ListId)
-				return nil
-			}, func(w *databricks.WorkspaceClient) error {
-				status, err := w.IpAccessLists.Create(ctx, iacl)
-				if err != nil {
-					return err
-				}
-				d.SetId(status.IpAccessList.ListId)
-				return nil
-			})
+			status, err := w.IpAccessLists.Create(ctx, iacl)
+			if err != nil {
+				return err
+			}
+			d.SetId(status.IpAccessList.ListId)
+			return nil
 		},
 		Read: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
-			return c.AccountOrWorkspaceRequest(func(acc *databricks.AccountClient) error {
-				status, err := acc.IpAccessLists.GetByIpAccessListId(ctx, d.Id())
-				if err != nil {
-					return err
-				}
-				common.StructToData(status.IpAccessList, s, d)
-				return nil
-			}, func(w *databricks.WorkspaceClient) error {
-				status, err := w.IpAccessLists.GetByIpAccessListId(ctx, d.Id())
-				if err != nil {
-					return err
-				}
-				common.StructToData(status.IpAccessList, s, d)
-				return nil
-			})
+			w, err := c.WorkspaceClient()
+			if err != nil {
+				return err
+			}
+			status, err := w.IpAccessLists.GetByIpAccessListId(ctx, d.Id())
+			if err != nil {
+				return err
+			}
+			common.StructToData(status.IpAccessList, s, d)
+			return nil
 		},
 		Update: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
+			w, err := c.WorkspaceClient()
+			if err != nil {
+				return err
+			}
 			var iacl settings.UpdateIpAccessList
 			common.DataToStructPointer(d, s, &iacl)
 			iacl.IpAccessListId = d.Id()
-			return c.AccountOrWorkspaceRequest(func(acc *databricks.AccountClient) error {
-				return acc.IpAccessLists.Update(ctx, iacl)
-			}, func(w *databricks.WorkspaceClient) error {
-				return w.IpAccessLists.Update(ctx, iacl)
-			})
+			return w.IpAccessLists.Update(ctx, iacl)
 		},
 		Delete: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
-			return c.AccountOrWorkspaceRequest(func(acc *databricks.AccountClient) error {
-				return acc.IpAccessLists.DeleteByIpAccessListId(ctx, d.Id())
-			}, func(w *databricks.WorkspaceClient) error {
-				return w.IpAccessLists.DeleteByIpAccessListId(ctx, d.Id())
-			})
+			w, err := c.WorkspaceClient()
+			if err != nil {
+				return err
+			}
+			return w.IpAccessLists.DeleteByIpAccessListId(ctx, d.Id())
 		},
 	}.ToResource()
 }

--- a/access/resource_ip_access_list_test.go
+++ b/access/resource_ip_access_list_test.go
@@ -27,7 +27,7 @@ var (
 )
 
 func TestIPACLCreate(t *testing.T) {
-	qa.ResourceFixture{
+	d, err := qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   http.MethodPost,
@@ -78,14 +78,13 @@ func TestIPACLCreate(t *testing.T) {
 			"ip_addresses": TestingIpAddressesState,
 		},
 		Create: true,
-	}.ApplyAndExpectData(t,
-		map[string]any{
-			"id":             TestingId,
-			"label":          TestingLabel,
-			"list_type":      TestingListTypeString,
-			"enabled":        TestingEnabled,
-			"ip_addresses.#": 2,
-		})
+	}.Apply(t)
+	assert.NoError(t, err)
+	assert.Equal(t, TestingId, d.Id())
+	assert.Equal(t, TestingLabel, d.Get("label"))
+	assert.Equal(t, TestingListTypeString, d.Get("list_type"))
+	assert.Equal(t, TestingEnabled, d.Get("enabled"))
+	assert.Equal(t, 2, d.Get("ip_addresses.#"))
 }
 
 func TestAPIACLCreate_Error(t *testing.T) {
@@ -115,7 +114,7 @@ func TestAPIACLCreate_Error(t *testing.T) {
 }
 
 func TestIPACLUpdate(t *testing.T) {
-	qa.ResourceFixture{
+	d, err := qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   http.MethodGet,
@@ -138,7 +137,7 @@ func TestIPACLUpdate(t *testing.T) {
 			{
 				Method:   http.MethodPatch,
 				Resource: "/api/2.0/ip-access-lists/" + TestingId,
-				ExpectedRequest: settings.UpdateIpAccessList{
+				ExpectedRequest: ipAccessListUpdateRequest{
 					Label:       TestingLabel,
 					ListType:    TestingListType,
 					IpAddresses: TestingIpAddresses,
@@ -168,14 +167,13 @@ func TestIPACLUpdate(t *testing.T) {
 		},
 		Update: true,
 		ID:     TestingId,
-	}.ApplyAndExpectData(t,
-		map[string]any{
-			"id":             TestingId,
-			"label":          TestingLabel,
-			"list_type":      TestingListTypeString,
-			"enabled":        TestingEnabled,
-			"ip_addresses.#": 2,
-		})
+	}.Apply(t)
+	assert.NoError(t, err)
+	assert.Equal(t, TestingId, d.Id())
+	assert.Equal(t, TestingLabel, d.Get("label"))
+	assert.Equal(t, TestingListTypeString, d.Get("list_type"))
+	assert.Equal(t, TestingEnabled, d.Get("enabled"))
+	assert.Equal(t, 2, d.Get("ip_addresses.#"))
 }
 
 func TestIPACLUpdate_Error(t *testing.T) {
@@ -184,7 +182,7 @@ func TestIPACLUpdate_Error(t *testing.T) {
 			{
 				Method:   http.MethodPatch,
 				Resource: "/api/2.0/ip-access-lists/" + TestingId,
-				ExpectedRequest: settings.UpdateIpAccessList{
+				ExpectedRequest: ipAccessListUpdateRequest{
 					Enabled: TestingEnabled,
 				},
 				Response: apierr.APIErrorBody{
@@ -202,7 +200,7 @@ func TestIPACLUpdate_Error(t *testing.T) {
 }
 
 func TestIPACLRead(t *testing.T) {
-	qa.ResourceFixture{
+	d, err := qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   http.MethodGet,
@@ -227,14 +225,13 @@ func TestIPACLRead(t *testing.T) {
 		Read:     true,
 		New:      true,
 		ID:       TestingId,
-	}.ApplyAndExpectData(t,
-		map[string]any{
-			"id":             TestingId,
-			"label":          TestingLabel,
-			"list_type":      TestingListTypeString,
-			"enabled":        TestingEnabled,
-			"ip_addresses.#": 2,
-		})
+	}.Apply(t)
+	assert.NoError(t, err)
+	assert.Equal(t, TestingId, d.Id())
+	assert.Equal(t, TestingLabel, d.Get("label"))
+	assert.Equal(t, TestingListTypeString, d.Get("list_type"))
+	assert.Equal(t, TestingEnabled, d.Get("enabled"))
+	assert.Equal(t, 2, d.Get("ip_addresses.#"))
 }
 
 func TestIPACLRead_NotFound(t *testing.T) {
@@ -336,298 +333,4 @@ func TestListIpAccessLists(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, 0, len(ipLists.IpAccessLists))
-}
-
-func TestAccIPACLCreate(t *testing.T) {
-	qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:   http.MethodPost,
-				Resource: "/api/2.0/accounts/100/ip-access-lists",
-				ExpectedRequest: settings.CreateIpAccessList{
-					Label:       TestingLabel,
-					ListType:    TestingListType,
-					IpAddresses: TestingIpAddresses,
-				},
-				Response: settings.CreateIpAccessListResponse{
-					IpAccessList: &settings.IpAccessListInfo{
-						ListId:       TestingId,
-						Label:        TestingLabel,
-						ListType:     TestingListType,
-						IpAddresses:  TestingIpAddresses,
-						AddressCount: 2,
-						CreatedAt:    87939234,
-						CreatedBy:    1234556,
-						UpdatedAt:    87939234,
-						UpdatedBy:    1234556,
-						Enabled:      false,
-					},
-				},
-			},
-			{
-				Method:   http.MethodPatch,
-				Resource: "/api/2.0/accounts/100/ip-access-lists/" + TestingId,
-				ExpectedRequest: settings.UpdateIpAccessList{
-					Label:       TestingLabel,
-					ListType:    TestingListType,
-					IpAddresses: TestingIpAddresses,
-					Enabled:     TestingEnabled,
-				},
-			},
-			{
-				Method:   http.MethodGet,
-				Resource: "/api/2.0/accounts/100/ip-access-lists/" + TestingId + "?",
-				Response: settings.GetIpAccessListResponse{
-					IpAccessList: &settings.IpAccessListInfo{
-						ListId:       TestingId,
-						Label:        TestingLabel,
-						ListType:     TestingListType,
-						IpAddresses:  TestingIpAddresses,
-						AddressCount: 2,
-						CreatedAt:    87939234,
-						CreatedBy:    1234556,
-						UpdatedAt:    87939234,
-						UpdatedBy:    1234556,
-						Enabled:      TestingEnabled,
-					},
-				},
-			},
-		},
-		Resource:  ResourceIPAccessList(),
-		AccountID: "100",
-		State: map[string]any{
-			"label":        TestingLabel,
-			"list_type":    TestingListTypeString,
-			"ip_addresses": TestingIpAddressesState,
-		},
-		Create: true,
-	}.ApplyAndExpectData(t,
-		map[string]any{
-			"id":             TestingId,
-			"label":          TestingLabel,
-			"list_type":      TestingListTypeString,
-			"enabled":        TestingEnabled,
-			"ip_addresses.#": 2,
-		})
-}
-
-func TestAccIPACLCreate_Error(t *testing.T) {
-	d, err := qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:   http.MethodPost,
-				Resource: "/api/2.0/accounts/100/ip-access-lists",
-				Response: apierr.APIErrorBody{
-					ErrorCode: "RESOURCE_ALREADY_EXISTS",
-					Message:   "IP access list with type (" + TestingListTypeString + ") and label (" + TestingLabel + ") already exists",
-				},
-				Status: 400,
-			},
-		},
-		Resource:  ResourceIPAccessList(),
-		AccountID: "100",
-		State: map[string]any{
-			"label":        TestingLabel,
-			"list_type":    TestingListTypeString,
-			"ip_addresses": TestingIpAddressesState,
-		},
-		Create: true,
-	}.Apply(t)
-	assert.Error(t, err)
-	qa.AssertErrorStartsWith(t, err, "IP access list with type")
-	assert.Equal(t, "", d.Id(), "Id should be empty for error creates")
-}
-
-func TestAccIPACLUpdate(t *testing.T) {
-	qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:   http.MethodPatch,
-				Resource: fmt.Sprintf("/api/2.0/accounts/100/ip-access-lists/%s", TestingId),
-				ExpectedRequest: settings.UpdateIpAccessList{
-					Label:       TestingLabel,
-					ListType:    TestingListType,
-					IpAddresses: TestingIpAddresses,
-					Enabled:     TestingEnabled,
-				},
-			},
-			{
-				Method:   http.MethodGet,
-				Resource: fmt.Sprintf("/api/2.0/accounts/100/ip-access-lists/%s?", TestingId),
-				Response: settings.GetIpAccessListResponse{
-					IpAccessList: &settings.IpAccessListInfo{
-						ListId:       TestingId,
-						Label:        TestingLabel,
-						ListType:     TestingListType,
-						IpAddresses:  TestingIpAddresses,
-						AddressCount: 2,
-						CreatedAt:    87939234,
-						CreatedBy:    1234556,
-						UpdatedAt:    87939234,
-						UpdatedBy:    1234556,
-						Enabled:      TestingEnabled,
-					},
-				},
-			},
-		},
-		Resource: ResourceIPAccessList(),
-		State: map[string]any{
-			"label":        TestingLabel,
-			"list_type":    TestingListTypeString,
-			"ip_addresses": TestingIpAddressesState,
-		},
-		Update:    true,
-		ID:        TestingId,
-		AccountID: "100",
-	}.ApplyAndExpectData(t,
-		map[string]any{
-			"id":             TestingId,
-			"label":          TestingLabel,
-			"list_type":      TestingListTypeString,
-			"enabled":        TestingEnabled,
-			"ip_addresses.#": 2,
-		})
-}
-
-func TestAccIPACLUpdate_Error(t *testing.T) {
-	_, err := qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:   http.MethodPatch,
-				Resource: "/api/2.0/accounts/100/ip-access-lists/" + TestingId,
-				ExpectedRequest: settings.UpdateIpAccessList{
-					Enabled: TestingEnabled,
-				},
-				Response: apierr.APIErrorBody{
-					ErrorCode: "SERVER_ERROR",
-					Message:   "Something unexpected happened",
-				},
-				Status: 500,
-			},
-		},
-		Resource:  ResourceIPAccessList(),
-		Update:    true,
-		ID:        TestingId,
-		AccountID: "100",
-	}.Apply(t)
-	qa.AssertErrorStartsWith(t, err, "Something unexpected")
-}
-
-func TestAccIPACLRead(t *testing.T) {
-	qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:   http.MethodGet,
-				Resource: "/api/2.0/accounts/100/ip-access-lists/" + TestingId + "?",
-				Response: settings.GetIpAccessListResponse{
-					IpAccessList: &settings.IpAccessListInfo{
-						ListId:       TestingId,
-						Label:        TestingLabel,
-						ListType:     TestingListType,
-						IpAddresses:  TestingIpAddresses,
-						AddressCount: 2,
-						CreatedAt:    87939234,
-						CreatedBy:    1234556,
-						UpdatedAt:    87939234,
-						UpdatedBy:    1234556,
-						Enabled:      TestingEnabled,
-					},
-				},
-			},
-		},
-		Resource:  ResourceIPAccessList(),
-		Read:      true,
-		New:       true,
-		ID:        TestingId,
-		AccountID: "100",
-	}.ApplyAndExpectData(t,
-		map[string]any{
-			"id":             TestingId,
-			"label":          TestingLabel,
-			"list_type":      TestingListTypeString,
-			"enabled":        TestingEnabled,
-			"ip_addresses.#": 2,
-		})
-}
-
-func TestAccIPACLRead_NotFound(t *testing.T) {
-	qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:   http.MethodGet,
-				Resource: "/api/2.0/accounts/100/ip-access-lists/" + TestingId + "?",
-				Response: apierr.APIErrorBody{
-					ErrorCode: "RESOURCE_DOES_NOT_EXIST",
-					Message:   "Can't find an IP access list with id: " + TestingId + ".",
-				},
-				Status: 404,
-			},
-		},
-		Resource:  ResourceIPAccessList(),
-		Read:      true,
-		Removed:   true,
-		ID:        TestingId,
-		AccountID: "100",
-	}.ApplyNoError(t)
-}
-
-func TestAccIPACLRead_Error(t *testing.T) {
-	d, err := qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:   http.MethodGet,
-				Resource: "/api/2.0/accounts/100/ip-access-lists/" + TestingId + "?",
-				Response: apierr.APIErrorBody{
-					ErrorCode: "SERVER_ERROR",
-					Message:   "Something unexpected happened",
-				},
-				Status: 500,
-			},
-		},
-		Resource:  ResourceIPAccessList(),
-		Read:      true,
-		ID:        TestingId,
-		AccountID: "100",
-	}.Apply(t)
-	assert.Error(t, err)
-	qa.AssertErrorStartsWith(t, err, "Something unexpected happened")
-	assert.Equal(t, TestingId, d.Id(), "Id should not be empty for error reads")
-}
-
-func TestAccIPACLDelete(t *testing.T) {
-	d, err := qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:   http.MethodDelete,
-				Resource: fmt.Sprintf("/api/2.0/accounts/100/ip-access-lists/%s?", TestingId),
-			},
-		},
-		Resource:  ResourceIPAccessList(),
-		Delete:    true,
-		AccountID: "100",
-		ID:        TestingId,
-	}.Apply(t)
-	assert.NoError(t, err)
-	assert.Equal(t, TestingId, d.Id())
-}
-
-func TestAccIPACLDelete_Error(t *testing.T) {
-	qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:   http.MethodDelete,
-				Resource: fmt.Sprintf("/api/2.0/accounts/100/ip-access-lists/%s?", TestingId),
-				Response: apierr.APIErrorBody{
-					ErrorCode: "INVALID_STATE",
-					Message:   "Something went wrong",
-				},
-				Status: 400,
-			},
-		},
-		Resource:  ResourceIPAccessList(),
-		Delete:    true,
-		Removed:   true,
-		AccountID: "100",
-		ID:        TestingId,
-	}.ExpectError(t, "Something went wrong")
 }

--- a/docs/resources/ip_access_list.md
+++ b/docs/resources/ip_access_list.md
@@ -5,33 +5,9 @@ subcategory: "Security"
 
 Security-conscious enterprises that use cloud SaaS applications need to restrict access to their own employees. Authentication helps to prove user identity, but that does not enforce network location of the users. Accessing a cloud service from an unsecured network can pose security risks to an enterprise, especially when the user may have authorized access to sensitive or personal data. Enterprise network perimeters apply security policies and limit access to external services (for example, firewalls, proxies, DLP, and logging), so access beyond these controls are assumed to be untrusted. Please see [IP Access List](https://docs.databricks.com/security/network/ip-access-list.html) for full feature documentation.
 
-This resource supports both IP access lists for workspaces and IP access lists for the account console.
-
 -> **Note** The total number of IP addresses and CIDR scopes provided across all ACL Lists in a workspace can not exceed 1000.  Refer to the docs above for specifics.
 
 ## Example Usage
-
-Creating IP Access lists for the account console
-
-```hcl
-provider "databricks" {
-  // other configuration
-  host       = "https://accounts.cloud.databricks.com"
-  account_id = "<databricks account id>"
-}
-
-resource "databricks_ip_access_list" "allowed-list" {
-  label     = "allow_in"
-  list_type = "ALLOW"
-  ip_addresses = [
-    "1.1.1.1",
-    "1.2.3.0/24",
-    "1.2.5.0/24"
-  ]
-}
-```
-
-Creating IP Access lists for a workspace
 
 ```hcl
 resource "databricks_workspace_conf" "this" {
@@ -51,7 +27,6 @@ resource "databricks_ip_access_list" "allowed-list" {
   depends_on = [databricks_workspace_conf.this]
 }
 ```
-
 ## Argument Reference
 
 The following arguments are supported:
@@ -72,7 +47,7 @@ In addition to all arguments above, the following attributes are exported:
 The databricks_ip_access_list can be imported using id:
 
 ```bash
-terraform import databricks_ip_access_list.this <list-id>
+$ terraform import databricks_ip_access_list.this <list-id>
 ```
 
 ## Related Resources

--- a/internal/acceptance/ip_access_list_test.go
+++ b/internal/acceptance/ip_access_list_test.go
@@ -2,7 +2,6 @@ package acceptance
 
 import (
 	"testing"
-	"time"
 )
 
 func TestAccIPACLListsResourceFullLifecycle(t *testing.T) {
@@ -26,30 +25,5 @@ func TestAccIPACLListsResourceFullLifecycle(t *testing.T) {
 				"10.0.11.0/24"
 			]
 		}`,
-	})
-}
-
-func TestMwsAccIPACLListsResourceFullLifecycle(t *testing.T) {
-	accountLevel(t, step{
-		Template: `
-		resource "databricks_ip_access_list" "this" {
-			label = "tf-{var.RANDOM}"
-			list_type = "BLOCK"
-			ip_addresses = [
-				"10.0.10.25",
-				"10.0.10.0/24"
-			]
-		}`,
-	}, step{
-		PreConfig: func() { time.Sleep(1 * time.Second) },
-		Template: `
-			resource "databricks_ip_access_list" "this" {
-				label = "tf-{var.RANDOM}"
-				list_type = "BLOCK"
-				ip_addresses = [
-					"10.0.11.25",
-					"10.0.11.0/24"
-				]
-			}`,
 	})
 }


### PR DESCRIPTION
This reverts commit 40c92d67d160de37ecd740d771ad3037ae398ab8.

## Changes
<!-- Summary of your changes that are easy to understand -->

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

