### PR TITLE
Exporter: omit `git_provider` only for well-known Git URLs

### DIFF
--- a/exporter/importables.go
+++ b/exporter/importables.go
@@ -1317,6 +1317,10 @@ var resourcesMap map[string]importable = map[string]importable{
 				return d.Get("branch").(string) == ""
 			case "tag":
 				return d.Get("tag").(string) == ""
+			case "git_provider":
+				url := d.Get("url").(string)
+				provider := repos.GetGitProviderFromUrl(url)
+				return provider != "" // omit git_provider only for well-known URLs
 			}
 			return defaultShouldOmitFieldFunc(ic, pathString, as, d)
 		},


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

The `git_provider` field is marked as `computed` because we're detecting it for well-known Git providers (GitHub, Azure DevOps, ...).  But because of this it was omitted from the generated code even for other Git providers.  This PR fixes this issue.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

