### PR TITLE
WIP: Exporter: Fix exporting of `parent` attribute for SQL objects

### DIFF
--- a/exporter/context.go
+++ b/exporter/context.go
@@ -810,6 +810,10 @@ func (ic *importContext) ResourceName(r *resource) string {
 	return name
 }
 
+func (ic *importContext) isServiceEnabled(service string) bool {
+	return strings.Contains(ic.services, service)
+}
+
 func (ic *importContext) Emit(r *resource) {
 	// TODO: change into channels, if stack trace depth issues would surface
 	_, v := r.MatchPair()
@@ -846,8 +850,8 @@ func (ic *importContext) Emit(r *resource) {
 	}
 	// TODO: add similar condition for checking workspace-level objects only. After new ACLs import is merged
 
-	// TODO: split services into slice?
-	if !strings.Contains(ic.services, ir.Service) {
+	// TODO: split services into slice?  Yes, otherwise it will be problematic with generic names like UC
+	if !ic.isServiceEnabled(ir.Service) {
 		log.Printf("[DEBUG] %s (%s service) is not part of the import", r.Resource, ir.Service)
 		return
 	}


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

There is an edge case when SQL object (dashboard/query/alert) is in the user home folder, not a subfolder - in this case instead of reference to a resource, we generated a reference to the data source, and because `parent` is marked as `ForceNew` it lead to SQL object recreation when importing existing SQL objects into the TF state.

The workaround is to check if the given parent folder is top-level user folder, and remove the `parent` because by default SQL object is put into home folder of the user.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

