### PR TITLE
Add .codegen.json configuration

### DIFF
--- a/.codegen.json
+++ b/.codegen.json
@@ -1,5 +1,5 @@
 {
-    "formatter": "go run golang.org/x/tools/cmd/goimports@latest -w $FILENAMES && gofmt -w $FILENAMES",
+    "formatter": "make fmt",
     "version": {
         "common/version.go": "version = \"$VERSION\""
     },
@@ -8,8 +8,7 @@
             "go"
         ],
         "post_generate": [
-            "go run honnef.co/go/tools/cmd/staticcheck@v0.4.0 ./...",
-            "go run gotest.tools/gotestsum@latest --format pkgname-and-test-fails --no-summary=skipped --raw-command go test -v -json -short -coverprofile=coverage.txt ./..."
+            "make test"
         ]
     }
 }

--- a/.codegen.json
+++ b/.codegen.json
@@ -1,0 +1,15 @@
+{
+    "formatter": "go run golang.org/x/tools/cmd/goimports@latest -w $FILENAMES && gofmt -w $FILENAMES",
+    "version": {
+        "common/version.go": "version = \"$VERSION\""
+    },
+    "toolchain": {
+        "required": [
+            "go"
+        ],
+        "post_generate": [
+            "go run honnef.co/go/tools/cmd/staticcheck@v0.4.0 ./...",
+            "go run gotest.tools/gotestsum@latest --format pkgname-and-test-fails --no-summary=skipped --raw-command go test -v -json -short -coverprofile=coverage.txt ./..."
+        ]
+    }
+}

--- a/.codegen/changelog.md.tmpl
+++ b/.codegen/changelog.md.tmpl
@@ -1,0 +1,22 @@
+# Version changelog
+
+## {{.Version}}
+
+### New Features and Improvements
+{{range .Changes -}}
+ * {{.}}.
+{{end}}
+
+### Documentation Changes
+
+### Exporter
+
+### Internal Changes
+{{if .DependencyUpdates}}
+Dependency updates:
+{{range .DependencyUpdates}}
+ * {{.}}.
+{{- end -}}
+{{end}}
+
+## {{.PrevVersion}}


### PR DESCRIPTION
## Change
This PR adds a .codegen.json file to the TF provider, like what we have in the other SDKs (e.g. [Go SDK](https://github.com/databricks/databricks-sdk-go/blob/main/.codegen.json)). This allows us to automate the release process for the provider, including autogenerating the entries in the changelog, and will also allow us to start using code generation for components of the provider.

The generated changelog still needs manual review, but it includes all of the sections that ought to be included in the changelog. It does not include the changes in the OpenAPI spec or provider schema itself for now, but this can be added later.

## Tests
Ran `deco openapi release-sdk terraform --no-reset-main --dry-run`, which generated this diff: https://github.com/databricks/terraform-provider-databricks/pull/3181
