### PR TITLE
Add `workspace_path` to the `databricks_directory` data source

### DIFF
--- a/docs/data-sources/directory.md
+++ b/docs/data-sources/directory.md
@@ -24,3 +24,4 @@ data "databricks_directory" "prod" {
 This data source exports the following attributes:
 
 * `object_id` - directory object ID
+* `workspace_path` - path on Workspace File System (WSFS) in form of `/Workspace` + `path`

--- a/docs/resources/directory.md
+++ b/docs/resources/directory.md
@@ -29,6 +29,7 @@ In addition to all arguments above, the following attributes are exported:
 
 - `id` - Path of directory on workspace
 - `object_id` - Unique identifier for a DIRECTORY
+- `workspace_path` - path on Workspace File System (WSFS) in form of `/Workspace` + `path`
 
 ## Access Control
 

--- a/workspace/data_directory.go
+++ b/workspace/data_directory.go
@@ -20,6 +20,10 @@ func DataSourceDirectory() *schema.Resource {
 			Optional: true,
 			Computed: true,
 		},
+		"workspace_path": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
 	}
 	return &schema.Resource{
 		Schema: s,
@@ -36,6 +40,7 @@ func DataSourceDirectory() *schema.Resource {
 			d.SetId(data.Path)
 			d.Set("object_id", data.ObjectID)
 			d.Set("path", path)
+			d.Set("workspace_path", "/Workspace"+data.Path)
 			return nil
 		},
 	}

--- a/workspace/data_directory_test.go
+++ b/workspace/data_directory_test.go
@@ -4,12 +4,10 @@ import (
 	"testing"
 
 	"github.com/databricks/terraform-provider-databricks/qa"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestDataSourceDirectory(t *testing.T) {
-	d, err := qa.ResourceFixture{
+	qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   "GET",
@@ -28,10 +26,11 @@ func TestDataSourceDirectory(t *testing.T) {
 		State: map[string]any{
 			"path": "/a/b/c",
 		},
-	}.Apply(t)
-	require.NoError(t, err)
-	assert.Equal(t, "/a/b/c", d.Id())
-	assert.Equal(t, 987, d.Get("object_id").(int))
+	}.ApplyAndExpectData(t, map[string]any{
+		"id":             "/a/b/c",
+		"object_id":      987,
+		"workspace_path": "/Workspace/a/b/c",
+	})
 }
 
 func TestDataSourceDirectory_NotDirectory(t *testing.T) {


### PR DESCRIPTION
This is for parity with resources

## Changes
<!-- Summary of your changes that are easy to understand -->

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

