### PR TITLE
Add support for Vector Search Endpoints

### DIFF
--- a/docs/resources/vector_search_endpoint.md
+++ b/docs/resources/vector_search_endpoint.md
@@ -1,0 +1,46 @@
+---
+subcategory: "Vector Search"
+---
+# databricks_vector_search_endpoint Resource
+
+This resource allows you to create [Vector Search Endpoint](https://docs.databricks.com/en/generative-ai/vector-search.html) in Databricks.  Vector Search is a serverless similarity search engine that allows you to store a vector representation of your data, including metadata, in a vector database.  The Vector Search Endpoint is used to create and access vector search indexes.
+
+## Example Usage
+
+
+```hcl
+resource "databricks_vector_search_endpoint" "this" {
+  name = "vector-search-test"
+  endpoint_type = "STANDARD"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) Name of the Vector Search Endpoint to create.  If name is changed, Vector Search Endpoint is recreated.
+* `endpoint_type` (Required) type of Vector Search Endpoint.  Currently only accepting single value: `STANDARD` (See [documentation](https://docs.databricks.com/api/workspace/vectorsearchendpoints/createendpoint) for the list of currently supported values).  If it changed, Vector Search Endpoint is recreated.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The same as the name of the endpoint.
+* `creator` - Creator of the endpoint.
+* `creation_timestamp` - Timestamp of endpoint creation (milliseconds).
+* `last_updated_user` - User who last updated the endpoint.
+* `last_updated_timestamp` - Timestamp of last update to the endpoint (milliseconds).
+* `endpoint_id` - Unique identifier of the endpoint.
+* `num_indexes` - Current status of the endpoint.
+* `endpoint_status` - Object describing the current status of the endpoint consisting of following fields:
+  * `state` - Current state of the endpoint. Currently following values are supported: `PROVISIONING`, `ONLINE`, `OFFLINE`.
+  * `message` - Additional status message.
+
+## Import
+
+The resource can be imported using the name of the Vector Search Endpoint
+
+```bash
+terraform import databricks_vector_search_endpoint.this <endpoint-name>
+```

--- a/docs/resources/vector_search_endpoint.md
+++ b/docs/resources/vector_search_endpoint.md
@@ -3,7 +3,9 @@ subcategory: "Vector Search"
 ---
 # databricks_vector_search_endpoint Resource
 
-This resource allows you to create [Vector Search Endpoint](https://docs.databricks.com/en/generative-ai/vector-search.html) in Databricks.  Vector Search is a serverless similarity search engine that allows you to store a vector representation of your data, including metadata, in a vector database.  The Vector Search Endpoint is used to create and access vector search indexes.
+-> **Note** This resource could be only used on Unity Catalog-enabled workspace!
+
+This resource allows you to create [Vector Search Endpoint](https://docs.databricks.com/en/generative-ai/vector-search.html) in Databricks.  Vector Search is a serverless similarity search engine that allows you to store a vector representation of your data, including metadata, in a vector database.  The Vector Search Endpoint is used to create and access vector search indexes. 
 
 ## Example Usage
 

--- a/docs/resources/vector_search_endpoint.md
+++ b/docs/resources/vector_search_endpoint.md
@@ -22,7 +22,7 @@ resource "databricks_vector_search_endpoint" "this" {
 The following arguments are supported:
 
 * `name` - (Required) Name of the Vector Search Endpoint to create.  If name is changed, Vector Search Endpoint is recreated.
-* `endpoint_type` (Required) type of Vector Search Endpoint.  Currently only accepting single value: `STANDARD` (See [documentation](https://docs.databricks.com/api/workspace/vectorsearchendpoints/createendpoint) for the list of currently supported values).  If it changed, Vector Search Endpoint is recreated.
+* `endpoint_type` (Required) type of Vector Search Endpoint.  Currently only accepting single value: `STANDARD` (See [documentation](https://docs.databricks.com/api/workspace/vectorsearchendpoints/createendpoint) for the list of currently supported values).  If it's changed, Vector Search Endpoint is recreated.
 
 ## Attribute Reference
 
@@ -33,8 +33,8 @@ In addition to all arguments above, the following attributes are exported:
 * `creation_timestamp` - Timestamp of endpoint creation (milliseconds).
 * `last_updated_user` - User who last updated the endpoint.
 * `last_updated_timestamp` - Timestamp of last update to the endpoint (milliseconds).
-* `endpoint_id` - Unique identifier of the endpoint.
-* `num_indexes` - Current status of the endpoint.
+* `endpoint_id` - Unique internal identifier of the endpoint (UUID).
+* `num_indexes` - Number of indexes on the endpoint.
 * `endpoint_status` - Object describing the current status of the endpoint consisting of following fields:
   * `state` - Current state of the endpoint. Currently following values are supported: `PROVISIONING`, `ONLINE`, `OFFLINE`.
   * `message` - Additional status message.

--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -2168,16 +2168,19 @@ func TestImportingNotebooksWorkspaceFiles(t *testing.T) {
 				Response: workspace.ObjectList{
 					Objects: []workspace.ObjectStatus{notebookStatus, fileStatus},
 				},
+				ReuseRequest: true,
 			},
 			{
-				Method:   "GET",
-				Resource: "/api/2.0/workspace/get-status?path=%2FNotebook",
-				Response: notebookStatus,
+				Method:       "GET",
+				Resource:     "/api/2.0/workspace/get-status?path=%2FNotebook",
+				Response:     notebookStatus,
+				ReuseRequest: true,
 			},
 			{
-				Method:   "GET",
-				Resource: "/api/2.0/workspace/get-status?path=%2FFile",
-				Response: fileStatus,
+				Method:       "GET",
+				Resource:     "/api/2.0/workspace/get-status?path=%2FFile",
+				Response:     fileStatus,
+				ReuseRequest: true,
 			},
 			{
 				Method:   "GET",
@@ -2185,6 +2188,7 @@ func TestImportingNotebooksWorkspaceFiles(t *testing.T) {
 				Response: workspace.ExportPath{
 					Content: "dGVzdA==",
 				},
+				ReuseRequest: true,
 			},
 			{
 				Method:   "GET",
@@ -2192,6 +2196,7 @@ func TestImportingNotebooksWorkspaceFiles(t *testing.T) {
 				Response: workspace.ExportPath{
 					Content: "dGVzdA==",
 				},
+				ReuseRequest: true,
 			},
 		},
 		func(ctx context.Context, client *common.DatabricksClient) {

--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -2168,19 +2168,16 @@ func TestImportingNotebooksWorkspaceFiles(t *testing.T) {
 				Response: workspace.ObjectList{
 					Objects: []workspace.ObjectStatus{notebookStatus, fileStatus},
 				},
-				ReuseRequest: true,
 			},
 			{
-				Method:       "GET",
-				Resource:     "/api/2.0/workspace/get-status?path=%2FNotebook",
-				Response:     notebookStatus,
-				ReuseRequest: true,
+				Method:   "GET",
+				Resource: "/api/2.0/workspace/get-status?path=%2FNotebook",
+				Response: notebookStatus,
 			},
 			{
-				Method:       "GET",
-				Resource:     "/api/2.0/workspace/get-status?path=%2FFile",
-				Response:     fileStatus,
-				ReuseRequest: true,
+				Method:   "GET",
+				Resource: "/api/2.0/workspace/get-status?path=%2FFile",
+				Response: fileStatus,
 			},
 			{
 				Method:   "GET",
@@ -2188,7 +2185,6 @@ func TestImportingNotebooksWorkspaceFiles(t *testing.T) {
 				Response: workspace.ExportPath{
 					Content: "dGVzdA==",
 				},
-				ReuseRequest: true,
 			},
 			{
 				Method:   "GET",
@@ -2196,7 +2192,6 @@ func TestImportingNotebooksWorkspaceFiles(t *testing.T) {
 				Response: workspace.ExportPath{
 					Content: "dGVzdA==",
 				},
-				ReuseRequest: true,
 			},
 		},
 		func(ctx context.Context, client *common.DatabricksClient) {

--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -2168,6 +2168,7 @@ func TestImportingNotebooksWorkspaceFiles(t *testing.T) {
 				Response: workspace.ObjectList{
 					Objects: []workspace.ObjectStatus{notebookStatus, fileStatus},
 				},
+				ReuseRequest: true,
 			},
 			{
 				Method:       "GET",

--- a/internal/acceptance/vector_search_test.go
+++ b/internal/acceptance/vector_search_test.go
@@ -1,0 +1,30 @@
+package acceptance
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+)
+
+func TestAccVectorSearchEndpoint(t *testing.T) {
+	cloudEnv := os.Getenv("CLOUD_ENV")
+	switch cloudEnv {
+	case "aws", "azure":
+	default:
+		t.Skipf("not available on %s", cloudEnv)
+	}
+
+	name := fmt.Sprintf("terraform-test-vector-search-%[1]s",
+		acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum))
+	workspaceLevel(t, step{
+		Template: fmt.Sprintf(`
+			resource "databricks_vector_search_endpoint" "this" {
+				name          = "%s"
+				endpoint_type = "STANDARD"
+			  }
+			`, name),
+	},
+	)
+}

--- a/internal/acceptance/vector_search_test.go
+++ b/internal/acceptance/vector_search_test.go
@@ -22,7 +22,7 @@ func TestUcAccVectorSearchEndpoint(t *testing.T) {
 		Template: fmt.Sprintf(`
 			resource "databricks_vector_search_endpoint" "this" {
 				name          = "%s"
-				mendpoint_type = "STANDARD"
+				endpoint_type = "STANDARD"
 			  }
 			`, name),
 	},

--- a/internal/acceptance/vector_search_test.go
+++ b/internal/acceptance/vector_search_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 )
 
-func TestAccVectorSearchEndpoint(t *testing.T) {
+func TestUcAccVectorSearchEndpoint(t *testing.T) {
 	cloudEnv := os.Getenv("CLOUD_ENV")
 	switch cloudEnv {
 	case "aws", "azure":
@@ -18,7 +18,7 @@ func TestAccVectorSearchEndpoint(t *testing.T) {
 
 	name := fmt.Sprintf("terraform-test-vector-search-%[1]s",
 		acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum))
-	workspaceLevel(t, step{
+	unityWorkspaceLevel(t, step{
 		Template: fmt.Sprintf(`
 			resource "databricks_vector_search_endpoint" "this" {
 				name          = "%s"

--- a/internal/acceptance/vector_search_test.go
+++ b/internal/acceptance/vector_search_test.go
@@ -11,7 +11,7 @@ import (
 func TestUcAccVectorSearchEndpoint(t *testing.T) {
 	cloudEnv := os.Getenv("CLOUD_ENV")
 	switch cloudEnv {
-	case "aws", "azure":
+	case "ucws", "azure":
 	default:
 		t.Skipf("not available on %s", cloudEnv)
 	}
@@ -22,7 +22,7 @@ func TestUcAccVectorSearchEndpoint(t *testing.T) {
 		Template: fmt.Sprintf(`
 			resource "databricks_vector_search_endpoint" "this" {
 				name          = "%s"
-				endpoint_type = "STANDARD"
+				mendpoint_type = "STANDARD"
 			  }
 			`, name),
 	},

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -39,6 +39,7 @@ import (
 	"github.com/databricks/terraform-provider-databricks/sql"
 	"github.com/databricks/terraform-provider-databricks/storage"
 	"github.com/databricks/terraform-provider-databricks/tokens"
+	"github.com/databricks/terraform-provider-databricks/vectorsearch"
 	"github.com/databricks/terraform-provider-databricks/workspace"
 )
 
@@ -173,6 +174,7 @@ func DatabricksProvider() *schema.Provider {
 			"databricks_user":                        scim.ResourceUser().ToResource(),
 			"databricks_user_instance_profile":       aws.ResourceUserInstanceProfile().ToResource(),
 			"databricks_user_role":                   aws.ResourceUserRole().ToResource(),
+			"databricks_vector_search_endpoint":      vectorsearch.ResourceVectorSearchEndpoint().ToResource(),
 			"databricks_volume":                      catalog.ResourceVolume().ToResource(),
 			"databricks_workspace_conf":              workspace.ResourceWorkspaceConf().ToResource(),
 			"databricks_workspace_file":              workspace.ResourceWorkspaceFile().ToResource(),

--- a/vectorsearch/resource_vector_search_endpoint.go
+++ b/vectorsearch/resource_vector_search_endpoint.go
@@ -1,0 +1,85 @@
+package vectorsearch
+
+import (
+	"context"
+	"time"
+
+	"github.com/databricks/databricks-sdk-go/retries"
+	"github.com/databricks/terraform-provider-databricks/common"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/databricks/databricks-sdk-go/service/vectorsearch"
+)
+
+const DefaultProvisionTimeout = 45 * time.Minute
+
+func ResourceVectorSearchEndpoint() *schema.Resource {
+	s := common.StructToSchema(
+		vectorsearch.EndpointInfo{},
+		func(s map[string]*schema.Schema) map[string]*schema.Schema {
+			common.CustomizeSchemaPath(s, "name").SetRequired()
+			s["name"].ForceNew = true
+			s["endpoint_type"].ForceNew = true
+			common.CustomizeSchemaPath(s, "endpoint_type").SetRequired()
+			delete(s, "id")
+			common.CustomizeSchemaPath(s, "creator").SetReadOnly()
+			common.CustomizeSchemaPath(s, "creation_timestamp").SetReadOnly()
+			common.CustomizeSchemaPath(s, "last_updated_timestamp").SetReadOnly()
+			common.CustomizeSchemaPath(s, "last_updated_user").SetReadOnly()
+			common.CustomizeSchemaPath(s, "endpoint_status").SetReadOnly()
+			common.CustomizeSchemaPath(s, "num_indexes").SetReadOnly()
+			common.CustomizeSchemaPath(s).AddNewField("endpoint_id", &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			})
+
+			return s
+		})
+
+	return common.Resource{
+		Create: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
+			w, err := c.WorkspaceClient()
+			if err != nil {
+				return err
+			}
+			var req vectorsearch.CreateEndpoint
+			common.DataToStructPointer(d, s, &req)
+			endpoint, err := w.VectorSearchEndpoints.CreateEndpointAndWait(ctx, req,
+				retries.Timeout[vectorsearch.EndpointInfo](d.Timeout(schema.TimeoutCreate)))
+			if err != nil {
+				return err
+			}
+			d.SetId(endpoint.Name)
+			return nil
+		},
+		Read: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
+			w, err := c.WorkspaceClient()
+			if err != nil {
+				return err
+			}
+			endpoint, err := w.VectorSearchEndpoints.GetEndpointByEndpointName(ctx, d.Id())
+			if err != nil {
+				return err
+			}
+			err = common.StructToData(*endpoint, s, d)
+			if err != nil {
+				return err
+			}
+			d.Set("endpoint_id", endpoint.Id)
+			return nil
+		},
+		Delete: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
+			w, err := c.WorkspaceClient()
+			if err != nil {
+				return err
+			}
+			return w.VectorSearchEndpoints.DeleteEndpointByEndpointName(ctx, d.Id())
+		},
+		StateUpgraders: []schema.StateUpgrader{},
+		Schema:         s,
+		SchemaVersion:  0,
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(DefaultProvisionTimeout),
+		},
+	}.ToResource()
+}

