### PR TITLE
fix: properly propagate auth_type to the databricks client

### DIFF
--- a/common/client.go
+++ b/common/client.go
@@ -267,6 +267,7 @@ func (c *DatabricksClient) ClientForHost(ctx context.Context, url string) (*Data
 		Host:                 url,
 		Username:             c.Config.Username,
 		Password:             c.Config.Password,
+		AuthType:             c.Config.AuthType,
 		Token:                c.Config.Token,
 		ClientID:             c.Config.ClientID,
 		ClientSecret:         c.Config.ClientSecret,


### PR DESCRIPTION
## Changes
We want to use basic creds for databricks, while using GOOGLE_CREDENTIALS for another provider.
Specifying `auth_type = "basic"` in the provider configuration did not resolve the `more than one authorization method configured` error, only setting `DATABRICKS_AUTH_TYPE=basic` envvar did.

After analysis, it looks like the databricks-sdk-go client is not receiving the auth_type value.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

