### PR TITLE
Remove AWS-only note for `databricks_service_principal_secret` resource

### DIFF
--- a/docs/resources/service_principal_secret.md
+++ b/docs/resources/service_principal_secret.md
@@ -3,7 +3,7 @@ subcategory: "Security"
 ---
 # databricks_service_principal_secret Resource
 
--> **Note** This resource could be used only with account-level provider.
+-> **Note** This resource can only be used with an account-level provider.
 
 With this resource you can create a secret for a given [Service Principals](https://docs.databricks.com/administration-guide/users-groups/service-principals.html).
 

--- a/docs/resources/service_principal_secret.md
+++ b/docs/resources/service_principal_secret.md
@@ -3,9 +3,9 @@ subcategory: "Security"
 ---
 # databricks_service_principal_secret Resource
 
--> **Note** This resource is only available in Databricks AWS.
+-> **Note** This resource could be used only with account-level provider.
 
-With this resource you can create a secret under the given [Service Principals](https://docs.databricks.com/administration-guide/users-groups/service-principals.html)
+With this resource you can create a secret for a given [Service Principals](https://docs.databricks.com/administration-guide/users-groups/service-principals.html).
 
 This secret can be used to configure the Databricks Terraform Provider to authenticate with the service principal. See [Authenticating with service principal](../index.md#authenticating-with-service-principal).
 
@@ -26,7 +26,7 @@ resource "databricks_service_principal_secret" "terraform_sp" {
 
 The following arguments are available:
 
-* `service_principal_id` - ID of the [databricks_service_principal](service_principal.md)
+* `service_principal_id` - ID of the [databricks_service_principal](service_principal.md) (not application ID).
 
 
 ## Attribute Reference


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

Tested on both Azure & GCP, and was able to generate a secret for a service principal. Additional work will be required for testing of these service principal secrets on the workspace level (this will be done as part of #3196).

This fixes #3160

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] ~`make test` run locally~
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

