### PR TITLE
Exporter: Generate zero values for required attributes & attributes with non-zero defaults

### DIFF
--- a/exporter/importables.go
+++ b/exporter/importables.go
@@ -178,6 +178,7 @@ var resourcesMap map[string]importable = map[string]importable{
 			r.Data.Set("source", fileName)
 			return nil
 		},
+		ShouldOmitField: shouldOmitMd5Field,
 		Depends: []reference{
 			{Path: "source", File: true},
 		},
@@ -1189,6 +1190,7 @@ var resourcesMap map[string]importable = map[string]importable{
 			}
 			return r.Data.Set("source", fileName)
 		},
+		ShouldOmitField: shouldOmitMd5Field,
 		Depends: []reference{
 			{Path: "source", File: true},
 		},
@@ -1400,6 +1402,7 @@ var resourcesMap map[string]importable = map[string]importable{
 
 			return r.Data.Set("source", fileName)
 		},
+		ShouldOmitField: shouldOmitMd5Field,
 		Depends: []reference{
 			{Path: "source", File: true},
 			{Path: "path", Resource: "databricks_user", Match: "home", MatchType: MatchPrefix},
@@ -1456,6 +1459,7 @@ var resourcesMap map[string]importable = map[string]importable{
 			log.Printf("Creating %s for %s", fileName, r)
 			return r.Data.Set("source", fileName)
 		},
+		ShouldOmitField: shouldOmitMd5Field,
 		Depends: []reference{
 			{Path: "source", File: true},
 			{Path: "path", Resource: "databricks_user", Match: "home", MatchType: MatchPrefix},

--- a/exporter/util.go
+++ b/exporter/util.go
@@ -810,6 +810,13 @@ func generateUniqueID(v string) string {
 	return fmt.Sprintf("%x", sha1.Sum([]byte(v)))[:10]
 }
 
+func shouldOmitMd5Field(ic *importContext, pathString string, as *schema.Schema, d *schema.ResourceData) bool {
+	if pathString == "md5" { // `md5` is kind of computed, but not declared as it...
+		return true
+	}
+	return defaultShouldOmitFieldFunc(ic, pathString, as, d)
+}
+
 func workspaceObjectResouceName(ic *importContext, d *schema.ResourceData) string {
 	name := d.Get("path").(string)
 	if name == "" {


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

When generating HCL code, the `dataToHcl` function checked if the value is zero, and as result, skipped the generation of the attribute even in following cases:

- the attribute is required even with zero value (for example, empty SQL query)
- the attribute has zero value, but attribute has non-zero default (disabled `scale_to_zero` in the model serving).

This PR fixes this issue by always generating required attributes, and also zero values with non-zero defaults.

This fixes #2511, fixes #2162


## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

