### PR TITLE
New `tf` tags for annotating resource schemas with `ExactlyOneOf`, `AtLeastOneOf`, `ConflictsWith`, and `RequiredWith`

### DIFF
--- a/common/reflect_resource.go
+++ b/common/reflect_resource.go
@@ -218,6 +218,46 @@ func handleSuppressDiff(typeField reflect.StructField, v *schema.Schema) {
 	}
 }
 
+func handleExactlyOneOf(typeField reflect.StructField, schema *schema.Schema) {
+	tfTags := strings.Split(typeField.Tag.Get("tf"), ",")
+	prefix := "exactly_one_of:"
+	for _, tag := range tfTags {
+		if strings.HasPrefix(tag, prefix) {
+			schema.ExactlyOneOf = strings.Split(strings.TrimPrefix(tag, prefix), ";")
+		}
+	}
+}
+
+func handleAtLeastOneOf(typeField reflect.StructField, schema *schema.Schema) {
+	tfTags := strings.Split(typeField.Tag.Get("tf"), ",")
+	prefix := "at_least_one_of:"
+	for _, tag := range tfTags {
+		if strings.HasPrefix(tag, prefix) {
+			schema.AtLeastOneOf = strings.Split(strings.TrimPrefix(tag, prefix), ";")
+		}
+	}
+}
+
+func handleConflictsWith(typeField reflect.StructField, schema *schema.Schema) {
+	tfTags := strings.Split(typeField.Tag.Get("tf"), ",")
+	prefix := "conflicts_with:"
+	for _, tag := range tfTags {
+		if strings.HasPrefix(tag, prefix) {
+			schema.ConflictsWith = strings.Split(strings.TrimPrefix(tag, prefix), ";")
+		}
+	}
+}
+
+func handleRequiredWith(typeField reflect.StructField, schema *schema.Schema) {
+	tfTags := strings.Split(typeField.Tag.Get("tf"), ",")
+	prefix := "required_with:"
+	for _, tag := range tfTags {
+		if strings.HasPrefix(tag, prefix) {
+			schema.RequiredWith = strings.Split(strings.TrimPrefix(tag, prefix), ";")
+		}
+	}
+}
+
 func getAlias(typeField reflect.StructField) string {
 	tfTags := strings.Split(typeField.Tag.Get("tf"), ",")
 	for _, tag := range tfTags {
@@ -322,10 +362,16 @@ func typeToSchema(v reflect.Value, path []string, aliases map[string]string) map
 				}
 			}
 		}
+
 		handleOptional(typeField, scm[fieldName])
 		handleComputed(typeField, scm[fieldName])
 		handleForceNew(typeField, scm[fieldName])
 		handleSensitive(typeField, scm[fieldName])
+		handleExactlyOneOf(typeField, scm[fieldName])
+		handleAtLeastOneOf(typeField, scm[fieldName])
+		handleConflictsWith(typeField, scm[fieldName])
+		handleRequiredWith(typeField, scm[fieldName])
+
 		switch typeField.Type.Kind() {
 		case reflect.Int, reflect.Int32, reflect.Int64:
 			scm[fieldName].Type = schema.TypeInt

--- a/common/reflect_resource_test.go
+++ b/common/reflect_resource_test.go
@@ -74,6 +74,10 @@ type testStruct struct {
 	FloatSlice     []float64         `json:"float_slice,omitempty"`
 	BoolSlice      []bool            `json:"bool_slice,omitempty"`
 	TfOptional     string            `json:"tf_optional" tf:"optional"`
+	ExactlyOneOf   string            `json:"exactly_one_of,omitempty" tf:"exactly_one_of:exactly_one_of;non_optional"`
+	AtLeastOneOf   string            `json:"at_least_one_of" tf:"at_least_one_of:at_least_one_of;integer;int_slice"`
+	ConflictsWith  string            `json:"conflicts_with" tf:"conflicts_with:at_least_one_of"`
+	RequiredWith   string            `json:"required_with" tf:"required_with:bool_slice;float_slice"`
 	Hidden         string            `json:"-"`
 	Hidden2        string
 }
@@ -82,10 +86,10 @@ var scm = StructToSchema(testStruct{}, nil)
 
 var testStructFields = []string{"integer", "float", "non_optional", "string", "computed_field", "force_new_field", "map_field",
 	"slice_set_struct", "slice_set_string", "ptr_item", "string_slice", "bool", "int_slice", "float_slice",
-	"bool_slice", "tf_optional"}
+	"bool_slice", "tf_optional", "exactly_one_of", "at_least_one_of", "conflicts_with", "required_with"}
 
 var testStructOptionalFields = []string{"integer", "float", "string", "computed_field", "force_new_field", "map_field", "slice_set_struct",
-	"ptr_item", "slice_set_string", "bool", "int_slice", "float_slice", "bool_slice", "tf_optional"}
+	"ptr_item", "slice_set_string", "bool", "int_slice", "float_slice", "bool_slice", "tf_optional", "exactly_one_of"}
 
 var testStructRequiredFields = []string{"non_optional"}
 
