### PR TITLE
Fix ViewDefinition Unexpected Diff Detection When Created By Here-document

### DIFF
--- a/catalog/resource_sql_table.go
+++ b/catalog/resource_sql_table.go
@@ -299,7 +299,7 @@ func (ti *SqlTableInfo) diff(oldti *SqlTableInfo) ([]string, error) {
 
 	if ti.TableType == "VIEW" {
 		// View only attributes
-		if ti.ViewDefinition != oldti.ViewDefinition {
+		if strings.TrimSpace(ti.ViewDefinition) != strings.TrimSpace(oldti.ViewDefinition) {
 			statements = append(statements, fmt.Sprintf("ALTER VIEW %s AS %s", ti.SQLFullName(), ti.ViewDefinition))
 		}
 	} else {


### PR DESCRIPTION
## Changes

trim space from view definition not to detect change when created by here-document

fixed this issue
https://github.com/databricks/terraform-provider-databricks/issues/3019


issue with `databricks_sql_table` resource. When we pass SQL using a here-document, differences appear even though there have been no changes. if we does not pass by here-document it will not detect the changes.

To add a view in Terraform without modifying the tf file. The SQL file used for the view is managed as a separate file(.sql) and passed as follows configuration. At this time, the SQL file is passed as a here-document and is detected as a change even though it has not been modified. I want to resolve this issue as it decreases deployment performance.

### Configuration
<!-- Please provide a minimal reproducible configuration for the issue -->
```hcl
# Copy-paste your Terraform configuration here
resource "databricks_sql_table" "views" {
  for_each = local.sql-association-map-read-from-json

  catalog_name    = each.value.catalog_name
  name            = each.value.name
  schema_name     = each.value.schema_name
  table_type      = "VIEW"
  view_definition =  each.value.sql
}
```
There are work around to avoid this using terraform `trimspace` function. This PR fix this issue without using `trimspace` by terraform user side.
```
resource "databricks_sql_table" "views" {
  for_each = local.sql-association-map-read-from-json

  catalog_name    = each.value.catalog_name
  name            = each.value.name
  schema_name     = each.value.schema_name
  table_type      = "VIEW"
  view_definition =  trimspace(each.value.sql)
}
```
## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [x] relevant acceptance tests are passing
- [x] using Go SDK

