### PR TITLE
Fix diff schema on PRs

### DIFF
--- a/.github/workflows/schema.yml
+++ b/.github/workflows/schema.yml
@@ -7,12 +7,12 @@ on:
   workflow_dispatch:
     inputs:
       base:
-        description: 'Base ref'
-        default: 'master'
+        description: "Base ref"
+        default: "master"
         required: true
       head:
-        description: 'Head ref'
-        default: 'master'
+        description: "Head ref"
+        default: "master"
         required: true
 
 jobs:
@@ -21,26 +21,39 @@ jobs:
 
     steps:
       - if: github.event_name == 'pull_request'
-        name: Checkout
+        name: Checkout PR base commit
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.base_ref }}
+      - if: github.event_name == 'pull_request'
+        name: Checkout PR merge commit
         uses: actions/checkout@v4
 
       - if: github.event_name == 'workflow_dispatch'
-        name: Checkout
+        name: Checkout base commit
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.base }}
+      - if: github.event_name == 'workflow_dispatch'
+        name: Checkout head commit
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.head }}
 
-      - name: 'Setup Go'
+      - name: "Setup Go"
         uses: actions/setup-go@v4
         with:
           go-version: 1.21.x
 
-      - name: 'Setup Terraform'
+      - name: "Setup Terraform"
         uses: hashicorp/setup-terraform@v2
         with:
           terraform_wrapper: false
 
-      - name: 'Install jd'
+      - name: "Install jd"
         run: go install github.com/josephburnett/jd@latest
 
       - run: make diff-schema
+        env:
+          BASE_COMMIT: ${{ github.event_name == 'pull_request' && github.base_ref || github.event.inputs.base }}
+          HEAD_COMMIT: ${{ github.event_name == 'pull_request' && github.head_ref || github.event.inputs.head }}

--- a/.github/workflows/schema.yml
+++ b/.github/workflows/schema.yml
@@ -20,6 +20,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      # Check out the base commit first and the head commit second. diff-schema
+      # uses the current commit as the head commit.
       - if: github.event_name == 'pull_request'
         name: Checkout PR base commit
         uses: actions/checkout@v4
@@ -56,4 +58,3 @@ jobs:
       - run: make diff-schema
         env:
           BASE_COMMIT: ${{ github.event_name == 'pull_request' && github.base_ref || github.event.inputs.base }}
-          HEAD_COMMIT: ${{ github.event_name == 'pull_request' && github.head_ref || github.event.inputs.head }}

--- a/scripts/diff-schema.sh
+++ b/scripts/diff-schema.sh
@@ -2,7 +2,8 @@
 
 source scripts/libschema.sh
 
-BASE_BRANCH="master"
+BASE=${BASE_COMMIT:-"master"}
+HEAD=${HEAD_COMMIT:-"HEAD"}
 
 checkout_branch() {
     local branch=$1
@@ -15,11 +16,11 @@ if [ -n "$(git status --porcelain)" ]; then
     exit 1
 fi
 
-CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref $HEAD)
 NEW_SCHEMA=$(generate_schema)
-checkout_branch $BASE_BRANCH
+checkout_branch $BASE
 CURRENT_SCHEMA=$(generate_schema)
-checkout_branch $CURRENT_BRANCH
+checkout_branch $HEAD
 
 set +e
 jd -color "$CURRENT_SCHEMA" "$NEW_SCHEMA"

--- a/scripts/diff-schema.sh
+++ b/scripts/diff-schema.sh
@@ -7,10 +7,10 @@ BASE=${BASE_COMMIT:-"master"}
 CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 HEAD=${HEAD_COMMIT:-$CURRENT_BRANCH}
 
-checkout_branch() {
-    local branch=$1
-    echo "Checking out branch: $branch"
-    git checkout $branch
+checkout() {
+    local ref=$1
+    echo "Checking out ref: $ref"
+    git checkout $ref
 }
 
 if [ -n "$(git status --porcelain)" ]; then
@@ -18,10 +18,11 @@ if [ -n "$(git status --porcelain)" ]; then
     exit 1
 fi
 
+checkout $HEAD
 NEW_SCHEMA=$(generate_schema)
-checkout_branch $BASE
+checkout $BASE
 CURRENT_SCHEMA=$(generate_schema)
-checkout_branch $HEAD
+checkout $CURRENT_BRANCH
 
 set +e
 jd -color "$CURRENT_SCHEMA" "$NEW_SCHEMA"

--- a/scripts/diff-schema.sh
+++ b/scripts/diff-schema.sh
@@ -3,7 +3,8 @@
 source scripts/libschema.sh
 
 BASE=${BASE_COMMIT:-"master"}
-HEAD=${HEAD_COMMIT:-"HEAD"}
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref $HEAD)
+HEAD=${HEAD_COMMIT:-$CURRENT_BRANCH}
 
 checkout_branch() {
     local branch=$1
@@ -16,7 +17,6 @@ if [ -n "$(git status --porcelain)" ]; then
     exit 1
 fi
 
-CURRENT_BRANCH=$(git rev-parse --abbrev-ref $HEAD)
 NEW_SCHEMA=$(generate_schema)
 checkout_branch $BASE
 CURRENT_SCHEMA=$(generate_schema)

--- a/scripts/diff-schema.sh
+++ b/scripts/diff-schema.sh
@@ -5,7 +5,6 @@ source scripts/libschema.sh
 
 BASE=${BASE_COMMIT:-"master"}
 CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
-HEAD=${HEAD_COMMIT:-$CURRENT_BRANCH}
 
 checkout() {
     local ref=$1
@@ -18,7 +17,6 @@ if [ -n "$(git status --porcelain)" ]; then
     exit 1
 fi
 
-checkout $HEAD
 NEW_SCHEMA=$(generate_schema)
 checkout $BASE
 CURRENT_SCHEMA=$(generate_schema)

--- a/scripts/diff-schema.sh
+++ b/scripts/diff-schema.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
+set -eo pipefail
 
 source scripts/libschema.sh
 
 BASE=${BASE_COMMIT:-"master"}
-CURRENT_BRANCH=$(git rev-parse --abbrev-ref $HEAD)
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 HEAD=${HEAD_COMMIT:-$CURRENT_BRANCH}
 
 checkout_branch() {


### PR DESCRIPTION
## Changes
The diff-schema workflow doesn't work anymore because it fails to checkout master. This PR should fix this by always checking out the base & head commits and passing those commits via env vars to `diff-schema.sh`. With no variables set, it will show the diff between the current checked-out branch and master.

## Tests
- [x] Ran locally with no flags, worked.
- [ ] Ran locally with BASE_COMMIT=bb12b5a614f9c1357356b68d58c15ad87f6cfa08, worked
- [ ] Triggered on this PR
- [ ] Triggered via workflow dispatch
