### PR TITLE
Migrate cluster schema to use the go-sdk struct

### DIFF
--- a/clusters/clusters_api.go
+++ b/clusters/clusters_api.go
@@ -523,7 +523,7 @@ type ClusterInfo struct {
 	DriverInstancePoolID      string                  `json:"driver_instance_pool_id,omitempty" tf:"computed"`
 	PolicyID                  string                  `json:"policy_id,omitempty"`
 	SingleUserName            string                  `json:"single_user_name,omitempty"`
-	ClusterSource             Availability            `json:"cluster_source,omitempty"`
+	ClusterSource             Availability            `json:"cluster_source" tf:"computed"`
 	DockerImage               *DockerImage            `json:"docker_image,omitempty"`
 	State                     ClusterState            `json:"state"`
 	StateMessage              string                  `json:"state_message,omitempty"`

--- a/clusters/resource_cluster.go
+++ b/clusters/resource_cluster.go
@@ -60,8 +60,8 @@ func ZoneDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
 
 type ClusterResourceProvider struct{}
 
-func (ClusterResourceProvider) UnderlyingType() compute.ClusterDetails {
-	return compute.ClusterDetails{}
+func (ClusterResourceProvider) UnderlyingType() compute.ClusterSpec {
+	return compute.ClusterSpec{}
 }
 
 func (ClusterResourceProvider) Aliases() map[string]string {

--- a/clusters/resource_cluster.go
+++ b/clusters/resource_cluster.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
+	"github.com/databricks/databricks-sdk-go/service/compute"
 	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/databricks/terraform-provider-databricks/libraries"
 )
@@ -57,71 +58,116 @@ func ZoneDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
 	return false
 }
 
-func resourceClusterSchema() map[string]*schema.Schema {
-	return common.StructToSchema(Cluster{}, func(s map[string]*schema.Schema) map[string]*schema.Schema {
-		s["spark_conf"].DiffSuppressFunc = SparkConfDiffSuppressFunc
-		common.MustSchemaPath(s, "aws_attributes", "zone_id").DiffSuppressFunc = ZoneDiffSuppress
-		common.MustSchemaPath(s, "gcp_attributes", "use_preemptible_executors").Deprecated = "Please use 'availability' instead."
+type ClusterResourceProvider struct{}
 
-		common.MustSchemaPath(s, "init_scripts", "dbfs").Deprecated = DbfsDeprecationWarning
+func (ClusterResourceProvider) UnderlyingType() compute.ClusterDetails {
+	return compute.ClusterDetails{}
+}
 
-		// adds `library` configuration block
-		s["library"] = common.StructToSchema(libraries.ClusterLibraryList{},
-			func(ss map[string]*schema.Schema) map[string]*schema.Schema {
-				ss["library"].Set = func(i any) int {
-					lib := libraries.NewLibraryFromInstanceState(i)
-					return schema.HashString(lib.String())
-				}
+func (ClusterResourceProvider) Aliases() map[string]string {
+	return map[string]string{"cluster_mount_infos": "cluster_mount_info"}
+}
+
+func (ClusterResourceProvider) CustomizeSchema(s map[string]*schema.Schema) map[string]*schema.Schema {
+	common.CustomizeSchemaPath(s, "enable_elastic_disk").SetOptional().SetComputed()
+	common.CustomizeSchemaPath(s, "enable_local_disk_encryption").SetOptional().SetComputed()
+	common.CustomizeSchemaPath(s, "node_type_id").SetComputed().SetOptional().SetConflictsWith([]string{"driver_instance_pool_id", "instance_pool_id"})
+	common.CustomizeSchemaPath(s, "driver_node_type_id").SetComputed().SetOptional().SetConflictsWith([]string{"driver_instance_pool_id", "instance_pool_id"})
+	common.CustomizeSchemaPath(s, "driver_instance_pool_id").SetComputed().SetOptional().SetConflictsWith([]string{"driver_node_type_id", "node_type_id"})
+	common.CustomizeSchemaPath(s, "ssh_public_keys").SetMaxItems(10)
+	common.CustomizeSchemaPath(s, "init_scripts").SetMaxItems(10).AddNewField("abfss", common.StructToSchema(InitScriptStorageInfo{}, func(ss map[string]*schema.Schema) map[string]*schema.Schema {
+		return ss
+	})["abfss"]).AddNewField("gcs", common.StructToSchema(InitScriptStorageInfo{}, func(ss map[string]*schema.Schema) map[string]*schema.Schema {
+		return ss
+	})["gcs"])
+	common.CustomizeSchemaPath(s, "init_scripts", "dbfs").SetDeprecated(DbfsDeprecationWarning)
+	common.CustomizeSchemaPath(s, "init_scripts", "dbfs", "destination").SetRequired()
+	common.CustomizeSchemaPath(s, "init_scripts", "s3", "destination").SetRequired()
+	common.CustomizeSchemaPath(s, "workload_type", "clients").SetRequired()
+	common.CustomizeSchemaPath(s, "workload_type", "clients", "notebooks").SetOptional().SetDefault(true)
+	common.CustomizeSchemaPath(s, "workload_type", "clients", "jobs").SetOptional().SetDefault(true)
+	s["idempotency_token"] = &schema.Schema{
+		Type:     schema.TypeString,
+		Optional: true,
+		ForceNew: true,
+	}
+	common.CustomizeSchemaPath(s, "data_security_mode").SetSuppressDiff()
+	common.CustomizeSchemaPath(s, "docker_image", "url").SetRequired()
+	common.CustomizeSchemaPath(s, "docker_image", "basic_auth", "password").SetRequired().SetSensitive()
+	common.CustomizeSchemaPath(s, "docker_image", "basic_auth", "username").SetRequired()
+	common.CustomizeSchemaPath(s, "spark_conf").SetCustomSuppressDiff(SparkConfDiffSuppressFunc)
+	common.CustomizeSchemaPath(s, "aws_attributes").SetSuppressDiff().SetConflictsWith([]string{"azure_attributes", "gcp_attributes"})
+	common.CustomizeSchemaPath(s, "aws_attributes", "zone_id").SetCustomSuppressDiff(ZoneDiffSuppress)
+	common.CustomizeSchemaPath(s, "azure_attributes").SetSuppressDiff().SetConflictsWith([]string{"aws_attributes", "gcp_attributes"})
+	common.CustomizeSchemaPath(s, "gcp_attributes").SetSuppressDiff().SetConflictsWith([]string{"aws_attributes", "azure_attributes"}).AddNewField(
+		"use_preemptible_executors",
+		&schema.Schema{
+			Type:       schema.TypeBool,
+			Optional:   true,
+			Deprecated: "Please use 'availability' instead.",
+		},
+	).AddNewField(
+		"zone_id",
+		&schema.Schema{
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+	)
+	s["library"] = common.StructToSchema(libraries.ClusterLibraryList{},
+		func(ss map[string]*schema.Schema) map[string]*schema.Schema {
+			ss["library"].Set = func(i any) int {
+				lib := libraries.NewLibraryFromInstanceState(i)
+				return schema.HashString(lib.String())
+			}
+			return ss
+		})["library"]
+
+	common.CustomizeSchemaPath(s, "autotermination_minutes").SetDefault(60)
+	common.CustomizeSchemaPath(s, "autoscale", "max_workers").SetOptional()
+	common.CustomizeSchemaPath(s, "autoscale", "min_workers").SetOptional()
+	s["apply_policy_default_values"] = &schema.Schema{
+		Optional: true,
+		Type:     schema.TypeBool,
+	}
+	common.CustomizeSchemaPath(s, "cluster_log_conf", "dbfs", "destination").SetRequired()
+	common.CustomizeSchemaPath(s, "cluster_log_conf", "s3", "destination").SetRequired()
+	common.CustomizeSchemaPath(s, "spark_version").SetRequired()
+	common.CustomizeSchemaPath(s, "cluster_id").SetOptional().SetComputed()
+	common.CustomizeSchemaPath(s, "instance_pool_id").SetConflictsWith([]string{"driver_node_type_id", "node_type_id"})
+	common.CustomizeSchemaPath(s, "runtime_engine").SetValidateFunc(validation.StringInSlice([]string{"PHOTON", "STANDARD"}, false))
+	s["is_pinned"] = &schema.Schema{
+		Type:     schema.TypeBool,
+		Optional: true,
+		Default:  false,
+		DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+			if old == "" && new == "false" {
+				return true
+			}
+			return old == new
+		},
+	}
+	common.CustomizeSchemaPath(s, "state").SetReadOnly()
+	s["url"] = &schema.Schema{
+		Type:     schema.TypeString,
+		Computed: true,
+	}
+	common.CustomizeSchemaPath(s, "default_tags").SetReadOnly()
+	common.CustomizeSchemaPath(s, "num_workers").SetDefault(0).SetValidateDiagFunc(validation.ToDiagFunc(validation.IntAtLeast(0)))
+	s["cluster_mount_info"] = &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		Elem: &schema.Resource{
+			Schema: common.StructToSchema(MountInfo{}, func(ss map[string]*schema.Schema) map[string]*schema.Schema {
 				return ss
-			})["library"]
+			}),
+		},
+	}
 
-		s["autotermination_minutes"].Default = 60
-		s["cluster_id"] = &schema.Schema{
-			Type:     schema.TypeString,
-			Optional: true,
-			Computed: true,
-		}
-		s["aws_attributes"].ConflictsWith = []string{"azure_attributes", "gcp_attributes"}
-		s["azure_attributes"].ConflictsWith = []string{"aws_attributes", "gcp_attributes"}
-		s["gcp_attributes"].ConflictsWith = []string{"aws_attributes", "azure_attributes"}
-		s["instance_pool_id"].ConflictsWith = []string{"driver_node_type_id", "node_type_id"}
-		s["driver_instance_pool_id"].ConflictsWith = []string{"driver_node_type_id", "node_type_id"}
-		s["driver_node_type_id"].ConflictsWith = []string{"driver_instance_pool_id", "instance_pool_id"}
-		s["node_type_id"].ConflictsWith = []string{"driver_instance_pool_id", "instance_pool_id"}
+	return s
+}
 
-		s["runtime_engine"].ValidateFunc = validation.StringInSlice([]string{"PHOTON", "STANDARD"}, false)
-
-		s["is_pinned"] = &schema.Schema{
-			Type:     schema.TypeBool,
-			Optional: true,
-			Default:  false,
-			DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-				if old == "" && new == "false" {
-					return true
-				}
-				return old == new
-			},
-		}
-		s["state"] = &schema.Schema{
-			Type:     schema.TypeString,
-			Computed: true,
-		}
-		s["default_tags"] = &schema.Schema{
-			Type:     schema.TypeMap,
-			Computed: true,
-		}
-		s["num_workers"] = &schema.Schema{
-			Type:             schema.TypeInt,
-			Optional:         true,
-			Default:          0,
-			ValidateDiagFunc: validation.ToDiagFunc(validation.IntAtLeast(0)),
-		}
-		s["url"] = &schema.Schema{
-			Type:     schema.TypeString,
-			Computed: true,
-		}
-		return s
-	})
+func resourceClusterSchema() map[string]*schema.Schema {
+	return common.ResourceProviderStructToSchema[compute.ClusterDetails](ClusterResourceProvider{})
 }
 
 func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {

--- a/clusters/resource_cluster.go
+++ b/clusters/resource_cluster.go
@@ -69,6 +69,7 @@ func (ClusterResourceProvider) Aliases() map[string]string {
 }
 
 func (ClusterResourceProvider) CustomizeSchema(s map[string]*schema.Schema) map[string]*schema.Schema {
+	common.CustomizeSchemaPath(s, "cluster_source").SetComputed()
 	common.CustomizeSchemaPath(s, "enable_elastic_disk").SetComputed()
 	common.CustomizeSchemaPath(s, "enable_local_disk_encryption").SetComputed()
 	common.CustomizeSchemaPath(s, "node_type_id").SetComputed().SetConflictsWith([]string{"driver_instance_pool_id", "instance_pool_id"})

--- a/clusters/resource_cluster.go
+++ b/clusters/resource_cluster.go
@@ -86,11 +86,11 @@ func (ClusterResourceProvider) CustomizeSchema(s map[string]*schema.Schema) map[
 	common.CustomizeSchemaPath(s, "workload_type", "clients").SetRequired()
 	common.CustomizeSchemaPath(s, "workload_type", "clients", "notebooks").SetOptional().SetDefault(true)
 	common.CustomizeSchemaPath(s, "workload_type", "clients", "jobs").SetOptional().SetDefault(true)
-	s["idempotency_token"] = &schema.Schema{
+	common.CustomizeSchemaPath(s).AddNewField("idempotency_token", &schema.Schema{
 		Type:     schema.TypeString,
 		Optional: true,
 		ForceNew: true,
-	}
+	})
 	common.CustomizeSchemaPath(s, "data_security_mode").SetSuppressDiff()
 	common.CustomizeSchemaPath(s, "docker_image", "url").SetRequired()
 	common.CustomizeSchemaPath(s, "docker_image", "basic_auth", "password").SetRequired().SetSensitive()
@@ -113,29 +113,30 @@ func (ClusterResourceProvider) CustomizeSchema(s map[string]*schema.Schema) map[
 			Optional: true,
 		},
 	)
-	s["library"] = common.StructToSchema(libraries.ClusterLibraryList{},
+
+	common.CustomizeSchemaPath(s).AddNewField("library", common.StructToSchema(libraries.ClusterLibraryList{},
 		func(ss map[string]*schema.Schema) map[string]*schema.Schema {
 			ss["library"].Set = func(i any) int {
 				lib := libraries.NewLibraryFromInstanceState(i)
 				return schema.HashString(lib.String())
 			}
 			return ss
-		})["library"]
+		})["library"])
 
 	common.CustomizeSchemaPath(s, "autotermination_minutes").SetDefault(60)
 	common.CustomizeSchemaPath(s, "autoscale", "max_workers").SetOptional()
 	common.CustomizeSchemaPath(s, "autoscale", "min_workers").SetOptional()
-	s["apply_policy_default_values"] = &schema.Schema{
+	common.CustomizeSchemaPath(s).AddNewField("apply_policy_default_values", &schema.Schema{
 		Optional: true,
 		Type:     schema.TypeBool,
-	}
+	})
 	common.CustomizeSchemaPath(s, "cluster_log_conf", "dbfs", "destination").SetRequired()
 	common.CustomizeSchemaPath(s, "cluster_log_conf", "s3", "destination").SetRequired()
 	common.CustomizeSchemaPath(s, "spark_version").SetRequired()
 	common.CustomizeSchemaPath(s, "cluster_id").SetOptional().SetComputed()
 	common.CustomizeSchemaPath(s, "instance_pool_id").SetConflictsWith([]string{"driver_node_type_id", "node_type_id"})
 	common.CustomizeSchemaPath(s, "runtime_engine").SetValidateFunc(validation.StringInSlice([]string{"PHOTON", "STANDARD"}, false))
-	s["is_pinned"] = &schema.Schema{
+	common.CustomizeSchemaPath(s).AddNewField("is_pinned", &schema.Schema{
 		Type:     schema.TypeBool,
 		Optional: true,
 		Default:  false,
@@ -145,15 +146,15 @@ func (ClusterResourceProvider) CustomizeSchema(s map[string]*schema.Schema) map[
 			}
 			return old == new
 		},
-	}
+	})
 	common.CustomizeSchemaPath(s, "state").SetReadOnly()
