### PR TITLE
Lock dummy workspace to limit concurrent changes to its metastore assignment

### DIFF
--- a/internal/acceptance/metastore_assignment_test.go
+++ b/internal/acceptance/metastore_assignment_test.go
@@ -1,10 +1,15 @@
 package acceptance
 
 import (
+	"sync"
 	"testing"
 )
 
+var dummyWsMetastoreMutex sync.Mutex
+
 func TestUcAccMetastoreAssignment(t *testing.T) {
+	dummyWsMetastoreMutex.Lock()
+	defer dummyWsMetastoreMutex.Unlock()
 	unityWorkspaceLevel(t, step{
 		Template: `resource "databricks_metastore_assignment" "this" {
 			metastore_id = "{env.TEST_METASTORE_ID}"
@@ -14,15 +19,8 @@ func TestUcAccMetastoreAssignment(t *testing.T) {
 }
 
 func TestUcAccAccountMetastoreAssignment(t *testing.T) {
-	unityAccountLevel(t, step{
-		Template: `resource "databricks_metastore_assignment" "this" {
-			metastore_id = "{env.TEST_METASTORE_ID}"
-			workspace_id = {env.DUMMY_WORKSPACE_ID}
-		}`,
-	})
-}
-
-func TestUcAccMetastoreReAssignment(t *testing.T) {
+	dummyWsMetastoreMutex.Lock()
+	defer dummyWsMetastoreMutex.Unlock()
 	unityAccountLevel(t, step{
 		Template: `resource "databricks_metastore_assignment" "this" {
 			metastore_id = "{env.TEST_METASTORE_ID}"


### PR DESCRIPTION
## Changes
Integration tests are at present making concurrent updates to the metastore assignment for the dummy workspace. This causes race conditions and flaky test failures. This PR removes one unnecessary test (covered by the Reassignment test) and adds a lock preventing this race condition from occurring.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

