### PR TITLE
Update service_principal.md

### DIFF
--- a/docs/resources/service_principal.md
+++ b/docs/resources/service_principal.md
@@ -107,6 +107,7 @@ The following arguments are available:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - Canonical unique identifier for the service principal.
+* `application_id` - Application Id of service principal. e.g. `00000000-0000-0000-0000-000000000000`.
 * `home` - Home folder of the service principal, e.g. `/Users/00000000-0000-0000-0000-000000000000`.
 * `repos` - Personal Repos location of the service principal, e.g. `/Repos/00000000-0000-0000-0000-000000000000`.
 * `acl_principal_id` - identifier for use in [databricks_access_control_rule_set](access_control_rule_set.md), e.g. `servicePrincipals/00000000-0000-0000-0000-000000000000`.


### PR DESCRIPTION
Based on my testing, `application_id` of service principal is returned as part of service principal creation in AWS

## Changes
<!-- Summary of your changes that are easy to understand -->

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

