### PR TITLE
Exporter: don't omit `source` for notebook tasks from workspace when there is a Git configuration

### DIFF
--- a/exporter/importables.go
+++ b/exporter/importables.go
@@ -566,7 +566,7 @@ var resourcesMap map[string]importable = map[string]importable{
 						}
 					}
 				}
-				if strings.HasSuffix(pathString, ".notebook_task.0.source") && d.Get(pathString).(string) == "WORKSPACE" {
+				if strings.HasSuffix(pathString, ".notebook_task.0.source") && js.GitSource == nil && d.Get(pathString).(string) == "WORKSPACE" {
 					return true
 				}
 			}


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

The Jobs API requires the explicit `source = "WORKSPACE"` value for notebook tasks in case `git_credentials` are configured on the job level if they aren't used for the notebook tasks.  The #2857 was too aggressive in the removal of `source` attributes for notebook tasks.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

