### PR TITLE
Exporter: better handling of ignored objects

### DIFF
--- a/exporter/context.go
+++ b/exporter/context.go
@@ -722,6 +722,7 @@ func (ic *importContext) Find(r *resource, pick string, ref reference) (string, 
 			if !matched {
 				continue
 			}
+			// TODO: we need to not generate traversals resources for which their Ignore function returns true...
 			if sr.Mode == "data" {
 				return strValue, hcl.Traversal{
 					hcl.TraverseRoot{Name: "data"},

--- a/exporter/context.go
+++ b/exporter/context.go
@@ -22,6 +22,7 @@ import (
 	"github.com/databricks/databricks-sdk-go/service/catalog"
 	"github.com/databricks/databricks-sdk-go/service/compute"
 	"golang.org/x/exp/slices"
+	"golang.org/x/exp/maps"
 
 	"github.com/databricks/terraform-provider-databricks/commands"
 	"github.com/databricks/terraform-provider-databricks/common"
@@ -145,6 +146,10 @@ type importContext struct {
 
 	// Workspace-level UC Metastore information
 	currentMetastore *catalog.GetMetastoreSummaryResponse
+
+	// tracking ignored objects
+	ignoredResourcesMutex sync.Mutex
+	ignoredResources      map[string]struct{}
 }
 
 type mount struct {
@@ -238,6 +243,7 @@ func newImportContext(c *common.DatabricksClient) *importContext {
 		allSps:              map[string]scim.User{},
 		waitGroup:           &sync.WaitGroup{},
 		channels:            makeResourcesChannels(p),
+		ignoredResources:    map[string]struct{}{},
 	}
 }
 
@@ -465,6 +471,17 @@ func (ic *importContext) Run() error {
 		statsBytes, _ := json.Marshal(statsData)
 		if _, err = stats.Write(statsBytes); err != nil {
 			return err
+		}
+	}
+
+	// output ignored resources...
+	if ignored, err := os.Create(fmt.Sprintf("%s/ignored_resources.txt", ic.Directory)); err == nil {
+		defer ignored.Close()
+		ic.ignoredResourcesMutex.Lock()
+		keys := maps.Keys(ic.ignoredResources)
+		sort.Strings(keys)
+		for _, s := range keys {
+			ignored.WriteString(s + "\n")
 		}
 	}
 

--- a/exporter/context.go
+++ b/exporter/context.go
@@ -21,8 +21,8 @@ import (
 	"github.com/databricks/databricks-sdk-go"
 	"github.com/databricks/databricks-sdk-go/service/catalog"
 	"github.com/databricks/databricks-sdk-go/service/compute"
-	"golang.org/x/exp/slices"
 	"golang.org/x/exp/maps"
+	"golang.org/x/exp/slices"
 
 	"github.com/databricks/terraform-provider-databricks/commands"
 	"github.com/databricks/terraform-provider-databricks/common"

--- a/exporter/context_test.go
+++ b/exporter/context_test.go
@@ -109,6 +109,7 @@ func TestEmitNoSearchAvail(t *testing.T) {
 		channels: map[string]resourceChannel{
 			"a": ch,
 		},
+		ignoredResources: map[string]struct{}{},
 	}
 	go func() {
 		for r := range ch {
@@ -181,6 +182,7 @@ func TestEmitNoSearchNoId(t *testing.T) {
 		channels: map[string]resourceChannel{
 			"a": ch,
 		},
+		ignoredResources: map[string]struct{}{},
 	}
 	go func() {
 		for r := range ch {

--- a/exporter/importables.go
+++ b/exporter/importables.go
@@ -575,6 +575,14 @@ var resourcesMap map[string]importable = map[string]importable{
 			}
 			return defaultShouldOmitFieldFunc(ic, pathString, as, d)
 		},
+		Ignore: func(ic *importContext, r *resource) bool {
+			numTasks := r.Data.Get("task.#").(int)
+			if numTasks == 0 {
+				log.Printf("[WARN] Ignoring job with ID %s", r.ID)
+				ic.addIgnoredResource(fmt.Sprintf("databricks_job. id=%s", r.ID))
+			}
+			return numTasks == 0
+		},
 	},
 	"databricks_cluster_policy": {
 		WorkspaceLevel: true,
@@ -1921,6 +1929,14 @@ var resourcesMap map[string]importable = map[string]importable{
 				return dltDefaultStorageRegex.FindStringSubmatch(d.Get("storage").(string)) != nil
 			}
 			return pathString == "creator_user_name" || defaultShouldOmitFieldFunc(ic, pathString, as, d)
+		},
+		Ignore: func(ic *importContext, r *resource) bool {
+			numLibraries := r.Data.Get("library.#").(int)
+			if numLibraries == 0 {
+				log.Printf("[WARN] Ignoring DLT Pipeline with ID %s", r.ID)
+				ic.addIgnoredResource(fmt.Sprintf("databricks_pipeline. id=%s", r.ID))
+			}
+			return numLibraries == 0
 		},
 		Depends: []reference{
 			{Path: "cluster.aws_attributes.instance_profile_arn", Resource: "databricks_instance_profile"},

--- a/exporter/importables_test.go
+++ b/exporter/importables_test.go
@@ -267,6 +267,26 @@ func TestRepoIgnore(t *testing.T) {
 	assert.False(t, resourcesMap["databricks_repo"].Ignore(ic, r))
 }
 
+func TestDLTIgnore(t *testing.T) {
+	ic := importContextForTest()
+	d := pipelines.ResourcePipeline().TestResourceData()
+	d.SetId("12345")
+	r := &resource{ID: "12345", Data: d}
+	// job without libraries
+	assert.True(t, resourcesMap["databricks_pipeline"].Ignore(ic, r))
+	assert.Equal(t, 1, len(ic.ignoredResources))
+}
+
+func TestJobsIgnore(t *testing.T) {
+	ic := importContextForTest()
+	d := jobs.ResourceJob().TestResourceData()
+	d.SetId("12345")
+	r := &resource{ID: "12345", Data: d}
+	// job without tasks
+	assert.True(t, resourcesMap["databricks_job"].Ignore(ic, r))
+	assert.Equal(t, 1, len(ic.ignoredResources))
+}
+
 func TestJobName(t *testing.T) {
 	ic := importContextForTest()
 	d := jobs.ResourceJob().TestResourceData()

--- a/exporter/importables_test.go
+++ b/exporter/importables_test.go
@@ -46,6 +46,7 @@ func importContextForTest() *importContext {
 		allSps:                   map[string]scim.User{},
 		channels:                 makeResourcesChannels(p),
 		exportDeletedUsersAssets: false,
+		ignoredResources:         map[string]struct{}{},
 	}
 }
 

--- a/exporter/importables_test.go
+++ b/exporter/importables_test.go
@@ -253,6 +253,20 @@ func TestRepoName(t *testing.T) {
 	assert.Equal(t, "user_test_12345", resourcesMap["databricks_repo"].Name(ic, d))
 }
 
+func TestRepoIgnore(t *testing.T) {
+	ic := importContextForTest()
+	d := repos.ResourceRepo().TestResourceData()
+	d.SetId("12345")
+	d.Set("path", "/Repos/user/test")
+	r := &resource{ID: "12345", Data: d}
+	// Repo without URL
+	assert.True(t, resourcesMap["databricks_repo"].Ignore(ic, r))
+	assert.Equal(t, 1, len(ic.ignoredResources))
+	// Repo with URL
+	d.Set("url", "https://github.com/abc/abc.git")
+	assert.False(t, resourcesMap["databricks_repo"].Ignore(ic, r))
+}
+
 func TestJobName(t *testing.T) {
 	ic := importContextForTest()
 	d := jobs.ResourceJob().TestResourceData()

--- a/exporter/model.go
+++ b/exporter/model.go
@@ -220,7 +220,8 @@ func (r *resource) ImportResource(ic *importContext) {
 			return
 		}
 		if r.ID == "" {
-			log.Printf("[INFO] Cannot find %s", r)
+			log.Printf("[WARN] Cannot find %s", r)
+			ic.addIgnoredResource(fmt.Sprintf("%s: %s=%s", r.Resource, r.Attribute, r.Value))
 			return
 		}
 	}


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

As we emit resources, some resources are ignored, for example:

* repos without URL
* deleted users & service principals, together with their directories
* ...

Before this change, information about these resources was available only in the logs - now we're collecting such resources in a separate structure, and output them as `ignored_resources.txt` file in the output directory.  This will help people to understand what resources weren't migrated...

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