--- a/vectorsearch/resource_vector_search_endpoint.go
+++ b/vectorsearch/resource_vector_search_endpoint.go
@@ -42,8 +42,7 @@ func ResourceVectorSearchEndpoint() *schema.Resource {
 			}
 			var req vectorsearch.CreateEndpoint
 			common.DataToStructPointer(d, s, &req)
-			endpoint, err := w.VectorSearchEndpoints.CreateEndpointAndWait(ctx, req,
-				retries.Timeout[vectorsearch.EndpointInfo](d.Timeout(schema.TimeoutCreate)))
+			endpoint, err := w.VectorSearchEndpoints.CreateEndpoint(ctx, req).GetWithTimeout(d.Timeout(schema.TimeoutCreate))
 			if err != nil {
 				return err
 			}

--- a/vectorsearch/resource_vector_search_endpoint.go
+++ b/vectorsearch/resource_vector_search_endpoint.go
@@ -12,7 +12,7 @@ import (
 
 const DefaultProvisionTimeout = 45 * time.Minute
 
-func ResourceVectorSearchEndpoint() *schema.Resource {
+func ResourceVectorSearchEndpoint() common.Resource {
 	s := common.StructToSchema(
 		vectorsearch.EndpointInfo{},
 		func(s map[string]*schema.Schema) map[string]*schema.Schema {
@@ -81,5 +81,5 @@ func ResourceVectorSearchEndpoint() *schema.Resource {
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(DefaultProvisionTimeout),
 		},
-	}.ToResource()
+	}
 }

--- a/vectorsearch/resource_vector_search_endpoint.go
+++ b/vectorsearch/resource_vector_search_endpoint.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/databricks/databricks-sdk-go/retries"
 	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
@@ -42,7 +41,11 @@ func ResourceVectorSearchEndpoint() *schema.Resource {
 			}
 			var req vectorsearch.CreateEndpoint
 			common.DataToStructPointer(d, s, &req)
-			endpoint, err := w.VectorSearchEndpoints.CreateEndpoint(ctx, req).GetWithTimeout(d.Timeout(schema.TimeoutCreate))
+			wait, err := w.VectorSearchEndpoints.CreateEndpoint(ctx, req)
+			if err != nil {
+				return err
+			}
+			endpoint, err := wait.GetWithTimeout(d.Timeout(schema.TimeoutCreate))
 			if err != nil {
 				return err
 			}

--- a/vectorsearch/resource_vector_search_endpoint.go
+++ b/vectorsearch/resource_vector_search_endpoint.go
@@ -17,10 +17,8 @@ func ResourceVectorSearchEndpoint() *schema.Resource {
 	s := common.StructToSchema(
 		vectorsearch.EndpointInfo{},
 		func(s map[string]*schema.Schema) map[string]*schema.Schema {
-			common.CustomizeSchemaPath(s, "name").SetRequired()
-			s["name"].ForceNew = true
-			s["endpoint_type"].ForceNew = true
-			common.CustomizeSchemaPath(s, "endpoint_type").SetRequired()
+			common.CustomizeSchemaPath(s, "name").SetRequired().SetForceNew()
+			common.CustomizeSchemaPath(s, "endpoint_type").SetRequired().SetForceNew()
 			delete(s, "id")
 			common.CustomizeSchemaPath(s, "creator").SetReadOnly()
 			common.CustomizeSchemaPath(s, "creation_timestamp").SetReadOnly()

--- a/vectorsearch/resource_vector_search_endpoint_test.go
+++ b/vectorsearch/resource_vector_search_endpoint_test.go
@@ -1,0 +1,17 @@
+package vectorsearch
+
+import (
+	"testing"
+
+	"github.com/databricks/terraform-provider-databricks/qa"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVectorSearchEndpointCornerCases(t *testing.T) {
+	qa.ResourceCornerCases(t, ResourceVectorSearchEndpoint())
+}
+
+func TestVectorSearchEndpointCreate(t *testing.T) {
+	assert.Equal(t, 1, 1)
+}

--- a/vectorsearch/resource_vector_search_endpoint_test.go
+++ b/vectorsearch/resource_vector_search_endpoint_test.go
@@ -3,9 +3,13 @@ package vectorsearch
 import (
 	"testing"
 
+	"github.com/databricks/databricks-sdk-go/experimental/mocks"
 	"github.com/databricks/terraform-provider-databricks/qa"
 
+	"github.com/databricks/databricks-sdk-go/service/vectorsearch"
+
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
 func TestVectorSearchEndpointCornerCases(t *testing.T) {
@@ -13,5 +17,41 @@ func TestVectorSearchEndpointCornerCases(t *testing.T) {
 }
 
 func TestVectorSearchEndpointCreate(t *testing.T) {
-	assert.Equal(t, 1, 1)
+	ei := &vectorsearch.EndpointInfo{
+		Name:           "abc",
+		EndpointStatus: &vectorsearch.EndpointStatus{State: "ONLINE"},
+		Id:             "1234-5678",
+	}
+	d, err := qa.ResourceFixture{
+		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
+			e := w.GetMockVectorSearchEndpointsAPI().EXPECT()
+			e.CreateEndpointAndWait(mock.Anything, vectorsearch.CreateEndpoint{
+				Name:         "abc",
+				EndpointType: "STANDARD",
+			}, mock.Anything).Return(ei, nil)
+			e.GetEndpointByEndpointName(mock.Anything, "abc").Return(ei, nil)
+		},
+		Resource: ResourceVectorSearchEndpoint(),
+		HCL: `
+		name          = "abc"
+		endpoint_type = "STANDARD"
+		`,
+		Create: true,
+	}.Apply(t)
+	assert.NoError(t, err)
+	assert.Equal(t, "abc", d.Id())
+	assert.Equal(t, "1234-5678", d.Get("endpoint_id"))
+}
+
+func TestResourcePASDelete(t *testing.T) {
+	d, err := qa.ResourceFixture{
+		MockWorkspaceClientFunc: func(a *mocks.MockWorkspaceClient) {
+			a.GetMockVectorSearchEndpointsAPI().EXPECT().DeleteEndpointByEndpointName(mock.Anything, "abc").Return(nil)
+		},
+		Resource: ResourceVectorSearchEndpoint(),
+		Delete:   true,
+		ID:       "abc",
+	}.Apply(t)
+	assert.NoError(t, err)
+	assert.Equal(t, "abc", d.Id())
 }

--- a/vectorsearch/resource_vector_search_endpoint_test.go
+++ b/vectorsearch/resource_vector_search_endpoint_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/databricks/databricks-sdk-go/experimental/mocks"
+	"github.com/databricks/databricks-sdk-go/qa/poll"
 	"github.com/databricks/terraform-provider-databricks/qa"
 
 	"github.com/databricks/databricks-sdk-go/service/vectorsearch"
@@ -25,10 +26,11 @@ func TestVectorSearchEndpointCreate(t *testing.T) {
 	d, err := qa.ResourceFixture{
 		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
 			e := w.GetMockVectorSearchEndpointsAPI().EXPECT()
-			e.CreateEndpointAndWait(mock.Anything, vectorsearch.CreateEndpoint{
+			e.CreateEndpoint(mock.Anything, vectorsearch.CreateEndpoint{
 				Name:         "abc",
 				EndpointType: "STANDARD",
-			}, mock.Anything).Return(ei, nil)
+			}).Return(&vectorsearch.WaitGetEndpointVectorSearchEndpointOnline[vectorsearch.EndpointInfo]{Poll: poll.Simple(*ei)}, nil)
+
 			e.GetEndpointByEndpointName(mock.Anything, "abc").Return(ei, nil)
 		},
 		Resource: ResourceVectorSearchEndpoint(),

--- a/vectorsearch/resource_vector_search_endpoint_test.go
+++ b/vectorsearch/resource_vector_search_endpoint_test.go
@@ -45,6 +45,30 @@ func TestVectorSearchEndpointCreate(t *testing.T) {
 	assert.Equal(t, "1234-5678", d.Get("endpoint_id"))
 }
 
+func TestVectorSearchEndpointRead(t *testing.T) {
+	ei := &vectorsearch.EndpointInfo{
+		Name:           "abc",
+		EndpointStatus: &vectorsearch.EndpointStatus{State: "ONLINE"},
+		Id:             "1234-5678",
+	}
+	d, err := qa.ResourceFixture{
+		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
+			e := w.GetMockVectorSearchEndpointsAPI().EXPECT()
+			e.GetEndpointByEndpointName(mock.Anything, "abc").Return(ei, nil)
+		},
+		Resource: ResourceVectorSearchEndpoint(),
+		ID:       "abc",
+		HCL: `
+		name          = "abc"
+		endpoint_type = "STANDARD"
+		`,
+		Read: true,
+	}.Apply(t)
+	assert.NoError(t, err)
+	assert.Equal(t, "abc", d.Id())
+	assert.Equal(t, "1234-5678", d.Get("endpoint_id"))
+}
+
 func TestResourcePASDelete(t *testing.T) {
 	d, err := qa.ResourceFixture{
 		MockWorkspaceClientFunc: func(a *mocks.MockWorkspaceClient) {


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

Added initial support for Databricks Vector Search endpoints that are the base for adding Vector Search Indexes.

It's not clear about adding an integration test - the provisioning of the endpoints is quite a long process (~25-30 minutes).

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [x] covered with integration tests in `internal/acceptance`
- [x] relevant acceptance tests are passing
- [x] using Go SDK

