### PR TITLE
Validate metastore id for databricks_grant and databricks_grants resources

### DIFF
--- a/catalog/resource_grant.go
+++ b/catalog/resource_grant.go
@@ -144,6 +144,14 @@ func ResourceGrant() *schema.Resource {
 	return common.Resource{
 		Schema: s,
 		Create: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
+			w, err := c.WorkspaceClient()
+			if err != nil {
+				return err
+			}
+			err = validateMetastoreId(ctx, w, d.Get("metastore").(string))
+			if err != nil {
+				return err
+			}
 			principal := d.Get("principal").(string)
 			privileges := permissions.SetToSlice(d.Get("privileges").(*schema.Set))
 			var grants = catalog.PermissionsList{
@@ -156,7 +164,7 @@ func ResourceGrant() *schema.Resource {
 			}
 			securable, name := permissions.Mappings.KeyValue(d)
 			unityCatalogPermissionsAPI := permissions.NewUnityCatalogPermissionsAPI(ctx, c)
-			err := replacePermissionsForPrincipal(unityCatalogPermissionsAPI, securable, name, principal, grants)
+			err = replacePermissionsForPrincipal(unityCatalogPermissionsAPI, securable, name, principal, grants)
 			if err != nil {
 				return err
 			}
@@ -179,6 +187,14 @@ func ResourceGrant() *schema.Resource {
 			return common.StructToData(*grantsForPrincipal, s, d)
 		},
 		Update: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
+			w, err := c.WorkspaceClient()
+			if err != nil {
+				return err
+			}
+			err = validateMetastoreId(ctx, w, d.Get("metastore").(string))
+			if err != nil {
+				return err
+			}
 			securable, name, principal, err := parseSecurableId(d)
 			if err != nil {
 				return err
@@ -196,6 +212,14 @@ func ResourceGrant() *schema.Resource {
 			return replacePermissionsForPrincipal(unityCatalogPermissionsAPI, securable, name, principal, grants)
 		},
 		Delete: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
+			w, err := c.WorkspaceClient()
+			if err != nil {
+				return err
+			}
+			err = validateMetastoreId(ctx, w, d.Get("metastore").(string))
+			if err != nil {
+				return err
+			}
 			securable, name, principal, err := parseSecurableId(d)
 			if err != nil {
 				return err

--- a/catalog/resource_grant_test.go
+++ b/catalog/resource_grant_test.go
@@ -88,6 +88,110 @@ func TestResourceGrantCreate(t *testing.T) {
 	}.ApplyNoError(t)
 }
 
+func TestResourceGrantCreateMetastoreId(t *testing.T) {
+	qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "GET",
+				Resource: "/api/2.1/unity-catalog/current-metastore-assignment",
+				Response: catalog.MetastoreAssignment{
+					MetastoreId: "metastore_id",
+				},
+			},
+			{
+				Method:   "GET",
+				Resource: "/api/2.1/unity-catalog/permissions/metastore/metastore_id?",
+				Response: catalog.PermissionsList{
+					PrivilegeAssignments: []catalog.PrivilegeAssignment{
+						{
+							Principal:  "me",
+							Privileges: []catalog.Privilege{"SELECT"},
+						},
+						{
+							Principal:  "someone-else",
+							Privileges: []catalog.Privilege{"MODIFY", "SELECT"},
+						},
+					},
+				},
+			},
+			{
+				Method:   "PATCH",
+				Resource: "/api/2.1/unity-catalog/permissions/metastore/metastore_id",
+				ExpectedRequest: catalog.UpdatePermissions{
+					Changes: []catalog.PermissionsChange{
+						{
+							Principal: "me",
+							Add:       []catalog.Privilege{"MODIFY"},
+							Remove:    []catalog.Privilege{"SELECT"},
+						},
+					},
+				},
+			},
+			{
+				Method:   "GET",
+				Resource: "/api/2.1/unity-catalog/permissions/metastore/metastore_id?",
+				Response: catalog.PermissionsList{
+					PrivilegeAssignments: []catalog.PrivilegeAssignment{
+						{
+							Principal:  "me",
+							Privileges: []catalog.Privilege{"MODIFY"},
+						},
+						{
+							Principal:  "someone-else",
+							Privileges: []catalog.Privilege{"MODIFY", "SELECT"},
+						},
+					},
+				},
+			},
+			{
+				Method:   "GET",
+				Resource: "/api/2.1/unity-catalog/permissions/metastore/metastore_id?",
+				Response: catalog.PermissionsList{
+					PrivilegeAssignments: []catalog.PrivilegeAssignment{
+						{
+							Principal:  "me",
+							Privileges: []catalog.Privilege{"MODIFY"},
+						},
+						{
+							Principal:  "someone-else",
+							Privileges: []catalog.Privilege{"MODIFY", "SELECT"},
+						},
+					},
+				},
+			},
+		},
+		Resource: ResourceGrant(),
+		Create:   true,
+		HCL: `
+		metastore = "metastore_id"
+		principal = "me"
+		privileges = ["MODIFY"]
+		`,
+	}.ApplyNoError(t)
+}
+
+func TestFailsWhenWrongMetastoreId(t *testing.T) {
+	qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "GET",
+				Resource: "/api/2.1/unity-catalog/current-metastore-assignment",
+				Response: catalog.MetastoreAssignment{
+					MetastoreId: "old_id",
+				},
+			},
+		},
+		Resource: ResourceGrant(),
+		Create:   true,
+		HCL: `
+		metastore = "new_id"
+		principal = "me"
+		privileges = ["MODIFY"]
+		`,
+	}.ExpectError(t, "metastore_id must be empty or equal to the metastore id assigned to the workspace: old_id. "+
+		"If the metastore assigned to the workspace has changed, the new metastore id must be explicitly set")
+}
+
 func TestResourceGrantWaitUntilReady(t *testing.T) {
 	qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{

--- a/catalog/resource_grants.go
+++ b/catalog/resource_grants.go
@@ -319,11 +319,19 @@ func ResourceGrants() *schema.Resource {
 			return mapping.validate(d, grants)
 		},
 		Create: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
+			w, err := c.WorkspaceClient()
+			if err != nil {
+				return err
+			}
+			err = validateMetastoreId(ctx, w, d.Get("metastore").(string))
+			if err != nil {
+				return err
+			}
 			var grants PermissionsList
 			common.DataToStructPointer(d, s, &grants)
 			securable, name := mapping.kv(d)
 			unityCatalogPermissionsAPI := permissions.NewUnityCatalogPermissionsAPI(ctx, c)
-			err := replaceAllPermissions(unityCatalogPermissionsAPI, securable, name, grants.toSdkPermissionsList())
+			err = replaceAllPermissions(unityCatalogPermissionsAPI, securable, name, grants.toSdkPermissionsList())
 			if err != nil {
 				return err
 			}
@@ -346,6 +354,14 @@ func ResourceGrants() *schema.Resource {
 			return common.StructToData(sdkPermissionsListToPermissionsList(*grants), s, d)
 		},
 		Update: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
+			w, err := c.WorkspaceClient()
+			if err != nil {
+				return err
+			}
+			err = validateMetastoreId(ctx, w, d.Get("metastore").(string))
+			if err != nil {
+				return err
+			}
 			securable, name, err := parseId(d)
 			if err != nil {
 				return err
@@ -356,6 +372,14 @@ func ResourceGrants() *schema.Resource {
 			return replaceAllPermissions(unityCatalogPermissionsAPI, securable, name, grants.toSdkPermissionsList())
 		},
 		Delete: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
+			w, err := c.WorkspaceClient()
+			if err != nil {
+				return err
+			}
+			err = validateMetastoreId(ctx, w, d.Get("metastore").(string))
+			if err != nil {
+				return err
+			}
 			securable, name, err := parseId(d)
 			if err != nil {
 				return err

--- a/catalog/resource_grants_test.go
+++ b/catalog/resource_grants_test.go
@@ -106,7 +106,7 @@ func TestGrantCreateMetastoreId(t *testing.T) {
 						},
 						{
 							Principal:  "someone-else",
-							Privileges: []catalog.Privilege{"MODIFY", "SELECT"},
+							Privileges: []catalog.Privilege{"SELECT", "USE_SHARE"},
 						},
 					},
 				},
@@ -118,12 +118,12 @@ func TestGrantCreateMetastoreId(t *testing.T) {
 					Changes: []catalog.PermissionsChange{
 						{
 							Principal: "me",
-							Add:       []catalog.Privilege{"MODIFY"},
+							Add:       []catalog.Privilege{"USE_SHARE"},
 							Remove:    []catalog.Privilege{"SELECT"},
 						},
 						{
 							Principal: "someone-else",
-							Remove:    []catalog.Privilege{"MODIFY", "SELECT"},
+							Remove:    []catalog.Privilege{"SELECT", "USE_SHARE"},
 						},
 					},
 				},
@@ -135,7 +135,7 @@ func TestGrantCreateMetastoreId(t *testing.T) {
 					PrivilegeAssignments: []catalog.PrivilegeAssignment{
 						{
 							Principal:  "me",
-							Privileges: []catalog.Privilege{"MODIFY"},
+							Privileges: []catalog.Privilege{"USE_SHARE"},
 						},
 					},
 				},
@@ -147,7 +147,7 @@ func TestGrantCreateMetastoreId(t *testing.T) {
 					PrivilegeAssignments: []catalog.PrivilegeAssignment{
 						{
 							Principal:  "me",
-							Privileges: []catalog.Privilege{"MODIFY"},
+							Privileges: []catalog.Privilege{"USE_SHARE"},
 						},
 					},
 				},
@@ -160,7 +160,7 @@ func TestGrantCreateMetastoreId(t *testing.T) {
 
 		grant {
 			principal = "me"
-			privileges = ["MODIFY"]
+			privileges = ["USE_SHARE"]
 		}`,
 	}.ApplyNoError(t)
 }

--- a/docs/resources/grant.md
+++ b/docs/resources/grant.md
@@ -32,15 +32,11 @@ See [databricks_grants Metastore grants](grants.md#metastore-grants) for the lis
 
 ```hcl
 resource "databricks_grant" "sandbox_data_engineers" {
-  metastore = databricks_metastore.this.id
-
   principal  = "Data Engineers"
   privileges = ["CREATE_CATALOG", "CREATE_EXTERNAL_LOCATION"]
 }
 
 resource "databricks_grant" "sandbox_data_sharer" {
-  metastore = databricks_metastore.this.id
-
   principal  = "Data Sharer"
   privileges = ["CREATE_RECIPIENT", "CREATE_SHARE"]
 }

--- a/docs/resources/grants.md
+++ b/docs/resources/grants.md
@@ -32,11 +32,10 @@ Unlike the [SQL specification](https://docs.databricks.com/sql/language-manual/s
 
 ## Metastore grants
 
-You can grant `CREATE_CATALOG`, `CREATE_CONNECTION`, `CREATE_EXTERNAL_LOCATION`, `CREATE_PROVIDER`, `CREATE_RECIPIENT`, `CREATE_SHARE`, `CREATE_STORAGE_CREDENTIAL`, `MANAGE_ALLOWLIST`, `SET_SHARE_PERMISSION`, `USE_MARKETPLACE_ASSETS`, `USE_CONNECTION`, `USE_PROVIDER`, `USE_RECIPIENT` and `USE_SHARE` privileges to [databricks_metastore](metastore.md) id specified in `metastore` attribute.
+You can grant `CREATE_CATALOG`, `CREATE_CONNECTION`, `CREATE_EXTERNAL_LOCATION`, `CREATE_PROVIDER`, `CREATE_RECIPIENT`, `CREATE_SHARE`, `CREATE_STORAGE_CREDENTIAL`, `MANAGE_ALLOWLIST`, `SET_SHARE_PERMISSION`, `USE_MARKETPLACE_ASSETS`, `USE_CONNECTION`, `USE_PROVIDER`, `USE_RECIPIENT` and `USE_SHARE` privileges to [databricks_metastore](metastore.md) assigned to the workspace.
 
 ```hcl
 resource "databricks_grants" "sandbox" {
-  metastore = databricks_metastore.this.id
   grant {
     principal  = "Data Engineers"
     privileges = ["CREATE_CATALOG", "CREATE_EXTERNAL_LOCATION"]


### PR DESCRIPTION

## Changes
Validate metastore id for databricks_grant and databricks_grants resources

## Tests

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [x] using Go SDK

