### PR TITLE
Fixed `SqlColumnInfo` for `force_new`

### DIFF
--- a/catalog/resource_sql_table.go
+++ b/catalog/resource_sql_table.go
@@ -20,10 +20,10 @@ import (
 var MaxSqlExecWaitTimeout = 50
 
 type SqlColumnInfo struct {
-	Name     string `json:"name"`
-	Type     string `json:"type_text,omitempty" tf:"suppress_diff,alias:type"`
-	Comment  string `json:"comment,omitempty"`
-	Nullable bool   `json:"nullable,omitempty" tf:"default:true"`
+	Name     string `json:"name" tf:"force_new"`
+	Type     string `json:"type_text,omitempty" tf:"suppress_diff,alias:type,force_new"`
+	Comment  string `json:"comment,omitempty" tf:"force_new"`
+	Nullable bool   `json:"nullable,omitempty" tf:"default:true,force_new"`
 }
 
 type SqlTableInfo struct {


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
We need to mark the fields as force_new since they are part of structure. As updating column isn't supported, we mark all the fields as force_new.

Relevant code ref:
````
ColumnInfos []SqlColumnInfo `json:"columns,omitempty" tf:"alias:column,computed,force_new"`
````

This doesn't seem to be regression on TF side, this test fails on 1.35.0 commit as well. 

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->
`TestUcAccResourceSqlTable_Managed` passes after change
- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

