### PR TITLE
Allow updating owner of `databricks_connection`

### DIFF
--- a/catalog/resource_connection_test.go
+++ b/catalog/resource_connection_test.go
@@ -64,6 +64,49 @@ func TestConnectionsCreate(t *testing.T) {
 					},
 				},
 			},
+			{
+				Method:   http.MethodPatch,
+				Resource: "/api/2.1/unity-catalog/connections/testConnectionName",
+				ExpectedRequest: catalog.UpdateConnection{
+					Name: "testConnectionName",
+					Options: map[string]string{
+						"host": "test.com",
+					},
+					Owner: "InitialOwner",
+				},
+				Response: catalog.ConnectionInfo{
+					Name:           "testConnectionName",
+					ConnectionType: catalog.ConnectionType("testConnectionType"),
+					Comment:        "This is a test comment.",
+					FullName:       "testConnectionName",
+					MetastoreId:    "abc",
+					Owner:          "InitialOwner",
+					Options: map[string]string{
+						"host": "test.com",
+					},
+					Properties: map[string]string{
+						"purpose": "testing",
+					},
+				},
+			},
+			{
+				Method:   http.MethodGet,
+				Resource: "/api/2.1/unity-catalog/connections/testConnectionName?",
+				Response: catalog.ConnectionInfo{
+					Name:           "testConnectionName",
+					ConnectionType: catalog.ConnectionType("testConnectionType"),
+					Comment:        "This is a test comment.",
+					FullName:       "testConnectionName",
+					Owner:          "InitialOwner",
+					MetastoreId:    "abc",
+					Options: map[string]string{
+						"host": "test.com",
+					},
+					Properties: map[string]string{
+						"purpose": "testing",
+					},
+				},
+			},
 		},
 		Resource: ResourceConnection(),
 		Create:   true,

