### PR TITLE
Suppress diff on whitespace change for resources that often use HERE-docs

### DIFF
--- a/catalog/resource_sql_table.go
+++ b/catalog/resource_sql_table.go
@@ -394,6 +394,7 @@ func ResourceSqlTable() common.Resource {
 				return strings.EqualFold(strings.ToLower(old), strings.ToLower(new))
 			}
 			s["storage_location"].DiffSuppressFunc = ucDirectoryPathSlashAndEmptySuppressDiff
+			s["view_definition"].DiffSuppressFunc = common.SuppressDiffWhitespaceChange
 
 			s["cluster_id"].ConflictsWith = []string{"warehouse_id"}
 			s["warehouse_id"].ConflictsWith = []string{"cluster_id"}

--- a/common/util.go
+++ b/common/util.go
@@ -2,7 +2,9 @@ package common
 
 import (
 	"context"
+	"log"
 	"regexp"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -26,4 +28,9 @@ func GetTerraformVersionFromContext(ctx context.Context) string {
 
 func IsExporter(ctx context.Context) bool {
 	return GetTerraformVersionFromContext(ctx) == "exporter"
+}
+
+func SuppressDiffWhitespaceChange(k, old, new string, d *schema.ResourceData) bool {
+	log.Printf("[DEBUG] Suppressing diff for %v: old=%#v new=%#v", k, old, new)
+	return strings.TrimSpace(old) == strings.TrimSpace(new)
 }

--- a/common/util_test.go
+++ b/common/util_test.go
@@ -25,3 +25,8 @@ func TestGetTerraformVersionFromContext(t *testing.T) {
 	//
 	assert.True(t, IsExporter(ctx))
 }
+
+func TestSuppressDiffWhitespaceChange(t *testing.T) {
+	assert.True(t, SuppressDiffWhitespaceChange("k", "value", "  value  ", nil))
+	assert.False(t, SuppressDiffWhitespaceChange("k", "value", "new_value", nil))
+}

--- a/policies/resource_cluster_policy.go
+++ b/policies/resource_cluster_policy.go
@@ -35,7 +35,10 @@ func ResourceClusterPolicy() common.Resource {
 			}
 			m["definition"].ConflictsWith = []string{"policy_family_definition_overrides", "policy_family_id"}
 			m["definition"].Computed = true
+			m["definition"].DiffSuppressFunc = common.SuppressDiffWhitespaceChange
+
 			m["policy_family_definition_overrides"].ConflictsWith = []string{"definition"}
+			m["policy_family_definition_overrides"].DiffSuppressFunc = common.SuppressDiffWhitespaceChange
 			m["policy_family_id"].ConflictsWith = []string{"definition"}
 			m["policy_family_definition_overrides"].RequiredWith = []string{"policy_family_id"}
 

--- a/sql/resource_sql_query.go
+++ b/sql/resource_sql_query.go
@@ -544,6 +544,7 @@ func ResourceSqlQuery() common.Resource {
 			}, false)
 
 			m["run_as_role"].ValidateFunc = validation.StringInSlice([]string{"viewer", "owner"}, false)
+			m["query"].DiffSuppressFunc = common.SuppressDiffWhitespaceChange
 			return m
 		})
 


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

Added suppress diff on whitespace change for following resources where HERE-docs are used most often for some attributes:

* `databricks_sql_table` - for `view_definition`
* `databricks_query` - for `query`
* `databricks_cluster_policy` - for `definition` and `policy_family_definition_overrides`

This fixes #3019

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

