### PR TITLE
[SC-151274] Add Self-Assume Capability to the Identity-Bound policy for IAM roles provisioned by TF

### DIFF
--- a/docs/guides/unity-catalog.md
+++ b/docs/guides/unity-catalog.md
@@ -297,7 +297,16 @@ resource "aws_iam_policy" "external_data_access" {
           "${aws_s3_bucket.external.arn}/*"
         ],
         "Effect" : "Allow"
-      }
+      }, 
+      {
+        "Action" : [
+          "sts:AssumeRole"
+        ],
+        "Resource" : [
+          "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${local.prefix}-uc-access"
+        ],
+        "Effect" : "Allow"
+      },
     ]
   })
   tags = merge(local.tags, {


### PR DESCRIPTION
This docs change is for this issue: https://github.com/databricks/terraform-provider-databricks/issues/3110

## Changes
The[ IAM policy terraform documentation](https://registry.terraform.io/providers/databricks/databricks/latest/docs/guides/unity-catalog) may be missing the self-assumeRole section. The resulting in-line policy is different from the (correct) policy that we specify in our [UC CreateMetastore documentation page](https://docs.databricks.com/en/data-governance/unity-catalog/create-metastore.html#step-2-optional-create-an-iam-role-to-access-the-storage-location):
```
{
 "Version": "2012-10-17",
 "Statement": [
     {
         "Action": [
             "s3:GetObject",
             "s3:PutObject",
             "s3:DeleteObject",
             "s3:ListBucket",
             "s3:GetBucketLocation",
             "s3:GetLifecycleConfiguration",
             "s3:PutLifecycleConfiguration"
         ],
         "Resource": [
             "arn:aws:s3:::<BUCKET>/*",
             "arn:aws:s3:::<BUCKET>"
         ],
         "Effect": "Allow"
     },
     {
         "Action": [
             "kms:Decrypt",
             "kms:Encrypt",
             "kms:GenerateDataKey*"
         ],
         "Resource": [
             "arn:aws:kms:<KMS-KEY>"
         ],
         "Effect": "Allow"
     },
     {
         "Action": [
             "sts:AssumeRole".  <-------- This section is missing from the IAM policy that the TF template creates
         ],
         "Resource": [
             "arn:aws:iam::<AWS-ACCOUNT-ID>:role/<AWS-IAM-ROLE-NAME>"
         ],
         "Effect": "Allow"
     }
   ]
}
```

### List of things to potentially add/remove:
We should change the `resource "aws_iam_policy" "external_data_access"` to instead have the body:
```
resource "aws_iam_policy" "external_data_access" {
  // Terraform's "jsonencode" function converts a
  // Terraform expression's result to valid JSON syntax.
  policy = jsonencode({
    Version = "2012-10-17"
    Id      = "${aws_s3_bucket.external.id}-access"
    Statement = [
      {
        "Action" : [
          "s3:GetObject",
          "s3:GetObjectVersion",
          "s3:PutObject",
          "s3:PutObjectAcl",
          "s3:DeleteObject",
          "s3:ListBucket",
          "s3:GetBucketLocation"
        ],
        "Resource" : [
          aws_s3_bucket.external.arn,
          "${aws_s3_bucket.external.arn}/*"
        ],
        "Effect" : "Allow"
      },
      {
        "Action" : [
          "sts:AssumeRole"
        ],
        "Resource" : [
          "arn:aws:iam::<AWS-ACCOUNT-ID>:role/<AWS-IAM-ROLE-NAME>"
        ],
        "Effect" : "Allow"
      },
    ]
  })
  tags = merge(local.tags, {
    Name = "${local.prefix}-unity-catalog external access IAM policy"
  })
}
```

## Tests
N/A, this is only docs

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

