### PR TITLE
Force creation of home folder if not created

### DIFF
--- a/internal/acceptance/user_test.go
+++ b/internal/acceptance/user_test.go
@@ -3,11 +3,12 @@ package acceptance
 import (
 	"context"
 	"fmt"
-	"os"
 	"strings"
 	"testing"
 
 	"github.com/databricks/databricks-sdk-go"
+	"github.com/databricks/databricks-sdk-go/client"
+	"github.com/databricks/databricks-sdk-go/config"
 	"github.com/databricks/databricks-sdk-go/logger"
 	"github.com/databricks/databricks-sdk-go/service/iam"
 
@@ -96,10 +97,6 @@ func TestAccUserHomeDelete(t *testing.T) {
 }
 
 func TestAccUserHomeDeleteNotDeleted(t *testing.T) {
-	loadDebugEnvIfRunsFromIDE(t, "workspace")
-	if os.Getenv("CLOUD_ENV") == "gcp" {
-		skipf(t)("Skipping test for GCP because home folders are not created synchronously")
-	}
 	username := qa.RandomEmail()
 	workspaceLevel(t, step{
 		Template: `
@@ -107,6 +104,22 @@ func TestAccUserHomeDeleteNotDeleted(t *testing.T) {
 				user_name = "` + username + `"
 			}`,
 		Check: func(s *terraform.State) error {
+			client, err := client.New(&config.Config{})
+			if err != nil {
+				return err
+			}
+			ctx := context.Background()
+			// Force creation of the home folder in case it is lazy
+			userId := s.Modules[0].Resources["databricks_user.a"].Primary.ID
+			err = client.Do(ctx, "PUT", fmt.Sprintf("/api/2.0/workspace/user/%s/homefolder", userId), nil, map[string]any{
+				"user": map[string]any{
+					"user_id":  userId,
+					"username": username,
+				},
+			}, nil)
+			if err != nil {
+				return err
+			}
 			return nil
 		},
 	}, step{

--- a/internal/acceptance/user_test.go
+++ b/internal/acceptance/user_test.go
@@ -3,6 +3,7 @@ package acceptance
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 
@@ -95,6 +96,10 @@ func TestAccUserHomeDelete(t *testing.T) {
 }
 
 func TestAccUserHomeDeleteNotDeleted(t *testing.T) {
+	loadDebugEnvIfRunsFromIDE(t, "workspace")
+	if os.Getenv("CLOUD_ENV") == "gcp" {
+		skipf(t)("Skipping test for GCP because home folders are not created synchronously")
+	}
 	username := qa.RandomEmail()
 	workspaceLevel(t, step{
 		Template: `

--- a/scim/resource_user_test.go
+++ b/scim/resource_user_test.go
@@ -592,6 +592,33 @@ func TestResourceUserDelete_NonExistingDir(t *testing.T) {
 	assert.EqualError(t, err, "force_delete_home_dir: Path (/Users/abc) doesn't exist.")
 }
 
+func TestResourceUserDelete_ForceDeleteHomeDir(t *testing.T) {
+	qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "DELETE",
+				Resource: "/api/2.0/preview/scim/v2/Users/abc",
+			},
+			{
+				Method:   "POST",
+				Resource: "/api/2.0/workspace/delete",
+				ExpectedRequest: workspace.DeletePath{
+					Path:      "/Users/abc",
+					Recursive: true,
+				},
+				Status: 200,
+			},
+		},
+		Resource: ResourceUser(),
+		Delete:   true,
+		ID:       "abc",
+		HCL: `
+			user_name    = "abc"
+			force_delete_home_dir = true
+		`,
+	}.ApplyNoError(t)
+}
+
 func TestCreateForceOverridesManuallyAddedUserErrorNotMatched(t *testing.T) {
 	d := ResourceUser().TestResourceData()
 	d.Set("force", true)


### PR DESCRIPTION
## Changes
Home folders may not be created in GCP when users are created. Now we ensure it is created to test that we are not cleaning it up when not requested.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] Ran the test locally, and it passed on GCP & AWS.