@@ -99,6 +103,14 @@ var testStructSliceStructFields = []string{"slice_set_struct"}
 
 var testStructSliceNonStructFields = []string{"slice_set_string", "string_slice", "int_slice", "float_slice",
 	"bool_slice"}
+
+var testStructExactlyOneOfFields = []string{"exactly_one_of"}
+
+var testStructAtLeastOneOfFields = []string{"at_least_one_of"}
+
+var testStructConflictsWith = []string{"conflicts_with"}
+
+var testStructRequiredWith = []string{"required_with"}
 
 func TestStructToSchema_type(t *testing.T) {
 	expectedMap := map[string]schema.ValueType{
@@ -188,6 +200,37 @@ func TestStructToSchema_required_values_set(t *testing.T) {
 	}
 }
 
+func TestStructToSchema_exactlyoneof_value_set(t *testing.T) {
+	for _, field := range testStructExactlyOneOfFields {
+		requiredField, ok := scm[field]
+		assert.Truef(t, ok, "%s key not found", field)
+		assert.Equalf(t, requiredField.ExactlyOneOf, []string{"exactly_one_of", "non_optional"}, "exactly_one_of is not set to an expected value")
+	}
+}
+
+func TestStructToSchema_atleastoneof_value_set(t *testing.T) {
+	for _, field := range testStructAtLeastOneOfFields {
+		requiredField, ok := scm[field]
+		assert.Truef(t, ok, "%s key not found", field)
+		assert.Equalf(t, requiredField.AtLeastOneOf, []string{"at_least_one_of", "integer", "int_slice"}, "at_least_one_of is not set to an expected value")
+	}
+}
+
+func TestStructToSchema_conflictswith_value_set(t *testing.T) {
+	for _, field := range testStructConflictsWith {
+		requiredField, ok := scm[field]
+		assert.Truef(t, ok, "%s key not found", field)
+		assert.Equalf(t, requiredField.ConflictsWith, []string{"at_least_one_of"}, "conflicts_with is not set to an expected value")
+	}
+}
+
+func TestStructToSchema_requiredwith_value_set(t *testing.T) {
+	for _, field := range testStructRequiredWith {
+		requiredField, ok := scm[field]
+		assert.Truef(t, ok, "%s key not found", field)
+		assert.Equalf(t, requiredField.RequiredWith, []string{"bool_slice", "float_slice"}, "required_with is not set to an expected value")
+	}
+}
 func TestStructToSchema_base_values_are_set(t *testing.T) {
 	for _, field := range testStructFields {
 		_, ok := scm[field]


### PR DESCRIPTION
## Changes
I am proposing to add additional supported `tf` tags values to enable annotating Terraform schema with `ExactlyOneOf`, `AtLeastOneOf`, `ConflictsWith`, `RequiredWith`. These would simplify schema validation and/or schema definition for a several resources and data sources by offloading the validation to Terraform SDK (https://github.com/hashicorp/terraform-plugin-sdk/blob/b7c8ee78f0ccdcdaa2a3fe4b26229203c7f5c3a3/helper/schema/schema.go)

Each of these attributes expects a slice of strings (`[]string`) representing attribute paths. In the `tf` tag, in the schema struct definition of resources/data, it is is proposed to separate attributes paths with `;` as a comma is already being used to separate multiple tags.

For example schema from `resource_entitlement.go` could be redefined from:
```go
	type entity struct {
		GroupId string `json:"group_id,omitempty" tf:"force_new"`
		UserId  string `json:"user_id,omitempty" tf:"force_new"`
		SpnId   string `json:"service_principal_id,omitempty" tf:"force_new"`
	}
	entitlementSchema := common.StructToSchema(entity{},
		func(m map[string]*schema.Schema) map[string]*schema.Schema {
			addEntitlementsToSchema(&m)
			alof := []string{"group_id", "user_id", "service_principal_id"}
			for _, field := range alof {
				m[field].AtLeastOneOf = alof
			}
			return m
		})
```
to:
```go
	type entity struct {
		GroupId string `json:"group_id,omitempty" tf:"force_new,at_least_one_of:user_id;service_principal_id"`
		UserId  string `json:"user_id,omitempty" tf:"force_new,at_least_one_of:group_id;service_principal_id"`
		SpnId   string `json:"service_principal_id,omitempty" tf:"force_new,at_least_one_of:user_id;service_principal_id"`
	}
	entitlementSchema := common.StructToSchema(entity{},
		func(m map[string]*schema.Schema) map[string]*schema.Schema {
			addEntitlementsToSchema(&m)
			return m
		})
```
## Tests
Unit tests added.

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

