### PR TITLE
Docs: Fix `databricks_grants` example for metastore

### DIFF
--- a/docs/resources/grants.md
+++ b/docs/resources/grants.md
@@ -35,6 +35,7 @@ You can grant `CREATE_CATALOG`, `CREATE_CONNECTION`, `CREATE_EXTERNAL_LOCATION`,
 
 ```hcl
 resource "databricks_grants" "sandbox" {
+  metastore    = "metastore_id"
   grant {
     principal  = "Data Engineers"
     privileges = ["CREATE_CATALOG", "CREATE_EXTERNAL_LOCATION"]


### PR DESCRIPTION
## Changes
Add required `metastore` argument for `databricks_grants` in metastore docs example.

Current example would return an error:

```
Error: Missing required argument
  with databricks_grants.catalog_staging,
  on [catalogs.tf](http://catalogs.tf/) line 24, in resource "databricks_grants" "catalog_staging":
  24: resource "databricks_grants" "catalog_staging" {
"model": one of
`catalog,external_location,foreign_connection,function,metastore,model,schema,share,storage_credential,table,volume`
must be specified
```

