### PR TITLE
Remove `omitempty` in `destination` fields in clustes_api

### DIFF
--- a/clusters/clusters_api.go
+++ b/clusters/clusters_api.go
@@ -194,22 +194,22 @@ type S3StorageInfo struct {
 
 // GcsStorageInfo contains the struct for when storing files in GCS
 type GcsStorageInfo struct {
-	Destination string `json:"destination,omitempty"`
+	Destination string `json:"destination"`
 }
 
 // AbfssStorageInfo contains the struct for when storing files in ADLS
 type AbfssStorageInfo struct {
-	Destination string `json:"destination,omitempty"`
+	Destination string `json:"destination"`
 }
 
 // LocalFileInfo represents a local file on disk, e.g. in a customer's container.
 type LocalFileInfo struct {
-	Destination string `json:"destination,omitempty"`
+	Destination string `json:"destination"`
 }
 
 // WorkspaceFileInfo represents a file in the Databricks workspace.
 type WorkspaceFileInfo struct {
-	Destination string `json:"destination,omitempty"`
+	Destination string `json:"destination"`
 }
 
 // StorageInfo contains the struct for either DBFS or S3 storage depending on which one is relevant.


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
- Addressing issue raised in https://github.com/databricks/terraform-provider-databricks/issues/3231

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

