### PR TITLE
Add support for setting table tags via terraform

### DIFF
--- a/docs/resources/sql_table.md
+++ b/docs/resources/sql_table.md
@@ -127,6 +127,7 @@ The following arguments are supported:
 * `comment` - (Optional) User-supplied free-form text. Changing comment is not currently supported on `VIEW` table_type.
 * `options` - (Optional) Map of user defined table options. Change forces creation of a new resource.
 * `properties` - (Optional) Map of table properties.
+* `tags` - (Optional) Map of table tags.
 * `partitions` - (Optional) a subset of columns to partition the table by. Change forces creation of a new resource. Conflicts with `cluster_keys`.
 
 ### `column` configuration block


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
Add support for setting table tags via terraform. 

https://docs.databricks.com/en/data-governance/unity-catalog/tags.html

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [x] covered with integration tests in `internal/acceptance`
       Not seeing these for similar fields e.g. properties/options
- [x] relevant acceptance tests are passing
- [ ] using Go SDK
- [x] Manual testing
* Able to create tags on table as well as create new ones, update values, and delete others

