### PR TITLE
Explicitly set securable field when reading `databricks_grants` or `databricks_grant`

### DIFF
--- a/catalog/resource_grant.go
+++ b/catalog/resource_grant.go
@@ -184,7 +184,11 @@ func ResourceGrant() common.Resource {
 			if err != nil {
 				return err
 			}
-			return common.StructToData(*grantsForPrincipal, s, d)
+			err = common.StructToData(*grantsForPrincipal, s, d)
+			if err != nil {
+				return err
+			}
+			return d.Set(securable, name)
 		},
 		Update: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
 			w, err := c.WorkspaceClient()

--- a/catalog/resource_grants.go
+++ b/catalog/resource_grants.go
@@ -351,7 +351,12 @@ func ResourceGrants() common.Resource {
 			if len(grants.PrivilegeAssignments) == 0 {
 				return apierr.NotFound("got empty permissions list")
 			}
-			return common.StructToData(sdkPermissionsListToPermissionsList(*grants), s, d)
+
+			err = common.StructToData(sdkPermissionsListToPermissionsList(*grants), s, d)
+			if err != nil {
+				return err
+			}
+			return d.Set(securable, name)
 		},
 		Update: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
 			w, err := c.WorkspaceClient()

--- a/docs/resources/grant.md
+++ b/docs/resources/grant.md
@@ -345,3 +345,12 @@ resource "databricks_grant" "some" {
 ## Other access control
 
 You can control Databricks General Permissions through [databricks_permissions](permissions.md) resource.
+
+## Import
+
+The resource can be imported using combination of securable type (`table`, `catalog`, `foreign_connection`, ...), it's name and `principal`:
+
+```bash
+terraform import databricks_grant.this catalog/abc/user_name
+```
+

--- a/docs/resources/grants.md
+++ b/docs/resources/grants.md
@@ -341,3 +341,12 @@ resource "databricks_grants" "some" {
 ## Other access control
 
 You can control Databricks General Permissions through [databricks_permissions](permissions.md) resource.
+
+## Import
+
+The resource can be imported using combination of securable type (`table`, `catalog`, `foreign_connection`, ...) and it's name:
+
+```bash
+terraform import databricks_grants.this catalog/abc
+```
+


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

The read method of corresponding resources was reading only a list of permissions, but it didn't set the securable field, so when doing the import, that field was empty and this lead to the recreation of the resource after import.  This PR explicitly sets that field on read.

This fixes #3245

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

