### PR TITLE
Exporter: small refactoring

### DIFF
--- a/exporter/command.go
+++ b/exporter/command.go
@@ -117,7 +117,8 @@ func Run(args ...string) error {
 	flags.StringVar(&ic.notebooksFormat, "notebooksFormat", "SOURCE",
 		"Format to export notebooks: SOURCE, DBC, JUPYTER. Default: SOURCE")
 	services, listing := ic.allServicesAndListing()
-	flags.StringVar(&ic.services, "services", services,
+	var configuredServices string
+	flags.StringVar(&configuredServices, "services", services,
 		"Comma-separated list of services to import. By default all services are imported.")
 	flags.StringVar(&ic.listing, "listing", listing,
 		"Comma-separated list of services to be listed and further passed on for importing. "+
@@ -145,5 +146,6 @@ func Run(args ...string) error {
 	if ic.debug {
 		logLevel = append(logLevel, "[DEBUG]")
 	}
+	ic.services = strings.Split(configuredServices, ",")
 	return ic.Run()
 }

--- a/exporter/context_test.go
+++ b/exporter/context_test.go
@@ -104,7 +104,7 @@ func TestEmitNoSearchAvail(t *testing.T) {
 				Service: "e",
 			},
 		},
-		services:  "e",
+		services:  []string{"e"},
 		waitGroup: &sync.WaitGroup{},
 		channels: map[string]resourceChannel{
 			"a": ch,
@@ -140,7 +140,7 @@ func TestEmitNoSearchFails(t *testing.T) {
 				},
 			},
 		},
-		services:  "e",
+		services:  []string{"e"},
 		waitGroup: &sync.WaitGroup{},
 		channels: map[string]resourceChannel{
 			"a": ch,
@@ -176,7 +176,7 @@ func TestEmitNoSearchNoId(t *testing.T) {
 				},
 			},
 		},
-		services:  "e",
+		services:  []string{"e"},
 		waitGroup: &sync.WaitGroup{},
 		channels: map[string]resourceChannel{
 			"a": ch,
@@ -216,7 +216,7 @@ func TestEmitNoSearchSucceedsImportFails(t *testing.T) {
 				},
 			},
 		},
