### PR TITLE
Docs: use tasks in the `databricks_job` examples

### DIFF
--- a/docs/data-sources/current_user.md
+++ b/docs/data-sources/current_user.md
@@ -31,14 +31,18 @@ resource "databricks_notebook" "this" {
 resource "databricks_job" "this" {
   name = "Terraform Demo (${data.databricks_current_user.me.alphanumeric})"
 
-  new_cluster {
-    num_workers   = 1
-    spark_version = data.databricks_spark_version.latest.id
-    node_type_id  = data.databricks_node_type.smallest.id
-  }
+  task {
+    task_key = "task1"
 
-  notebook_task {
-    notebook_path = databricks_notebook.this.path
+    new_cluster {
+      num_workers   = 1
+      spark_version = data.databricks_spark_version.latest.id
+      node_type_id  = data.databricks_node_type.smallest.id
+    }
+
+    notebook_task {
+      notebook_path = databricks_notebook.this.path
+    }
   }
 }
 

--- a/docs/guides/unity-catalog-azure.md
+++ b/docs/guides/unity-catalog-azure.md
@@ -204,7 +204,7 @@ Each metastore exposes a 3-level namespace (catalog-schema-table) by which data 
 
 ```hcl
 resource "databricks_catalog" "sandbox" {
-  name         = "sandbox"
+  name = "sandbox"
   storage_root = format("abfss://%s@%s.dfs.core.windows.net",
     azurerm_storage_container.ext_storage.name,
   azurerm_storage_account.ext_storage.name)

--- a/docs/guides/workspace-management.md
+++ b/docs/guides/workspace-management.md
@@ -57,14 +57,18 @@ resource "databricks_notebook" "this" {
 resource "databricks_job" "this" {
   name = "Terraform Demo (${data.databricks_current_user.me.alphanumeric})"
 
-  new_cluster {
-    num_workers   = 1
-    spark_version = data.databricks_spark_version.latest.id
-    node_type_id  = data.databricks_node_type.smallest.id
-  }
+  task {
+    task_key = "task1"
 
-  notebook_task {
-    notebook_path = databricks_notebook.this.path
+    new_cluster {
+      num_workers   = 1
+      spark_version = data.databricks_spark_version.latest.id
+      node_type_id  = data.databricks_node_type.smallest.id
+    }
+
+    notebook_task {
+      notebook_path = databricks_notebook.this.path
+    }
   }
 }
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -84,14 +84,18 @@ resource "databricks_notebook" "this" {
 resource "databricks_job" "this" {
   name = "Terraform Demo (${data.databricks_current_user.me.alphanumeric})"
 
-  new_cluster {
-    num_workers   = 1
-    spark_version = data.databricks_spark_version.latest.id
-    node_type_id  = data.databricks_node_type.smallest.id
-  }
+  task {
+    task_key = "task1"
 
-  notebook_task {
-    notebook_path = databricks_notebook.this.path
+    notebook_task {
+      notebook_path = databricks_notebook.this.path
+    }
+
+    new_cluster {
+      num_workers   = 1
+      spark_version = data.databricks_spark_version.latest.id
+      node_type_id  = data.databricks_node_type.smallest.id
+    }
   }
 }
 

--- a/docs/resources/catalog.md
+++ b/docs/resources/catalog.md
@@ -13,8 +13,8 @@ A `databricks_catalog` is contained within [databricks_metastore](metastore.md) 
 
 ```hcl
 resource "databricks_catalog" "sandbox" {
-  name         = "sandbox"
-  comment      = "this catalog is managed by terraform"
+  name    = "sandbox"
+  comment = "this catalog is managed by terraform"
   properties = {
     purpose = "testing"
   }

--- a/docs/resources/grants.md
+++ b/docs/resources/grants.md
@@ -54,8 +54,8 @@ You can grant `ALL_PRIVILEGES`, `APPLY_TAG`, `CREATE_CONNECTION`, `CREATE_SCHEMA
 
 ```hcl
 resource "databricks_catalog" "sandbox" {
-  name         = "sandbox"
-  comment      = "this catalog is managed by terraform"
+  name    = "sandbox"
+  comment = "this catalog is managed by terraform"
   properties = {
     purpose = "testing"
   }

--- a/docs/resources/mlflow_webhook.md
+++ b/docs/resources/mlflow_webhook.md
@@ -32,14 +32,18 @@ resource "databricks_notebook" "this" {
 resource "databricks_job" "this" {
   name = "Terraform MLflowWebhook Demo (${data.databricks_current_user.me.alphanumeric})"
 
-  new_cluster {
-    num_workers   = 1
-    spark_version = data.databricks_spark_version.latest.id
-    node_type_id  = data.databricks_node_type.smallest.id
-  }
+  task {
+    task_key = "task1"
 
-  notebook_task {
-    notebook_path = databricks_notebook.this.path
+    new_cluster {
+      num_workers   = 1
+      spark_version = data.databricks_spark_version.latest.id
+      node_type_id  = data.databricks_node_type.smallest.id
+    }
+
+    notebook_task {
+      notebook_path = databricks_notebook.this.path
+    }
   }
 }
 

--- a/docs/resources/permissions.md
+++ b/docs/resources/permissions.md
@@ -181,14 +181,18 @@ resource "databricks_job" "this" {
   name                = "Featurization"
   max_concurrent_runs = 1
 
-  new_cluster {
-    num_workers   = 300
-    spark_version = data.databricks_spark_version.latest.id
-    node_type_id  = data.databricks_node_type.smallest.id
-  }
+  task {
+    task_key = "task1"
 
-  notebook_task {
-    notebook_path = "/Production/MakeFeatures"
+    new_cluster {
+      num_workers   = 300
+      spark_version = data.databricks_spark_version.latest.id
+      node_type_id  = data.databricks_node_type.smallest.id
+    }
+
+    notebook_task {
+      notebook_path = "/Production/MakeFeatures"
+    }
   }
 }
 

--- a/docs/resources/schema.md
+++ b/docs/resources/schema.md
@@ -13,8 +13,8 @@ A `databricks_schema` is contained within [databricks_catalog](catalog.md) and c
 
 ```hcl
 resource "databricks_catalog" "sandbox" {
-  name         = "sandbox"
-  comment      = "this catalog is managed by terraform"
+  name    = "sandbox"
+  comment = "this catalog is managed by terraform"
   properties = {
     purpose = "testing"
   }

--- a/docs/resources/sql_table.md
+++ b/docs/resources/sql_table.md
@@ -13,8 +13,8 @@ This resource creates and updates the Unity Catalog table/view by executing the 
 
 ```hcl
 resource "databricks_catalog" "sandbox" {
-  name         = "sandbox"
-  comment      = "this catalog is managed by terraform"
+  name    = "sandbox"
+  comment = "this catalog is managed by terraform"
   properties = {
     purpose = "testing"
   }

--- a/docs/resources/volume.md
+++ b/docs/resources/volume.md
@@ -37,8 +37,8 @@ This resource manages Volumes in Unity Catalog.
 
 ```hcl
 resource "databricks_catalog" "sandbox" {
-  name         = "sandbox"
-  comment      = "this catalog is managed by terraform"
+  name    = "sandbox"
+  comment = "this catalog is managed by terraform"
   properties = {
     purpose = "testing"
   }


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

We had a number of places, including the main page, where we used old way of tasks specification instead of using `task` blocks, and that generated deprecation warning. This PR fixes that.

Also run `make fmt-docs` to format Terraform code examples.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