--- a/catalog/resource_connection_test.go
+++ b/catalog/resource_connection_test.go
@@ -226,7 +226,7 @@ func TestConnectionRead_Error(t *testing.T) {
 }
 
 func TestConnectionsUpdate(t *testing.T) {
-	d, err := qa.ResourceFixture{
+	qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   http.MethodGet,
@@ -242,13 +242,13 @@ func TestConnectionsUpdate(t *testing.T) {
 				Method:   http.MethodPatch,
 				Resource: "/api/2.1/unity-catalog/connections/testConnectionName",
 				ExpectedRequest: catalog.UpdateConnection{
-					Name: "testConnectionNameNew",
+					Name: "testConnectionName",
 					Options: map[string]string{
 						"host": "test.com",
 					},
 				},
 				Response: catalog.ConnectionInfo{
-					Name:           "testConnectionNameNew",
+					Name:           "testConnectionName",
 					ConnectionType: catalog.ConnectionType("testConnectionType"),
 					Comment:        "testComment",
 					MetastoreId:    "abc",
@@ -259,9 +259,9 @@ func TestConnectionsUpdate(t *testing.T) {
 			},
 			{
 				Method:   http.MethodGet,
-				Resource: "/api/2.1/unity-catalog/connections/testConnectionNameNew?",
+				Resource: "/api/2.1/unity-catalog/connections/testConnectionName?",
 				Response: catalog.ConnectionInfo{
-					Name:           "testConnectionNameNew",
+					Name:           "testConnectionName",
 					ConnectionType: catalog.ConnectionType("testConnectionType"),
 					Comment:        "testComment",
 					MetastoreId:    "abc",
@@ -279,18 +279,108 @@ func TestConnectionsUpdate(t *testing.T) {
 			"comment":         "testComment",
 		},
 		HCL: `
-		name = "testConnectionNameNew"
+		name = "testConnectionName"
 		connection_type = "testConnectionType"
 		comment = "testComment"
 		options = {
 			host     = "test.com"
 		}
 		`,
-	}.Apply(t)
-	assert.NoError(t, err)
-	assert.Equal(t, "testConnectionNameNew", d.Get("name"))
-	assert.Equal(t, "testConnectionType", d.Get("connection_type"))
-	assert.Equal(t, "testComment", d.Get("comment"))
+	}.ApplyAndExpectData(t, map[string]any{
+		"name":            "testConnectionName",
+		"connection_type": "testConnectionType",
+		"comment":         "testComment",
+	})
+}
+
+func TestConnectionsUpdateOwnerAndOtherFields(t *testing.T) {
+	qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   http.MethodGet,
+				Resource: "/api/2.1/unity-catalog/connections/testConnectionName?",
+				Response: catalog.ConnectionInfo{
+					Name:           "testConnectionName",
+					ConnectionType: catalog.ConnectionType("testConnectionType"),
+					MetastoreId:    "abc",
+					Comment:        "testComment",
+				},
+			},
+			{
+				Method:   http.MethodPatch,
+				Resource: "/api/2.1/unity-catalog/connections/testConnectionName",
+				ExpectedRequest: catalog.UpdateConnection{
+					Name:  "testConnectionName",
+					Owner: "admin",
+				},
+				Response: catalog.ConnectionInfo{
+					Name:           "testConnectionName",
+					ConnectionType: catalog.ConnectionType("testConnectionType"),
+					Comment:        "testComment",
+					MetastoreId:    "abc",
+					Options: map[string]string{
+						"host": "test.com",
+					},
+					Owner: "admin",
+				},
+			},
+			{
+				Method:   http.MethodPatch,
+				Resource: "/api/2.1/unity-catalog/connections/testConnectionName",
+				ExpectedRequest: catalog.UpdateConnection{
+					Name: "testConnectionName",
+					Options: map[string]string{
+						"host": "test.com",
+					},
+				},
+				Response: catalog.ConnectionInfo{
+					Name:           "testConnectionName",
+					ConnectionType: catalog.ConnectionType("testConnectionType"),
+					Comment:        "testComment",
+					MetastoreId:    "abc",
+					Options: map[string]string{
+						"host": "test.com",
+					},
+					Owner: "admin",
+				},
+			},
+			{
+				Method:   http.MethodGet,
+				Resource: "/api/2.1/unity-catalog/connections/testConnectionName?",
+				Response: catalog.ConnectionInfo{
+					Name:           "testConnectionName",
+					ConnectionType: catalog.ConnectionType("testConnectionType"),
+					Comment:        "testComment",
+					MetastoreId:    "abc",
+					Options: map[string]string{
+						"host": "test.com",
+					},
+					Owner: "admin",
+				},
+			},
+		},
+		Resource: ResourceConnection(),
+		Update:   true,
+		ID:       "abc|testConnectionName",
+		InstanceState: map[string]string{
+			"connection_type": "testConnectionType",
+			"comment":         "testComment",
+		},
+		HCL: `
+		name = "testConnectionName"
+		connection_type = "testConnectionType"
+		comment = "testComment"
+		options = {
+			host     = "test.com"
+		}
+		owner = "admin"
+		`,
+	}.ApplyAndExpectData(t, map[string]any{
+		"name":            "testConnectionName",
+		"connection_type": "testConnectionType",
+		"comment":         "testComment",
+		"owner":           "admin",
+	})
 }
 
 func TestConnectionUpdate_Error(t *testing.T) {
@@ -300,7 +390,7 @@ func TestConnectionUpdate_Error(t *testing.T) {
 				Method:   http.MethodPatch,
 				Resource: "/api/2.1/unity-catalog/connections/testConnectionName",
 				ExpectedRequest: catalog.UpdateConnection{
-					Name: "testConnectionNameNew",
+					Name: "testConnectionName",
 					Options: map[string]string{
 						"host": "test.com",
 					},
@@ -320,7 +410,7 @@ func TestConnectionUpdate_Error(t *testing.T) {
 			"comment":         "testComment",
 		},
 		HCL: `
-		name = "testConnectionNameNew"
+		name = "testConnectionName"
 		connection_type = "testConnectionType"
 		options = {
 			host     = "test.com"

--- a/internal/acceptance/connection_test.go
+++ b/internal/acceptance/connection_test.go
@@ -1,22 +1,32 @@
 package acceptance
 
 import (
+	"fmt"
 	"testing"
 )
 
+func connectionTemplateWithOwner(host string, owner string) string {
+	return fmt.Sprintf(`
+	resource "databricks_connection" "this" {
+		name = "name-{var.STICKY_RANDOM}"
+		connection_type = "MYSQL"
+		comment         = "this is a connection to mysql db"
+		options         = {
+			host     = %s
+			port     = "3306"
+			user     = "user"
+			password = "password"
+		}
+		owner = %s
+	}
+	`, host, owner)
+}
 func TestUcAccConnectionsResourceFullLifecycle(t *testing.T) {
 	unityWorkspaceLevel(t, step{
-		Template: `
-		resource "databricks_connection" "this" {
-			name = "name-{var.STICKY_RANDOM}"
-			connection_type = "MYSQL"
-			comment         = "this is a connection to mysql db"
-			options         = {
-				host     = "test.mysql.database.azure.com"
-				port     = "3306"
-				user     = "user"
-				password = "password"
-			}
-		}`,
+		Template: connectionTemplateWithOwner("test.mysql.database.azure.com", "account users"),
+	}, step{
+		Template: connectionTemplateWithOwner("test.mysql.database.aws.com", "account users"),
+	}, step{
+		Template: connectionTemplateWithOwner("test.mysql.database.azure.com", "{env.TEST_METASTORE_ADMIN_GROUP_NAME}"),
 	})
 }

--- a/internal/acceptance/connection_test.go
+++ b/internal/acceptance/connection_test.go
@@ -12,12 +12,12 @@ func connectionTemplateWithOwner(host string, owner string) string {
 		connection_type = "MYSQL"
 		comment         = "this is a connection to mysql db"
 		options         = {
-			host     = %s
+			host     = "%s"
 			port     = "3306"
 			user     = "user"
 			password = "password"
 		}
-		owner = %s
+		owner = "%s"
 	}
 	`, host, owner)
 }


### PR DESCRIPTION
## Changes
- Allow updating owner of `databricks_connection`, now that the API supports it
- Add `GoogleServiceAccountKeyJson` to list of secret options that are redacted by API

Closes #3079 

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [x] covered with integration tests in `internal/acceptance`
- [x] relevant acceptance tests are passing
- [x] using Go SDK