-		services:  "e",
+		services:  []string{"e"},
 		waitGroup: &sync.WaitGroup{},
 		channels: map[string]resourceChannel{
 			"a": ch,

--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -219,7 +219,7 @@ func TestImportingMounts(t *testing.T) {
 		}, func(ctx context.Context, client *common.DatabricksClient) {
 			ic := newImportContext(client)
 			ic.setClientsForTests()
-			ic.services = "mounts"
+			ic.services = []string{"mounts"}
 			ic.listing = "mounts"
 			ic.mounts = true
 
@@ -654,7 +654,7 @@ func TestImportingUsersGroupsSecretScopes(t *testing.T) {
 			ic := newImportContext(client)
 			ic.Directory = tmpDir
 			services, listing := ic.allServicesAndListing()
-			ic.services = services
+			ic.services = strings.Split(services, ",")
 			ic.listing = listing
 
 			err := ic.Run()
@@ -726,7 +726,7 @@ func TestImportingNoResourcesError(t *testing.T) {
 			ic.Directory = tmpDir
 			services, listing := ic.allServicesAndListing()
 			ic.listing = listing
-			ic.services = services
+			ic.services = strings.Split(services, ",")
 
 			err := ic.Run()
 			assert.EqualError(t, err, "no resources to import")
@@ -923,7 +923,7 @@ func TestImportingClusters(t *testing.T) {
 			ic := newImportContext(client)
 			ic.Directory = tmpDir
 			ic.listing = "compute"
-			ic.services = "access,users,policies,compute,secrets,groups,storage"
+			ic.services = []string{"access", "users", "policies", "compute", "secrets", "groups", "storage"}
 
 			err := ic.Run()
 			assert.NoError(t, err)
@@ -1125,7 +1125,7 @@ func TestImportingJobs_JobList(t *testing.T) {
 		},
 		func(ctx context.Context, client *common.DatabricksClient) {
 			ic := newImportContext(client)
-			ic.services = "jobs,access,storage,clusters,pools"
+			ic.services = []string{"jobs", "access", "storage", "clusters", "pools"}
 			ic.listing = "jobs"
 			ic.mounts = true
 			ic.meAdmin = true
@@ -1376,7 +1376,7 @@ func TestImportingJobs_JobListMultiTask(t *testing.T) {
 		},
 		func(ctx context.Context, client *common.DatabricksClient) {
 			ic := newImportContext(client)
-			ic.services = "jobs,access,storage,clusters,pools"
+			ic.services = []string{"jobs", "access", "storage", "clusters", "pools"}
 			ic.listing = "jobs"
 			ic.mounts = true
 			ic.meAdmin = true
@@ -1466,7 +1466,7 @@ func TestImportingSecrets(t *testing.T) {
 			ic.Directory = tmpDir
 			ic.listing = "secrets"
 			services, _ := ic.allServicesAndListing()
-			ic.services = services
+			ic.services = strings.Split(services, ",")
 			ic.generateDeclaration = true
 
 			err := ic.Run()
@@ -1532,7 +1532,7 @@ func TestImportingGlobalInitScripts(t *testing.T) {
 			ic.Directory = tmpDir
 			ic.listing = "workspace"
 			services, _ := ic.allServicesAndListing()
-			ic.services = services
+			ic.services = strings.Split(services, ",")
 			ic.generateDeclaration = true
 
 			err := ic.Run()
@@ -1637,7 +1637,7 @@ func TestImportingRepos(t *testing.T) {
 			ic := newImportContext(client)
 			ic.Directory = tmpDir
 			ic.listing = "repos"
-			ic.services = "repos"
+			ic.services = []string{"repos"}
 
 			err := ic.Run()
 			assert.NoError(t, err)
@@ -1708,7 +1708,7 @@ func TestImportingIPAccessLists(t *testing.T) {
 			ic := newImportContext(client)
 			ic.Directory = tmpDir
 			ic.listing = "workspace,access"
-			ic.services = "workspace,access"
+			ic.services = []string{"workspace", "access"}
 
 			err := ic.Run()
 			assert.NoError(t, err)
@@ -1844,7 +1844,7 @@ func TestImportingSqlObjects(t *testing.T) {
 			ic := newImportContext(client)
 			ic.Directory = tmpDir
 			ic.listing = "sql-dashboards,sql-queries,sql-endpoints,sql-alerts"
-			ic.services = "sql-dashboards,sql-queries,sql-alerts,sql-endpoints,access,notebooks"
+			ic.services = []string{"sql-dashboards", "sql-queries", "sql-alerts", "sql-endpoints", "access", "notebooks"}
 
 			err := ic.Run()
 			assert.NoError(t, err)
@@ -2023,7 +2023,7 @@ func TestImportingDLTPipelines(t *testing.T) {
 			ic := newImportContext(client)
 			ic.Directory = tmpDir
 			ic.listing = "dlt"
-			ic.services = "dlt,access,notebooks,users,repos,secrets"
+			ic.services = []string{"dlt", "access", "notebooks", "users", "repos", "secrets"}
 
 			err := ic.Run()
 			assert.NoError(t, err)
@@ -2081,7 +2081,7 @@ func TestImportingDLTPipelinesMatchingOnly(t *testing.T) {
 			ic.Directory = tmpDir
 			ic.match = "test"
 			ic.listing = "dlt"
-			ic.services = "dlt,access"
+			ic.services = []string{"dlt", "access"}
 
 			err := ic.Run()
 			assert.NoError(t, err)
@@ -2123,7 +2123,7 @@ func TestImportingGlobalSqlConfig(t *testing.T) {
 			ic := newImportContext(client)
 			ic.Directory = tmpDir
 			ic.listing = "sql-endpoints"
-			ic.services = "sql-endpoints"
+			ic.services = []string{"sql-endpoints"}
 
 			err := ic.Run()
 			assert.NoError(t, err)
@@ -2187,7 +2187,7 @@ func TestImportingNotebooksWorkspaceFiles(t *testing.T) {
 			ic := newImportContext(client)
 			ic.Directory = tmpDir
 			ic.listing = "notebooks"
-			ic.services = "notebooks"
+			ic.services = []string{"notebooks"}
 
 			err := ic.Run()
 			assert.NoError(t, err)
@@ -2238,7 +2238,7 @@ func TestImportingModelServing(t *testing.T) {
 			ic := newImportContext(client)
 			ic.Directory = tmpDir
 			ic.listing = "model-serving"
-			ic.services = "model-serving"
+			ic.services = []string{"model-serving"}
 
 			err := ic.Run()
 			assert.NoError(t, err)
@@ -2290,7 +2290,7 @@ func TestImportingMlfloweWebhooks(t *testing.T) {
 			ic := newImportContext(client)
 			ic.Directory = tmpDir
 			ic.listing = "mlflow-webhooks"
-			ic.services = "mlflow-webhooks"
+			ic.services = []string{"mlflow-webhooks"}
 
 			err := ic.Run()
 			assert.NoError(t, err)
@@ -2303,7 +2303,7 @@ func TestIncrementalErrors(t *testing.T) {
 		[]qa.HTTPFixture{},
 		func(ctx context.Context, client *common.DatabricksClient) {
 			ic := newImportContext(client)
-			ic.services = "model-serving"
+			ic.services = []string{"model-serving"}
 			ic.incremental = true
 
 			err := ic.Run()
@@ -2314,7 +2314,7 @@ func TestIncrementalErrors(t *testing.T) {
 		[]qa.HTTPFixture{},
 		func(ctx context.Context, client *common.DatabricksClient) {
 			ic := newImportContext(client)
-			ic.services = "model-serving"
+			ic.services = []string{"model-serving"}
 			ic.incremental = true
 			ic.updatedSinceStr = "aaa"
 
@@ -2422,7 +2422,7 @@ resource "databricks_pipeline" "def" {
 			ic := newImportContext(client)
 			ic.Directory = tmpDir
 			ic.listing = "dlt,mlflow-webhooks"
-			ic.services = "dlt,mlflow-webhooks"
+			ic.services = []string{"dlt", "mlflow-webhooks"}
 			ic.incremental = true
 			ic.updatedSinceStr = "2023-07-24T00:00:00Z"
 			ic.meAdmin = false
@@ -2485,7 +2485,7 @@ func TestImportingRunJobTask(t *testing.T) {
 			ic := newImportContext(client)
 			ic.Directory = tmpDir
 			ic.listing = "jobs"
-			ic.services = "jobs"
+			ic.services = []string{"jobs"}
 			ic.match = "runjobtask"
 
 			err := ic.Run()

--- a/exporter/importables.go
+++ b/exporter/importables.go
@@ -1540,16 +1540,7 @@ var resourcesMap map[string]importable = map[string]importable{
 					})
 				}
 			}
-			if query.Parent != "" {
-				res := sqlParentRegexp.FindStringSubmatch(query.Parent)
-				if len(res) > 1 {
-					ic.Emit(&resource{
-						Resource:  "databricks_directory",
-						Attribute: "object_id",
-						Value:     res[1],
-					})
-				}
-			}
+			ic.emitSqlParentDirectory(query.Parent)
 			if ic.meAdmin {
 				ic.Emit(&resource{
 					Resource: "databricks_permissions",
@@ -1685,16 +1676,8 @@ var resourcesMap map[string]importable = map[string]importable{
 			if err != nil {
 				return err
 			}
-			if dashboard.Parent != "" {
-				res := sqlParentRegexp.FindStringSubmatch(dashboard.Parent)
-				if len(res) > 1 {
-					ic.Emit(&resource{
-						Resource:  "databricks_directory",
-						Attribute: "object_id",
-						Value:     res[1],
-					})
-				}
-			}
+
+			ic.emitSqlParentDirectory(dashboard.Parent)
 			for _, rv := range dashboard.Widgets {
 				var widget sql_api.Widget
 				err = json.Unmarshal(rv, &widget)
@@ -1814,16 +1797,7 @@ var resourcesMap map[string]importable = map[string]importable{
 			if alert.QueryId != "" {
 				ic.Emit(&resource{Resource: "databricks_sql_query", ID: alert.QueryId})
 			}
-			if alert.Parent != "" {
-				res := sqlParentRegexp.FindStringSubmatch(alert.Parent)
-				if len(res) > 1 {
-					ic.Emit(&resource{
-						Resource:  "databricks_directory",
-						Attribute: "object_id",
-						Value:     res[1],
-					})
-				}
-			}
+			ic.emitSqlParentDirectory(alert.Parent)
 			if ic.meAdmin {
 				ic.Emit(&resource{
 					Resource: "databricks_permissions",
@@ -1957,11 +1931,11 @@ var resourcesMap map[string]importable = map[string]importable{
 		Service:        "directories",
 		Name:           workspaceObjectResouceName,
 		Search: func(ic *importContext, r *resource) error {
-			directoryList := ic.getAllDirectories()
 			objId, err := strconv.ParseInt(r.Value, 10, 64)
 			if err != nil {
 				return err
 			}
+			directoryList := ic.getAllDirectories()
 			for _, directory := range directoryList {
 				if directory.ObjectID == objId {
 					r.ID = directory.Path

--- a/exporter/importables_test.go
+++ b/exporter/importables_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 	"sync"
 	"testing"
 
@@ -915,7 +916,7 @@ func testGenerate(t *testing.T, fixtures []qa.HTTPFixture, services string, asAd
 		ic.meAdmin = asAdmin
 		ic.importing = map[string]bool{}
 		ic.variables = map[string]string{}
-		ic.services = services
+		ic.services = strings.Split(services, ",")
 		ic.startImportChannels()
 		cb(ic)
 	})
@@ -1359,4 +1360,13 @@ func TestListUcAllowListSuccess(t *testing.T) {
 	err := resourcesMap["databricks_artifact_allowlist"].List(ic)
 	assert.NoError(t, err)
 	assert.Equal(t, len(ic.testEmits), 3)
+}
+
+func TestEmitSqlParent(t *testing.T) {
+	ic := importContextForTest()
+	ic.emitSqlParentDirectory("")
+	assert.Equal(t, len(ic.testEmits), 0)
+	ic.emitSqlParentDirectory("folders/12345")
+	assert.Equal(t, 1, len(ic.testEmits))
+	assert.Contains(t, ic.testEmits, "databricks_directory[<unknown>] (object_id: 12345)")
 }

--- a/exporter/util.go
+++ b/exporter/util.go
@@ -853,6 +853,20 @@ func (ic *importContext) maybeEmitWorkspaceObject(resourceType, path string) {
 	}
 }
 
+func (ic *importContext) emitSqlParentDirectory(parent string) {
+	if parent == "" {
+		return
+	}
+	res := sqlParentRegexp.FindStringSubmatch(parent)
+	if len(res) > 1 {
+		ic.Emit(&resource{
+			Resource:  "databricks_directory",
+			Attribute: "object_id",
+			Value:     res[1],
+		})
+	}
+}
+
 func createListWorkspaceObjectsFunc(objType string, resourceType string, objName string) func(ic *importContext) error {
 	return func(ic *importContext) error {
 		// TODO: can we pass a visitor here, that will emit corresponding object earlier?


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

This PR contains following changes:

* emitting of the parent directory for SQL objects is moved to a separate function to simplify code, and allow refactoring in one place
* enabled services are now represented as slice of strings instead of string - this will allow to avoid matching on a partial line when there are services like `uc` and `uc-system-schemas`

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

