### PR TITLE
Add `source` attribute to `dbt_task` and `sql_task.file` tasks to support files from workspace

### DIFF
--- a/docs/resources/job.md
+++ b/docs/resources/job.md
@@ -323,7 +323,7 @@ You can invoke Spark submit tasks only on new clusters. **In the `new_cluster` s
 ### dbt_task Configuration Block
 
 * `commands` - (Required) (Array) Series of dbt commands to execute in sequence. Every command must start with "dbt".
-* `source` - (Optional) What is the source of this project. Possible values are `WORKSPACE` and `GIT`.  Default value depends on if `git_source` block presents in the job definition or not - if it's present, then the default value is `GIT`.
+* `source` - (Optional) The source of the project. Possible values are `WORKSPACE` and `GIT`.  Defaults to `GIT` if a `git_source` block is present in the job definition.
 * `project_directory` - (Optional  if `source` is `GIT`, Required when `source` is `WORKSPACE`) If `source` is `GIT`, then it should be a relative path to the directory in the repository specified in `git_source` where dbt should look in for the `dbt_project.yml` file. If not specified, defaults to the repository's root directory. Equivalent to passing `--project-dir` to a dbt command.  If `source` is `WORKSPACE`, then it should be absolute path to the folder in the workspace.
 * `profiles_directory` - (Optional) The relative path to the directory in the repository specified by `git_source` where dbt should look in for the `profiles.yml` file. If not specified, defaults to the repository's root directory. Equivalent to passing `--profile-dir` to a dbt command.
 * `catalog` - (Optional) The name of the catalog to use inside Unity Catalog.

--- a/docs/resources/job.md
+++ b/docs/resources/job.md
@@ -367,7 +367,7 @@ One of the `query`, `dashboard` or `alert` needs to be provided.
   * `pause_subscriptions` - (Optional) flag that specifies if subscriptions are paused or not.
 * `file` - (Optional) block consisting of single string fields: 
   * `source` - (Optional) The source of the project. Possible values are `WORKSPACE` and `GIT`.
-  * `path` - If `source` is `GIT`, then it a relative path to the file (inside the Git repository) with SQL commands to execute.  If `source` is `WORKSPACE` then it should be absolute path to the file in the workspace.
+  * `path` - If `source` is `GIT`: Relative path to the file in the repository specified in the `git_source` block with SQL commands to execute. If `source` is `WORKSPACE`: Absolute path to the file in the workspace with SQL commands to execute.
 
 Example
 

--- a/docs/resources/job.md
+++ b/docs/resources/job.md
@@ -323,7 +323,8 @@ You can invoke Spark submit tasks only on new clusters. **In the `new_cluster` s
 ### dbt_task Configuration Block
 
 * `commands` - (Required) (Array) Series of dbt commands to execute in sequence. Every command must start with "dbt".
-* `project_directory` - (Optional) The relative path to the directory in the repository specified in `git_source` where dbt should look in for the `dbt_project.yml` file. If not specified, defaults to the repository's root directory. Equivalent to passing `--project-dir` to a dbt command.
+* `source` - (Optional) What is the source of this project. Possible values are `WORKSPACE` and `GIT`.  Default value depends on if `git_source` block presents in the job definition or not - if it's present, then the default value is `GIT`.
+* `project_directory` - (Optional  if `source` is `GIT`, Required when `source` is `WORKSPACE`) If `source` is `GIT`, then it should be a relative path to the directory in the repository specified in `git_source` where dbt should look in for the `dbt_project.yml` file. If not specified, defaults to the repository's root directory. Equivalent to passing `--project-dir` to a dbt command.  If `source` is `WORKSPACE`, then it should be absolute path to the folder in the workspace.
 * `profiles_directory` - (Optional) The relative path to the directory in the repository specified by `git_source` where dbt should look in for the `profiles.yml` file. If not specified, defaults to the repository's root directory. Equivalent to passing `--profile-dir` to a dbt command.
 * `catalog` - (Optional) The name of the catalog to use inside Unity Catalog.
 * `schema` - (Optional) The name of the schema dbt should run in. Defaults to `default`.
@@ -362,7 +363,9 @@ One of the `query`, `dashboard` or `alert` needs to be provided.
   * `alert_id` - (Required) (String) identifier of the Databricks SQL Alert.
   * `subscriptions` - (Required) a list of subscription blocks consisting out of one of the required fields: `user_name` for user emails or `destination_id` - for Alert destination's identifier.
   * `pause_subscriptions` - (Optional) flag that specifies if subscriptions are paused or not.
-* `file` - (Optional) block consisting of single string field: `path` - a relative path to the file (inside the Git repository) with SQL commands to execute.  *Requires `git_source` configuration block*.
+* `file` - (Optional) block consisting of single string fields: 
+  * `source` - (Optional) What is the source of this project. Possible values are `WORKSPACE` and `GIT`.
+  * `path` - If `source` is `GIT`, then it a relative path to the file (inside the Git repository) with SQL commands to execute.  If `source` is `WORKSPACE` then it should be absolute path to the file in the workspace.
 
 Example
 

--- a/docs/resources/job.md
+++ b/docs/resources/job.md
@@ -366,7 +366,7 @@ One of the `query`, `dashboard` or `alert` needs to be provided.
   * `subscriptions` - (Required) a list of subscription blocks consisting out of one of the required fields: `user_name` for user emails or `destination_id` - for Alert destination's identifier.
   * `pause_subscriptions` - (Optional) flag that specifies if subscriptions are paused or not.
 * `file` - (Optional) block consisting of single string fields: 
