### PR TITLE
Fix Read operation in `databricks_catalog_workspace_binding` so we can perform import

### DIFF
--- a/catalog/resource_catalog_workspace_binding.go
+++ b/catalog/resource_catalog_workspace_binding.go
@@ -89,13 +89,13 @@ func ResourceCatalogWorkspaceBinding() common.Resource {
 			if workspaceId == 0 || securable_name == "" || securable_type == "" {
 				parts := strings.Split(d.Id(), "|")
 				if len(parts) != 3 {
-					return fmt.Errorf("incorrect binding id: %s", d.Id())
+					return fmt.Errorf("incorrect binding id: %s. Correct format: <workspace_id>|<securable_type>|<securable_name>", d.Id())
 				}
 				securable_name = parts[2]
 				securable_type = parts[1]
 				workspaceId, err = strconv.ParseInt(parts[0], 10, 0)
 				if err != nil {
-					return err
+					return fmt.Errorf("can't parse workspace_id: %w", err)
 				}
 				d.Set("securable_name", securable_name)
 				d.Set("securable_type", securable_type)

--- a/catalog/resource_catalog_workspace_binding.go
+++ b/catalog/resource_catalog_workspace_binding.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"strconv"
+	"strings"
 
 	"github.com/databricks/databricks-sdk-go/apierr"
 	"github.com/databricks/databricks-sdk-go/service/catalog"
@@ -80,10 +82,28 @@ func ResourceCatalogWorkspaceBinding() common.Resource {
 			if err != nil {
 				return err
 			}
+			// TODO: fix Read operation by splitting `id` into parts... Test with actual import. Remove not necessary code in exporter?
 			workspaceId := int64(d.Get("workspace_id").(int))
+			securable_name := getSecurableName(d)
+			securable_type := d.Get("securable_type").(string)
+			if workspaceId == 0 || securable_name == "" || securable_type == "" {
+				parts := strings.Split(d.Id(), "|")
+				if len(parts) != 3 {
+					return fmt.Errorf("incorrect binding id: %s", d.Id())
+				}
+				securable_name = parts[2]
+				securable_type = parts[1]
+				workspaceId, err = strconv.ParseInt(parts[0], 10, 0)
+				if err != nil {
+					return err
+				}
+				d.Set("securable_name", securable_name)
+				d.Set("securable_type", securable_type)
+				d.Set("workspace_id", workspaceId)
+			}
 			bindings, err := w.WorkspaceBindings.GetBindings(ctx, catalog.GetBindingsRequest{
-				SecurableName: getSecurableName(d),
-				SecurableType: d.Get("securable_type").(string),
+				SecurableName: securable_name,
+				SecurableType: securable_type,
 			})
 			if err != nil {
 				return err

--- a/catalog/resource_catalog_workspace_binding_test.go
+++ b/catalog/resource_catalog_workspace_binding_test.go
@@ -236,12 +236,12 @@ func TestCatalogWorkspaceBindingsReadErrors(t *testing.T) {
 		ID:       "1234567890101112|catalog",
 		New:      true,
 		Read:     true,
-	}.ExpectError(t, "incorrect binding id: 1234567890101112|catalog")
+	}.ExpectError(t, "incorrect binding id: 1234567890101112|catalog. Correct format: <workspace_id>|<securable_type>|<securable_name>")
 
 	qa.ResourceFixture{
 		Resource: ResourceCatalogWorkspaceBinding(),
 		ID:       "A234567890101112|catalog|my_catalog",
 		New:      true,
 		Read:     true,
-	}.ExpectError(t, "strconv.ParseInt: parsing \"A234567890101112\": invalid syntax")
+	}.ExpectError(t, "can't parse workspace_id: strconv.ParseInt: parsing \"A234567890101112\": invalid syntax")
 }

--- a/catalog/resource_catalog_workspace_binding_test.go
+++ b/catalog/resource_catalog_workspace_binding_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestCatalogWorkspaceBindingsCornerCases(t *testing.T) {
 	qa.ResourceCornerCases(t, ResourceCatalogWorkspaceBinding(),
-		qa.CornerCaseID("my_catalog|1234567890101112"),
+		qa.CornerCaseID("1234567890101112|catalog|my_catalog"),
 		qa.CornerCaseSkipCRUD("create"))
 }
 
@@ -201,4 +201,47 @@ func TestSecurableWorkspaceBindings_Delete(t *testing.T) {
 		binding_type   = "BINDING_TYPE_READ_ONLY"
 		`,
 	}.ApplyNoError(t)
+}
+
+func TestCatalogWorkspaceBindingsReadImport(t *testing.T) {
+	qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "GET",
+				Resource: "/api/2.1/unity-catalog/bindings/catalog/my_catalog?",
+				Response: catalog.WorkspaceBindingsResponse{
+					Bindings: []catalog.WorkspaceBinding{
+						{
+							BindingType: catalog.WorkspaceBindingBindingTypeBindingTypeReadOnly,
+							WorkspaceId: int64(1234567890101112),
+						},
+					},
+				},
+			},
+		},
+		Resource: ResourceCatalogWorkspaceBinding(),
+		ID:       "1234567890101112|catalog|my_catalog",
+		New:      true,
+		Read:     true,
+	}.ApplyAndExpectData(t, map[string]any{
+		"workspace_id":   1234567890101112,
+		"securable_type": "catalog",
+		"securable_name": "my_catalog",
+	})
+}
+
+func TestCatalogWorkspaceBindingsReadErrors(t *testing.T) {
+	qa.ResourceFixture{
+		Resource: ResourceCatalogWorkspaceBinding(),
+		ID:       "1234567890101112|catalog",
+		New:      true,
+		Read:     true,
+	}.ExpectError(t, "incorrect binding id: 1234567890101112|catalog")
+
+	qa.ResourceFixture{
+		Resource: ResourceCatalogWorkspaceBinding(),
+		ID:       "A234567890101112|catalog|my_catalog",
+		New:      true,
+		Read:     true,
+	}.ExpectError(t, "strconv.ParseInt: parsing \"A234567890101112\": invalid syntax")
 }

--- a/docs/resources/catalog_workspace_binding.md
+++ b/docs/resources/catalog_workspace_binding.md
@@ -40,4 +40,8 @@ The following arguments are required:
 
 ## Import
 
--> **Note** Importing this resource is not currently supported.
+This resource can be imported by using combination of workspace ID, securable type and name:
+
+```sh
+terraform import databricks_catalog_workspace_binding.this "<workspace_id>|<securable_type>|<securable_name>"
+```

--- a/exporter/importables.go
+++ b/exporter/importables.go
@@ -2389,6 +2389,9 @@ var resourcesMap map[string]importable = map[string]importable{
 				if err == nil {
 					for _, binding := range bindings.Bindings {
 						id := fmt.Sprintf("%d|%s|%s", binding.WorkspaceId, securable, cat.Name)
+						// We were creating Data instance explicitly because of the bug in the databricks_catalog_workspace_binding
+						// implementation. Technically, after the fix is merged we can remove this, but we're keeping it as-is now
+						// to decrease a number of API calls.
 						d := ic.Resources["databricks_catalog_workspace_binding"].Data(
 							&terraform.InstanceState{
 								ID: id,


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

During work on exporter, we found that the Read operation for this resource doesn't work when
it's used from scratch, so we needed to explicitly fill the TF state with data.   This
also doesn't allow to import of this resource.  This PR fixes the problem and uses data from
`Id` to retrieve all necessary information.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

