### PR TITLE
Use diffSuppressor instead of makeEmptyBlockSuppressFunc

### DIFF
--- a/common/reflect_resource.go
+++ b/common/reflect_resource.go
@@ -88,7 +88,7 @@ func StructToSchema(v any, customize func(map[string]*schema.Schema) map[string]
 // fields for which the platform returns a value, but the user has not configured any value.
 // For example: the REST API returns `{"tags": {}}` for a resource with no tags.
 func SetSuppressDiff(v *schema.Schema) {
-	v.DiffSuppressFunc = diffSuppressor(fmt.Sprintf("%v", v.Type.Zero()))
+	v.DiffSuppressFunc = diffSuppressor(v)
 }
 
 // SetDefault sets the default value for a schema.
@@ -170,7 +170,7 @@ func handleSuppressDiff(typeField reflect.StructField, v *schema.Schema) {
 	tfTags := strings.Split(typeField.Tag.Get("tf"), ",")
 	for _, tag := range tfTags {
 		if tag == "suppress_diff" {
-			v.DiffSuppressFunc = diffSuppressor(fmt.Sprintf("%v", v.Type.Zero()))
+			v.DiffSuppressFunc = diffSuppressor(v)
 			break
 		}
 	}
@@ -200,7 +200,8 @@ func chooseFieldName(typeField reflect.StructField) string {
 	return strings.Split(jsonTag, ",")[0]
 }
 
-func diffSuppressor(zero string) func(k, old, new string, d *schema.ResourceData) bool {
+func diffSuppressor(v *schema.Schema) func(k, old, new string, d *schema.ResourceData) bool {
+	zero := fmt.Sprintf("%v", v.Type.Zero())
 	return func(k, old, new string, d *schema.ResourceData) bool {
 		if new == zero && old != zero {
 			log.Printf("[DEBUG] Suppressing diff for %v: platform=%#v config=%#v", k, old, new)
@@ -319,10 +320,10 @@ func typeToSchema(v reflect.Value, path []string) map[string]*schema.Schema {
 			sv := reflect.New(elem).Elem()
 			nestedSchema := typeToSchema(sv, append(path, fieldName, "0"))
 			if strings.Contains(tfTag, "suppress_diff") {
-				scm[fieldName].DiffSuppressFunc = diffSuppressor(fmt.Sprintf("%v", scm[fieldName].Type.Zero()))
+				scm[fieldName].DiffSuppressFunc = diffSuppressor(scm[fieldName])
 				for _, v := range nestedSchema {
 					// to those relatively new to GoLang: we must explicitly pass down v by copy
-					v.DiffSuppressFunc = diffSuppressor(fmt.Sprintf("%v", v.Type.Zero()))
+					v.DiffSuppressFunc = diffSuppressor(v)
 				}
 			}
 			scm[fieldName].Elem = &schema.Resource{
@@ -337,10 +338,10 @@ func typeToSchema(v reflect.Value, path []string) map[string]*schema.Schema {
 
 			nestedSchema := typeToSchema(sv, append(path, fieldName, "0"))
 			if strings.Contains(tfTag, "suppress_diff") {
-				scm[fieldName].DiffSuppressFunc = diffSuppressor(fmt.Sprintf("%v", scm[fieldName].Type.Zero()))
+				scm[fieldName].DiffSuppressFunc = diffSuppressor(scm[fieldName])
 				for _, v := range nestedSchema {
 					// to those relatively new to GoLang: we must explicitly pass down v by copy
-					v.DiffSuppressFunc = diffSuppressor(fmt.Sprintf("%v", v.Type.Zero()))
+					v.DiffSuppressFunc = diffSuppressor(v)
 				}
 			}
 			scm[fieldName].Elem = &schema.Resource{

--- a/common/reflect_resource.go
+++ b/common/reflect_resource.go
@@ -319,8 +319,7 @@ func typeToSchema(v reflect.Value, path []string) map[string]*schema.Schema {
 			sv := reflect.New(elem).Elem()
 			nestedSchema := typeToSchema(sv, append(path, fieldName, "0"))
 			if strings.Contains(tfTag, "suppress_diff") {
-				blockCount := strings.Join(append(path, fieldName, "#"), ".")
-				scm[fieldName].DiffSuppressFunc = makeEmptyBlockSuppressFunc(blockCount)
+				scm[fieldName].DiffSuppressFunc = diffSuppressor(fmt.Sprintf("%v", scm[fieldName].Type.Zero()))
 				for _, v := range nestedSchema {
 					// to those relatively new to GoLang: we must explicitly pass down v by copy
 					v.DiffSuppressFunc = diffSuppressor(fmt.Sprintf("%v", v.Type.Zero()))
@@ -338,8 +337,7 @@ func typeToSchema(v reflect.Value, path []string) map[string]*schema.Schema {
 
 			nestedSchema := typeToSchema(sv, append(path, fieldName, "0"))
 			if strings.Contains(tfTag, "suppress_diff") {
-				blockCount := strings.Join(append(path, fieldName, "#"), ".")
-				scm[fieldName].DiffSuppressFunc = makeEmptyBlockSuppressFunc(blockCount)
+				scm[fieldName].DiffSuppressFunc = diffSuppressor(fmt.Sprintf("%v", scm[fieldName].Type.Zero()))
 				for _, v := range nestedSchema {
 					// to those relatively new to GoLang: we must explicitly pass down v by copy
 					v.DiffSuppressFunc = diffSuppressor(fmt.Sprintf("%v", v.Type.Zero()))

--- a/common/reflect_resource_test.go
+++ b/common/reflect_resource_test.go
@@ -424,7 +424,10 @@ func TestStructToData(t *testing.T) {
 }
 
 func TestDiffSuppressor(t *testing.T) {
-	dsf := diffSuppressor("")
+	stringSchema := &schema.Schema{
+		Type: schema.TypeString,
+	}
+	dsf := diffSuppressor(stringSchema)
 	d := schema.TestResourceDataRaw(t, map[string]*schema.Schema{
 		"foo": {
 			Type:     schema.TypeBool,

--- a/common/resource.go
+++ b/common/resource.go
@@ -198,17 +198,6 @@ func MustCompileKeyRE(name string) *regexp.Regexp {
 	return regexp.MustCompile(regexFromName)
 }
 
-func makeEmptyBlockSuppressFunc(name string) func(k, old, new string, d *schema.ResourceData) bool {
-	re := MustCompileKeyRE(name)
-	return func(k, old, new string, d *schema.ResourceData) bool {
-		if re.Match([]byte(name)) && old == "1" && new == "0" {
-			log.Printf("[DEBUG] Suppressing diff for name=%s k=%#v platform=%#v config=%#v", name, k, old, new)
-			return true
-		}
-		return false
-	}
-}
-
 // Deprecated: migrate to WorkspaceData
 func DataResource(sc any, read func(context.Context, any, *DatabricksClient) error) *schema.Resource {
 	// TODO: migrate to go1.18 and get schema from second function argument?..


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
- As introduced in this PR, we don't have to use `makeEmptyBlockSuppressFunc` any more, simplifying this so that we can remove `makeEmptyBlockSuppressFunc`
- Meanwhile modified the signature of `diffSuppressor` to take in the schema type so we don't have to use `Sprintf` every time we call this


## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [x] covered with integration tests in `internal/acceptance`
- [x] relevant acceptance tests are passing
- [ ] using Go SDK

