### PR TITLE
Fix create storage credentials with owner for account

### DIFF
--- a/catalog/resource_storage_credential.go
+++ b/catalog/resource_storage_credential.go
@@ -75,7 +75,7 @@ func ResourceStorageCredential() common.Resource {
 				_, err = acc.StorageCredentials.Update(ctx, catalog.AccountsUpdateStorageCredential{
 					CredentialInfo:        &update,
 					MetastoreId:           metastoreId,
-					StorageCredentialName: storageCredential.CredentialInfo.Id,
+					StorageCredentialName: storageCredential.CredentialInfo.Name,
 				})
 				if err != nil {
 					return err

--- a/catalog/resource_storage_credential_test.go
+++ b/catalog/resource_storage_credential_test.go
@@ -115,6 +115,72 @@ func TestCreateStorageCredentialWithOwner(t *testing.T) {
 	}.ApplyNoError(t)
 }
 
+func TestCreateAccountStorageCredentialWithOwner(t *testing.T) {
+	qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "POST",
+				Resource: "/api/2.0/accounts/account_id/metastores/metastore_id/storage-credentials",
+				ExpectedRequest: &catalog.AccountsCreateStorageCredential{
+					MetastoreId: "metastore_id",
+					CredentialInfo: &catalog.CreateStorageCredential{
+						Name: "storage_credential_name",
+						AwsIamRole: &catalog.AwsIamRole{
+							RoleArn: "arn:aws:iam::1234567890:role/MyRole-AJJHDSKSDF",
+						},
+					},
+				},
+				Response: catalog.AccountsStorageCredentialInfo{
+					CredentialInfo: &catalog.StorageCredentialInfo{
+						Name: "storage_credential_name",
+					},
+				},
+			},
+			{
+				Method:   "PUT",
+				Resource: "/api/2.0/accounts/account_id/metastores/metastore_id/storage-credentials/storage_credential_name",
+				ExpectedRequest: &catalog.AccountsUpdateStorageCredential{
+					CredentialInfo: &catalog.UpdateStorageCredential{
+						Name:  "storage_credential_name",
+						Owner: "administrators",
+						AwsIamRole: &catalog.AwsIamRole{
+							RoleArn: "arn:aws:iam::1234567890:role/MyRole-AJJHDSKSDF",
+						},
+					},
+				},
+				Response: &catalog.AccountsStorageCredentialInfo{
+					CredentialInfo: &catalog.StorageCredentialInfo{
+						Name: "storage_credential_name",
+					},
+				},
+			},
+			{
+				Method:   "GET",
+				Resource: "/api/2.0/accounts/account_id/metastores/metastore_id/storage-credentials/storage_credential_name?",
+				Response: &catalog.AccountsStorageCredentialInfo{
+					CredentialInfo: &catalog.StorageCredentialInfo{
+						Name: "storage_credential_name",
+						AwsIamRole: &catalog.AwsIamRole{
+							RoleArn: "arn:aws:iam::1234567890:role/MyRole-AJJHDSKSDF",
+						},
+					},
+				},
+			},
+		},
+		Resource:  ResourceStorageCredential(),
+		AccountID: "account_id",
+		Create:    true,
+		HCL: `
+		name = "storage_credential_name"
+		metastore_id = "metastore_id"
+		aws_iam_role {
+			role_arn = "arn:aws:iam::1234567890:role/MyRole-AJJHDSKSDF"
+		}
+		owner = "administrators"
+		`,
+	}.ApplyNoError(t)
+}
+
 func TestCreateStorageCredentialsReadOnly(t *testing.T) {
 	qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{

--- a/internal/acceptance/storage_credential_test.go
+++ b/internal/acceptance/storage_credential_test.go
@@ -32,3 +32,22 @@ func TestUcAccStorageCredential(t *testing.T) {
 		})
 	}
 }
+
+func TestAccStorageCredentialOwner(t *testing.T) {
+	unityAccountLevel(t, step{
+		Template: `
+			resource "databricks_service_principal" "test_acc_storage_credential_owner" {
+				display_name = "test_acc_storage_credential_owner {var.RANDOM}"
+			}
+
+			resource "databricks_storage_credential" "test_acc_storage_credential_owner" {
+				name = "test_acc_storage_credential_owner-{var.RANDOM}"
+				owner = databricks_service_principal.test_acc_storage_credential_owner.application_id
+				metastore_id = "{env.TEST_METASTORE_ID}"
+				aws_iam_role {
+					role_arn = "{env.TEST_METASTORE_DATA_ACCESS_ARN}"
+				}
+			}
+		`,
+	})
+}


### PR DESCRIPTION
## Changes

For the given account storage credentials definition:

```hcl
resource "databricks_storage_credential" "catalog_staging" {
  name  = "catalog_staging"
  owner = databricks_service_principal.catalog["staging"].application_id
  metastore_id = databricks_metastore.unity_metastore.id
  aws_iam_role {
    role_arn = "arn:aws:iam::1234567890:role/MyRole-AJJHDSKSDF"
  }
  provider = databricks.account
}
```

