### PR TITLE
Docs: Fix images and add note on setting multiple authorizations for workspace setup

### DIFF
--- a/docs/guides/aws-workspace.md
+++ b/docs/guides/aws-workspace.md
@@ -331,7 +331,7 @@ resource "time_sleep" "wait" {
 }
 ```
 
-#### IAM policy error
+### IAM policy error
 
 If you notice the below error:
 
@@ -341,8 +341,29 @@ Error: MALFORMED_REQUEST: Failed credentials validation checks: Spot Cancellatio
 
 - Try creating workspace from UI:
 
-![create_workspace_error](https://github.com/databricks/terraform-provider-databricks/raw/master/docs/images/create_workspace_error.png)
+![create_workspace_error](https://raw.githubusercontent.com/databricks/terraform-provider-databricks/main/docs/images/create_workspace_error.png)
 
 - Verify if the role and policy exist (assume role should allow external ID)
 
-![iam_role_trust_error](https://github.com/databricks/terraform-provider-databricks/raw/master/docs/images/iam_role_trust_error.png)
+![iam_role_trust_error](https://raw.githubusercontent.com/databricks/terraform-provider-databricks/main/docs/images/iam_role_trust_error.png)
+
+### More than one authorization method configured error
+
+If you notice the below error:
+
+```sh
+Error: validate: more than one authorization method configured
+```
+
+Ensure that you only have one authorization method set in the provider block. All available authorization methods are documented [here](https://registry.terraform.io/providers/databricks/databricks/latest/docs#auth_type).
+
+If you want to enforce a specific authorization method, you can set the `auth_type` attribute in the provider block:
+
+```hcl
+provider "databricks" {
+  ...
+  auth_type = "pat"
+}
+```
+
+The above would enforce the use of PAT authorization.

--- a/docs/guides/aws-workspace.md
+++ b/docs/guides/aws-workspace.md
@@ -355,7 +355,7 @@ If you notice the below error:
 Error: validate: more than one authorization method configured
 ```
 
-Ensure that you only have one authorization method set in the provider block. All available authorization methods are documented [here](https://registry.terraform.io/providers/databricks/databricks/latest/docs#auth_type).
+Ensure that you only have one authorization method set. All available authorization methods are documented [here](https://registry.terraform.io/providers/databricks/databricks/latest/docs#auth_type).
 
 If you want to enforce a specific authorization method, you can set the `auth_type` attribute in the provider block:
 

--- a/docs/guides/aws-workspace.md
+++ b/docs/guides/aws-workspace.md
@@ -349,21 +349,4 @@ Error: MALFORMED_REQUEST: Failed credentials validation checks: Spot Cancellatio
 
 ### More than one authorization method configured error
 
-If you notice the below error:
-
-```sh
-Error: validate: more than one authorization method configured
-```
-
-Ensure that you only have one authorization method set. All available authorization methods are documented [here](https://registry.terraform.io/providers/databricks/databricks/latest/docs#auth_type).
-
-If you want to enforce a specific authorization method, you can set the `auth_type` attribute in the provider block:
-
-```hcl
-provider "databricks" {
-  ...
-  auth_type = "pat"
-}
-```
-
-The above would enforce the use of PAT authorization.
+See the [troubleshooting guide](https://registry.terraform.io/providers/databricks/databricks/latest/docs/guides/troubleshooting#more-than-one-authorization-method-configured)

--- a/docs/guides/gcp-workspace.md
+++ b/docs/guides/gcp-workspace.md
@@ -271,21 +271,4 @@ We assume that you have a terraform module in your project that creates a worksp
 
 ### More than one authorization method configured error
 
-If you notice the below error:
-
-```sh
-Error: validate: more than one authorization method configured
-```
-
-Ensure that you only have one authorization method set. All available authorization methods are documented [here](https://registry.terraform.io/providers/databricks/databricks/latest/docs#auth_type).
-
-If you want to enforce a specific authorization method, you can set the `auth_type` attribute in the provider block:
-
-```hcl
-provider "databricks" {
-  ...
-  auth_type = "pat"
-}
-```
-
-The above would enforce the use of PAT authorization.
+See the [troubleshooting guide](https://registry.terraform.io/providers/databricks/databricks/latest/docs/guides/troubleshooting#more-than-one-authorization-method-configured)

--- a/docs/guides/gcp-workspace.md
+++ b/docs/guides/gcp-workspace.md
@@ -268,3 +268,24 @@ provider "databricks" {
 ```
 
 We assume that you have a terraform module in your project that creates a workspace (using [Databricks Workspace](#creating-a-databricks-workspace) section), and you named it as `dbx_gcp` while calling it in the **main.tf** file of your terraform project. And `workspace_url` and `token_value` are the output attributes of that module. This provider configuration will allow you to use the generated token to authenticate to the created workspace during workspace creation.
+
+### More than one authorization method configured error
+
+If you notice the below error:
+
+```sh
+Error: validate: more than one authorization method configured
+```
+
+Ensure that you only have one authorization method set in the provider block. All available authorization methods are documented [here](https://registry.terraform.io/providers/databricks/databricks/latest/docs#auth_type).
+
+If you want to enforce a specific authorization method, you can set the `auth_type` attribute in the provider block:
+
+```hcl
+provider "databricks" {
+  ...
+  auth_type = "pat"
+}
+```
+
+The above would enforce the use of PAT authorization.

--- a/docs/guides/gcp-workspace.md
+++ b/docs/guides/gcp-workspace.md
@@ -277,7 +277,7 @@ If you notice the below error:
 Error: validate: more than one authorization method configured
 ```
 
-Ensure that you only have one authorization method set in the provider block. All available authorization methods are documented [here](https://registry.terraform.io/providers/databricks/databricks/latest/docs#auth_type).
+Ensure that you only have one authorization method set. All available authorization methods are documented [here](https://registry.terraform.io/providers/databricks/databricks/latest/docs#auth_type).
 
 If you want to enforce a specific authorization method, you can set the `auth_type` attribute in the provider block:
 

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -183,3 +183,24 @@ If the metastore assigned to the workspace has changed, the new metastore id mus
 ```
 
 To solve this error, the new Metastore ID must be set in the field `metastore_id` of the failing resources.
+
+### More than one authorization method configured error
+
+If you notice the below error:
+
+```sh
+Error: validate: more than one authorization method configured
+```
+
+Ensure that you only have one authorization method set. All available authorization methods are documented [here](https://registry.terraform.io/providers/databricks/databricks/latest/docs#auth_type).
+
+If you want to enforce a specific authorization method, you can set the `auth_type` attribute in the provider block:
+
+```hcl
+provider "databricks" {
+  ...
+  auth_type = "pat"
+}
+```
+
+The above would enforce the use of PAT authorization.


### PR DESCRIPTION
## Changes
- Fix broken images in the doc
- Describe the `more than one authorization method configured` error for AWS and GCP setup

Resolves #3257 

## Tests

- [ ] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

