### PR TITLE
[JOBS-16324] Terraform support for Foreach tasks (private preview)

### DIFF
--- a/docs/resources/job.md
+++ b/docs/resources/job.md
@@ -116,6 +116,7 @@ This block describes individual tasks:
   * `spark_python_task`
   * `spark_submit_task`
   * `sql_task`
+  * `for_each_task`
 * `library` - (Optional) (Set) An optional list of libraries to be installed on the cluster that will execute the job. Please consult [libraries section](cluster.md#libraries) for [databricks_cluster](cluster.md) resource.
 * `depends_on` - (Optional) block specifying dependency(-ies) for a given task.
 * `run_if` - (Optional) An optional value indicating the condition that determines whether the task should be run once its dependencies have been completed. When omitted, defaults to `ALL_SUCCESS`.
@@ -345,6 +346,12 @@ The `condition_task` specifies a condition with an outcome that can be used to c
 * `op` - The string specifying the operation used to compare operands.  Currently, following operators are supported: `EQUAL_TO`, `GREATER_THAN`, `GREATER_THAN_OR_EQUAL`, `LESS_THAN`, `LESS_THAN_OR_EQUAL`, `NOT_EQUAL`. (Check the [API docs](https://docs.databricks.com/api/workspace/jobs/create) for the latest information).
 
 This task does not require a cluster to execute and does not support retries or notifications.
+
+### for_each_task Configuration Block
+
+* `concurrency` - (Optional) Controls the number of active iteration task runs. Default is 100 (maximal value).
+* `inputs` - (Required) (String) Array for task to iterate on. This can be a JSON string or a reference to an array parameter.
+* `task` - (Required) Task to run against the `inputs` list. 
 
 ### sql_task Configuration Block
 

--- a/jobs/resource_job.go
+++ b/jobs/resource_job.go
@@ -118,7 +118,8 @@ type RunJobTask struct {
 	JobParameters map[string]string `json:"job_parameters,omitempty"`
 }
 
-// TODO: migrate to go sdk
+// TODO: As TF does not support recursive nesting, limit the nesting depth. Example:
+// https://github.com/hashicorp/terraform-provider-aws/blob/b4a9f93a2b7323202c8904e86cff03d3f2cb006b/internal/service/wafv2/rule_group.go#L110
 type ForEachTask struct {
 	Concurrency int               `json:"concurrency,omitempty"`
 	Inputs      string            `json:"inputs"`

--- a/jobs/resource_job.go
+++ b/jobs/resource_job.go
@@ -118,6 +118,46 @@ type RunJobTask struct {
 	JobParameters map[string]string `json:"job_parameters,omitempty"`
 }
 
+// TODO: migrate to go sdk
+type ForEachTask struct {
+	Concurrency int               `json:"concurrency,omitempty"`
+	Inputs      string            `json:"inputs"`
+	Task        ForEachNestedTask `json:"task"`
+}
+
+type ForEachNestedTask struct {
+	TaskKey     string                `json:"task_key,omitempty"`
+	Description string                `json:"description,omitempty"`
+	DependsOn   []jobs.TaskDependency `json:"depends_on,omitempty"`
+	RunIf       string                `json:"run_if,omitempty" tf:"suppress_diff"`
+
+	ExistingClusterID string              `json:"existing_cluster_id,omitempty" tf:"group:cluster_type"`
+	NewCluster        *clusters.Cluster   `json:"new_cluster,omitempty" tf:"group:cluster_type"`
+	JobClusterKey     string              `json:"job_cluster_key,omitempty" tf:"group:cluster_type"`
+	ComputeKey        string              `json:"compute_key,omitempty" tf:"group:cluster_type"`
+	Libraries         []libraries.Library `json:"libraries,omitempty" tf:"slice_set,alias:library"`
+
+	NotebookTask    *NotebookTask       `json:"notebook_task,omitempty" tf:"group:task_type"`
+	SparkJarTask    *SparkJarTask       `json:"spark_jar_task,omitempty" tf:"group:task_type"`
+	SparkPythonTask *SparkPythonTask    `json:"spark_python_task,omitempty" tf:"group:task_type"`
+	SparkSubmitTask *SparkSubmitTask    `json:"spark_submit_task,omitempty" tf:"group:task_type"`
+	PipelineTask    *PipelineTask       `json:"pipeline_task,omitempty" tf:"group:task_type"`
+	PythonWheelTask *PythonWheelTask    `json:"python_wheel_task,omitempty" tf:"group:task_type"`
+	SqlTask         *SqlTask            `json:"sql_task,omitempty" tf:"group:task_type"`
+	DbtTask         *DbtTask            `json:"dbt_task,omitempty" tf:"group:task_type"`
+	RunJobTask      *RunJobTask         `json:"run_job_task,omitempty" tf:"group:task_type"`
+	ConditionTask   *jobs.ConditionTask `json:"condition_task,omitempty" tf:"group:task_type"`
+
+	EmailNotifications     *jobs.TaskEmailNotifications   `json:"email_notifications,omitempty" tf:"suppress_diff"`
+	WebhookNotifications   *jobs.WebhookNotifications     `json:"webhook_notifications,omitempty" tf:"suppress_diff"`
+	NotificationSettings   *jobs.TaskNotificationSettings `json:"notification_settings,omitempty"`
+	TimeoutSeconds         int32                          `json:"timeout_seconds,omitempty"`
+	MaxRetries             int32                          `json:"max_retries,omitempty"`
+	MinRetryIntervalMillis int32                          `json:"min_retry_interval_millis,omitempty"`
+	RetryOnTimeout         bool                           `json:"retry_on_timeout,omitempty" tf:"computed"`
+	Health                 *JobHealth                     `json:"health,omitempty"`
+}
+
 func sortWebhookNotifications(wn *jobs.WebhookNotifications) {
 	if wn == nil {
 		return
@@ -187,6 +227,7 @@ type JobTaskSettings struct {
 	DbtTask         *DbtTask            `json:"dbt_task,omitempty" tf:"group:task_type"`
 	RunJobTask      *RunJobTask         `json:"run_job_task,omitempty" tf:"group:task_type"`
 	ConditionTask   *jobs.ConditionTask `json:"condition_task,omitempty" tf:"group:task_type"`
+	ForEachTask     *ForEachTask        `json:"for_each_task,omitempty" tf:"group:task_type"`
 
 	EmailNotifications     *jobs.TaskEmailNotifications   `json:"email_notifications,omitempty" tf:"suppress_diff"`
 	WebhookNotifications   *jobs.WebhookNotifications     `json:"webhook_notifications,omitempty" tf:"suppress_diff"`


### PR DESCRIPTION
## Changes
Add terraform support for foreach task (going private preview soon). 

Terraform does not support cyclic dependencies, hence we need to limit the nesting depth manually. Implemented using separate structs for the time being. 

## Tests

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

