### PR TITLE
add `skip_validation` to `databricks_storage_credential`

### DIFF
--- a/catalog/resource_metastore_data_access.go
+++ b/catalog/resource_metastore_data_access.go
@@ -53,6 +53,10 @@ func adjustDataAccessSchema(m map[string]*schema.Schema) map[string]*schema.Sche
 		Optional: true,
 	}
 
+	m["skip_validation"].DiffSuppressFunc = func(k, old, new string, d *schema.ResourceData) bool {
+		return old == "false" && new == "true"
+	}
+
 	return m
 }
 

--- a/catalog/resource_storage_credential.go
+++ b/catalog/resource_storage_credential.go
@@ -20,6 +20,7 @@ type StorageCredentialInfo struct {
 	DatabricksGcpServiceAccount *catalog.DatabricksGcpServiceAccountResponse `json:"databricks_gcp_service_account,omitempty" tf:"computed"`
 	MetastoreID                 string                                       `json:"metastore_id,omitempty" tf:"computed"`
 	ReadOnly                    bool                                         `json:"read_only,omitempty"`
+	SkipValidation              bool                                         `json:"skip_validation,omitempty"`
 }
 
 func removeGcpSaField(originalSchema map[string]*schema.Schema) map[string]*schema.Schema {

--- a/docs/resources/external_location.md
+++ b/docs/resources/external_location.md
@@ -134,7 +134,7 @@ The following arguments are required:
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - ID of this external location - same as `name`.
+- `id` - ID of this external location - same as `name`.
 
 ## Import
 

--- a/docs/resources/storage_credential.md
+++ b/docs/resources/storage_credential.md
@@ -77,6 +77,7 @@ The following arguments are required:
 - `metastore_id` - (Required for account-level) Unique identifier of the parent Metastore. If set for workspace-level, it must match the ID of the metastore assigned to the worspace. When changing the metastore assigned to a workspace, this field becomes required.
 - `owner` - (Optional) Username/groupname/sp application_id of the storage credential owner.
 - `read_only` - (Optional) Indicates whether the storage credential is only usable for read operations.
+- `skip_validation` - (Optional) Suppress validation errors if any & force save the storage credential.
 - `force_destroy` - (Optional) Delete storage credential regardless of its dependencies.
 
 `aws_iam_role` optional configuration block for credential details for AWS:

--- a/internal/acceptance/storage_credential_test.go
+++ b/internal/acceptance/storage_credential_test.go
@@ -16,17 +16,6 @@ func TestUcAccStorageCredential(t *testing.T) {
 					aws_iam_role {
 						role_arn = "{env.TEST_METASTORE_DATA_ACCESS_ARN}"
 					}
-					comment = "Managed by TF"
-				}`,
-		})
-	case "azure":
-		unityWorkspaceLevel(t, step{
-			Template: `
-				resource "databricks_storage_credential" "external" {
-					name = "cred-{var.RANDOM}"
-					azure_managed_identity {
-						access_connector_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-name/providers/Microsoft.Databricks/accessConnectors/connector-name"
-					}
 					skip_validation = true
 					comment = "Managed by TF"
 				}`,
@@ -37,6 +26,7 @@ func TestUcAccStorageCredential(t *testing.T) {
 				resource "databricks_storage_credential" "external" {
 					name = "cred-{var.RANDOM}"
 					databricks_gcp_service_account {}
+					skip_validation = true
 					comment = "Managed by TF"
 				}`,
 		})

--- a/internal/acceptance/storage_credential_test.go
+++ b/internal/acceptance/storage_credential_test.go
@@ -1,0 +1,44 @@
+package acceptance
+
+import (
+	"os"
+	"testing"
+)
+
+func TestUcAccStorageCredential(t *testing.T) {
+	cloudEnv := os.Getenv("CLOUD_ENV")
+	switch cloudEnv {
+	case "ucws":
+		unityWorkspaceLevel(t, step{
+			Template: `
+				resource "databricks_storage_credential" "external" {
+					name = "cred-{var.RANDOM}"
+					aws_iam_role {
+						role_arn = "{env.TEST_METASTORE_DATA_ACCESS_ARN}"
+					}
+					comment = "Managed by TF"
+				}`,
+		})
+	case "azure":
+		unityWorkspaceLevel(t, step{
+			Template: `
+				resource "databricks_storage_credential" "external" {
+					name = "cred-{var.RANDOM}"
+					azure_managed_identity {
+						access_connector_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-name/providers/Microsoft.Databricks/accessConnectors/connector-name"
+					}
+					skip_validation = true
+					comment = "Managed by TF"
+				}`,
+		})
+	case "gcp-ucws":
+		unityWorkspaceLevel(t, step{
+			Template: `
+				resource "databricks_storage_credential" "external" {
+					name = "cred-{var.RANDOM}"
+					databricks_gcp_service_account {}
+					comment = "Managed by TF"
+				}`,
+		})
+	}
+}


### PR DESCRIPTION
## Changes
- Add `skip_validation` parameter to `databricks_storage_credential`
- Add integration tests for other clouds

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [x] covered with integration tests in `internal/acceptance`
- [x] relevant acceptance tests are passing
- [x] using Go SDK