-  * `source` - (Optional) What is the source of this project. Possible values are `WORKSPACE` and `GIT`.
+  * `source` - (Optional) The source of the project. Possible values are `WORKSPACE` and `GIT`.
   * `path` - If `source` is `GIT`, then it a relative path to the file (inside the Git repository) with SQL commands to execute.  If `source` is `WORKSPACE` then it should be absolute path to the file in the workspace.
 
 Example

--- a/docs/resources/job.md
+++ b/docs/resources/job.md
@@ -324,7 +324,9 @@ You can invoke Spark submit tasks only on new clusters. **In the `new_cluster` s
 
 * `commands` - (Required) (Array) Series of dbt commands to execute in sequence. Every command must start with "dbt".
 * `source` - (Optional) The source of the project. Possible values are `WORKSPACE` and `GIT`.  Defaults to `GIT` if a `git_source` block is present in the job definition.
-* `project_directory` - (Optional  if `source` is `GIT`, Required when `source` is `WORKSPACE`) If `source` is `GIT`, then it should be a relative path to the directory in the repository specified in `git_source` where dbt should look in for the `dbt_project.yml` file. If not specified, defaults to the repository's root directory. Equivalent to passing `--project-dir` to a dbt command.  If `source` is `WORKSPACE`, then it should be absolute path to the folder in the workspace.
+* `project_directory` - (Required when `source` is `WORKSPACE`) The path where dbt should look for `dbt_project.yml`. Equivalent to passing `--project-dir` to the dbt CLI. 
+  * If `source` is `GIT`: Relative path to the directory in the repository specified in the `git_source` block. Defaults to the repository's root directory when not specified.
+  * If `source` is `WORKSPACE`: Absolute path to the folder in the workspace.
 * `profiles_directory` - (Optional) The relative path to the directory in the repository specified by `git_source` where dbt should look in for the `profiles.yml` file. If not specified, defaults to the repository's root directory. Equivalent to passing `--profile-dir` to a dbt command.
 * `catalog` - (Optional) The name of the catalog to use inside Unity Catalog.
 * `schema` - (Optional) The name of the schema dbt should run in. Defaults to `default`.

--- a/exporter/importables.go
+++ b/exporter/importables.go
@@ -511,6 +511,7 @@ var resourcesMap map[string]importable = map[string]importable{
 						if strings.HasPrefix(directory, "/Repos") {
 							ic.emitRepoByPath(directory)
 						} else {
+							// Traverse the dbt project directory and emit all objects found in it
 							nbAPI := workspace.NewNotebooksAPI(ic.Context, ic.Client)
 							objects, err := nbAPI.List(directory, true, true)
 							if err == nil {

--- a/exporter/util.go
+++ b/exporter/util.go
@@ -218,6 +218,9 @@ func (ic *importContext) IsUserOrServicePrincipalDirectory(path, prefix string, 
 }
 
 func (ic *importContext) emitRepoByPath(path string) {
+	// Path to Repos objects consits of following parts: /Repos, folder, repository, path inside Repo.
+	// Because it starts with `/`, it will produce empty string as first element in the slice.
+	// And we're stopping splitting to avoid producing too many not necessary parts, so we have 5 parts only.
 	parts := strings.SplitN(path, "/", 5)
 	if len(parts) >= 4 {
 		ic.Emit(&resource{

--- a/exporter/util.go
+++ b/exporter/util.go
@@ -218,17 +218,24 @@ func (ic *importContext) IsUserOrServicePrincipalDirectory(path, prefix string, 
 }
 
 func (ic *importContext) emitRepoByPath(path string) {
-	ic.Emit(&resource{
-		Resource:  "databricks_repo",
-		Attribute: "path",
-		Value:     strings.Join(strings.SplitN(path, "/", 5)[:4], "/"),
-	})
+	parts := strings.SplitN(path, "/", 5)
+	if len(parts) >= 4 {
+		ic.Emit(&resource{
+			Resource:  "databricks_repo",
+			Attribute: "path",
+			Value:     strings.Join(parts[:4], "/"),
+		})
+	} else {
+		log.Printf("[WARN] Incorrect Repos path")
+	}
 }
 
 func (ic *importContext) emitWorkspaceFileOrRepo(path string) {
 	if strings.HasPrefix(path, "/Repos") {
 		ic.emitRepoByPath(path)
 	} else {
+		// TODO: wrap this into ic.shouldEmit...
+		// TODO: strip /Workspace prefix if it's provided
 		ic.Emit(&resource{
 			Resource: "databricks_workspace_file",
 			ID:       path,
@@ -240,6 +247,7 @@ func (ic *importContext) emitNotebookOrRepo(path string) {
 	if strings.HasPrefix(path, "/Repos") {
 		ic.emitRepoByPath(path)
 	} else {
+		// TODO: strip /Workspace prefix if it's provided
 		ic.maybeEmitWorkspaceObject("databricks_notebook", path)
 	}
 }

--- a/jobs/resource_job.go
+++ b/jobs/resource_job.go
@@ -87,7 +87,8 @@ type SqlAlertTask struct {
 }
 
 type SqlFileTask struct {
-	Path string `json:"path"`
+	Path   string `json:"path"`
+	Source string `json:"source,omitempty" tf:"suppress_diff"`
 }
 
 // SqlTask contains information about DBSQL task
@@ -110,6 +111,7 @@ type DbtTask struct {
 	Schema            string   `json:"schema,omitempty" tf:"default:default"`
 	Catalog           string   `json:"catalog,omitempty"`
 	WarehouseId       string   `json:"warehouse_id,omitempty"`
+	Source            string   `json:"source,omitempty" tf:"suppress_diff"`
 }
 
 // RunJobTask contains information about RunJobTask


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

Also added support for it in TF exporter

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

