### PR TITLE
Docs: Remove `data_object_type=TABLE` only restriction in `databricks_share`

### DIFF
--- a/docs/resources/share.md
+++ b/docs/resources/share.md
@@ -88,7 +88,7 @@ The following arguments are required:
 ### object Configuration Block
 
 * `name` (Required) - Full name of the object, e.g. `catalog.schema.name` for a table.
-* `data_object_type` (Required) - Type of the data object.
+* `data_object_type` (Required) - Type of the data object, currently `TABLE`, `SCHEMA`, `VOLUME`, `NOTEBOOK_FILE` are supported.
 * `comment` (Optional) -  Description about the object.
 * `shared_as` (Optional) - A user-provided new name for the data object within the share. If this new name is not provided, the object's original name will be used as the `shared_as` name. The `shared_as` name must be unique within a Share. Change forces creation of a new resource.
 * `cdf_enabled` (Optional) - Whether to enable Change Data Feed (cdf) on the shared object. When this field is set, field `history_data_sharing_status` can not be set.

--- a/docs/resources/share.md
+++ b/docs/resources/share.md
@@ -33,6 +33,19 @@ resource "databricks_share" "some" {
 }
 ```
 
+Creating a Delta Sharing share and add a schema to it(including all current and future tables).
+
+```hcl
+resource "databricks_share" "schema_share" {
+    name = "schema_share"
+    object {
+        name = "catalog_name.schema_name"
+        data_object_type = "SCHEMA"
+        history_data_sharing_status = "ENABLED"
+    }
+}
+```
+
 Creating a Delta Sharing share and share a table with partitions spec and history
 
 ```hcl

--- a/docs/resources/share.md
+++ b/docs/resources/share.md
@@ -75,7 +75,7 @@ The following arguments are required:
 ### object Configuration Block
 
 * `name` (Required) - Full name of the object, e.g. `catalog.schema.name` for a table.
-* `data_object_type` (Required) - Type of the object.
+* `data_object_type` (Required) - Type of the data object.
 * `comment` (Optional) -  Description about the object.
 * `shared_as` (Optional) - A user-provided new name for the data object within the share. If this new name is not provided, the object's original name will be used as the `shared_as` name. The `shared_as` name must be unique within a Share. Change forces creation of a new resource.
 * `cdf_enabled` (Optional) - Whether to enable Change Data Feed (cdf) on the shared object. When this field is set, field `history_data_sharing_status` can not be set.

--- a/docs/resources/share.md
+++ b/docs/resources/share.md
@@ -75,7 +75,7 @@ The following arguments are required:
 ### object Configuration Block
 
 * `name` (Required) - Full name of the object, e.g. `catalog.schema.name` for a table.
-* `data_object_type` (Required) - Type of the object, currently only `TABLE` is allowed.
+* `data_object_type` (Required) - Type of the object.
 * `comment` (Optional) -  Description about the object.
 * `shared_as` (Optional) - A user-provided new name for the data object within the share. If this new name is not provided, the object's original name will be used as the `shared_as` name. The `shared_as` name must be unique within a Share. Change forces creation of a new resource.
 * `cdf_enabled` (Optional) - Whether to enable Change Data Feed (cdf) on the shared object. When this field is set, field `history_data_sharing_status` can not be set.


### PR DESCRIPTION
## Changes
In UI/API/CLI, creating share at the SCHEMA level is supported, but the doc mentions only TABLE is supported.
The doc(data_object_type field) was last updated on oct-2022.
https://github.com/databricks/databricks-cli/blob/main/databricks_cli/unity_catalog/delta_sharing_cli.py#L213

Updating TF doc to match REST API doc.
https://docs.databricks.com/api/workspace/shares/create#:~:text=The%20type%20of%20the%20data%20object.

## Tests
- Created a share in TF using `data_object_type=SCHEMA`
- Created new tables in the schema, which are automatically added to the share.
```
resource "databricks_share" "ravi-share-tf" {
  name = "ravi-share-tf"
  object {
    name                        = "ravi_test_catalog.share_schema"
    data_object_type            = "SCHEMA"
    history_data_sharing_status = "ENABLED"
  }
}
```

- [ ] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
