### PR TITLE
Allow using empty strings as job parameters

### DIFF
--- a/internal/acceptance/job_test.go
+++ b/internal/acceptance/job_test.go
@@ -90,7 +90,21 @@ func TestAccJobTasks(t *testing.T) {
 
 				notebook_task {
 					notebook_path = databricks_notebook.this.path
+					base_parameters = {
+						"param_0" = "{{job.parameters.empty_default}}"
+						"param_0" = "{{job.parameters.non_empty}}"
+					}
 				}
+			}
+
+			parameter {
+				name = "empty_default"
+				default = ""
+			}
+
+			parameter {
+				name = "non_empty_default"
+				default = "non_empty"
 			}
 		}`,
 	})

--- a/internal/acceptance/job_test.go
+++ b/internal/acceptance/job_test.go
@@ -92,7 +92,7 @@ func TestAccJobTasks(t *testing.T) {
 					notebook_path = databricks_notebook.this.path
 					base_parameters = {
 						"param_0" = "{{job.parameters.empty_default}}"
-						"param_0" = "{{job.parameters.non_empty}}"
+						"param_0" = "{{job.parameters.non_empty_default}}"
 					}
 				}
 			}

--- a/jobs/resource_job.go
+++ b/jobs/resource_job.go
@@ -273,7 +273,7 @@ type JobSettings struct {
 	Queue                *jobs.QueueSettings           `json:"queue,omitempty"`
 	RunAs                *JobRunAs                     `json:"run_as,omitempty" tf:"computed"`
 	Health               *JobHealth                    `json:"health,omitempty"`
-	Parameters           []JobParameterDefinition      `json:"parameters,omitempty" tf:"alias:parameter"`
+	Parameters           []jobs.JobParameterDefinition `json:"parameters,omitempty" tf:"alias:parameter"`
 	Deployment           *jobs.JobDeployment           `json:"deployment,omitempty"`
 	EditMode             jobs.CreateJobEditMode        `json:"edit_mode,omitempty"`
 }
@@ -340,12 +340,6 @@ type JobParameter struct {
 	Name    string `json:"name,omitempty"`
 	Default string `json:"default,omitempty"`
 	Value   string `json:"value,omitempty"`
-}
-
-// Job-level parameter definitions
-type JobParameterDefinition struct {
-	Name    string `json:"name,omitempty"`
-	Default string `json:"default,omitempty"`
 }
 
 // RunState of the job

--- a/jobs/resource_job_test.go
+++ b/jobs/resource_job_test.go
@@ -371,7 +371,7 @@ func TestResourceJobCreate_JobParameters(t *testing.T) {
 						},
 					},
 					MaxConcurrentRuns: 1,
-					Parameters: []JobParameterDefinition{
+					Parameters: []jobs.JobParameterDefinition{
 						{
 							Name:    "hello",
 							Default: "world",
@@ -400,7 +400,7 @@ func TestResourceJobCreate_JobParameters(t *testing.T) {
 								TaskKey: "b",
 							},
 						},
-						Parameters: []JobParameterDefinition{
+						Parameters: []jobs.JobParameterDefinition{
 							{
 								Name:    "hello",
 								Default: "world",


### PR DESCRIPTION
## Changes
Allow using an empty string as the "default" value for job parameters, otherwise, such jobs are rejected because "default" field is required.

Remove "omitempty" modifier because both fields are required.

## Tests

Verified manually with Terraform

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [x] using Go SDK

