### PR TITLE
Stop using `/api/2.0/preview/accounts/` API in `databricks_mws_permission_assignment`

### DIFF
--- a/mws/resource_mws_permission_assignment.go
+++ b/mws/resource_mws_permission_assignment.go
@@ -29,7 +29,7 @@ func (a PermissionAssignmentAPI) CreateOrUpdate(workspaceId, principalId int64, 
 		return errors.New("must have `account_id` on provider")
 	}
 	path := fmt.Sprintf(
-		"/preview/accounts/%s/workspaces/%d/permissionassignments/principals/%d",
+		"/accounts/%s/workspaces/%d/permissionassignments/principals/%d",
 		a.client.Config.AccountID, workspaceId, principalId)
 	return a.client.Put(a.context, path, r)
 }
@@ -39,7 +39,7 @@ func (a PermissionAssignmentAPI) Remove(workspaceId, principalId string) error {
 		return errors.New("must have `account_id` on provider")
 	}
 	path := fmt.Sprintf(
-		"/preview/accounts/%s/workspaces/%s/permissionassignments/principals/%s",
+		"/accounts/%s/workspaces/%s/permissionassignments/principals/%s",
 		a.client.Config.AccountID, workspaceId, principalId)
 	return a.client.Delete(a.context, path, nil)
 }
@@ -75,7 +75,7 @@ func (a PermissionAssignmentAPI) List(workspaceId int64) (list PermissionAssignm
 	if a.client.Config.AccountID == "" {
 		return list, errors.New("must have `account_id` on provider")
 	}
-	path := fmt.Sprintf("/preview/accounts/%s/workspaces/%d/permissionassignments",
+	path := fmt.Sprintf("/accounts/%s/workspaces/%d/permissionassignments",
 		a.client.Config.AccountID, workspaceId)
 	err = a.client.Get(a.context, path, nil, &list)
 	return

--- a/mws/resource_mws_permission_assignment_test.go
+++ b/mws/resource_mws_permission_assignment_test.go
@@ -11,14 +11,14 @@ func TestPermissionAssignmentCreate(t *testing.T) {
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   "PUT",
-				Resource: "/api/2.0/preview/accounts/abc/workspaces/123/permissionassignments/principals/345",
+				Resource: "/api/2.0/accounts/abc/workspaces/123/permissionassignments/principals/345",
 				ExpectedRequest: Permissions{
 					Permissions: []string{"USER"},
 				},
 			},
 			{
 				Method:   "GET",
-				Resource: "/api/2.0/preview/accounts/abc/workspaces/123/permissionassignments",
+				Resource: "/api/2.0/accounts/abc/workspaces/123/permissionassignments",
 				Response: PermissionAssignmentList{
 					PermissionAssignments: []PermissionAssignment{
 						{
@@ -47,7 +47,7 @@ func TestPermissionAssignmentReadNotFound(t *testing.T) {
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   "GET",
-				Resource: "/api/2.0/preview/accounts/abc/workspaces/123/permissionassignments",
+				Resource: "/api/2.0/accounts/abc/workspaces/123/permissionassignments",
 				Response: PermissionAssignmentList{
 					PermissionAssignments: []PermissionAssignment{
 						{
@@ -73,7 +73,7 @@ func TestPermissionAssignmentDelete(t *testing.T) {
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   "DELETE",
-				Resource: "/api/2.0/preview/accounts/abc/workspaces/123/permissionassignments/principals/456",
+				Resource: "/api/2.0/accounts/abc/workspaces/123/permissionassignments/principals/456",
 			},
 		},
 		Resource:  ResourceMwsPermissionAssignment(),


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

The preview API went away and we need to use the non-preview version now.  This is short-term fix before we switch to Go SDK...

This fixes #3058

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

