### PR TITLE
Exporter: rework handling of listings and interactive prompting

### DIFF
--- a/exporter/command.go
+++ b/exporter/command.go
@@ -6,12 +6,14 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"slices"
 	"strings"
 	"time"
 
 	"github.com/databricks/databricks-sdk-go/client"
 	"github.com/databricks/databricks-sdk-go/config"
 	"github.com/databricks/terraform-provider-databricks/common"
+	"golang.org/x/exp/maps"
 )
 
 type levelWriter []string
@@ -31,23 +33,15 @@ func (lw *levelWriter) Write(p []byte) (n int, err error) {
 }
 
 func (ic *importContext) allServicesAndListing() (string, string) {
-	services := ""
-	listing := ""
+	services := map[string]struct{}{}
+	listing := map[string]struct{}{}
 	for _, ir := range ic.Importables {
-		if !strings.Contains(services, ir.Service) {
-			if len(services) > 0 {
-				services += ","
-			}
-			services += ir.Service
-		}
-		if ir.List != nil && !strings.Contains(listing, ir.Service) {
-			if len(listing) > 0 {
-				listing += ","
-			}
-			listing += ir.Service
+		services[ir.Service] = struct{}{}
+		if ir.List != nil {
+			listing[ir.Service] = struct{}{}
 		}
 	}
-	return services, listing
+	return strings.Join(maps.Keys(services), ","), strings.Join(maps.Keys(listing), ",")
 }
 
 func (ic *importContext) interactivePrompts() {
@@ -57,23 +51,35 @@ func (ic *importContext) interactivePrompts() {
 		ic.Client.DatabricksClient.Config.Token = askFor("🔑 Databricks Workspace PAT:")
 	}
 	ic.match = askFor("🔍 Match entity names (optional):")
-	listing := ""
+
+	services := map[string][]string{}
 	for r, ir := range ic.Importables {
 		if ir.List == nil {
 			continue
 		}
-		if !askFlag(fmt.Sprintf("✅ Generate `%s` and related resources?", r)) {
+		service := ir.Service
+		v, exists := services[service]
+		if exists {
+			services[service] = append(v, r)
+		} else {
+			services[service] = []string{r}
+		}
+	}
+
+	ic.listing = map[string]struct{}{}
+	keys := maps.Keys(services)
+	slices.Sort(keys)
+	for _, service := range keys {
+		resources := services[service]
+		if !askFlag(fmt.Sprintf("✅ Generate for service `%s` (%s) and related resources?",
+			service, strings.Join(resources, ","))) {
 			continue
 		}
-		if len(listing) > 0 {
-			listing += ","
-		}
-		listing += ir.Service
-		if ir.Service == "mounts" {
+		ic.listing[service] = struct{}{}
+		if service == "mounts" {
 			ic.mounts = true
 		}
 	}
-	ic.listing = listing
 }
 
 // Run import according to flags
@@ -124,7 +130,8 @@ func Run(args ...string) error {
 	var configuredServices string
 	flags.StringVar(&configuredServices, "services", services,
 		"Comma-separated list of services to import. By default all services are imported.")
-	flags.StringVar(&ic.listing, "listing", listing,
+	var configuredListing string
+	flags.StringVar(&configuredListing, "listing", listing,
 		"Comma-separated list of services to be listed and further passed on for importing. "+
 			"`-services` parameter controls which transitive dependencies will be processed. "+
 			"We recommend limiting services with `-listing` more often, than `-services`.")
@@ -153,5 +160,6 @@ func Run(args ...string) error {
 		logLevel = append(logLevel, "[DEBUG]")
 	}
 	ic.enableServices(configuredServices)
+	ic.enableListing(configuredListing)
 	return ic.Run()
 }

--- a/exporter/context.go
+++ b/exporter/context.go
@@ -264,6 +264,8 @@ func newImportContext(c *common.DatabricksClient) *importContext {
 		deletedResources:          map[string]struct{}{},
 		emittedUsers:              map[string]struct{}{},
 		userOrSpDirectories:       map[string]bool{},
+		services:                  map[string]struct{}{},
+		listing:                   map[string]struct{}{},
 	}
 }
 

--- a/exporter/context.go
+++ b/exporter/context.go
@@ -92,7 +92,7 @@ type importContext struct {
 	mounts                   bool
 	noFormat                 bool
 	services                 map[string]struct{}
-	listing                  string
+	listing                  map[string]struct{}
 	match                    string
 	lastActiveDays           int64
 	lastActiveMs             int64
@@ -314,8 +314,8 @@ func (ic *importContext) Run() error {
 		ic.loadOldWorkspaceObjects(wsObjectsFileName)
 	}
 
-	log.Printf("[INFO] Importing %s module into %s directory Databricks resources of %s services",
-		ic.Module, ic.Directory, maps.Keys(ic.services))
+	log.Printf("[INFO] Importing %s module into %s directory Databricks resources of %s services. Listing %s",
+		ic.Module, ic.Directory, maps.Keys(ic.services), maps.Keys(ic.listing))
 
 	ic.notebooksFormat = strings.ToUpper(ic.notebooksFormat)
 	_, supportedFormat := fileExtensionFormatMapping[ic.notebooksFormat]
@@ -376,7 +376,8 @@ func (ic *importContext) Run() error {
 		if ir.List == nil {
 			continue
 		}
-		if !strings.Contains(ic.listing, ir.Service) {
+		_, exists := ic.listing[ir.Service]
+		if !exists {
 			log.Printf("[DEBUG] %s (%s service) is not part of listing", resourceName, ir.Service)
 			continue
 		}
@@ -881,8 +882,8 @@ func (ic *importContext) generateAndWriteResources(sh *os.File) {
 	resourcesChan := make(resourceChannel, defaultChannelSize)
 
 	resourceWriters := make(map[string]dataWriteChannel, len(ic.Resources))
-	for _, imp := range ic.Importables {
-		resourceWriters[imp.Service] = make(dataWriteChannel, defaultChannelSize)
+	for service := range ic.services {
+		resourceWriters[service] = make(dataWriteChannel, defaultChannelSize)
 	}
 	importChan := make(importWriteChannel, defaultChannelSize)
 	writersWaitGroup := &sync.WaitGroup{}

--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -220,7 +220,7 @@ func TestImportingMounts(t *testing.T) {
 			ic := newImportContext(client)
 			ic.setClientsForTests()
 			ic.enableServices("mounts")
-			ic.listing = "mounts"
+			ic.enableListing("mounts")
 			ic.mounts = true
 
 			err := ic.Importables["databricks_mount"].List(ic)
@@ -671,7 +671,7 @@ func TestImportingUsersGroupsSecretScopes(t *testing.T) {
 			ic.Directory = tmpDir
 			services, listing := ic.allServicesAndListing()
 			ic.enableServices(services)
-			ic.listing = listing
+			ic.enableListing(listing)
 
 			err := ic.Run()
 			assert.NoError(t, err)
@@ -743,7 +743,7 @@ func TestImportingNoResourcesError(t *testing.T) {
 			ic := newImportContext(client)
 			ic.Directory = tmpDir
 			services, listing := ic.allServicesAndListing()
-			ic.listing = listing
+			ic.enableListing(listing)
 			ic.enableServices(services)
 
 			err := ic.Run()
@@ -953,7 +953,7 @@ func TestImportingClusters(t *testing.T) {
 
 			ic := newImportContext(client)
 			ic.Directory = tmpDir
-			ic.listing = "compute"
+			ic.enableListing("compute")
 			ic.enableServices("access,users,policies,compute,secrets,groups,storage")
 
 			err := ic.Run()
@@ -1158,7 +1158,7 @@ func TestImportingJobs_JobList(t *testing.T) {
 		func(ctx context.Context, client *common.DatabricksClient) {
 			ic := newImportContext(client)
 			ic.enableServices("jobs,access,storage,clusters,pools")
-			ic.listing = "jobs"
+			ic.enableListing("jobs")
 			ic.mounts = true
 			ic.meAdmin = true
 			tmpDir := fmt.Sprintf("/tmp/tf-%s", qa.RandomName())
@@ -1409,7 +1409,7 @@ func TestImportingJobs_JobListMultiTask(t *testing.T) {
 		func(ctx context.Context, client *common.DatabricksClient) {
 			ic := newImportContext(client)
 			ic.enableServices("jobs,access,storage,clusters,pools")
-			ic.listing = "jobs"
+			ic.enableListing("jobs")
 			ic.mounts = true
 			ic.meAdmin = true
 			tmpDir := fmt.Sprintf("/tmp/tf-%s", qa.RandomName())
@@ -1496,7 +1496,7 @@ func TestImportingSecrets(t *testing.T) {
 
 			ic := newImportContext(client)
 			ic.Directory = tmpDir
-			ic.listing = "secrets"
+			ic.enableListing("secrets")
 			services, _ := ic.allServicesAndListing()
 			ic.enableServices(services)
 			ic.generateDeclaration = true
@@ -1562,7 +1562,7 @@ func TestImportingGlobalInitScripts(t *testing.T) {
 
 			ic := newImportContext(client)
 			ic.Directory = tmpDir
-			ic.listing = "workspace"
+			ic.enableListing("workspace")
 			services, _ := ic.allServicesAndListing()
 			ic.enableServices(services)
 			ic.generateDeclaration = true
@@ -1668,8 +1668,8 @@ func TestImportingRepos(t *testing.T) {
 
 			ic := newImportContext(client)
 			ic.Directory = tmpDir
-			ic.listing = "repos"
-			ic.enableServices(ic.listing)
+			ic.enableListing("repos")
+			ic.enableServices("repos")
 
 			err := ic.Run()
 			assert.NoError(t, err)
@@ -1739,8 +1739,9 @@ func TestImportingIPAccessLists(t *testing.T) {
 
 			ic := newImportContext(client)
 			ic.Directory = tmpDir
-			ic.listing = "workspace,access"
-			ic.enableServices(ic.listing)
+			services := "workspace,access"
+			ic.enableListing(services)
+			ic.enableServices(services)
 
 			err := ic.Run()
 			assert.NoError(t, err)
@@ -1875,7 +1876,7 @@ func TestImportingSqlObjects(t *testing.T) {
 
 			ic := newImportContext(client)
 			ic.Directory = tmpDir
-			ic.listing = "sql-dashboards,sql-queries,sql-endpoints,sql-alerts"
+			ic.enableListing("sql-dashboards,sql-queries,sql-endpoints,sql-alerts")
 			ic.enableServices("sql-dashboards,sql-queries,sql-alerts,sql-endpoints,access,notebooks")
 
 			err := ic.Run()
@@ -2054,7 +2055,7 @@ func TestImportingDLTPipelines(t *testing.T) {
 
 			ic := newImportContext(client)
 			ic.Directory = tmpDir
-			ic.listing = "dlt"
+			ic.enableListing("dlt")
 			ic.enableServices("dlt,access,notebooks,users,repos,secrets")
 
 			err := ic.Run()
@@ -2112,7 +2113,7 @@ func TestImportingDLTPipelinesMatchingOnly(t *testing.T) {
 			ic := newImportContext(client)
 			ic.Directory = tmpDir
 			ic.match = "test"
-			ic.listing = "dlt"
+			ic.enableListing("dlt")
 			ic.enableServices("dlt,access")
 
 			err := ic.Run()
@@ -2154,8 +2155,8 @@ func TestImportingGlobalSqlConfig(t *testing.T) {
 
 			ic := newImportContext(client)
 			ic.Directory = tmpDir
-			ic.listing = "sql-endpoints"
-			ic.enableServices(ic.listing)
+			ic.enableListing("sql-endpoints")
+			ic.enableServices("sql-endpoints")
 
 			err := ic.Run()
 			assert.NoError(t, err)
@@ -2222,8 +2223,8 @@ func TestImportingNotebooksWorkspaceFiles(t *testing.T) {
 
 			ic := newImportContext(client)
 			ic.Directory = tmpDir
-			ic.listing = "notebooks"
-			ic.enableServices(ic.listing)
+			ic.enableListing("notebooks")
+			ic.enableServices("notebooks")
 
 			err := ic.Run()
 			assert.NoError(t, err)
@@ -2273,8 +2274,8 @@ func TestImportingModelServing(t *testing.T) {
 
 			ic := newImportContext(client)
 			ic.Directory = tmpDir
-			ic.listing = "model-serving"
-			ic.enableServices(ic.listing)
+			ic.enableListing("model-serving")
+			ic.enableServices("model-serving")
 
 			err := ic.Run()
 			assert.NoError(t, err)
@@ -2325,8 +2326,8 @@ func TestImportingMlfloweWebhooks(t *testing.T) {
 
 			ic := newImportContext(client)
 			ic.Directory = tmpDir
-			ic.listing = "mlflow-webhooks"
-			ic.enableServices(ic.listing)
+			ic.enableListing("mlflow-webhooks")
+			ic.enableServices("mlflow-webhooks")
 
 			err := ic.Run()
 			assert.NoError(t, err)
@@ -2457,8 +2458,9 @@ resource "databricks_pipeline" "def" {
 
 			ic := newImportContext(client)
 			ic.Directory = tmpDir
-			ic.listing = "dlt,mlflow-webhooks"
-			ic.enableServices(ic.listing)
+			services := "dlt,mlflow-webhooks"
+			ic.enableListing(services)
+			ic.enableServices(services)
 			ic.incremental = true
 			ic.updatedSinceStr = "2023-07-24T00:00:00Z"
 			ic.meAdmin = false
@@ -2520,8 +2522,8 @@ func TestImportingRunJobTask(t *testing.T) {
 
 			ic := newImportContext(client)
 			ic.Directory = tmpDir
-			ic.listing = "jobs"
-			ic.enableServices(ic.listing)
+			ic.enableListing("jobs")
+			ic.enableServices("jobs")
 			ic.match = "runjobtask"
 
 			err := ic.Run()

--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -219,7 +219,6 @@ func TestImportingMounts(t *testing.T) {
 		}, func(ctx context.Context, client *common.DatabricksClient) {
 			ic := newImportContext(client)
 			ic.setClientsForTests()
-			ic.enableServices("mounts")
 			ic.enableListing("mounts")
 			ic.mounts = true
 
@@ -669,8 +668,7 @@ func TestImportingUsersGroupsSecretScopes(t *testing.T) {
 
 			ic := newImportContext(client)
 			ic.Directory = tmpDir
-			services, listing := ic.allServicesAndListing()
-			ic.enableServices(services)
+			_, listing := ic.allServicesAndListing()
 			ic.enableListing(listing)
 
 			err := ic.Run()
@@ -742,9 +740,8 @@ func TestImportingNoResourcesError(t *testing.T) {
 
 			ic := newImportContext(client)
 			ic.Directory = tmpDir
-			services, listing := ic.allServicesAndListing()
+			_, listing := ic.allServicesAndListing()
 			ic.enableListing(listing)
-			ic.enableServices(services)
 
 			err := ic.Run()
 			assert.EqualError(t, err, "no resources to import or delete")
@@ -1669,7 +1666,6 @@ func TestImportingRepos(t *testing.T) {
 			ic := newImportContext(client)
 			ic.Directory = tmpDir
 			ic.enableListing("repos")
-			ic.enableServices("repos")
 
 			err := ic.Run()
 			assert.NoError(t, err)
@@ -1741,7 +1737,6 @@ func TestImportingIPAccessLists(t *testing.T) {
 			ic.Directory = tmpDir
 			services := "workspace,access"
 			ic.enableListing(services)
-			ic.enableServices(services)
 
 			err := ic.Run()
 			assert.NoError(t, err)
@@ -2156,7 +2151,6 @@ func TestImportingGlobalSqlConfig(t *testing.T) {
 			ic := newImportContext(client)
 			ic.Directory = tmpDir
 			ic.enableListing("sql-endpoints")
-			ic.enableServices("sql-endpoints")
 
 			err := ic.Run()
 			assert.NoError(t, err)
@@ -2224,7 +2218,6 @@ func TestImportingNotebooksWorkspaceFiles(t *testing.T) {
 			ic := newImportContext(client)
 			ic.Directory = tmpDir
 			ic.enableListing("notebooks")
-			ic.enableServices("notebooks")
 
 			err := ic.Run()
 			assert.NoError(t, err)
@@ -2275,7 +2268,6 @@ func TestImportingModelServing(t *testing.T) {
 			ic := newImportContext(client)
 			ic.Directory = tmpDir
 			ic.enableListing("model-serving")
-			ic.enableServices("model-serving")
 
 			err := ic.Run()
 			assert.NoError(t, err)
@@ -2327,7 +2319,6 @@ func TestImportingMlfloweWebhooks(t *testing.T) {
 			ic := newImportContext(client)
 			ic.Directory = tmpDir
 			ic.enableListing("mlflow-webhooks")
-			ic.enableServices("mlflow-webhooks")
 
 			err := ic.Run()
 			assert.NoError(t, err)
@@ -2460,7 +2451,6 @@ resource "databricks_pipeline" "def" {
 			ic.Directory = tmpDir
 			services := "dlt,mlflow-webhooks"
 			ic.enableListing(services)
-			ic.enableServices(services)
 			ic.incremental = true
 			ic.updatedSinceStr = "2023-07-24T00:00:00Z"
 			ic.meAdmin = false
@@ -2523,7 +2513,6 @@ func TestImportingRunJobTask(t *testing.T) {
 			ic := newImportContext(client)
 			ic.Directory = tmpDir
 			ic.enableListing("jobs")
-			ic.enableServices("jobs")
 			ic.match = "runjobtask"
 
 			err := ic.Run()

--- a/exporter/importables_test.go
+++ b/exporter/importables_test.go
@@ -55,6 +55,8 @@ func importContextForTest() *importContext {
 		emittedUsers:              map[string]struct{}{},
 		userOrSpDirectories:       map[string]bool{},
 		defaultChannel:            make(resourceChannel, defaultChannelSize),
+		services:                  map[string]struct{}{},
+		listing:                   map[string]struct{}{},
 	}
 }
 

--- a/exporter/util.go
+++ b/exporter/util.go
@@ -947,12 +947,16 @@ func (ic *importContext) enableServices(services string) {
 	for _, s := range strings.Split(services, ",") {
 		ic.services[strings.TrimSpace(s)] = struct{}{}
 	}
+	for s := range ic.listing { // Add all services mentioned in the listing
+		ic.services[strings.TrimSpace(s)] = struct{}{}
+	}
 }
 
 func (ic *importContext) enableListing(listing string) {
 	ic.listing = map[string]struct{}{}
 	for _, s := range strings.Split(listing, ",") {
 		ic.listing[strings.TrimSpace(s)] = struct{}{}
+		ic.services[strings.TrimSpace(s)] = struct{}{}
 	}
 }
 

--- a/exporter/util.go
+++ b/exporter/util.go
@@ -949,6 +949,13 @@ func (ic *importContext) enableServices(services string) {
 	}
 }
 
+func (ic *importContext) enableListing(listing string) {
+	ic.listing = map[string]struct{}{}
+	for _, s := range strings.Split(listing, ",") {
+		ic.listing[strings.TrimSpace(s)] = struct{}{}
+	}
+}
+
 func (ic *importContext) emitSqlParentDirectory(parent string) {
 	if parent == "" {
 		return


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

When configuring services to list, the old code was relying on the substring match, and this lead to problems when we have overlapping matches, like, `uc` service matched `uc-allowlist`, etc.  This PR changed to use a map to store services to list so we don't have a problem with overlapping services.

Changes also were made to the interactive prompting - instead of asking for each resource type separately, we now ask about service and show which resources belong to that service.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

