### PR TITLE
Fix Read operation of `databricks_permission_assignment` resource

### DIFF
--- a/access/resource_permission_assignment.go
+++ b/access/resource_permission_assignment.go
@@ -81,8 +81,7 @@ func ResourcePermissionAssignment() *schema.Resource {
 		PrincipalId int64    `json:"principal_id"`
 		Permissions []string `json:"permissions" tf:"slice_as_set"`
 	}
-	s := common.StructToSchema(entity{},
-		common.NoCustomize)
+	s := common.StructToSchema(entity{}, common.NoCustomize)
 	return common.Resource{
 		Schema: s,
 		Create: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
@@ -101,11 +100,15 @@ func ResourcePermissionAssignment() *schema.Resource {
 			if err != nil {
 				return err
 			}
-			permissions, err := list.ForPrincipal(mustInt64(d.Id()))
+			data := entity{
+				PrincipalId: mustInt64(d.Id()),
+			}
+			permissions, err := list.ForPrincipal(data.PrincipalId)
 			if err != nil {
 				return err
 			}
-			return common.StructToData(permissions, s, d)
+			data.Permissions = permissions.Permissions
+			return common.StructToData(data, s, d)
 		},
 		Delete: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
 			return NewPermissionAssignmentAPI(ctx, c).Remove(d.Id())

--- a/access/resource_permission_assignment_test.go
+++ b/access/resource_permission_assignment_test.go
@@ -31,14 +31,41 @@ func TestPermissionAssignmentCreate(t *testing.T) {
 				},
 			},
 		},
-		Resource:  ResourcePermissionAssignment(),
-		Create:    true,
-		AccountID: "abc",
+		Resource: ResourcePermissionAssignment(),
+		Create:   true,
 		HCL: `
 		principal_id = 345
 		permissions  = ["USER"]
 		`,
 	}.ApplyNoError(t)
+}
+
+func TestPermissionAssignmentRead(t *testing.T) {
+	qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "GET",
+				Resource: "/api/2.0/preview/permissionassignments",
+				Response: PermissionAssignmentList{
+					PermissionAssignments: []PermissionAssignment{
+						{
+							Permissions: []string{"USER"},
+							Principal: Principal{
+								PrincipalID: 345,
+							},
+						},
+					},
+				},
+			},
+		},
+		Resource: ResourcePermissionAssignment(),
+		Read:     true,
+		New:      true,
+		ID:       "345",
+	}.ApplyAndExpectData(t, map[string]any{
+		"principal_id": 345,
+		"permissions":  []any{"USER"},
+	})
 }
 
 func TestPermissionAssignmentReadNotFound(t *testing.T) {


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

The problem was that the `Read` operation did fill only the `permissions` field, but not the `principal_id`, so exporter didn't generate correct code.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

