### PR TITLE
Add computed `volume_path` attribute to `databricks_volume` resource

### DIFF
--- a/catalog/resource_volume.go
+++ b/catalog/resource_volume.go
@@ -42,6 +42,11 @@ func ResourceVolume() common.Resource {
 	s := common.StructToSchema(VolumeInfo{},
 		func(m map[string]*schema.Schema) map[string]*schema.Schema {
 			m["storage_location"].DiffSuppressFunc = ucDirectoryPathSlashAndEmptySuppressDiff
+			m["volume_path"] = &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+				Optional: true,
+			}
 			return m
 		})
 	return common.Resource{
@@ -82,7 +87,11 @@ func ResourceVolume() common.Resource {
 			if err != nil {
 				return err
 			}
-			return common.StructToData(v, s, d)
+			err = common.StructToData(v, s, d)
+			if err != nil {
+				return err
+			}
+			return d.Set("volume_path", "/Volumes/"+strings.ReplaceAll(v.FullName, ".", "/"))
 		},
 		Update: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
 			w, err := c.WorkspaceClient()

--- a/catalog/resource_volume.go
+++ b/catalog/resource_volume.go
@@ -45,7 +45,6 @@ func ResourceVolume() common.Resource {
 			m["volume_path"] = &schema.Schema{
 				Type:     schema.TypeString,
 				Computed: true,
-				Optional: true,
 			}
 			return m
 		})
@@ -144,6 +143,7 @@ func ResourceVolume() common.Resource {
 			// We need to update the resource Id because Name is updatable and FullName consists of Name,
 			// So if we don't update the field then the requests would be made to old FullName which doesn't exists.
 			d.SetId(v.FullName)
+			d.Set("volume_path", "/Volumes/"+strings.ReplaceAll(v.FullName, ".", "/"))
 			return nil
 		},
 		Delete: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {

--- a/catalog/resource_volume_test.go
+++ b/catalog/resource_volume_test.go
@@ -270,6 +270,7 @@ func TestVolumesRead(t *testing.T) {
 	assert.Equal(t, "testCatalogName", d.Get("catalog_name"))
 	assert.Equal(t, "testSchemaName", d.Get("schema_name"))
 	assert.Equal(t, "This is a test comment.", d.Get("comment"))
+	assert.Equal(t, "/Volumes/testCatalogName/testSchemaName/testName", d.Get("volume_path"))
 }
 
 func TestResourceVolumeRead_Error(t *testing.T) {

--- a/catalog/resource_volume_test.go
+++ b/catalog/resource_volume_test.go
@@ -358,6 +358,7 @@ func TestVolumesUpdate(t *testing.T) {
 	assert.Equal(t, "testCatalogName", d.Get("catalog_name"))
 	assert.Equal(t, "testSchemaName", d.Get("schema_name"))
 	assert.Equal(t, "This is a new test comment.", d.Get("comment"))
+	assert.Equal(t, "/Volumes/testCatalogName/testSchemaName/testNameNew", d.Get("volume_path"))
 }
 
 func TestVolumesUpdateForceNewOnCatalog(t *testing.T) {

--- a/docs/resources/volume.md
+++ b/docs/resources/volume.md
@@ -93,6 +93,7 @@ The following arguments are supported:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - ID of this Unity Catalog Volume in form of `<catalog>.<schema>.<name>`.
+* `volume_path` - base file path for this Unity Catalog Volume in form of `/Volumes/<catalog>/<schema>/<name>`.
 
 ## Import
 


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

This attribute will expose path in form of `/Volumes/<catalog>/<schema>/<name>` for use with other resources, such as, `databricks_file`.  Plus it's necessary for Terraform Exporter to detect references between resources.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

