### PR TITLE
Use double quotes with filters in SCIM

### DIFF
--- a/scim/data_group_test.go
+++ b/scim/data_group_test.go
@@ -18,7 +18,7 @@ func TestDataSourceGroup(t *testing.T) {
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   "GET",
-				Resource: "/api/2.0/preview/scim/v2/Groups?filter=displayName%20eq%20%27ds%27",
+				Resource: `/api/2.0/preview/scim/v2/Groups?filter=displayName%20eq%20%22ds%22`,
 				Response: GroupList{
 					Resources: []Group{
 						{

--- a/scim/data_service_principal.go
+++ b/scim/data_service_principal.go
@@ -30,9 +30,9 @@ func DataSourceServicePrincipal() *schema.Resource {
 			return fmt.Errorf("please specify only one of application_id or display_name")
 		}
 		if response.ApplicationID != "" {
-			spList, err = spnAPI.Filter(fmt.Sprintf("applicationId eq '%s'", response.ApplicationID), true)
+			spList, err = spnAPI.Filter(fmt.Sprintf(`applicationId eq "%s"`, response.ApplicationID), true)
 		} else if response.DisplayName != "" {
-			spList, err = spnAPI.Filter(fmt.Sprintf("displayName eq '%s'", response.DisplayName), true)
+			spList, err = spnAPI.Filter(fmt.Sprintf(`displayName eq "%s"`, response.DisplayName), true)
 		} else {
 			return fmt.Errorf("please specify either application_id or display_name")
 		}

--- a/scim/data_service_principal_test.go
+++ b/scim/data_service_principal_test.go
@@ -12,7 +12,7 @@ func TestDataServicePrincipalReadByAppId(t *testing.T) {
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   "GET",
-				Resource: "/api/2.0/preview/scim/v2/ServicePrincipals?excludedAttributes=roles&filter=applicationId%20eq%20%27abc%27",
+				Resource: "/api/2.0/preview/scim/v2/ServicePrincipals?excludedAttributes=roles&filter=applicationId%20eq%20%22abc%22",
 				Response: UserList{
 					Resources: []User{
 						{
@@ -57,7 +57,7 @@ func TestDataServicePrincipalReadByIdNotFound(t *testing.T) {
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   "GET",
-				Resource: "/api/2.0/preview/scim/v2/ServicePrincipals?excludedAttributes=roles&filter=applicationId%20eq%20%27abc%27",
+				Resource: "/api/2.0/preview/scim/v2/ServicePrincipals?excludedAttributes=roles&filter=applicationId%20eq%20%22abc%22",
 				Response: UserList{},
 			},
 		},
@@ -74,7 +74,7 @@ func TestDataServicePrincipalReadByNameNotFound(t *testing.T) {
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   "GET",
-				Resource: "/api/2.0/preview/scim/v2/ServicePrincipals?excludedAttributes=roles&filter=displayName%20eq%20%27abc%27",
+				Resource: "/api/2.0/preview/scim/v2/ServicePrincipals?excludedAttributes=roles&filter=displayName%20eq%20%22abc%22",
 				Response: UserList{},
 			},
 		},
@@ -91,7 +91,7 @@ func TestDataServicePrincipalReadError(t *testing.T) {
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   "GET",
-				Resource: "/api/2.0/preview/scim/v2/ServicePrincipals?excludedAttributes=roles&filter=applicationId%20eq%20%27abc%27",
+				Resource: "/api/2.0/preview/scim/v2/ServicePrincipals?excludedAttributes=roles&filter=applicationId%20eq%20%22abc%22",
 				Status:   500,
 			},
 		},
@@ -109,7 +109,7 @@ func TestDataServicePrincipalReadByNameDuplicates(t *testing.T) {
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   "GET",
-				Resource: "/api/2.0/preview/scim/v2/ServicePrincipals?excludedAttributes=roles&filter=displayName%20eq%20%27abc%27",
+				Resource: "/api/2.0/preview/scim/v2/ServicePrincipals?excludedAttributes=roles&filter=displayName%20eq%20%22abc%22",
 				Response: UserList{
 					Resources: []User{
 						{

--- a/scim/data_service_principals.go
+++ b/scim/data_service_principals.go
@@ -22,7 +22,7 @@ func DataSourceServicePrincipals() *schema.Resource {
 		var filter string
 
 		if response.DisplayNameContains != "" {
-			filter = fmt.Sprintf("displayName co '%s'", response.DisplayNameContains)
+			filter = fmt.Sprintf(`displayName co "%s"`, response.DisplayNameContains)
 		}
 		spList, err := spnAPI.Filter(filter, true)
 		if err != nil {

--- a/scim/data_service_principals_test.go
+++ b/scim/data_service_principals_test.go
@@ -12,7 +12,7 @@ func TestDataServicePrincipalsReadByDisplayName(t *testing.T) {
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   "GET",
-				Resource: "/api/2.0/preview/scim/v2/ServicePrincipals?excludedAttributes=roles&filter=displayName%20co%20%27def%27",
+				Resource: "/api/2.0/preview/scim/v2/ServicePrincipals?excludedAttributes=roles&filter=displayName%20co%20%22def%22",
 				Response: UserList{
 					Resources: []User{
 						{
@@ -46,7 +46,7 @@ func TestDataServicePrincipalsReadNotFound(t *testing.T) {
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   "GET",
-				Resource: "/api/2.0/preview/scim/v2/ServicePrincipals?excludedAttributes=roles&filter=displayName%20co%20%27def%27",
+				Resource: "/api/2.0/preview/scim/v2/ServicePrincipals?excludedAttributes=roles&filter=displayName%20co%20%22def%22",
 				Response: UserList{},
 			},
 		},
@@ -98,7 +98,7 @@ func TestDataServicePrincipalsReadError(t *testing.T) {
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   "GET",
-				Resource: "/api/2.0/preview/scim/v2/ServicePrincipals?excludedAttributes=roles&filter=displayName%20co%20%27def%27",
+				Resource: "/api/2.0/preview/scim/v2/ServicePrincipals?excludedAttributes=roles&filter=displayName%20co%20%22def%22",
 				Status:   500,
 			},
 		},

--- a/scim/data_user.go
+++ b/scim/data_user.go
@@ -13,7 +13,7 @@ func getUser(usersAPI UsersAPI, id, name string) (user User, err error) {
 	if id != "" {
 		return usersAPI.Read(id, "userName,displayName,externalId,applicationId")
 	}
-	userList, err := usersAPI.Filter(fmt.Sprintf("userName eq '%s'", name), true)
+	userList, err := usersAPI.Filter(fmt.Sprintf(`userName eq "%s"`, name), true)
 	if err != nil {
 		return
 	}

--- a/scim/data_user_test.go
+++ b/scim/data_user_test.go
@@ -16,7 +16,7 @@ func TestDataSourceUser(t *testing.T) {
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   "GET",
-				Resource: "/api/2.0/preview/scim/v2/Users?excludedAttributes=roles&filter=userName%20eq%20%27ds%27",
+				Resource: "/api/2.0/preview/scim/v2/Users?excludedAttributes=roles&filter=userName%20eq%20%22ds%22",
 				Response: UserList{
 					Resources: []User{
 						{
@@ -54,7 +54,7 @@ func TestDataSourceUserGerUser(t *testing.T) {
 		},
 		{
 			Method:   "GET",
-			Resource: "/api/2.0/preview/scim/v2/Users?excludedAttributes=roles&filter=userName%20eq%20%27searching_error%27",
+			Resource: "/api/2.0/preview/scim/v2/Users?excludedAttributes=roles&filter=userName%20eq%20%22searching_error%22",
 			Status:   404,
 			Response: apierr.APIError{
 				Message: "searching_error",
@@ -62,7 +62,7 @@ func TestDataSourceUserGerUser(t *testing.T) {
 		},
 		{
 			Method:   "GET",
-			Resource: "/api/2.0/preview/scim/v2/Users?excludedAttributes=roles&filter=userName%20eq%20%27empty_search%27",
+			Resource: "/api/2.0/preview/scim/v2/Users?excludedAttributes=roles&filter=userName%20eq%20%22empty_search%22",
 			Response: UserList{},
 		},
 	}, func(ctx context.Context, client *common.DatabricksClient) {

--- a/scim/groups.go
+++ b/scim/groups.go
@@ -51,7 +51,7 @@ func (a GroupsAPI) Filter(filter string) (GroupList, error) {
 }
 
 func (a GroupsAPI) ReadByDisplayName(displayName, attributes string) (group Group, err error) {
-	groupList, err := a.Filter(fmt.Sprintf("displayName eq '%s'", displayName))
+	groupList, err := a.Filter(fmt.Sprintf(`displayName eq "%s"`, displayName))
 	if err != nil {
 		return
 	}

--- a/scim/resource_group_test.go
+++ b/scim/resource_group_test.go
@@ -355,7 +355,7 @@ func TestCreateForceOverwriteCannotListGroups(t *testing.T) {
 	qa.HTTPFixturesApply(t, []qa.HTTPFixture{
 		{
 			Method:   "GET",
-			Resource: "/api/2.0/preview/scim/v2/Groups?filter=displayName%20eq%20%27abc%27",
+			Resource: "/api/2.0/preview/scim/v2/Groups?filter=displayName%20eq%20%22abc%22",
 			Status:   417,
 			Response: apierr.APIError{
 				Message: "cannot find group",
@@ -377,7 +377,7 @@ func TestCreateForceOverwriteFindsAndSetsGroupID(t *testing.T) {
 	qa.HTTPFixturesApply(t, []qa.HTTPFixture{
 		{
 			Method:   "GET",
-			Resource: "/api/2.0/preview/scim/v2/Groups?filter=displayName%20eq%20%27abc%27",
+			Resource: "/api/2.0/preview/scim/v2/Groups?filter=displayName%20eq%20%22abc%22",
 			Response: GroupList{
 				Resources: []Group{
 					{

--- a/scim/resource_service_principal.go
+++ b/scim/resource_service_principal.go
@@ -252,7 +252,7 @@ func createForceOverridesManuallyAddedServicePrincipal(err error, d *schema.Reso
 	if !slices.Contains(knownErrs, err.Error()) {
 		return err
 	}
-	spList, err := spAPI.Filter(fmt.Sprintf("applicationId eq '%s'", strings.ReplaceAll(u.ApplicationID, "'", "")), true)
+	spList, err := spAPI.Filter(fmt.Sprintf(`applicationId eq "%s"`, strings.ReplaceAll(u.ApplicationID, "'", "")), true)
 	if err != nil {
 		return err
 	}

--- a/scim/resource_service_principal_test.go
+++ b/scim/resource_service_principal_test.go
@@ -556,7 +556,7 @@ func TestCreateForceOverwriteCannotListServicePrincipals(t *testing.T) {
 	qa.HTTPFixturesApply(t, []qa.HTTPFixture{
 		{
 			Method:   "GET",
-			Resource: fmt.Sprintf("/api/2.0/preview/scim/v2/ServicePrincipals?excludedAttributes=roles&filter=applicationId%%20eq%%20%%27%s%%27", appID),
+			Resource: fmt.Sprintf("/api/2.0/preview/scim/v2/ServicePrincipals?excludedAttributes=roles&filter=applicationId%%20eq%%20%%22%s%%22", appID),
 			Status:   417,
 			Response: apierr.APIError{
 				Message: "cannot find service principal",
@@ -579,7 +579,7 @@ func TestCreateForceOverwriteCannotListAccServicePrincipals(t *testing.T) {
 	qa.HTTPFixturesApply(t, []qa.HTTPFixture{
 		{
 			Method:   "GET",
-			Resource: fmt.Sprintf("/api/2.0/preview/scim/v2/ServicePrincipals?excludedAttributes=roles&filter=applicationId%%20eq%%20%%27%s%%27", appID),
+			Resource: fmt.Sprintf("/api/2.0/preview/scim/v2/ServicePrincipals?excludedAttributes=roles&filter=applicationId%%20eq%%20%%22%s%%22", appID),
 			Response: UserList{
 				TotalResults: 0,
 			},
@@ -601,7 +601,7 @@ func TestCreateForceOverwriteFindsAndSetsServicePrincipalID(t *testing.T) {
 	qa.HTTPFixturesApply(t, []qa.HTTPFixture{
 		{
 			Method:   "GET",
-			Resource: fmt.Sprintf("/api/2.0/preview/scim/v2/ServicePrincipals?excludedAttributes=roles&filter=applicationId%%20eq%%20%%27%s%%27", appID),
+			Resource: fmt.Sprintf("/api/2.0/preview/scim/v2/ServicePrincipals?excludedAttributes=roles&filter=applicationId%%20eq%%20%%22%s%%22", appID),
 			Response: UserList{
 				Resources: []User{
 					{

--- a/scim/resource_user.go
+++ b/scim/resource_user.go
@@ -176,7 +176,7 @@ func createForceOverridesManuallyAddedUser(err error, d *schema.ResourceData, us
 		(!strings.HasPrefix(err.Error(), userExistsErrorMessage(userName, true))) {
 		return err
 	}
-	userList, err := usersAPI.Filter(fmt.Sprintf("userName eq '%s'", userName), true)
+	userList, err := usersAPI.Filter(fmt.Sprintf(`userName eq "%s"`, userName), true)
 	if err != nil {
 		return err
 	}

--- a/scim/resource_user_test.go
+++ b/scim/resource_user_test.go
@@ -632,7 +632,7 @@ func TestCreateForceOverwriteCannotListUsers(t *testing.T) {
 	qa.HTTPFixturesApply(t, []qa.HTTPFixture{
 		{
 			Method:   "GET",
-			Resource: "/api/2.0/preview/scim/v2/Users?excludedAttributes=roles&filter=userName%20eq%20%27me%40example.com%27",
+			Resource: "/api/2.0/preview/scim/v2/Users?excludedAttributes=roles&filter=userName%20eq%20%22me%40example.com%22",
 			Status:   417,
 			Response: apierr.APIErrorBody{
 				Message: "cannot find user",
@@ -654,7 +654,7 @@ func TestCreateForceOverwriteCannotListAccUsers(t *testing.T) {
 	qa.HTTPFixturesApply(t, []qa.HTTPFixture{
 		{
 			Method:   "GET",
-			Resource: "/api/2.0/preview/scim/v2/Users?excludedAttributes=roles&filter=userName%20eq%20%27me%40example.com%27",
+			Resource: "/api/2.0/preview/scim/v2/Users?excludedAttributes=roles&filter=userName%20eq%20%22me%40example.com%22",
 			Response: UserList{
 				TotalResults: 0,
 			},
@@ -675,7 +675,7 @@ func TestCreateForceOverwriteFindsAndSetsID(t *testing.T) {
 	qa.HTTPFixturesApply(t, []qa.HTTPFixture{
 		{
 			Method:   "GET",
-			Resource: "/api/2.0/preview/scim/v2/Users?excludedAttributes=roles&filter=userName%20eq%20%27me%40example.com%27",
+			Resource: "/api/2.0/preview/scim/v2/Users?excludedAttributes=roles&filter=userName%20eq%20%22me%40example.com%22",
 			Response: UserList{
 				Resources: []User{
 					{
@@ -717,7 +717,7 @@ func TestCreateForceOverwriteFindsAndSetsAccID(t *testing.T) {
 	qa.HTTPFixturesApply(t, []qa.HTTPFixture{
 		{
 			Method:   "GET",
-			Resource: "/api/2.0/preview/scim/v2/Users?excludedAttributes=roles&filter=userName%20eq%20%27me%40example.com%27",
+			Resource: "/api/2.0/preview/scim/v2/Users?excludedAttributes=roles&filter=userName%20eq%20%22me%40example.com%22",
 			Response: UserList{
 				Resources: []User{
 					{


### PR DESCRIPTION
## Changes
The SCIM API team is changing the library used to parse SCIM requests. This library is more strict with the interpretation of filters, specifically mandating that string values in filters, like for display name or application ID, must use double quotes instead of single quotes. This PR modifies SCIM APIs to use double quotes for strings in filters instead.

## Tests
- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