fixes the error:

```bash
Error: cannot create storage credential: Storage Credential '02e010b4-0fdb-46d7-af9f-706e99f2b19b' does not exist.
```

as described in https://github.com/databricks/terraform-provider-databricks/issues/3134#issuecomment-1900468908.

From the logs, before this change, storage credential ID is used instead of a name when calling `PUT`:

```
2024-01-19T13:34:51.868Z [DEBUG] provider.terraform-provider-databricks_v1.34.0: POST /api/2.0/accounts/b0834ee0-0ead-4165-9d0a-6f081fdae9bc/metastores/79ba06d5-3c04-4fc1-9df2-a82ac2ec27e4/storage-credentials
> {
>   "credential_info": {
>     "aws_iam_role": {
>       "role_arn": "arn:aws:iam::1234567890:role/MyRole-AJJHDSKSDF"
>     },
>     "name": "catalog_staging"
>   }
> }
< HTTP/2.0 200 OK
< {
<   "credential_info": {
<     "aws_iam_role": {
<       "external_id": "b0834ee0-0ead-4165-9d0a-6f081fdae9bc",
<       "role_arn": "arn:aws:iam::1234567890:role/MyRole-AJJHDSKSDF",
<       "unity_catalog_iam_arn": "arn:aws:iam::414351767826:role/unity-catalog-prod-UCMasterRole-14S5ZJVKOTYTL"
<     },
<     "created_at": 1705671291796,
<     "created_by": "info@email.com",
<     "full_name": "catalog_staging",
<     "id": "02e010b4-0fdb-46d7-af9f-706e99f2b19b",
<     "isolation_mode": "ISOLATION_MODE_OPEN",
<     "metastore_id": "79ba06d5-3c04-4fc1-9df2-a82ac2ec27e4",
<     "name": "catalog_staging",
<     "owner": "info@email.com",
<     "read_only": false,
<     "securable_kind": "STORAGE_CREDENTIAL_AWS_IAM",
<     "securable_type": "STORAGE_CREDENTIAL",
<     "updated_at": 1705671291796,
<     "updated_by": "info@email.com"
<   }
< }: tf_provider_addr=registry.terraform.io/databricks/databricks tf_rpc=ApplyResourceChange @caller=/home/runner/work/terraform-provider-databricks/terraform-provider-databricks/logger/logger.go:33 @module=databricks tf_req_id=3be0adc2-8aa6-6a10-3bf7-5f2b15ecde33 tf_resource_type=databricks_storage_credential timestamp=2024-01-19T13:34:51.868Z
2024-01-19T13:34:52.457Z [DEBUG] provider.terraform-provider-databricks_v1.34.0: non-retriable error: Storage Credential '02e010b4-0fdb-46d7-af9f-706e99f2b19b' does not exist.: tf_provider_addr=registry.terraform.io/databricks/databricks tf_resource_type=databricks_storage_credential tf_rpc=ApplyResourceChange @caller=/home/runner/work/terraform-provider-databricks/terraform-provider-databricks/logger/logger.go:33 @module=databricks tf_req_id=3be0adc2-8aa6-6a10-3bf7-5f2b15ecde33 timestamp=2024-01-19T13:34:52.457Z
2024-01-19T13:34:52.457Z [DEBUG] provider.terraform-provider-databricks_v1.34.0: PUT /api/2.0/accounts/b0834ee0-0ead-4165-9d0a-6f081fdae9bc/metastores/79ba06d5-3c04-4fc1-9df2-a82ac2ec27e4/storage-credentials/02e010b4-0fdb-46d7-af9f-706e99f2b19b
> {
>   "credential_info": {
>     "aws_iam_role": {
>       "role_arn": "arn:aws:iam::1234567890:role/MyRole-AJJHDSKSDF"
>     },
>     "owner": "0c6b1aa7-c609-4605-9195-710ec90cb478"
>   }
> }
< HTTP/2.0 404 Not Found
< {
<   "details": [
<     {
<       "@type": "type.googleapis.com/google.rpc.RequestInfo",
<       "request_id": "f31c49ab-ab2f-4d13-9275-16df29b08747",
<       "serving_data": ""
<     }
<   ],
<   "error_code": "STORAGE_CREDENTIAL_DOES_NOT_EXIST",
<   "message": "Storage Credential '02e010b4-0fdb-46d7-af9f-706e99f2b19b' does not exist."
```

which leads to `STORAGE_CREDENTIAL_DOES_NOT_EXIST` error, because [storage_credential_name is expected](https://docs.databricks.com/api/account/accountstoragecredentials/update), not the ID.

This change passes storage credential name instead of an ID.

## Tests

Tested on live Databricks account with the patched [version](https://registry.terraform.io/providers/donatasm/databricks/latest) of the provider. Account REST API behavior captured in basic unit test.
