### PR TITLE
Fix Exporter unit tests

### DIFF
--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -2170,14 +2170,16 @@ func TestImportingNotebooksWorkspaceFiles(t *testing.T) {
 				},
 			},
 			{
-				Method:   "GET",
-				Resource: "/api/2.0/workspace/get-status?path=%2FNotebook",
-				Response: notebookStatus,
+				Method:       "GET",
+				Resource:     "/api/2.0/workspace/get-status?path=%2FNotebook",
+				Response:     notebookStatus,
+				ReuseRequest: true,
 			},
 			{
-				Method:   "GET",
-				Resource: "/api/2.0/workspace/get-status?path=%2FFile",
-				Response: fileStatus,
+				Method:       "GET",
+				Resource:     "/api/2.0/workspace/get-status?path=%2FFile",
+				Response:     fileStatus,
+				ReuseRequest: true,
 			},
 			{
 				Method:   "GET",
@@ -2185,6 +2187,7 @@ func TestImportingNotebooksWorkspaceFiles(t *testing.T) {
 				Response: workspace.ExportPath{
 					Content: "dGVzdA==",
 				},
+				ReuseRequest: true,
 			},
 			{
 				Method:   "GET",
@@ -2192,6 +2195,7 @@ func TestImportingNotebooksWorkspaceFiles(t *testing.T) {
 				Response: workspace.ExportPath{
 					Content: "dGVzdA==",
 				},
+				ReuseRequest: true,
 			},
 		},
 		func(ctx context.Context, client *common.DatabricksClient) {


### PR DESCRIPTION
## Changes
This PR fixes fixtures in exporter unit tests to make the tests pass on `main`.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

