### PR TITLE
Fix `TestClustersDataSourceErrorsOut` test that run too long

### DIFF
--- a/clusters/data_clusters_test.go
+++ b/clusters/data_clusters_test.go
@@ -73,8 +73,10 @@ func TestClustersDataSourceContainsName(t *testing.T) {
 
 func TestClustersDataSourceErrorsOut(t *testing.T) {
 	client, _ := client.New(&config.Config{
-		Host:  ".",
-		Token: ".",
+		Host:                ".",
+		Token:               ".",
+		RetryTimeoutSeconds: 1,
+		HTTPTimeoutSeconds:  1,
 	})
 	diag := DataSourceClusters().ReadContext(context.Background(), nil, &common.DatabricksClient{
 		DatabricksClient: client,


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

The `TestClustersDataSourceErrorsOut` wasn't able to resolve a host name, and retries happened for long time, making execution of the test suite very long.  By setting some settings explicitly it fails fast now.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