-	s["url"] = &schema.Schema{
+	common.CustomizeSchemaPath(s).AddNewField("url", &schema.Schema{
 		Type:     schema.TypeString,
 		Computed: true,
-	}
+	})
 	common.CustomizeSchemaPath(s, "default_tags").SetReadOnly()
 	common.CustomizeSchemaPath(s, "num_workers").SetDefault(0).SetValidateDiagFunc(validation.ToDiagFunc(validation.IntAtLeast(0)))
-	s["cluster_mount_info"] = &schema.Schema{
+	common.CustomizeSchemaPath(s).AddNewField("cluster_mount_info", &schema.Schema{
 		Type:     schema.TypeList,
 		Optional: true,
 		Elem: &schema.Resource{
@@ -161,7 +162,7 @@ func (ClusterResourceProvider) CustomizeSchema(s map[string]*schema.Schema) map[
 				return ss
 			}),
 		},
-	}
+	})
 
 	return s
 }

--- a/clusters/resource_cluster.go
+++ b/clusters/resource_cluster.go
@@ -69,11 +69,11 @@ func (ClusterResourceProvider) Aliases() map[string]string {
 }
 
 func (ClusterResourceProvider) CustomizeSchema(s map[string]*schema.Schema) map[string]*schema.Schema {
-	common.CustomizeSchemaPath(s, "enable_elastic_disk").SetOptional().SetComputed()
-	common.CustomizeSchemaPath(s, "enable_local_disk_encryption").SetOptional().SetComputed()
-	common.CustomizeSchemaPath(s, "node_type_id").SetComputed().SetOptional().SetConflictsWith([]string{"driver_instance_pool_id", "instance_pool_id"})
-	common.CustomizeSchemaPath(s, "driver_node_type_id").SetComputed().SetOptional().SetConflictsWith([]string{"driver_instance_pool_id", "instance_pool_id"})
-	common.CustomizeSchemaPath(s, "driver_instance_pool_id").SetComputed().SetOptional().SetConflictsWith([]string{"driver_node_type_id", "node_type_id"})
+	common.CustomizeSchemaPath(s, "enable_elastic_disk").SetComputed()
+	common.CustomizeSchemaPath(s, "enable_local_disk_encryption").SetComputed()
+	common.CustomizeSchemaPath(s, "node_type_id").SetComputed().SetConflictsWith([]string{"driver_instance_pool_id", "instance_pool_id"})
+	common.CustomizeSchemaPath(s, "driver_node_type_id").SetComputed().SetConflictsWith([]string{"driver_instance_pool_id", "instance_pool_id"})
+	common.CustomizeSchemaPath(s, "driver_instance_pool_id").SetComputed().SetConflictsWith([]string{"driver_node_type_id", "node_type_id"})
 	common.CustomizeSchemaPath(s, "ssh_public_keys").SetMaxItems(10)
 	common.CustomizeSchemaPath(s, "init_scripts").SetMaxItems(10).AddNewField("abfss", common.StructToSchema(InitScriptStorageInfo{}, nil)["abfss"]).AddNewField("gcs", common.StructToSchema(InitScriptStorageInfo{}, nil)["gcs"])
 	common.CustomizeSchemaPath(s, "init_scripts", "dbfs").SetDeprecated(DbfsDeprecationWarning)
@@ -82,8 +82,8 @@ func (ClusterResourceProvider) CustomizeSchema(s map[string]*schema.Schema) map[
 	common.CustomizeSchemaPath(s, "init_scripts", "volumes", "destination").SetRequired()
 	common.CustomizeSchemaPath(s, "init_scripts", "workspace", "destination").SetRequired()
 	common.CustomizeSchemaPath(s, "workload_type", "clients").SetRequired()
-	common.CustomizeSchemaPath(s, "workload_type", "clients", "notebooks").SetOptional().SetDefault(true)
-	common.CustomizeSchemaPath(s, "workload_type", "clients", "jobs").SetOptional().SetDefault(true)
+	common.CustomizeSchemaPath(s, "workload_type", "clients", "notebooks").SetDefault(true)
+	common.CustomizeSchemaPath(s, "workload_type", "clients", "jobs").SetDefault(true)
 	common.CustomizeSchemaPath(s).AddNewField("idempotency_token", &schema.Schema{
 		Type:     schema.TypeString,
 		Optional: true,

--- a/clusters/resource_cluster.go
+++ b/clusters/resource_cluster.go
@@ -174,7 +174,7 @@ func (ClusterResourceProvider) CustomizeSchema(s map[string]*schema.Schema) map[
 }
 
 func resourceClusterSchema() map[string]*schema.Schema {
-	return common.ResourceProviderStructToSchema[compute.ClusterDetails](ClusterResourceProvider{})
+	return common.ResourceProviderStructToSchema[compute.ClusterSpec](ClusterResourceProvider{})
 }
 
 func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {

--- a/clusters/resource_cluster.go
+++ b/clusters/resource_cluster.go
@@ -122,14 +122,14 @@ func (ClusterResourceProvider) CustomizeSchema(s map[string]*schema.Schema) map[
 	common.CustomizeSchemaPath(s, "autotermination_minutes").SetDefault(60)
 	common.CustomizeSchemaPath(s, "autoscale", "max_workers").SetOptional()
 	common.CustomizeSchemaPath(s, "autoscale", "min_workers").SetOptional()
-	common.CustomizeSchemaPath(s).AddNewField("apply_policy_default_values", &schema.Schema{
-		Optional: true,
-		Type:     schema.TypeBool,
-	})
 	common.CustomizeSchemaPath(s, "cluster_log_conf", "dbfs", "destination").SetRequired()
 	common.CustomizeSchemaPath(s, "cluster_log_conf", "s3", "destination").SetRequired()
 	common.CustomizeSchemaPath(s, "spark_version").SetRequired()
-	common.CustomizeSchemaPath(s, "cluster_id").SetOptional().SetComputed()
+	common.CustomizeSchemaPath(s).AddNewField("cluster_id", &schema.Schema{
+		Type:     schema.TypeString,
+		Optional: true,
+		Computed: true,
+	})
 	common.CustomizeSchemaPath(s, "instance_pool_id").SetConflictsWith([]string{"driver_node_type_id", "node_type_id"})
 	common.CustomizeSchemaPath(s, "runtime_engine").SetValidateFunc(validation.StringInSlice([]string{"PHOTON", "STANDARD"}, false))
 	common.CustomizeSchemaPath(s).AddNewField("is_pinned", &schema.Schema{
@@ -143,24 +143,10 @@ func (ClusterResourceProvider) CustomizeSchema(s map[string]*schema.Schema) map[
 			return old == new
 		},
 	})
-	common.CustomizeSchemaPath(s, "cluster_cores").SetReadOnly()
-	common.CustomizeSchemaPath(s, "cluster_memory_mb").SetReadOnly()
-	common.CustomizeSchemaPath(s, "driver").SetReadOnly()
-	common.CustomizeSchemaPath(s, "executors").SetReadOnly()
-	common.CustomizeSchemaPath(s, "jdbc_port").SetReadOnly()
-	common.CustomizeSchemaPath(s, "last_restarted_time").SetReadOnly()
-	common.CustomizeSchemaPath(s, "last_state_loss_time").SetReadOnly()
-	common.CustomizeSchemaPath(s, "spark_context_id").SetReadOnly()
-	common.CustomizeSchemaPath(s, "start_time").SetReadOnly()
-	common.CustomizeSchemaPath(s, "state_message").SetReadOnly()
-	common.CustomizeSchemaPath(s, "terminated_time").SetReadOnly()
-	common.CustomizeSchemaPath(s, "termination_reason").SetReadOnly()
-	common.CustomizeSchemaPath(s, "state").SetReadOnly()
 	common.CustomizeSchemaPath(s).AddNewField("url", &schema.Schema{
 		Type:     schema.TypeString,
 		Computed: true,
 	})
-	common.CustomizeSchemaPath(s, "default_tags").SetReadOnly()
 	common.CustomizeSchemaPath(s, "num_workers").SetDefault(0).SetValidateDiagFunc(validation.ToDiagFunc(validation.IntAtLeast(0)))
 	common.CustomizeSchemaPath(s).AddNewField("cluster_mount_info", &schema.Schema{
 		Type:     schema.TypeList,

--- a/clusters/resource_cluster.go
+++ b/clusters/resource_cluster.go
@@ -143,6 +143,19 @@ func (ClusterResourceProvider) CustomizeSchema(s map[string]*schema.Schema) map[
 			return old == new
 		},
 	})
+	common.CustomizeSchemaPath(s, "cluster_cores").SetReadOnly()
+	common.CustomizeSchemaPath(s, "cluster_memory_mb").SetReadOnly()
+	common.CustomizeSchemaPath(s, "creator_user_name").SetReadOnly()
+	common.CustomizeSchemaPath(s, "driver").SetReadOnly()
+	common.CustomizeSchemaPath(s, "executors").SetReadOnly()
+	common.CustomizeSchemaPath(s, "jdbc_port").SetReadOnly()
+	common.CustomizeSchemaPath(s, "last_restarted_time").SetReadOnly()
+	common.CustomizeSchemaPath(s, "last_state_loss_time").SetReadOnly()
+	common.CustomizeSchemaPath(s, "spark_context_id").SetReadOnly()
+	common.CustomizeSchemaPath(s, "start_time").SetReadOnly()
+	common.CustomizeSchemaPath(s, "state_message").SetReadOnly()
+	common.CustomizeSchemaPath(s, "terminated_time").SetReadOnly()
+	common.CustomizeSchemaPath(s, "termination_reason").SetReadOnly()
 	common.CustomizeSchemaPath(s, "state").SetReadOnly()
 	common.CustomizeSchemaPath(s).AddNewField("url", &schema.Schema{
 		Type:     schema.TypeString,

--- a/clusters/resource_cluster.go
+++ b/clusters/resource_cluster.go
@@ -130,6 +130,15 @@ func (ClusterResourceProvider) CustomizeSchema(s map[string]*schema.Schema) map[
 		Optional: true,
 		Computed: true,
 	})
+	common.CustomizeSchemaPath(s).AddNewField("default_tags", &schema.Schema{
+		Type:     schema.TypeString,
+		Computed: true,
+	})
+	common.CustomizeSchemaPath(s).AddNewField("state", &schema.Schema{
+		Type:     schema.TypeMap,
+		Computed: true,
+	})
+	common.CustomizeSchemaPath(s, "cluster_source").SetReadOnly()
 	common.CustomizeSchemaPath(s, "instance_pool_id").SetConflictsWith([]string{"driver_node_type_id", "node_type_id"})
 	common.CustomizeSchemaPath(s, "runtime_engine").SetValidateFunc(validation.StringInSlice([]string{"PHOTON", "STANDARD"}, false))
 	common.CustomizeSchemaPath(s).AddNewField("is_pinned", &schema.Schema{

--- a/clusters/resource_cluster.go
+++ b/clusters/resource_cluster.go
@@ -79,6 +79,8 @@ func (ClusterResourceProvider) CustomizeSchema(s map[string]*schema.Schema) map[
 	common.CustomizeSchemaPath(s, "init_scripts", "dbfs").SetDeprecated(DbfsDeprecationWarning)
 	common.CustomizeSchemaPath(s, "init_scripts", "dbfs", "destination").SetRequired()
 	common.CustomizeSchemaPath(s, "init_scripts", "s3", "destination").SetRequired()
+	common.CustomizeSchemaPath(s, "init_scripts", "volumes", "destination").SetRequired()
+	common.CustomizeSchemaPath(s, "init_scripts", "workspace", "destination").SetRequired()
 	common.CustomizeSchemaPath(s, "workload_type", "clients").SetRequired()
 	common.CustomizeSchemaPath(s, "workload_type", "clients", "notebooks").SetOptional().SetDefault(true)
 	common.CustomizeSchemaPath(s, "workload_type", "clients", "jobs").SetOptional().SetDefault(true)

--- a/clusters/resource_cluster.go
+++ b/clusters/resource_cluster.go
@@ -75,11 +75,7 @@ func (ClusterResourceProvider) CustomizeSchema(s map[string]*schema.Schema) map[
 	common.CustomizeSchemaPath(s, "driver_node_type_id").SetComputed().SetOptional().SetConflictsWith([]string{"driver_instance_pool_id", "instance_pool_id"})
 	common.CustomizeSchemaPath(s, "driver_instance_pool_id").SetComputed().SetOptional().SetConflictsWith([]string{"driver_node_type_id", "node_type_id"})
 	common.CustomizeSchemaPath(s, "ssh_public_keys").SetMaxItems(10)
-	common.CustomizeSchemaPath(s, "init_scripts").SetMaxItems(10).AddNewField("abfss", common.StructToSchema(InitScriptStorageInfo{}, func(ss map[string]*schema.Schema) map[string]*schema.Schema {
-		return ss
-	})["abfss"]).AddNewField("gcs", common.StructToSchema(InitScriptStorageInfo{}, func(ss map[string]*schema.Schema) map[string]*schema.Schema {
-		return ss
-	})["gcs"])
+	common.CustomizeSchemaPath(s, "init_scripts").SetMaxItems(10).AddNewField("abfss", common.StructToSchema(InitScriptStorageInfo{}, nil)["abfss"]).AddNewField("gcs", common.StructToSchema(InitScriptStorageInfo{}, nil)["gcs"])
 	common.CustomizeSchemaPath(s, "init_scripts", "dbfs").SetDeprecated(DbfsDeprecationWarning)
 	common.CustomizeSchemaPath(s, "init_scripts", "dbfs", "destination").SetRequired()
 	common.CustomizeSchemaPath(s, "init_scripts", "s3", "destination").SetRequired()
@@ -158,9 +154,7 @@ func (ClusterResourceProvider) CustomizeSchema(s map[string]*schema.Schema) map[
 		Type:     schema.TypeList,
 		Optional: true,
 		Elem: &schema.Resource{
-			Schema: common.StructToSchema(MountInfo{}, func(ss map[string]*schema.Schema) map[string]*schema.Schema {
-				return ss
-			}),
+			Schema: common.StructToSchema(MountInfo{}, nil),
 		},
 	})
 

--- a/clusters/resource_cluster.go
+++ b/clusters/resource_cluster.go
@@ -140,7 +140,6 @@ func (ClusterResourceProvider) CustomizeSchema(s map[string]*schema.Schema) map[
 		Type:     schema.TypeString,
 		Computed: true,
 	})
-	common.CustomizeSchemaPath(s, "cluster_source").SetReadOnly()
 	common.CustomizeSchemaPath(s, "instance_pool_id").SetConflictsWith([]string{"driver_node_type_id", "node_type_id"})
 	common.CustomizeSchemaPath(s, "runtime_engine").SetValidateFunc(validation.StringInSlice([]string{"PHOTON", "STANDARD"}, false))
 	common.CustomizeSchemaPath(s).AddNewField("is_pinned", &schema.Schema{

--- a/clusters/resource_cluster.go
+++ b/clusters/resource_cluster.go
@@ -145,7 +145,6 @@ func (ClusterResourceProvider) CustomizeSchema(s map[string]*schema.Schema) map[
 	})
 	common.CustomizeSchemaPath(s, "cluster_cores").SetReadOnly()
 	common.CustomizeSchemaPath(s, "cluster_memory_mb").SetReadOnly()
-	common.CustomizeSchemaPath(s, "creator_user_name").SetReadOnly()
 	common.CustomizeSchemaPath(s, "driver").SetReadOnly()
 	common.CustomizeSchemaPath(s, "executors").SetReadOnly()
 	common.CustomizeSchemaPath(s, "jdbc_port").SetReadOnly()

--- a/clusters/resource_cluster.go
+++ b/clusters/resource_cluster.go
@@ -69,7 +69,7 @@ func (ClusterResourceProvider) Aliases() map[string]string {
 }
 
 func (ClusterResourceProvider) CustomizeSchema(s map[string]*schema.Schema) map[string]*schema.Schema {
-	common.CustomizeSchemaPath(s, "cluster_source").SetComputed()
+	common.CustomizeSchemaPath(s, "cluster_source").SetComputed().SetReadOnly()
 	common.CustomizeSchemaPath(s, "enable_elastic_disk").SetComputed()
 	common.CustomizeSchemaPath(s, "enable_local_disk_encryption").SetComputed()
 	common.CustomizeSchemaPath(s, "node_type_id").SetComputed().SetConflictsWith([]string{"driver_instance_pool_id", "instance_pool_id"})

--- a/clusters/resource_cluster.go
+++ b/clusters/resource_cluster.go
@@ -69,7 +69,7 @@ func (ClusterResourceProvider) Aliases() map[string]string {
 }
 
 func (ClusterResourceProvider) CustomizeSchema(s map[string]*schema.Schema) map[string]*schema.Schema {
-	common.CustomizeSchemaPath(s, "cluster_source").SetComputed().SetReadOnly()
+	common.CustomizeSchemaPath(s, "cluster_source").SetReadOnly()
 	common.CustomizeSchemaPath(s, "enable_elastic_disk").SetComputed()
 	common.CustomizeSchemaPath(s, "enable_local_disk_encryption").SetComputed()
 	common.CustomizeSchemaPath(s, "node_type_id").SetComputed().SetConflictsWith([]string{"driver_instance_pool_id", "instance_pool_id"})

--- a/clusters/resource_cluster.go
+++ b/clusters/resource_cluster.go
@@ -131,11 +131,11 @@ func (ClusterResourceProvider) CustomizeSchema(s map[string]*schema.Schema) map[
 		Computed: true,
 	})
 	common.CustomizeSchemaPath(s).AddNewField("default_tags", &schema.Schema{
-		Type:     schema.TypeString,
+		Type:     schema.TypeMap,
 		Computed: true,
 	})
 	common.CustomizeSchemaPath(s).AddNewField("state", &schema.Schema{
-		Type:     schema.TypeMap,
+		Type:     schema.TypeString,
 		Computed: true,
 	})
 	common.CustomizeSchemaPath(s, "cluster_source").SetReadOnly()

--- a/clusters/resource_cluster_test.go
+++ b/clusters/resource_cluster_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/databricks/databricks-sdk-go/apierr"
 	"github.com/databricks/terraform-provider-databricks/libraries"
 
+	"github.com/databricks/databricks-sdk-go/service/compute"
 	"github.com/databricks/terraform-provider-databricks/qa"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -19,15 +20,15 @@ func TestResourceClusterCreate(t *testing.T) {
 			{
 				Method:   "POST",
 				Resource: "/api/2.0/clusters/create",
-				ExpectedRequest: Cluster{
+				ExpectedRequest: compute.ClusterSpec{
 					NumWorkers:             100,
 					ClusterName:            "Shared Autoscaling",
 					SparkVersion:           "7.1-scala12",
-					NodeTypeID:             "i3.xlarge",
+					NodeTypeId:             "i3.xlarge",
 					AutoterminationMinutes: 15,
 				},
-				Response: ClusterInfo{
-					ClusterID: "abc",
+				Response: compute.ClusterDetails{
+					ClusterId: "abc",
 					State:     ClusterStateRunning,
 				},
 			},
@@ -35,12 +36,12 @@ func TestResourceClusterCreate(t *testing.T) {
 				Method:       "GET",
 				ReuseRequest: true,
 				Resource:     "/api/2.0/clusters/get?cluster_id=abc",
-				Response: ClusterInfo{
-					ClusterID:              "abc",
+				Response: compute.ClusterDetails{
+					ClusterId:              "abc",
 					NumWorkers:             100,
 					ClusterName:            "Shared Autoscaling",
 					SparkVersion:           "7.1-scala12",
-					NodeTypeID:             "i3.xlarge",
+					NodeTypeId:             "i3.xlarge",
 					AutoterminationMinutes: 15,
 					State:                  ClusterStateRunning,
 				},

--- a/common/customizable_schema.go
+++ b/common/customizable_schema.go
@@ -1,0 +1,129 @@
+package common
+
+import (
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type CustomizableSchema struct {
+	Schema *schema.Schema
+}
+
+func CustomizeSchemaPath(s map[string]*schema.Schema, path ...string) *CustomizableSchema {
+	if len(path) == 0 {
+		// Wrapping the input map into a schema when the path is empty.
+		// The primary use case for this situation is for adding a new field at the top level.
+		wrappedSch := &schema.Schema{
+			Elem: &schema.Resource{
+				Schema: s,
+			},
+		}
+		return &CustomizableSchema{Schema: wrappedSch}
+	}
+	sch := MustSchemaPath(s, path...)
+	return &CustomizableSchema{Schema: sch}
+}
+
+func (s *CustomizableSchema) SetOptional() *CustomizableSchema {
+	s.Schema.Optional = true
+	s.Schema.Required = false
+	return s
+}
+
+func (s *CustomizableSchema) SetComputed() *CustomizableSchema {
+	s.Schema.Computed = true
+	return s
+}
+
+func (s *CustomizableSchema) SetDefault(value any) *CustomizableSchema {
+	s.Schema.Default = value
+	s.Schema.Optional = true
+	s.Schema.Required = false
+	return s
+}
+
+// SetReadOnly sets the schema to be read-only (i.e. computed, non-optional).
+// This should be used for fields that are not user-configurable but are returned
+// by the platform.
+func (s *CustomizableSchema) SetReadOnly() *CustomizableSchema {
+	s.Schema.Optional = false
+	s.Schema.Required = false
+	s.Schema.MaxItems = 0
+	s.Schema.Computed = true
+	return s
+}
+
+// SetRequired sets the schema to be required.
+func (s *CustomizableSchema) SetRequired() *CustomizableSchema {
+	s.Schema.Optional = false
+	s.Schema.Required = true
+	s.Schema.Computed = false
+	return s
+}
+
+func (s *CustomizableSchema) SetSuppressDiff() *CustomizableSchema {
+	s.Schema.DiffSuppressFunc = diffSuppressor(s.Schema)
+	return s
+}
+
+func (s *CustomizableSchema) SetCustomSuppressDiff(suppressor func(k, old, new string, d *schema.ResourceData) bool) *CustomizableSchema {
+	s.Schema.DiffSuppressFunc = suppressor
+	return s
+}
+
+func (s *CustomizableSchema) SetSensitive() *CustomizableSchema {
+	s.Schema.Sensitive = true
+	return s
+}
+
+func (s *CustomizableSchema) SetForceNew() *CustomizableSchema {
+	s.Schema.ForceNew = true
+	return s
+}
+
+func (s *CustomizableSchema) SetMaxItems(value int) *CustomizableSchema {
+	s.Schema.MaxItems = value
+	return s
+}
+
+func (s *CustomizableSchema) SetMinItems(value int) *CustomizableSchema {
+	s.Schema.MinItems = value
+	return s
+}
+
+func (s *CustomizableSchema) SetConflictsWith(value []string) *CustomizableSchema {
+	if len(value) == 0 {
+		panic("SetConflictsWith cannot take in empty list")
+	}
+	s.Schema.ConflictsWith = value
+	return s
+}
+
+func (s *CustomizableSchema) SetDeprecated(reason string) *CustomizableSchema {
+	s.Schema.Deprecated = reason
+	return s
+}
+
+func (s *CustomizableSchema) SetValidateFunc(validate func(interface{}, string) ([]string, []error)) *CustomizableSchema {
+	s.Schema.ValidateFunc = validate
+	return s
+}
+
+func (s *CustomizableSchema) SetValidateDiagFunc(validate func(interface{}, cty.Path) diag.Diagnostics) *CustomizableSchema {
+	s.Schema.ValidateDiagFunc = validate
+	return s
+}
+
+func (s *CustomizableSchema) AddNewField(key string, newField *schema.Schema) *CustomizableSchema {
+	cv, ok := s.Schema.Elem.(*schema.Resource)
+	if !ok {
+		panic("Cannot add new field, target is not nested resource")
+	}
+	_, exists := cv.Schema[key]
+	if exists {
+		panic("Cannot add new field, " + key + " already exists in the schema")
+	}
+	cv.Schema[key] = newField
+	return s
+}

--- a/common/reflect_resource.go
+++ b/common/reflect_resource.go
@@ -348,7 +348,7 @@ func (s *CustomizableSchema) AddNewField(key string, newField *schema.Schema) *C
 // StructToSchema makes schema from a struct type & applies customizations from callback given
 func StructToSchema(v any, customize func(map[string]*schema.Schema) map[string]*schema.Schema) map[string]*schema.Schema {
 	rv := reflect.ValueOf(v)
-	scm := typeToSchema(rv, []string{})
+	scm := typeToSchema(rv, []string{}, map[string]string{})
 	if customize != nil {
 		scm = customize(scm)
 	}
@@ -588,7 +588,7 @@ func typeToSchema(v reflect.Value, path []string, aliases map[string]string) map
 			scm[fieldName].Type = schema.TypeList
 			elem := typeField.Type.Elem()
 			sv := reflect.New(elem).Elem()
-			nestedSchema := typeToSchema(sv, append(path, fieldName))
+			nestedSchema := typeToSchema(sv, append(path, fieldName), aliases)
 			if strings.Contains(tfTag, "suppress_diff") {
 				scm[fieldName].DiffSuppressFunc = diffSuppressor(scm[fieldName])
 				for _, v := range nestedSchema {
@@ -606,7 +606,7 @@ func typeToSchema(v reflect.Value, path []string, aliases map[string]string) map
 			elem := typeField.Type  // changed from ptr
 			sv := reflect.New(elem) // changed from ptr
 
-			nestedSchema := typeToSchema(sv, append(path, fieldName))
+			nestedSchema := typeToSchema(sv, append(path, fieldName), aliases)
 			if strings.Contains(tfTag, "suppress_diff") {
 				scm[fieldName].DiffSuppressFunc = diffSuppressor(scm[fieldName])
 				for _, v := range nestedSchema {
@@ -636,7 +636,7 @@ func typeToSchema(v reflect.Value, path []string, aliases map[string]string) map
 			case reflect.Struct:
 				sv := reflect.New(elem).Elem()
 				scm[fieldName].Elem = &schema.Resource{
-					Schema: typeToSchema(sv, append(path, fieldName)),
+					Schema: typeToSchema(sv, append(path, fieldName), aliases),
 				}
 			}
 		default:

--- a/common/reflect_resource.go
+++ b/common/reflect_resource.go
@@ -224,6 +224,16 @@ func MustSchemaPath(s map[string]*schema.Schema, path ...string) *schema.Schema 
 }
 
 func CustomizeSchemaPath(s map[string]*schema.Schema, path ...string) *CustomizableSchema {
+	if len(path) == 0 {
+		// Wrapping the input map into a schema when the path is empty.
+		// The primary use case for this situation is for adding a new field at the top level.
+		wrappedSch := &schema.Schema{
+			Elem: &schema.Resource{
+				Schema: s,
+			},
+		}
+		return &CustomizableSchema{Schema: wrappedSch}
+	}
 	sch := MustSchemaPath(s, path...)
 	return &CustomizableSchema{Schema: sch}
 }

--- a/common/reflect_resource.go
+++ b/common/reflect_resource.go
@@ -7,8 +7,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/hashicorp/go-cty/cty"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -120,128 +118,6 @@ func MustSchemaPath(s map[string]*schema.Schema, path ...string) *schema.Schema 
 		panic(err)
 	}
 	return sch
-}
-
-func CustomizeSchemaPath(s map[string]*schema.Schema, path ...string) *CustomizableSchema {
-	if len(path) == 0 {
-		// Wrapping the input map into a schema when the path is empty.
-		// The primary use case for this situation is for adding a new field at the top level.
-		wrappedSch := &schema.Schema{
-			Elem: &schema.Resource{
-				Schema: s,
-			},
-		}
-		return &CustomizableSchema{Schema: wrappedSch}
-	}
-	sch := MustSchemaPath(s, path...)
-	return &CustomizableSchema{Schema: sch}
-}
-
-type CustomizableSchema struct {
-	Schema *schema.Schema
-}
-
-func (s *CustomizableSchema) SetOptional() *CustomizableSchema {
-	s.Schema.Optional = true
-	s.Schema.Required = false
-	return s
-}
-
-func (s *CustomizableSchema) SetComputed() *CustomizableSchema {
-	s.Schema.Computed = true
-	return s
-}
-
-func (s *CustomizableSchema) SetDefault(value any) *CustomizableSchema {
-	s.Schema.Default = value
-	s.Schema.Optional = true
-	s.Schema.Required = false
-	return s
-}
-
-// SetReadOnly sets the schema to be read-only (i.e. computed, non-optional).
-// This should be used for fields that are not user-configurable but are returned
-// by the platform.
-func (s *CustomizableSchema) SetReadOnly() *CustomizableSchema {
-	s.Schema.Optional = false
-	s.Schema.Required = false
-	s.Schema.MaxItems = 0
-	s.Schema.Computed = true
-	return s
-}
-
-// SetRequired sets the schema to be required.
-func (s *CustomizableSchema) SetRequired() *CustomizableSchema {
-	s.Schema.Optional = false
-	s.Schema.Required = true
-	s.Schema.Computed = false
-	return s
-}
-
-func (s *CustomizableSchema) SetSuppressDiff() *CustomizableSchema {
-	s.Schema.DiffSuppressFunc = diffSuppressor(s.Schema)
-	return s
-}
-
-func (s *CustomizableSchema) SetCustomSuppressDiff(suppressor func(k, old, new string, d *schema.ResourceData) bool) *CustomizableSchema {
-	s.Schema.DiffSuppressFunc = suppressor
-	return s
-}
-
-func (s *CustomizableSchema) SetSensitive() *CustomizableSchema {
-	s.Schema.Sensitive = true
-	return s
-}
-
-func (s *CustomizableSchema) SetForceNew() *CustomizableSchema {
-	s.Schema.ForceNew = true
-	return s
-}
-
-func (s *CustomizableSchema) SetMaxItems(value int) *CustomizableSchema {
-	s.Schema.MaxItems = value
-	return s
-}
-
-func (s *CustomizableSchema) SetMinItems(value int) *CustomizableSchema {
-	s.Schema.MinItems = value
-	return s
-}
-
-func (s *CustomizableSchema) SetConflictsWith(value []string) *CustomizableSchema {
-	if len(value) == 0 {
-		panic("SetConflictsWith cannot take in empty list")
-	}
-	s.Schema.ConflictsWith = value
-	return s
-}
-
-func (s *CustomizableSchema) SetDeprecated(reason string) *CustomizableSchema {
-	s.Schema.Deprecated = reason
-	return s
-}
-
-func (s *CustomizableSchema) SetValidateFunc(validate func(interface{}, string) ([]string, []error)) *CustomizableSchema {
-	s.Schema.ValidateFunc = validate
-	return s
-}
-
-func (s *CustomizableSchema) SetValidateDiagFunc(validate func(interface{}, cty.Path) diag.Diagnostics) *CustomizableSchema {
-	s.Schema.ValidateDiagFunc = validate
-	return s
-}
-
-func (s *CustomizableSchema) AddNewField(key string, newField *schema.Schema) *CustomizableSchema {
-	cv, ok := s.Schema.Elem.(*schema.Resource)
-	if !ok {
-		panic("Cannot add new field, target is not nested resource")
-	}
-	_, exists := cv.Schema[key]
-	if exists {
-		panic("Cannot add new field, " + key + " already exists in the schema")
-	}
-	cv.Schema[key] = newField
-	return s
 }
 
 // StructToSchema makes schema from a struct type & applies customizations from callback given

--- a/common/reflect_resource.go
+++ b/common/reflect_resource.go
@@ -57,6 +57,8 @@ func ResourceProviderStructToSchema[T any](v ResourceProviderStruct[T]) map[stri
 	return scm
 }
 
+// A copy of typeToSchema that works with the ResourceProviderStruct, by taking in an aliases map and handling the `tf` overrides differently from
+// the existing typeToSchema function.
 func resourceProviderTypeToSchema(v reflect.Value, t reflect.Type, fieldNamePath []string, aliases map[string]string) map[string]*schema.Schema {
 	scm := map[string]*schema.Schema{}
 	rk := v.Kind()

--- a/common/reflect_resource.go
+++ b/common/reflect_resource.go
@@ -57,107 +57,6 @@ func ResourceProviderStructToSchema[T any](v ResourceProviderStruct[T]) map[stri
 	return scm
 }
 
-// A copy of typeToSchema that works with the ResourceProviderStruct, by taking in an aliases map and handling the `tf` overrides differently from
-// the existing typeToSchema function.
-// func resourceProviderTypeToSchema(v reflect.Value, t reflect.Type, fieldNamePath []string, aliases map[string]string) map[string]*schema.Schema {
-// 	scm := map[string]*schema.Schema{}
-// 	rk := v.Kind()
-// 	if rk == reflect.Ptr {
-// 		v = v.Elem()
-// 		t = v.Type()
-// 		rk = v.Kind()
-// 	}
-// 	if rk != reflect.Struct {
-// 		panic(fmt.Errorf("Schema value of Struct is expected, but got %s: %#v", reflectKind(rk), v))
-// 	}
-// 	for i := 0; i < v.NumField(); i++ {
-// 		typeField := t.Field(i)
-
-// 		fieldName := chooseFieldNameWithAliases(typeField, fieldNamePath, aliases)
-
-// 		if fieldName == "-" {
-// 			continue
-// 		}
-// 		scm[fieldName] = &schema.Schema{}
-// 		handleOptional(typeField, scm[fieldName])
-// 		switch typeField.Type.Kind() {
-// 		case reflect.Int, reflect.Int32, reflect.Int64:
-// 			scm[fieldName].Type = schema.TypeInt
-// 		case reflect.Float64:
-// 			scm[fieldName].Type = schema.TypeFloat
-// 		case reflect.Bool:
-// 			scm[fieldName].Type = schema.TypeBool
-// 		case reflect.String:
-// 			scm[fieldName].Type = schema.TypeString
-// 		case reflect.Map:
-// 			scm[fieldName].Type = schema.TypeMap
-// 			elem := typeField.Type.Elem()
-// 			switch elem.Kind() {
-// 			case reflect.String:
-// 				scm[fieldName].Elem = schema.TypeString
-// 			case reflect.Int64:
-// 				scm[fieldName].Elem = schema.TypeInt
-// 			default:
-// 				panic(fmt.Errorf("unsupported map value for %s: %s", fieldName, reflectKind(elem.Kind())))
-// 			}
-// 		case reflect.Ptr:
-// 			scm[fieldName].MaxItems = 1
-// 			scm[fieldName].Type = schema.TypeList
-// 			elem := typeField.Type.Elem()
-// 			sv := reflect.New(elem).Elem()
-// 			nestedSchema := resourceProviderTypeToSchema(sv, elem, append(fieldNamePath, fieldName), aliases)
-// 			if scm[fieldName].DiffSuppressFunc != nil {
-// 				for _, v := range nestedSchema {
-// 					// to those relatively new to GoLang: we must explicitly pass down v by copy
-// 					v.DiffSuppressFunc = diffSuppressor(v)
-// 				}
-// 			}
-// 			scm[fieldName].Elem = &schema.Resource{
-// 				Schema: nestedSchema,
-// 			}
-// 		case reflect.Struct:
-// 			scm[fieldName].MaxItems = 1
-// 			scm[fieldName].Type = schema.TypeList
-
-// 			elem := typeField.Type  // changed from ptr
-// 			sv := reflect.New(elem) // changed from ptr
-
-// 			nestedSchema := resourceProviderTypeToSchema(sv, elem, append(fieldNamePath, fieldName), aliases)
-// 			if scm[fieldName].DiffSuppressFunc != nil {
-// 				for _, v := range nestedSchema {
-// 					// to those relatively new to GoLang: we must explicitly pass down v by copy
-// 					v.DiffSuppressFunc = diffSuppressor(v)
-// 				}
-// 			}
-// 			scm[fieldName].Elem = &schema.Resource{
-// 				Schema: nestedSchema,
-// 			}
-// 		case reflect.Slice:
-// 			ft := schema.TypeList
-// 			scm[fieldName].Type = ft
-// 			elem := typeField.Type.Elem()
-// 			switch elem.Kind() {
-// 			case reflect.Int, reflect.Int32, reflect.Int64:
-// 				scm[fieldName].Elem = &schema.Schema{Type: schema.TypeInt}
-// 			case reflect.Float64:
-// 				scm[fieldName].Elem = &schema.Schema{Type: schema.TypeFloat}
-// 			case reflect.Bool:
-// 				scm[fieldName].Elem = &schema.Schema{Type: schema.TypeBool}
-// 			case reflect.String:
-// 				scm[fieldName].Elem = &schema.Schema{Type: schema.TypeString}
-// 			case reflect.Struct:
-// 				sv := reflect.New(elem).Elem()
-// 				scm[fieldName].Elem = &schema.Resource{
-// 					Schema: resourceProviderTypeToSchema(sv, elem, append(fieldNamePath, fieldName), aliases),
-// 				}
-// 			}
-// 		default:
-// 			panic(fmt.Errorf("unknown type for %s: %s", fieldName, reflectKind(typeField.Type.Kind())))
-// 		}
-// 	}
-// 	return scm
-// }
-
 func reflectKind(k reflect.Kind) string {
 	n, ok := kindMap[k]
 	if !ok {
@@ -503,8 +402,6 @@ func listAllFields(v reflect.Value) []field {
 	return fields
 }
 
-// typeToSchema converts struct into terraform schema. `path` is used for block suppressions
-// special path element `"0"` is used to denote either arrays or sets of elements
 func typeToSchema(v reflect.Value, path []string, aliases map[string]string) map[string]*schema.Schema {
 	scm := map[string]*schema.Schema{}
 	rk := v.Kind()

--- a/common/reflect_resource.go
+++ b/common/reflect_resource.go
@@ -166,6 +166,9 @@ func reflectKind(k reflect.Kind) string {
 
 func chooseFieldNameWithAliases(typeField reflect.StructField, fieldNamePath []string, aliases map[string]string) string {
 	jsonFieldName := getJsonFieldName(typeField)
+	if jsonFieldName == "-" {
+		return "-"
+	}
 
 	aliasKey := strings.Join(append(fieldNamePath, jsonFieldName), ".")
 
@@ -295,6 +298,10 @@ func (s *CustomizableSchema) SetMinItems(value int) *CustomizableSchema {
 }
 
 func (s *CustomizableSchema) SetConflictsWith(value []string) *CustomizableSchema {
+	if len(value) == 0 {
+		panic("SetConflictsWith cannot take in empty list")
+		return s
+	}
 	s.Schema.ConflictsWith = value
 	return s
 }

--- a/common/reflect_resource.go
+++ b/common/reflect_resource.go
@@ -182,6 +182,7 @@ func handleComputed(typeField reflect.StructField, schema *schema.Schema) {
 	for _, tag := range tfTags {
 		if tag == "computed" {
 			schema.Computed = true
+			schema.Required = false
 			break
 		}
 	}

--- a/common/reflect_resource.go
+++ b/common/reflect_resource.go
@@ -312,7 +312,6 @@ func (s *CustomizableSchema) SetMinItems(value int) *CustomizableSchema {
 func (s *CustomizableSchema) SetConflictsWith(value []string) *CustomizableSchema {
 	if len(value) == 0 {
 		panic("SetConflictsWith cannot take in empty list")
-		return s
 	}
 	s.Schema.ConflictsWith = value
 	return s
@@ -337,6 +336,10 @@ func (s *CustomizableSchema) AddNewField(key string, newField *schema.Schema) *C
 	cv, ok := s.Schema.Elem.(*schema.Resource)
 	if !ok {
 		panic("Cannot add new field, target is not nested resource")
+	}
+	_, exists := cv.Schema[key]
+	if exists {
+		panic("Cannot add new field, " + key + " already exists in the schema")
 	}
 	cv.Schema[key] = newField
 	return s

--- a/common/reflect_resource.go
+++ b/common/reflect_resource.go
@@ -583,7 +583,7 @@ func typeToSchema(v reflect.Value, path []string) map[string]*schema.Schema {
 			scm[fieldName].Type = schema.TypeList
 			elem := typeField.Type.Elem()
 			sv := reflect.New(elem).Elem()
-			nestedSchema := typeToSchema(sv, append(path, fieldName, "0"))
+			nestedSchema := typeToSchema(sv, append(path, fieldName))
 			if strings.Contains(tfTag, "suppress_diff") {
 				scm[fieldName].DiffSuppressFunc = diffSuppressor(scm[fieldName])
 				for _, v := range nestedSchema {
@@ -601,7 +601,7 @@ func typeToSchema(v reflect.Value, path []string) map[string]*schema.Schema {
 			elem := typeField.Type  // changed from ptr
 			sv := reflect.New(elem) // changed from ptr
 
-			nestedSchema := typeToSchema(sv, append(path, fieldName, "0"))
+			nestedSchema := typeToSchema(sv, append(path, fieldName))
 			if strings.Contains(tfTag, "suppress_diff") {
 				scm[fieldName].DiffSuppressFunc = diffSuppressor(scm[fieldName])
 				for _, v := range nestedSchema {
@@ -631,7 +631,7 @@ func typeToSchema(v reflect.Value, path []string) map[string]*schema.Schema {
 			case reflect.Struct:
 				sv := reflect.New(elem).Elem()
 				scm[fieldName].Elem = &schema.Resource{
-					Schema: typeToSchema(sv, append(path, fieldName, "0")),
+					Schema: typeToSchema(sv, append(path, fieldName)),
 				}
 			}
 		default:

--- a/common/reflect_resource.go
+++ b/common/reflect_resource.go
@@ -265,7 +265,7 @@ func (s *CustomizableSchema) SetRequired() *CustomizableSchema {
 }
 
 func (s *CustomizableSchema) SetSuppressDiff() *CustomizableSchema {
-	s.Schema.DiffSuppressFunc = diffSuppressor(fmt.Sprintf(s.Schema))
+	s.Schema.DiffSuppressFunc = diffSuppressor(s.Schema)
 	return s
 }
 

--- a/common/reflect_resource.go
+++ b/common/reflect_resource.go
@@ -71,15 +71,10 @@ func chooseFieldNameWithAliases(typeField reflect.StructField, fieldNamePath []s
 
 	aliasKey := strings.Join(append(fieldNamePath, jsonFieldName), ".")
 
-	var fieldName string
-
 	if value, ok := aliases[aliasKey]; ok {
-		fieldName = value
-	} else {
-		fieldName = jsonFieldName
+		return value
 	}
-
-	return fieldName
+	return jsonFieldName
 }
 
 func getJsonFieldName(typeField reflect.StructField) string {

--- a/common/reflect_resource.go
+++ b/common/reflect_resource.go
@@ -505,7 +505,7 @@ func listAllFields(v reflect.Value) []field {
 
 // typeToSchema converts struct into terraform schema. `path` is used for block suppressions
 // special path element `"0"` is used to denote either arrays or sets of elements
-func typeToSchema(v reflect.Value, path []string) map[string]*schema.Schema {
+func typeToSchema(v reflect.Value, path []string, aliases map[string]string) map[string]*schema.Schema {
 	scm := map[string]*schema.Schema{}
 	rk := v.Kind()
 	if rk == reflect.Ptr {
@@ -520,7 +520,12 @@ func typeToSchema(v reflect.Value, path []string) map[string]*schema.Schema {
 		typeField := field.sf
 		tfTag := typeField.Tag.Get("tf")
 
-		fieldName := chooseFieldName(typeField)
+		var fieldName string
+		if len(aliases) == 0 {
+			fieldName = chooseFieldName(typeField)
+		} else {
+			fieldName = chooseFieldNameWithAliases(typeField, path, aliases)
+		}
 		if fieldName == "-" {
 			continue
 		}

--- a/common/reflect_resource.go
+++ b/common/reflect_resource.go
@@ -479,6 +479,7 @@ func listAllFields(v reflect.Value) []field {
 		}
 	}
 	return fields
+}
 
 // typeToSchema converts struct into terraform schema. `path` is used for block suppressions
 // special path element `"0"` is used to denote either arrays or sets of elements

--- a/common/reflect_resource.go
+++ b/common/reflect_resource.go
@@ -107,7 +107,7 @@ func resourceProviderTypeToSchema(v reflect.Value, t reflect.Type, fieldNamePath
 			if scm[fieldName].DiffSuppressFunc != nil {
 				for _, v := range nestedSchema {
 					// to those relatively new to GoLang: we must explicitly pass down v by copy
-					v.DiffSuppressFunc = diffSuppressor(fmt.Sprintf("%v", v.Type.Zero()))
+					v.DiffSuppressFunc = diffSuppressor(v)
 				}
 			}
 			scm[fieldName].Elem = &schema.Resource{
@@ -124,7 +124,7 @@ func resourceProviderTypeToSchema(v reflect.Value, t reflect.Type, fieldNamePath
 			if scm[fieldName].DiffSuppressFunc != nil {
 				for _, v := range nestedSchema {
 					// to those relatively new to GoLang: we must explicitly pass down v by copy
-					v.DiffSuppressFunc = diffSuppressor(fmt.Sprintf("%v", v.Type.Zero()))
+					v.DiffSuppressFunc = diffSuppressor(v)
 				}
 			}
 			scm[fieldName].Elem = &schema.Resource{
@@ -265,7 +265,7 @@ func (s *CustomizableSchema) SetRequired() *CustomizableSchema {
 }
 
 func (s *CustomizableSchema) SetSuppressDiff() *CustomizableSchema {
-	s.Schema.DiffSuppressFunc = diffSuppressor(fmt.Sprintf("%v", s.Schema.Type.Zero()))
+	s.Schema.DiffSuppressFunc = diffSuppressor(fmt.Sprintf(s.Schema))
 	return s
 }
 

--- a/common/reflect_resource_test.go
+++ b/common/reflect_resource_test.go
@@ -42,6 +42,12 @@ func TestChooseFieldName(t *testing.T) {
 	}))
 }
 
+func TestChooseFieldNameWithAliasesMap(t *testing.T) {
+	assert.Equal(t, "foo", chooseFieldNameWithAliases(reflect.StructField{
+		Tag: `json:"bar"`,
+	}, []string{"a"}, map[string]string{"a.bar": "foo"}))
+}
+
 type testSliceItem struct {
 	SliceItem string   `json:"slice_item,omitempty"`
 	Nested    *testPtr `json:"nested,omitempty"`

--- a/common/reflect_resource_test.go
+++ b/common/reflect_resource_test.go
@@ -448,7 +448,7 @@ func TestTypeToSchemaNoStruct(t *testing.T) {
 			fmt.Sprintf("%s", p))
 	}()
 	v := reflect.ValueOf(1)
-	typeToSchema(v, []string{})
+	typeToSchema(v, []string{}, map[string]string{})
 }
 
 func TestTypeToSchemaUnsupported(t *testing.T) {
@@ -461,7 +461,7 @@ func TestTypeToSchemaUnsupported(t *testing.T) {
 		New chan int `json:"new"`
 	}
 	v := reflect.ValueOf(nonsense{})
-	typeToSchema(v, []string{})
+	typeToSchema(v, []string{}, map[string]string{})
 }
 
 type data map[string]any


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
- Before we are able to migrate the cluster resources to use the go-sdk schema, we need to figure out a way to represent the current `tf` tags on the manually maintained structs
- This PR introduces a new interface `ResourceProviderStruct` which contains a method for aliases and all of the customizations.
  - `Aliases() map[string]string`
  - `CustomizeSchema(map[string]*schema.Schema) map[string]*schema.Schema`
- Also added a series of customization functions such as `SetOptional`, etc so that we can easily write customization logics into the `CustomizeSchema` function to replace the current `tf` tags
- Migrated the cluster schema into the go-sdk schema with this new interface

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [x] covered with integration tests in `internal/acceptance`
- [x] relevant acceptance tests are passing
- [x] using Go SDK

