### PR TITLE
DON'T MERGE: Added `IS_OWNER` permission and fixed support for service principals for SQL Alerts/Dashboards/Queries

### DIFF
--- a/docs/resources/permissions.md
+++ b/docs/resources/permissions.md
@@ -660,7 +660,11 @@ resource "databricks_permissions" "endpoint_usage" {
 
 ## SQL Dashboard usage
 
-[SQL dashboards](https://docs.databricks.com/sql/user/security/access-control/dashboard-acl.html) have three possible permissions: `CAN_VIEW`, `CAN_RUN` and `CAN_MANAGE`:
+[SQL dashboards](https://docs.databricks.com/sql/user/security/access-control/dashboard-acl.html) have four possible permissions: `CAN_VIEW`, `CAN_RUN`, `CAN_MANAGE` and `IS_OWNER`:
+
+- The creator of a SQL Dashboard has implicit `IS_OWNER` permission.
+- A SQL Dashboard must have exactly one owner.  A SQL Dashboard cannot have a group as an owner.
+- If `IS_OWNER` was set explicitly, it won't be reverted back when resource is destroyed because information about creator isn't persisted.
 
 ```hcl
 resource "databricks_group" "auto" {
@@ -688,7 +692,11 @@ resource "databricks_permissions" "endpoint_usage" {
 
 ## SQL Query usage
 
-[SQL queries](https://docs.databricks.com/sql/user/security/access-control/query-acl.html) have three possible permissions: `CAN_VIEW`, `CAN_RUN` and `CAN_MANAGE`:
+[SQL queries](https://docs.databricks.com/sql/user/security/access-control/query-acl.html) have four possible permissions: `CAN_VIEW`, `CAN_RUN`, `CAN_MANAGE` and `IS_OWNER`:
+
+- The creator of a SQL Query has implicit `IS_OWNER` permission.
+- A SQL Query must have exactly one owner.  A SQL Query cannot have a group as an owner.
+- If `IS_OWNER` was set explicitly, it won't be reverted back when resource is destroyed because information about creator isn't persisted.
 
 -> **Note** If you do not define an `access_control` block granting `CAN_MANAGE` explictly for the user calling this provider, Databricks Terraform Provider will add `CAN_MANAGE` permission for the caller. This is a failsafe to prevent situations where the caller is locked out from making changes to the targeted `databricks_sql_query` resource when backend API do not apply permission inheritance correctly.
 
@@ -718,7 +726,11 @@ resource "databricks_permissions" "endpoint_usage" {
 
 ## SQL Alert usage
 
-[SQL alerts](https://docs.databricks.com/sql/user/security/access-control/alert-acl.html) have three possible permissions: `CAN_VIEW`, `CAN_RUN` and `CAN_MANAGE`:
+[SQL alerts](https://docs.databricks.com/sql/user/security/access-control/alert-acl.html) have four possible permissions: `CAN_VIEW`, `CAN_RUN`, `CAN_MANAGE` and `IS_OWNER`:
+
+- The creator of a SQL Alert has implicit `IS_OWNER` permission.
+- A SQL Alert must have exactly one owner.  A SQL Alert cannot have a group as an owner.
+- If `IS_OWNER` was set explicitly, it won't be reverted back when resource is destroyed because information about creator isn't persisted.
 
 ```hcl
 resource "databricks_group" "auto" {

--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -1796,14 +1796,22 @@ func TestImportingSqlObjects(t *testing.T) {
 				ReuseRequest: true,
 			},
 			{
-				Method:   "GET",
-				Resource: "/api/2.0/preview/sql/alerts/3cf91a42-6217-4f3c-a6f0-345d489051b9?",
-				Response: getJSONObject("test-data/get-sql-alert.json"),
+				Method:       "GET",
+				Resource:     "/api/2.0/preview/sql/alerts/3cf91a42-6217-4f3c-a6f0-345d489051b9?",
+				Response:     getJSONObject("test-data/get-sql-alert.json"),
+				ReuseRequest: true,
 			},
 			{
-				Method:   "GET",
-				Resource: "/api/2.0/preview/sql/permissions/alerts/3cf91a42-6217-4f3c-a6f0-345d489051b9",
-				Response: getJSONObject("test-data/get-sql-alert-permissions.json"),
+				Method:       "GET",
+				Resource:     "/api/2.0/preview/sql/alerts/3cf91a42-6217-4f3c-a6f0-345d489051b9",
+				Response:     getJSONObject("test-data/get-sql-alert.json"),
+				ReuseRequest: true,
+			},
+			{
+				Method:       "GET",
+				Resource:     "/api/2.0/preview/sql/permissions/alerts/3cf91a42-6217-4f3c-a6f0-345d489051b9",
+				Response:     getJSONObject("test-data/get-sql-alert-permissions.json"),
+				ReuseRequest: true,
 			},
 		},
 		func(ctx context.Context, client *common.DatabricksClient) {


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

Default permissions API for SQL Alerts/Dashboards/Queries doesn't have `IS_OWNER` permission. Instead, there is a separate [REST API](https://docs.databricks.com/api/workspace/dbsqlpermissions/transferownership) to change ownership of the objects.

This PR implements the following things:

* Adds `IS_OWNER` permission for SQL Alerts/Dashboards/Queries by using a separate REST API
* It also fixes the previously existing issue with setting permissions for SQL Alerts/Dashboards/Queries for service principals. The current implementation has a problem with permanent drift because the [corresponding API](https://docs.databricks.com/api/workspace/dbsqlpermissions/set) doesn't have a setting for service principals, and it uses `user_name` instead.  The code now correctly rewrites SP -> user when setting permissions and user -> SP when reading permissions back.
* 
## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

