### PR TITLE
Exporter: fix generation of cluster policy resources

### DIFF
--- a/exporter/importables.go
+++ b/exporter/importables.go
@@ -726,8 +726,8 @@ var resourcesMap map[string]importable = map[string]importable{
 				// generated HCL code for data source, and it only supports the `name` attribute
 				r.Data.Set("definition", "")
 				builtInClusterPolicies := ic.getBuiltinPolicyFamilies()
-				_, isBuiltin := builtInClusterPolicies[policyFamilyId]
-				if isBuiltin && clusterPolicy.PolicyFamilyDefinitionOverrides == "" {
+				v, isBuiltin := builtInClusterPolicies[policyFamilyId]
+				if isBuiltin && clusterPolicy.PolicyFamilyDefinitionOverrides == "" && v.Name == clusterPolicy.Name {
 					r.Mode = "data"
 				}
 			}

--- a/exporter/importables_test.go
+++ b/exporter/importables_test.go
@@ -118,6 +118,7 @@ func TestClusterPolicy(t *testing.T) {
 func TestPredefinedClusterPolicy(t *testing.T) {
 	d := policies.ResourceClusterPolicy().TestResourceData()
 	d.Set("policy_family_id", "job-cluster")
+	d.Set("name", "Job Compute")
 	policy, _ := json.Marshal(map[string]map[string]string{})
 	d.Set("definition", string(policy))
 	ic := importContextForTest()


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

There was an edge case when cluster policy based on cluster policy family but without definition was marked as `data` instead of resource. This PR fixes it

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

