### PR TITLE
Support source for SQL file and dbt tasks

### DIFF
--- a/jobs/resource_job.go
+++ b/jobs/resource_job.go
@@ -87,7 +87,8 @@ type SqlAlertTask struct {
 }
 
 type SqlFileTask struct {
-	Path string `json:"path"`
+	Path   string `json:"path"`
+	Source string `json:"source,omitempty" tf:"suppress_diff"`
 }
 
 // SqlTask contains information about DBSQL task
@@ -110,6 +111,7 @@ type DbtTask struct {
 	Schema            string   `json:"schema,omitempty" tf:"default:default"`
 	Catalog           string   `json:"catalog,omitempty"`
 	WarehouseId       string   `json:"warehouse_id,omitempty"`
+	Source            string   `json:"source,omitempty" tf:"suppress_diff"`
 }
 
 // RunJobTask contains information about RunJobTask


### PR DESCRIPTION
## Changes
Doc: https://docs.databricks.com/api/workspace/jobs/get
Both SQL file task and dbt task now supports `source` field with value `WORKSPACE` and `GIT`, same as notebook task.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

