### PR TITLE
Make IterFields take in aliases

### DIFF
--- a/clusters/resource_cluster.go
+++ b/clusters/resource_cluster.go
@@ -169,7 +169,7 @@ func (ClusterResourceProvider) CustomizeSchema(s map[string]*schema.Schema) map[
 }
 
 func resourceClusterSchema() map[string]*schema.Schema {
-	return common.ResourceProviderStructToSchema(ClusterResourceProvider{})
+	return common.StructToSchema(ClusterResourceProvider{}, nil)
 }
 
 func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {

--- a/clusters/resource_cluster.go
+++ b/clusters/resource_cluster.go
@@ -58,15 +58,15 @@ func ZoneDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
 	return false
 }
 
-type ClusterResourceProvider struct {
+type ClusterSpec struct {
 	compute.ClusterSpec
 }
 
-func (ClusterResourceProvider) Aliases() map[string]string {
+func (ClusterSpec) Aliases() map[string]string {
 	return map[string]string{"cluster_mount_infos": "cluster_mount_info"}
 }
 
-func (ClusterResourceProvider) CustomizeSchema(s map[string]*schema.Schema) map[string]*schema.Schema {
+func (ClusterSpec) CustomizeSchema(s map[string]*schema.Schema) map[string]*schema.Schema {
 	common.CustomizeSchemaPath(s, "cluster_source").SetReadOnly()
 	common.CustomizeSchemaPath(s, "enable_elastic_disk").SetComputed()
 	common.CustomizeSchemaPath(s, "enable_local_disk_encryption").SetComputed()
@@ -169,7 +169,7 @@ func (ClusterResourceProvider) CustomizeSchema(s map[string]*schema.Schema) map[
 }
 
 func resourceClusterSchema() map[string]*schema.Schema {
-	return common.StructToSchema(ClusterResourceProvider{}, nil)
+	return common.StructToSchema(ClusterSpec{}, nil)
 }
 
 func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {

--- a/clusters/resource_cluster.go
+++ b/clusters/resource_cluster.go
@@ -58,7 +58,9 @@ func ZoneDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
 	return false
 }
 
-type ClusterResourceProvider struct{}
+type ClusterResourceProvider struct {
+	compute.ClusterSpec
+}
 
 func (ClusterResourceProvider) UnderlyingType() compute.ClusterSpec {
 	return compute.ClusterSpec{}

--- a/clusters/resource_cluster.go
+++ b/clusters/resource_cluster.go
@@ -62,10 +62,6 @@ type ClusterResourceProvider struct {
 	compute.ClusterSpec
 }
 
-func (ClusterResourceProvider) UnderlyingType() compute.ClusterSpec {
-	return compute.ClusterSpec{}
-}
-
 func (ClusterResourceProvider) Aliases() map[string]string {
 	return map[string]string{"cluster_mount_infos": "cluster_mount_info"}
 }
@@ -173,7 +169,7 @@ func (ClusterResourceProvider) CustomizeSchema(s map[string]*schema.Schema) map[
 }
 
 func resourceClusterSchema() map[string]*schema.Schema {
-	return common.ResourceProviderStructToSchema[compute.ClusterSpec](ClusterResourceProvider{})
+	return common.ResourceProviderStructToSchema(ClusterResourceProvider{})
 }
 
 func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {

--- a/common/reflect_resource.go
+++ b/common/reflect_resource.go
@@ -122,6 +122,9 @@ func MustSchemaPath(s map[string]*schema.Schema, path ...string) *schema.Schema 
 func StructToSchema(v any, customize func(map[string]*schema.Schema) map[string]*schema.Schema) map[string]*schema.Schema {
 	// If the input 'v' is an instance of ResourceProvider, call resourceProviderStructToSchema instead.
 	if rp, ok := v.(ResourceProvider); ok {
+		if customize != nil {
+			panic("Customize should be nil if the input struct is an instance of ResourceProvider, use CustomizeSchema of ResourceProvider instead.")
+		}
 		return resourceProviderStructToSchema(rp)
 	}
 	rv := reflect.ValueOf(v)
@@ -689,14 +692,13 @@ func DataToReflectValue(d *schema.ResourceData, s map[string]*schema.Schema, rv 
 	return readReflectValueFromData([]string{}, d, rv, s, map[string]string{})
 }
 
+// Get the aliases map from the given struct if it is an instance of ResourceProvider.
+// NOTE: This does not return aliases defined on `tf` tags.
 func getAliasesMapFromStruct(s any) map[string]string {
-	var aliases map[string]string
 	if v, ok := s.(ResourceProvider); ok {
-		aliases = v.Aliases()
-	} else {
-		aliases = map[string]string{}
+		return v.Aliases()
 	}
-	return aliases
+	return map[string]string{}
 }
 
 func readReflectValueFromData(path []string, d attributeGetter,

--- a/common/reflect_resource.go
+++ b/common/reflect_resource.go
@@ -466,6 +466,8 @@ func unwrapAliasesMap(fieldName string, aliases map[string]string) map[string]st
 	return result
 }
 
+// Iterate through each field of the given reflect.Value object and execute a callback function with the corresponding
+// terraform schema object as the input.
 func iterFields(rv reflect.Value, path []string, s map[string]*schema.Schema, aliases map[string]string,
 	cb func(fieldSchema *schema.Schema, path []string, valueField *reflect.Value) error) error {
 	rk := rv.Kind()

--- a/common/reflect_resource.go
+++ b/common/reflect_resource.go
@@ -452,19 +452,15 @@ func isGoSdk(v reflect.Value) bool {
 // For example
 //
 //	fieldName = "cluster"
-//	aliases = {"cluster.clusterName": "name"}
+//	aliases = {"cluster.clusterName": "name", "libraries": "library"}
 //	would return: {"clusterName": "name"}
 func unwrapAliasesMap(fieldName string, aliases map[string]string) map[string]string {
 	result := make(map[string]string)
 	prefix := fieldName + "."
 	for key, value := range aliases {
 		// Only keep the keys that have the prefix.
-		if strings.HasPrefix(key, prefix) {
-			// Trim the prefix to unwrap.
-			newKey := strings.TrimPrefix(key, prefix)
-			if newKey != "" {
-				result[newKey] = value
-			}
+		if strings.HasPrefix(key, prefix) && key != prefix {
+			result[key] = value
 		}
 	}
 	return result

--- a/common/reflect_resource.go
+++ b/common/reflect_resource.go
@@ -40,15 +40,13 @@ var kindMap = map[reflect.Kind]string{
 
 // Generic interface for resource provider struct. Using CustomizeSchema and Aliases functions to keep track of additional information
 // on top of the generated go-sdk struct. This is used to replace manually maintained structs with `tf` tags.
-type ResourceProviderStruct[T any] interface {
-	UnderlyingType() T
+type ResourceProviderStruct interface {
 	Aliases() map[string]string
 	CustomizeSchema(map[string]*schema.Schema) map[string]*schema.Schema
 }
 
 // Takes in a ResourceProviderStruct and converts that into a map from string to schema.
-func ResourceProviderStructToSchema[T any](v ResourceProviderStruct[T]) map[string]*schema.Schema {
-	// underlyingType := v.UnderlyingType()
+func ResourceProviderStructToSchema(v ResourceProviderStruct) map[string]*schema.Schema {
 	rv := reflect.ValueOf(v)
 	scm := typeToSchema(rv, []string{}, v.Aliases())
 	scm = v.CustomizeSchema(scm)

--- a/common/reflect_resource.go
+++ b/common/reflect_resource.go
@@ -448,6 +448,28 @@ func isGoSdk(v reflect.Value) bool {
 	return false
 }
 
+// Unwraps aliases map given a fieldname. Should be called everytime we recursively call iterFields.
+// For example
+//
+//	fieldName = "cluster"
+//	aliases = {"cluster.clusterName": "name"}
+//	would return: {"clusterName": "name"}
+func unwrapAliasesMap(fieldName string, aliases map[string]string) map[string]string {
+	result := make(map[string]string)
+	prefix := fieldName + "."
+	for key, value := range aliases {
+		// Only keep the keys that have the prefix.
+		if strings.HasPrefix(key, prefix) {
+			// Trim the prefix to unwrap.
+			newKey := strings.TrimPrefix(key, prefix)
+			if newKey != "" {
+				result[newKey] = value
+			}
+		}
+	}
+	return result
+}
+
 func iterFields(rv reflect.Value, path []string, s map[string]*schema.Schema, aliases map[string]string,
 	cb func(fieldSchema *schema.Schema, path []string, valueField *reflect.Value) error) error {
 	rk := rv.Kind()
@@ -461,7 +483,16 @@ func iterFields(rv reflect.Value, path []string, s map[string]*schema.Schema, al
 	fields := listAllFields(rv)
 	for _, field := range fields {
 		typeField := field.sf
-		fieldName := chooseFieldNameWithAliases(typeField, path, aliases)
+		var fieldName string
+		if len(aliases) == 0 {
+			fieldName = chooseFieldName(typeField)
+		} else {
+			// Always pass in an empty list for path because we unwrap the aliases map on each call.
+			// We do not use the `path` variable in this function because it sometimes contains indices
+			// and sometimes it is empty. Thus we rely on the caller of iterFields to unwrap the keys
+			// of the aliases map.
+			fieldName = chooseFieldNameWithAliases(typeField, []string{}, aliases)
+		}
 		if fieldName == "-" {
 			continue
 		}
@@ -487,7 +518,7 @@ func iterFields(rv reflect.Value, path []string, s map[string]*schema.Schema, al
 	return nil
 }
 
-func collectionToMaps(v any, s *schema.Schema) ([]any, error) {
+func collectionToMaps(v any, s *schema.Schema, aliases map[string]string) ([]any, error) {
 	resultList := []any{}
 	if sl, ok := v.([]string); ok {
 		// most likely list of parameters to job task
@@ -519,14 +550,15 @@ func collectionToMaps(v any, s *schema.Schema) ([]any, error) {
 			}
 			v = v.Elem()
 		}
-		err := iterFields(v, []string{}, r.Schema, map[string]string{}, func(fieldSchema *schema.Schema,
+		err := iterFields(v, []string{}, r.Schema, aliases, func(fieldSchema *schema.Schema,
 			path []string, valueField *reflect.Value) error {
 			fieldName := path[len(path)-1]
+			newAliases := unwrapAliasesMap(fieldName, aliases)
 			fieldValue := valueField.Interface()
 			fieldPath := strings.Join(path, ".")
 			switch fieldSchema.Type {
 			case schema.TypeList, schema.TypeSet:
-				nv, err := collectionToMaps(fieldValue, fieldSchema)
+				nv, err := collectionToMaps(fieldValue, fieldSchema, newAliases)
 				if err != nil {
 					return fmt.Errorf("%s: %v", path, err)
 				}
@@ -568,11 +600,12 @@ func isValueNilOrEmpty(valueField *reflect.Value, fieldPath string) bool {
 
 // StructToData reads result using schema onto resource data
 func StructToData(result any, s map[string]*schema.Schema, d *schema.ResourceData) error {
+	aliases := getAliasesMapFromStruct(result)
 	v := reflect.ValueOf(result)
 	if v.Kind() == reflect.Ptr {
 		v = v.Elem()
 	}
-	return iterFields(v, []string{}, s, map[string]string{}, func(
+	return iterFields(v, []string{}, s, aliases, func(
 		fieldSchema *schema.Schema, path []string, valueField *reflect.Value) error {
 		fieldValue := valueField.Interface()
 		if fieldValue == nil {
@@ -597,7 +630,7 @@ func StructToData(result any, s map[string]*schema.Schema, d *schema.ResourceDat
 				// validation, so we don't to it twice
 				return d.Set(fieldPath, fieldValue)
 			}
-			nv, err := collectionToMaps(fieldValue, fieldSchema)
+			nv, err := collectionToMaps(fieldValue, fieldSchema, aliases)
 			if err != nil {
 				return fmt.Errorf("%s: %v", fieldPath, err)
 			}
@@ -631,7 +664,8 @@ func DiffToStructPointer(d attributeGetter, scm map[string]*schema.Schema, resul
 		panic(fmt.Errorf("pointer is expected, but got %s: %#v", reflectKind(rk), result))
 	}
 	rv = rv.Elem()
-	err := readReflectValueFromData([]string{}, d, rv, scm)
+	aliases := getAliasesMapFromStruct(result)
+	err := readReflectValueFromData([]string{}, d, rv, scm, aliases)
 	if err != nil {
 		panic(err)
 	}
@@ -639,13 +673,14 @@ func DiffToStructPointer(d attributeGetter, scm map[string]*schema.Schema, resul
 
 // DataToStructPointer reads resource data with given schema onto result pointer. Panics.
 func DataToStructPointer(d *schema.ResourceData, scm map[string]*schema.Schema, result any) {
+	aliases := getAliasesMapFromStruct(result)
 	rv := reflect.ValueOf(result)
 	rk := rv.Kind()
 	if rk != reflect.Ptr {
 		panic(fmt.Errorf("pointer is expected, but got %s: %#v", reflectKind(rk), result))
 	}
 	rv = rv.Elem()
-	err := readReflectValueFromData([]string{}, d, rv, scm)
+	err := readReflectValueFromData([]string{}, d, rv, scm, aliases)
 	if err != nil {
 		panic(err)
 	}
@@ -653,14 +688,27 @@ func DataToStructPointer(d *schema.ResourceData, scm map[string]*schema.Schema, 
 
 // DataToReflectValue reads reflect value from data
 func DataToReflectValue(d *schema.ResourceData, s map[string]*schema.Schema, rv reflect.Value) error {
-	return readReflectValueFromData([]string{}, d, rv, s)
+	// TODO: Pass in the right aliases map.
+	return readReflectValueFromData([]string{}, d, rv, s, map[string]string{})
+}
+
+func getAliasesMapFromStruct(s any) map[string]string {
+	var aliases map[string]string
+	if v, ok := s.(ResourceProviderStruct); ok {
+		aliases = v.Aliases()
+	} else {
+		aliases = map[string]string{}
+	}
+	return aliases
 }
 
 func readReflectValueFromData(path []string, d attributeGetter,
-	rv reflect.Value, s map[string]*schema.Schema) error {
-	return iterFields(rv, path, s, map[string]string{}, func(fieldSchema *schema.Schema,
+	rv reflect.Value, s map[string]*schema.Schema, aliases map[string]string) error {
+	return iterFields(rv, path, s, aliases, func(fieldSchema *schema.Schema,
 		path []string, valueField *reflect.Value) error {
 		fieldPath := strings.Join(path, ".")
+		fieldName := path[len(path)-1]
+		newAliases := unwrapAliasesMap(fieldName, aliases)
 		raw, ok := d.GetOk(fieldPath)
 		if !ok {
 			return nil
@@ -697,13 +745,13 @@ func readReflectValueFromData(path []string, d attributeGetter,
 			rawSet := raw.(*schema.Set)
 			rawList := rawSet.List()
 			return readListFromData(path, d, rawList, valueField,
-				fieldSchema, func(i int) string {
+				fieldSchema, newAliases, func(i int) string {
 					return strconv.Itoa(rawSet.F(rawList[i]))
 				})
 		case schema.TypeList:
 			// here we rely on Terraform SDK to perform validation, so we don't to it twice
 			rawList := raw.([]any)
-			return readListFromData(path, d, rawList, valueField, fieldSchema, strconv.Itoa)
+			return readListFromData(path, d, rawList, valueField, fieldSchema, newAliases, strconv.Itoa)
 		default:
 			return fmt.Errorf("%s[%v] unsupported field type", fieldPath, raw)
 		}
@@ -756,7 +804,7 @@ func primitiveReflectValueFromInterface(rk reflect.Kind,
 }
 
 func readListFromData(path []string, d attributeGetter,
-	rawList []any, valueField *reflect.Value, fieldSchema *schema.Schema,
+	rawList []any, valueField *reflect.Value, fieldSchema *schema.Schema, aliases map[string]string,
 	offsetConverter func(i int) string) error {
 	if len(rawList) == 0 {
 		return nil
@@ -770,7 +818,7 @@ func readListFromData(path []string, d attributeGetter,
 		// here we rely on Terraform SDK to perform validation, so we don't to it twice
 		nestedResource := fieldSchema.Elem.(*schema.Resource)
 		nestedPath := append(path, offsetConverter(0))
-		return readReflectValueFromData(nestedPath, d, ve, nestedResource.Schema)
+		return readReflectValueFromData(nestedPath, d, ve, nestedResource.Schema, aliases)
 	case reflect.Struct:
 		// code path for setting the struct value is different from pointer value
 		// in a single way: we set the field only after readReflectValueFromData
@@ -779,7 +827,7 @@ func readListFromData(path []string, d attributeGetter,
 		ve := vstruct.Elem()
 		nestedResource := fieldSchema.Elem.(*schema.Resource)
 		nestedPath := append(path, offsetConverter(0))
-		err := readReflectValueFromData(nestedPath, d, ve, nestedResource.Schema)
+		err := readReflectValueFromData(nestedPath, d, ve, nestedResource.Schema, aliases)
 		if err != nil {
 			return err
 		}
@@ -798,7 +846,7 @@ func readListFromData(path []string, d attributeGetter,
 				nestedPath := append(path, offsetConverter(i))
 				vpointer := reflect.New(valueField.Type().Elem())
 				ve := vpointer.Elem()
-				err := readReflectValueFromData(nestedPath, d, ve, nestedResource.Schema)
+				err := readReflectValueFromData(nestedPath, d, ve, nestedResource.Schema, aliases)
 				if err != nil {
 					return err
 				}

--- a/common/reflect_resource.go
+++ b/common/reflect_resource.go
@@ -46,7 +46,7 @@ type ResourceProvider interface {
 }
 
 // Takes in a ResourceProvider and converts that into a map from string to schema.
-func ResourceProviderStructToSchema(v ResourceProvider) map[string]*schema.Schema {
+func resourceProviderStructToSchema(v ResourceProvider) map[string]*schema.Schema {
 	rv := reflect.ValueOf(v)
 	scm := typeToSchema(rv, []string{}, v.Aliases())
 	scm = v.CustomizeSchema(scm)
@@ -120,6 +120,10 @@ func MustSchemaPath(s map[string]*schema.Schema, path ...string) *schema.Schema 
 
 // StructToSchema makes schema from a struct type & applies customizations from callback given
 func StructToSchema(v any, customize func(map[string]*schema.Schema) map[string]*schema.Schema) map[string]*schema.Schema {
+	// If the input 'v' is an instance of ResourceProvider, call resourceProviderStructToSchema instead.
+	if rp, ok := v.(ResourceProvider); ok {
+		return resourceProviderStructToSchema(rp)
+	}
 	rv := reflect.ValueOf(v)
 	scm := typeToSchema(rv, []string{}, map[string]string{})
 	if customize != nil {

--- a/common/reflect_resource.go
+++ b/common/reflect_resource.go
@@ -121,7 +121,7 @@ func StructToSchema(v any, customize func(map[string]*schema.Schema) map[string]
 	// If the input 'v' is an instance of ResourceProvider, call resourceProviderStructToSchema instead.
 	if rp, ok := v.(ResourceProvider); ok {
 		if customize != nil {
-			panic("Customize should be nil if the input struct is an instance of ResourceProvider, use CustomizeSchema of ResourceProvider instead.")
+			panic("customize should be nil if the input implements the ResourceProvider interface; use CustomizeSchema of ResourceProvider instead")
 		}
 		return resourceProviderStructToSchema(rp)
 	}

--- a/common/reflect_resource.go
+++ b/common/reflect_resource.go
@@ -48,8 +48,8 @@ type ResourceProviderStruct[T any] interface {
 
 // Takes in a ResourceProviderStruct and converts that into a map from string to schema.
 func ResourceProviderStructToSchema[T any](v ResourceProviderStruct[T]) map[string]*schema.Schema {
-	underlyingType := v.UnderlyingType()
-	rv := reflect.ValueOf(underlyingType)
+	// underlyingType := v.UnderlyingType()
+	rv := reflect.ValueOf(v)
 	scm := typeToSchema(rv, []string{}, v.Aliases())
 	scm = v.CustomizeSchema(scm)
 	return scm

--- a/common/reflect_resource.go
+++ b/common/reflect_resource.go
@@ -62,6 +62,11 @@ func reflectKind(k reflect.Kind) string {
 }
 
 func chooseFieldNameWithAliases(typeField reflect.StructField, fieldNamePath []string, aliases map[string]string) string {
+	// If nothing in the aliases map, return the field name from plain chooseFieldName method.
+	if len(aliases) == 0 {
+		return chooseFieldName(typeField)
+	}
+
 	jsonFieldName := getJsonFieldName(typeField)
 	if jsonFieldName == "-" {
 		return "-"
@@ -287,12 +292,7 @@ func typeToSchema(v reflect.Value, path []string, aliases map[string]string) map
 		typeField := field.sf
 		tfTag := typeField.Tag.Get("tf")
 
-		var fieldName string
-		if len(aliases) == 0 {
-			fieldName = chooseFieldName(typeField)
-		} else {
-			fieldName = chooseFieldNameWithAliases(typeField, path, aliases)
-		}
+		fieldName := chooseFieldNameWithAliases(typeField, path, aliases)
 		if fieldName == "-" {
 			continue
 		}
@@ -481,16 +481,11 @@ func iterFields(rv reflect.Value, path []string, s map[string]*schema.Schema, al
 	fields := listAllFields(rv)
 	for _, field := range fields {
 		typeField := field.sf
-		var fieldName string
-		if len(aliases) == 0 {
-			fieldName = chooseFieldName(typeField)
-		} else {
-			// Always pass in an empty list for path because we unwrap the aliases map on each call.
-			// We do not use the `path` variable in this function because it sometimes contains indices
-			// and sometimes it is empty. Thus we rely on the caller of iterFields to unwrap the keys
-			// of the aliases map.
-			fieldName = chooseFieldNameWithAliases(typeField, []string{}, aliases)
-		}
+		// Always pass in an empty list for path because we unwrap the aliases map on each call.
+		// We do not use the `path` variable in this function because it sometimes contains indices
+		// and sometimes it is empty. Thus we rely on the caller of iterFields to unwrap the keys
+		// of the aliases map.
+		fieldName := chooseFieldNameWithAliases(typeField, []string{}, aliases)
 		if fieldName == "-" {
 			continue
 		}

--- a/common/reflect_resource.go
+++ b/common/reflect_resource.go
@@ -38,15 +38,15 @@ var kindMap = map[reflect.Kind]string{
 	reflect.UnsafePointer: "UnsafePointer",
 }
 
-// Generic interface for resource provider struct. Using CustomizeSchema and Aliases functions to keep track of additional information
+// Generic interface for ResourceProvider. Using CustomizeSchema and Aliases functions to keep track of additional information
 // on top of the generated go-sdk struct. This is used to replace manually maintained structs with `tf` tags.
-type ResourceProviderStruct interface {
+type ResourceProvider interface {
 	Aliases() map[string]string
 	CustomizeSchema(map[string]*schema.Schema) map[string]*schema.Schema
 }
 
-// Takes in a ResourceProviderStruct and converts that into a map from string to schema.
-func ResourceProviderStructToSchema(v ResourceProviderStruct) map[string]*schema.Schema {
+// Takes in a ResourceProvider and converts that into a map from string to schema.
+func ResourceProviderStructToSchema(v ResourceProvider) map[string]*schema.Schema {
 	rv := reflect.ValueOf(v)
 	scm := typeToSchema(rv, []string{}, v.Aliases())
 	scm = v.CustomizeSchema(scm)
@@ -694,7 +694,7 @@ func DataToReflectValue(d *schema.ResourceData, s map[string]*schema.Schema, rv 
 
 func getAliasesMapFromStruct(s any) map[string]string {
 	var aliases map[string]string
-	if v, ok := s.(ResourceProviderStruct); ok {
+	if v, ok := s.(ResourceProvider); ok {
 		aliases = v.Aliases()
 	} else {
 		aliases = map[string]string{}

--- a/common/reflect_resource_test.go
+++ b/common/reflect_resource_test.go
@@ -397,13 +397,13 @@ func TestIterFields(t *testing.T) {
 }
 
 func TestCollectionToMaps(t *testing.T) {
-	v, err := collectionToMaps([]string{"a", "b"}, nil, map[string]string{})
+	v, err := collectionToMaps([]string{"a", "b"}, nil, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, []any{"a", "b"}, v)
 
 	_, err = collectionToMaps([]int{1, 2}, &schema.Schema{
 		Elem: schema.TypeBool,
-	}, map[string]string{})
+	}, nil)
 	assert.EqualError(t, err, "not resource")
 }
 
@@ -647,11 +647,11 @@ func TestDiffToStructPointer(t *testing.T) {
 }
 
 func TestReadListFromData(t *testing.T) {
-	err := readListFromData([]string{}, data{}, []any{}, nil, nil, map[string]string{}, nil)
+	err := readListFromData([]string{}, data{}, []any{}, nil, nil, nil, nil)
 	assert.NoError(t, err)
 
 	x := reflect.ValueOf(0)
-	err = readListFromData([]string{}, data{}, []any{1}, &x, nil, map[string]string{}, nil)
+	err = readListFromData([]string{}, data{}, []any{1}, &x, nil, nil, nil)
 	assert.EqualError(t, err, "[[1]] unknown collection field")
 }
 
@@ -673,7 +673,7 @@ func TestReadReflectValueFromDataCornerCases(t *testing.T) {
 	var n Nonsense
 	v := reflect.ValueOf(&n)
 	rv := v.Elem()
-	err := readReflectValueFromData([]string{}, data{"new": 0.123, "invalid": 1}, rv, s, map[string]string{})
+	err := readReflectValueFromData([]string{}, data{"new": 0.123, "invalid": 1}, rv, s, nil)
 	assert.EqualError(t, err, "invalid: invalid[1] unsupported field type")
 }
 

--- a/common/reflect_resource_test.go
+++ b/common/reflect_resource_test.go
@@ -248,6 +248,7 @@ func (DummyResourceProvider) Aliases() map[string]string {
 }
 
 func (DummyResourceProvider) CustomizeSchema(s map[string]*schema.Schema) map[string]*schema.Schema {
+	CustomizeSchemaPath(s, "addresses").SetMinItems(1)
 	CustomizeSchemaPath(s, "addresses").SetMaxItems(10)
 	CustomizeSchemaPath(s, "tags").SetMaxItems(5)
 	CustomizeSchemaPath(s, "home").SetSuppressDiff()

--- a/common/reflect_resource_test.go
+++ b/common/reflect_resource_test.go
@@ -383,7 +383,7 @@ func TestCollectionToMaps(t *testing.T) {
 }
 
 func TestStructToDataWithResourceProviderStruct(t *testing.T) {
-	s := ResourceProviderStructToSchema(DummyResourceProvider{})
+	s := StructToSchema(DummyResourceProvider{}, nil)
 	assert.NotNil(t, s)
 	assert.Equal(t, 5, s["tags"].MaxItems)
 	assert.Equal(t, 10, s["addresses"].MaxItems)

--- a/common/reflect_resource_test.go
+++ b/common/reflect_resource_test.go
@@ -230,12 +230,12 @@ type DummyNoTfTag struct {
 	Enabled     bool              `json:"enabled"`
 	Workers     int               `json:"workers,omitempty"`
 	Description string            `json:"description,omitempty"`
-	Addresses   []Address         `json:"addresses,omitempty"`
+	Addresses   []AddressNoTfTag  `json:"addresses,omitempty"`
 	Things      []string          `json:"things,omitempty"`
 	Tags        map[string]string `json:"tags,omitempty"`
-	Home        *Address          `json:"home,omitempty"`
-	House       *Address          `json:"house,omitempty"`
-	Other       *Address          `json:"other,omitempty"`
+	Home        *AddressNoTfTag   `json:"home,omitempty"`
+	House       *AddressNoTfTag   `json:"house,omitempty"`
+	Other       *AddressNoTfTag   `json:"other,omitempty"`
 }
 
 type DummyResourceProvider struct {
@@ -260,7 +260,7 @@ var dummy = DummyNoTfTag{
 	Enabled:     true,
 	Workers:     1004,
 	Description: "something",
-	Addresses: []Address{
+	Addresses: []AddressNoTfTag{
 		{
 			Line:      "abc",
 			IsPrimary: false,
@@ -274,7 +274,7 @@ var dummy = DummyNoTfTag{
 	Tags: map[string]string{
 		"Foo": "Bar",
 	},
-	Home: &Address{
+	Home: &AddressNoTfTag{
 		Line:      "bcd",
 		IsPrimary: true,
 	},

--- a/common/reflect_resource_test.go
+++ b/common/reflect_resource_test.go
@@ -446,7 +446,7 @@ func TestStructToDataWithResourceProviderStruct(t *testing.T) {
 
 	{
 		//lint:ignore SA1019 Empty required string should be set.
-		_, ok := d.GetOkExists("addresses.0.required_string")
+		_, ok := d.GetOk("addresses.0.required_string")
 		assert.Truef(t, ok, "Empty required string should be set in ResourceData")
 	}
 }

--- a/common/reflect_resource_test.go
+++ b/common/reflect_resource_test.go
@@ -301,7 +301,7 @@ func TestPrimitiveReflectValueFromInterface(t *testing.T) {
 
 func TestIterFields(t *testing.T) {
 	v := reflect.ValueOf("x")
-	err := iterFields(v, []string{"x"}, scm, nil)
+	err := iterFields(v, []string{"x"}, scm, map[string]string{}, nil)
 	assert.EqualError(t, err, "value of Struct is expected, but got String: \"x\"")
 
 	v = reflect.ValueOf(testStruct{})
@@ -309,7 +309,7 @@ func TestIterFields(t *testing.T) {
 		"integer": {
 			Type: schema.TypeInt,
 		},
-	}, nil)
+	}, map[string]string{}, nil)
 	assert.EqualError(t, err, "inconsistency: integer has omitempty, but is not optional")
 
 	err = iterFields(v, []string{}, map[string]*schema.Schema{
@@ -318,7 +318,7 @@ func TestIterFields(t *testing.T) {
 			Default:  nil,
 			Optional: true,
 		},
-	}, nil)
+	}, map[string]string{}, nil)
 	assert.EqualError(t, err, "inconsistency: non_optional is optional, default is empty, but has no omitempty")
 
 	err = iterFields(v, []string{}, map[string]*schema.Schema{
@@ -327,7 +327,7 @@ func TestIterFields(t *testing.T) {
 			Default:  "_",
 			Optional: true,
 		},
-	}, func(fieldSchema *schema.Schema, path []string, valueField *reflect.Value) error {
+	}, map[string]string{}, func(fieldSchema *schema.Schema, path []string, valueField *reflect.Value) error {
 		return fmt.Errorf("test error")
 	})
 	assert.EqualError(t, err, "non_optional: test error")

--- a/common/reflect_resource_test.go
+++ b/common/reflect_resource_test.go
@@ -586,7 +586,7 @@ func TestTypeToSchemaNoStruct(t *testing.T) {
 			fmt.Sprintf("%s", p))
 	}()
 	v := reflect.ValueOf(1)
-	typeToSchema(v, []string{}, map[string]string{})
+	typeToSchema(v, nil)
 }
 
 func TestTypeToSchemaUnsupported(t *testing.T) {
@@ -599,7 +599,7 @@ func TestTypeToSchemaUnsupported(t *testing.T) {
 		New chan int `json:"new"`
 	}
 	v := reflect.ValueOf(nonsense{})
-	typeToSchema(v, []string{}, map[string]string{})
+	typeToSchema(v, nil)
 }
 
 type data map[string]any

--- a/common/reflect_resource_test.go
+++ b/common/reflect_resource_test.go
@@ -364,7 +364,7 @@ func TestPrimitiveReflectValueFromInterface(t *testing.T) {
 
 func TestIterFields(t *testing.T) {
 	v := reflect.ValueOf("x")
-	err := iterFields(v, []string{"x"}, scm, map[string]string{}, nil)
+	err := iterFields(v, []string{"x"}, scm, nil, nil)
 	assert.EqualError(t, err, "value of Struct is expected, but got String: \"x\"")
 
 	v = reflect.ValueOf(testStruct{})
@@ -372,7 +372,7 @@ func TestIterFields(t *testing.T) {
 		"integer": {
 			Type: schema.TypeInt,
 		},
-	}, map[string]string{}, nil)
+	}, nil, nil)
 	assert.EqualError(t, err, "inconsistency: integer has omitempty, but is not optional")
 
 	err = iterFields(v, []string{}, map[string]*schema.Schema{
@@ -381,7 +381,7 @@ func TestIterFields(t *testing.T) {
 			Default:  nil,
 			Optional: true,
 		},
-	}, map[string]string{}, nil)
+	}, nil, nil)
 	assert.EqualError(t, err, "inconsistency: non_optional is optional, default is empty, but has no omitempty")
 
 	err = iterFields(v, []string{}, map[string]*schema.Schema{
@@ -390,7 +390,7 @@ func TestIterFields(t *testing.T) {
 			Default:  "_",
 			Optional: true,
 		},
-	}, map[string]string{}, func(fieldSchema *schema.Schema, path []string, valueField *reflect.Value) error {
+	}, nil, func(fieldSchema *schema.Schema, path []string, valueField *reflect.Value) error {
 		return fmt.Errorf("test error")
 	})
 	assert.EqualError(t, err, "non_optional: test error")

--- a/common/reflect_resource_test.go
+++ b/common/reflect_resource_test.go
@@ -440,7 +440,7 @@ func TestStructToDataWithResourceProviderStruct(t *testing.T) {
 
 	{
 		//lint:ignore SA1019 Empty optional string should not be set.
-		_, ok := d.GetOk("addresses.0.optional_string")
+		_, ok := d.GetOkExists("addresses.0.optional_string")
 		assert.Falsef(t, ok, "Empty optional string should not be set in ResourceData")
 	}
 
@@ -539,7 +539,7 @@ func TestStructToData(t *testing.T) {
 
 	{
 		//lint:ignore SA1019 Empty required string should be set.
-		_, ok := d.GetOk("addresses.0.required_string")
+		_, ok := d.GetOkExists("addresses.0.required_string")
 		assert.Truef(t, ok, "Empty required string should be set in ResourceData")
 	}
 

--- a/common/reflect_resource_test.go
+++ b/common/reflect_resource_test.go
@@ -446,7 +446,7 @@ func TestStructToDataWithResourceProviderStruct(t *testing.T) {
 
 	{
 		//lint:ignore SA1019 Empty required string should be set.
-		_, ok := d.GetOk("addresses.0.required_string")
+		_, ok := d.GetOkExists("addresses.0.required_string")
 		assert.Truef(t, ok, "Empty required string should be set in ResourceData")
 	}
 }
@@ -539,7 +539,7 @@ func TestStructToData(t *testing.T) {
 
 	{
 		//lint:ignore SA1019 Empty required string should be set.
-		_, ok := d.GetOkExists("addresses.0.required_string")
+		_, ok := d.GetOk("addresses.0.required_string")
 		assert.Truef(t, ok, "Empty required string should be set in ResourceData")
 	}
 

--- a/common/reflect_resource_test.go
+++ b/common/reflect_resource_test.go
@@ -45,7 +45,7 @@ func TestChooseFieldName(t *testing.T) {
 func TestChooseFieldNameWithAliasesMap(t *testing.T) {
 	assert.Equal(t, "foo", chooseFieldNameWithAliases(reflect.StructField{
 		Tag: `json:"bar"`,
-	}, []string{"a"}, map[string]string{"a.bar": "foo"}))
+	}, map[string]string{"bar": "foo"}))
 }
 
 type testSliceItem struct {

--- a/common/reflect_resource_test.go
+++ b/common/reflect_resource_test.go
@@ -446,7 +446,7 @@ func TestStructToDataWithResourceProviderStruct(t *testing.T) {
 
 	{
 		//lint:ignore SA1019 Empty required string should be set.
-		_, ok := d.GetOk("addresses.0.required_string")
+		_, ok := d.GetOkExists("addresses.0.required_string")
 		assert.Truef(t, ok, "Empty required string should be set in ResourceData")
 	}
 }


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
- Make aliases information from `ResourceProviderStruct` take effect in `iterFields` function so that `StructToData` and `DataToStructPointer` will take information about the aliases
- Taking out `UnderlyingType` method because it is no longer needed
- Adding an anonymous field for the `ClusterResourceProvider` struct so that reflection will work without `UnderlyingType`
- Make `iterField` check alias information
- Adding unit test case

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [x] covered with integration tests in `internal/acceptance`
- [x] relevant acceptance tests are passing
- [x] using Go SDK

