### PR TITLE
Docs: add information on `id` and other exposed attributes where appropriate

### DIFF
--- a/docs/data-sources/aws_unity_catalog_policy.md
+++ b/docs/data-sources/aws_unity_catalog_policy.md
@@ -12,9 +12,9 @@ This data source constructs necessary AWS Unity Catalog policy for you, which is
 ```hcl
 data "databricks_aws_unity_catalog_policy" "this" {
   aws_account_id = var.aws_account_id
-  bucket_name = "databricks-bucket"
-  role_name = "databricks-role"
-  kms_name = "databricks-kms"
+  bucket_name    = "databricks-bucket"
+  role_name      = "databricks-role"
+  kms_name       = "databricks-kms"
 }
 
 data "aws_iam_policy_document" "passrole_for_uc" {
@@ -50,7 +50,7 @@ data "aws_iam_policy_document" "passrole_for_uc" {
 }
 
 resource "aws_iam_policy" "unity_metastore" {
-  name = "${var.prefix}-unity-catalog-metastore-access-iam-policy"
+  name   = "${var.prefix}-unity-catalog-metastore-access-iam-policy"
   policy = data.databricks_aws_unity_catalog_policy.this.json
 }
 

--- a/docs/data-sources/volumes.md
+++ b/docs/data-sources/volumes.md
@@ -12,7 +12,7 @@ Listing all volumes in a _things_ [databricks_schema](../resources/schema.md) of
 ```hcl
 data "databricks_volumes" "this" {
   catalog_name = "sandbox"
-  schema_name = "things"
+  schema_name  = "things"
 }
 
 output "all_volumes" {

--- a/docs/guides/unity-catalog.md
+++ b/docs/guides/unity-catalog.md
@@ -297,7 +297,7 @@ resource "aws_iam_policy" "external_data_access" {
           "${aws_s3_bucket.external.arn}/*"
         ],
         "Effect" : "Allow"
-      }, 
+      },
       {
         "Action" : [
           "sts:AssumeRole"

--- a/docs/resources/access_control_rule_set.md
+++ b/docs/resources/access_control_rule_set.md
@@ -248,6 +248,12 @@ Arguments of the `grant_rules` block are:
   * `groups/{groupname}` (also exposed as `acl_principal_id` attribute of `databricks_group` resource).
   * `servicePrincipals/{applicationId}` (also exposed as `acl_principal_id` attribute of `databricks_service_principal` resource).
 
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - ID of the access control rule set - the same as `name`.
+
 ## Related Resources
 
 The following resources are often used in the same context:

--- a/docs/resources/artifact_allowlist.md
+++ b/docs/resources/artifact_allowlist.md
@@ -41,12 +41,18 @@ In addition to all arguments above, the following attributes are exported:
 * `created_at` -  Time at which this artifact allowlist was set.
 * `created_by` -  Identity that set the artifact allowlist.
 
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - ID of the artifact allow list in form of `metastore_id|artifact_type`.
+
 ## Import
 
 This resource can be imported by name:
 
 ```bash
-terraform import databricks_artifact_allowlist.this <metastore_id>|<artifact_type>
+terraform import databricks_artifact_allowlist.this '<metastore_id>|<artifact_type>'
 ```
 
 ## Related Resources

--- a/docs/resources/catalog.md
+++ b/docs/resources/catalog.md
@@ -41,8 +41,8 @@ The following arguments are required:
 
 In addition to all arguments above, the following attributes are exported:
 
-* `metastore_id` - ID of the parent metastore.
 * `id` - ID of this catalog - same as the `name`.
+* `metastore_id` - ID of the parent metastore.
 
 ## Import
 

--- a/docs/resources/cluster_policy.md
+++ b/docs/resources/cluster_policy.md
@@ -148,7 +148,7 @@ The following arguments are supported:
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - Canonical unique identifier for the cluster policy. This is equal to policy_id.
+* `id` - Canonical unique identifier for the cluster policy. This is equal to `policy_id`.
 * `policy_id` - Canonical unique identifier for the cluster policy.
 
 ## Import

--- a/docs/resources/ip_access_list.md
+++ b/docs/resources/ip_access_list.md
@@ -40,6 +40,7 @@ The following arguments are supported:
 
 In addition to all arguments above, the following attributes are exported:
 
+* `id` - Canonical unique identifier for the IP Access List, same as `list_id`.
 * `list_id` - Canonical unique identifier for the IP Access List.
 
 ## Import

--- a/docs/resources/mlflow_experiment.md
+++ b/docs/resources/mlflow_experiment.md
@@ -25,6 +25,12 @@ The following arguments are supported:
 * `artifact_location` - Path to dbfs:/ or s3:// artifact location of the MLflow experiment.
 * `description` - The description of the MLflow experiment.
 
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - ID of the MLflow experiment.
+
 ## Access Control
 
 * [databricks_permissions](permissions.md#MLflow-Experiment-usage) can control which groups or individual users can *Read*, *Edit*, or *Manage* individual experiments.

--- a/docs/resources/mlflow_model.md
+++ b/docs/resources/mlflow_model.md
@@ -34,6 +34,12 @@ The following arguments are supported:
 * `description` - The description of the MLflow model.
 * `tags` - Tags for the MLflow model.
 
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - ID of the MLflow model, the same as `name`.
+
 ## Import
 
 The model resource can be imported using the name

--- a/docs/resources/mlflow_webhook.md
+++ b/docs/resources/mlflow_webhook.md
@@ -100,6 +100,12 @@ Configuration must include one of `http_url_spec` or `job_spec` blocks, but not 
 * `enable_ssl_verification` - (Optional) Enable/disable SSL certificate validation. Default is `true`. For self-signed certificates, this field must be `false` AND the destination server must disable certificate validation as well. For security purposes, it is encouraged to perform secret validation with the HMAC-encoded portion of the payload and acknowledge the risk associated with disabling hostname validation whereby it becomes more likely that requests can be maliciously routed to an unintended host.
 * `secret` - (Optional) Shared secret required for HMAC encoding payload. The HMAC-encoded payload will be sent in the header as `X-Databricks-Signature: encoded_payload`.
 
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Unique ID of the MLflow Webhook.
+
 ## Access Control
 
 * MLflow webhooks could be configured only by workspace admins.

--- a/docs/resources/mws_log_delivery.md
+++ b/docs/resources/mws_log_delivery.md
@@ -145,6 +145,7 @@ resource "databricks_mws_log_delivery" "audit_logs" {
 
 Resource exports the following attributes:
 
+* `id` - the ID of log delivery configuration in form of `account_id|config_id`.
 * `config_id` - Databricks log delivery configuration ID.
 
 ## Import

--- a/docs/resources/mws_permission_assignment.md
+++ b/docs/resources/mws_permission_assignment.md
@@ -74,6 +74,12 @@ The following arguments are required:
   * `"USER"` - Can access the workspace with basic privileges.
   * `"ADMIN"` - Can access the workspace and has workspace admin privileges to manage users and groups, workspace configurations, and more.
 
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - ID of the permission assignment in form of `workspace_id|principal_id`.
+
 ## Import
 
 The resource `databricks_mws_permission_assignment` can be imported using the workspace id and principal id

--- a/docs/resources/mws_private_access_settings.md
+++ b/docs/resources/mws_private_access_settings.md
@@ -82,6 +82,7 @@ The following arguments are available:
 
 In addition to all arguments above, the following attributes are exported:
 
+* `id` - the ID of the Private Access Settings in form of `account_id/private_access_settings_id`.
 * `private_access_settings_id` - Canonical unique identifier of Private Access Settings in Databricks Account
 * `status` - (AWS only) Status of Private Access Settings
 

--- a/docs/resources/mws_vpc_endpoint.md
+++ b/docs/resources/mws_vpc_endpoint.md
@@ -190,6 +190,7 @@ The following arguments are required:
 
 In addition to all arguments above, the following attributes are exported:
 
+* `id` - the ID of VPC Endpoint in form of `account_id/vpc_endpoint_id`
 * `vpc_endpoint_id` - Canonical unique identifier of VPC Endpoint in Databricks Account
 * `aws_endpoint_service_id` - (AWS Only) The ID of the Databricks endpoint service that this VPC endpoint is connected to. Please find the list of endpoint service IDs for each supported region in the [Databricks PrivateLink documentation](https://docs.databricks.com/administration-guide/cloud-configurations/aws/privatelink.html)
 * `state` - (AWS Only) State of VPC Endpoint

--- a/docs/resources/permission_assignment.md
+++ b/docs/resources/permission_assignment.md
@@ -75,6 +75,12 @@ The following arguments are required:
   * `"USER"` - Can access the workspace with basic privileges.
   * `"ADMIN"` - Can access the workspace and has workspace admin privileges to manage users and groups, workspace configurations, and more.
 
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - ID of the permission assignment - same as `principal_id`.
+
 ## Import
 
 The resource `databricks_permission_assignment` can be imported using the principal id

--- a/docs/resources/permissions.md
+++ b/docs/resources/permissions.md
@@ -819,7 +819,7 @@ Exactly one of the below arguments is required:
 
 In addition to all arguments above, the following attributes are exported:
 
-- `id` - Canonical unique identifier for the permissions.
+- `id` - Canonical unique identifier for the permissions in form of `/object_type/object_id`.
 - `object_type` - type of permissions.
 
 ## Import

--- a/docs/resources/pipeline.md
+++ b/docs/resources/pipeline.md
@@ -94,6 +94,12 @@ DLT allows to specify one or more notification blocks to get notifications about
   * `on-update-fatal-failure` - a pipeline update fails with a non-retryable (fatal) error.
   * `on-flow-failure` - a single data flow fails.
 
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Canonical unique identifier of the DLT pipeline.
+* `url` - URL of the DLT pipeline on the given workspace.
 
 ## Import
 

--- a/docs/resources/recipient.md
+++ b/docs/resources/recipient.md
@@ -94,6 +94,7 @@ Exactly one of the below arguments is required:
 
 In addition to all arguments above, the following attributes are exported:
 
+* `id` - the ID of the recipient - the same as the `name`.
 * `tokens` - List of Recipient Tokens. This field is only present when the authentication_type is TOKEN. Each list element is an object with following attributes:
   * `id` - Unique ID of the recipient token.
   * `created_at` - Time at which this recipient Token was created, in epoch milliseconds.

--- a/docs/resources/share.md
+++ b/docs/resources/share.md
@@ -95,6 +95,7 @@ To share only part of a table when you add the table to a share, you can provide
 
 In addition to all arguments above, the following attributes are exported:
 
+* `id` - the ID of the share, the same as `name`.
 * `created_at` - Time when the share was created.
 * `created_by` - The principal that created the share.
 * `status` - Status of the object, one of: `ACTIVE`, `PERMISSION_DENIED`.

--- a/docs/resources/sql_alert.md
+++ b/docs/resources/sql_alert.md
@@ -52,6 +52,12 @@ The following arguments are available:
 * `parent` - (Optional, String) The identifier of the workspace folder containing the alert. The default is ther user's home folder. The folder identifier is formatted as `folder/<folder_id>`.
 * `rearm` - (Optional, Integer) Number of seconds after being triggered before the alert rearms itself and can be triggered again. If not defined, alert will never be triggered again. 
 
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - unique ID of the SQL Alert.
+
 ## Related Resources
 
 The following resources are often used in the same context:

--- a/docs/resources/sql_dashboard.md
+++ b/docs/resources/sql_dashboard.md
@@ -40,6 +40,12 @@ resource "databricks_permissions" "d1" {
 }
 ```
 
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - the unique ID of the SQL Dashboard.
+
 ## Import
 
 You can import a `databricks_sql_dashboard` resource with ID like the following:

--- a/docs/resources/sql_endpoint.md
+++ b/docs/resources/sql_endpoint.md
@@ -52,6 +52,7 @@ The following arguments are supported:
 
 In addition to all arguments above, the following attributes are exported:
 
+* `id` - the unique ID of the SQL warehouse.
 * `jdbc_url` - JDBC connection string.
 * `odbc_params` - ODBC connection params: `odbc_params.hostname`, `odbc_params.path`, `odbc_params.protocol`, and `odbc_params.port`.
 * `data_source_id` - ID of the data source for this endpoint. This is used to bind an Databricks SQL query to an endpoint.

--- a/docs/resources/sql_query.md
+++ b/docs/resources/sql_query.md
@@ -111,6 +111,12 @@ For `text`, `number`, `date`, `datetime`, `datetimesec` block
 
 * `value` - The default value for this parameter.
 
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - the unique ID of the SQL Query.
+
 ## Import
 
 You can import a `databricks_sql_query` resource with ID like the following:

--- a/docs/resources/system_schema.md
+++ b/docs/resources/system_schema.md
@@ -29,6 +29,7 @@ The following arguments are available:
 
 In addition to all arguments above, the following attributes are exported:
 
+* `id` - the ID of system schema in form of `metastore_id|schema_name`.
 * `state` - The current state of enablement for the system schema.
 
 ## Import


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

In many resources, we didn't have an attributes reference section at all, or it didn't have information about the `id` attribute.  This PR adds relevant information.

Also run `make fmt-docs` to format code snippets.

This fixes #3235

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

