### PR TITLE
Use stable IDs for settings resources

### DIFF
--- a/docs/resources/default_namespace_settings.md
+++ b/docs/resources/default_namespace_settings.md
@@ -29,3 +29,11 @@ The resource supports the following arguments:
 
 * `namespace` - (Required) The configuration details.
 * `value` - (Required) The value for the setting.
+
+## Import
+
+This resource can be imported by predefined name `global`:
+
+```bash
+terraform import databricks_default_namespace_setting.this global
+```

--- a/docs/resources/restrict_workspace_admins_setting.md
+++ b/docs/resources/restrict_workspace_admins_setting.md
@@ -38,3 +38,11 @@ The resource supports the following arguments:
 
 * `restrict_workspace_admins` - (Required) The configuration details.
 * `status` - (Required) The restrict workspace admins status for the workspace.
+
+## Import
+
+This resource can be imported by predefined name `global`:
+
+```bash
+terraform import databricks_restrict_workspace_admins_setting.this global
+```

--- a/settings/generic_setting.go
+++ b/settings/generic_setting.go
@@ -13,7 +13,7 @@ import (
 )
 
 var (
-	defaultSettingName = "global"
+	defaultSettingId = "global"
 )
 
 func retryOnEtagError[Req, Resp any](f func(req Req) (Resp, error), firstReq Req, updateReq func(req *Req, newEtag string), retriableErrors []error) (Resp, error) {
@@ -133,7 +133,7 @@ func (w workspaceSetting[T]) GetETag(t *T) string {
 }
 
 func (w workspaceSetting[T]) GetId(t *T) string {
-	id := defaultSettingName
+	id := defaultSettingId
 	if w.generateIdFunc != nil {
 		id = w.generateIdFunc(t)
 	}
@@ -189,7 +189,7 @@ func (w accountSetting[T]) SetETag(t *T, newEtag string) {
 }
 
 func (w accountSetting[T]) GetId(t *T) string {
-	id := defaultSettingName
+	id := defaultSettingId
 	if w.generateIdFunc != nil {
 		id = w.generateIdFunc(t)
 	}

--- a/settings/generic_setting_test.go
+++ b/settings/generic_setting_test.go
@@ -74,7 +74,7 @@ func TestQueryCreateDefaultNameSetting(t *testing.T) {
 			}
 		`,
 	}.ApplyAndExpectData(t, map[string]any{
-		"id":                defaultSettingName,
+		"id":                defaultSettingId,
 		"etag":              "etag2",
 		"namespace.0.value": "namespace_value",
 	})
@@ -101,9 +101,9 @@ func TestQueryReadDefaultNameSetting(t *testing.T) {
 			}
 			etag = "etag1"
 		`,
-		ID: defaultSettingName,
+		ID: defaultSettingId,
 	}.ApplyAndExpectData(t, map[string]any{
-		"id":                defaultSettingName,
+		"id":                defaultSettingId,
 		"etag":              "etag2",
 		"namespace.0.value": "namespace_value",
 	})
@@ -148,9 +148,9 @@ func TestQueryUpdateDefaultNameSetting(t *testing.T) {
 			}
 			etag = "etag1"
 		`,
-		ID: defaultSettingName,
+		ID: defaultSettingId,
 	}.ApplyAndExpectData(t, map[string]any{
-		"id":                defaultSettingName,
+		"id":                defaultSettingId,
 		"etag":              "etag2",
 		"namespace.0.value": "new_namespace_value",
 	})
@@ -216,9 +216,9 @@ func TestQueryUpdateDefaultNameSettingWithConflict(t *testing.T) {
 			}
 			etag = "etag1"
 		`,
-		ID: defaultSettingName,
+		ID: defaultSettingId,
 	}.ApplyAndExpectData(t, map[string]any{
-		"id":                defaultSettingName,
+		"id":                defaultSettingId,
 		"etag":              "etag3",
 		"namespace.0.value": "new_namespace_value",
 	})
@@ -241,7 +241,7 @@ func TestQueryDeleteDefaultNameSetting(t *testing.T) {
 			}
 			etag = "etag1"
 		`,
-		ID: defaultSettingName,
+		ID: defaultSettingId,
 	}.Apply(t)
 
 	assert.NoError(t, err)
@@ -278,7 +278,7 @@ func TestQueryDeleteDefaultNameSettingWithConflict(t *testing.T) {
 			}
 			etag = "etag1"
 		`,
-		ID: defaultSettingName,
+		ID: defaultSettingId,
 	}.Apply(t)
 
 	assert.NoError(t, err)

--- a/settings/resource_restrict_workspace_admins_setting_test.go
+++ b/settings/resource_restrict_workspace_admins_setting_test.go
@@ -76,7 +76,8 @@ func TestQueryCreateRestrictWsAdminsSetting(t *testing.T) {
 
 	assert.NoError(t, err)
 
-	assert.Equal(t, "etag2", d.Id())
+	assert.Equal(t, defaultSettingId, d.Id())
+	assert.Equal(t, "etag2", d.Get("etag").(string))
 	assert.Equal(t, "RESTRICT_TOKENS_AND_JOB_RUN_AS", d.Get("restrict_workspace_admins.0.status"))
 }
 
@@ -99,13 +100,15 @@ func TestQueryReadRestrictWsAdminsSetting(t *testing.T) {
 			restrict_workspace_admins {
 				status = "RESTRICT_TOKENS_AND_JOB_RUN_AS"
 			}
+			etag = "etag1"
 		`,
-		ID: "etag1",
+		ID: defaultSettingId,
 	}.Apply(t)
 
 	assert.NoError(t, err)
 
-	assert.Equal(t, "etag2", d.Id())
+	assert.Equal(t, defaultSettingId, d.Id())
+	assert.Equal(t, "etag2", d.Get("etag").(string))
 	res := d.Get("restrict_workspace_admins").([]interface{})[0].(map[string]interface{})
 	assert.Equal(t, "RESTRICT_TOKENS_AND_JOB_RUN_AS", res["status"])
 }
@@ -147,13 +150,15 @@ func TestQueryUpdateRestrictWsAdminsSetting(t *testing.T) {
 			restrict_workspace_admins {
 				status = "ALLOW_ALL"
 			}
+			etag = "etag1"
 		`,
-		ID: "etag1",
+		ID: defaultSettingId,
 	}.Apply(t)
 
 	assert.NoError(t, err)
 
-	assert.Equal(t, "etag2", d.Id())
+	assert.Equal(t, defaultSettingId, d.Id())
+	assert.Equal(t, "etag2", d.Get("etag").(string))
 	res := d.Get("restrict_workspace_admins").([]interface{})[0].(map[string]interface{})
 	assert.Equal(t, "ALLOW_ALL", res["status"])
 }
@@ -216,19 +221,21 @@ func TestQueryUpdateRestrictWsAdminsSettingWithConflict(t *testing.T) {
 			restrict_workspace_admins {
 				status = "RESTRICT_TOKENS_AND_JOB_RUN_AS"
 			}
+			etag = "etag1"
 		`,
-		ID: "etag1",
+		ID: defaultSettingId,
 	}.Apply(t)
 
 	assert.NoError(t, err)
 
-	assert.Equal(t, "etag3", d.Id())
+	assert.Equal(t, defaultSettingId, d.Id())
+	assert.Equal(t, "etag3", d.Get("etag").(string))
 	res := d.Get("restrict_workspace_admins").([]interface{})[0].(map[string]interface{})
 	assert.Equal(t, "RESTRICT_TOKENS_AND_JOB_RUN_AS", res["status"])
 }
 
 func TestQueryDeleteRestrictWsAdminsSetting(t *testing.T) {
-	d, err := qa.ResourceFixture{
+	qa.ResourceFixture{
 		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
 			w.GetMockSettingsAPI().EXPECT().DeleteRestrictWorkspaceAdminsSetting(mock.Anything, settings.DeleteRestrictWorkspaceAdminsSettingRequest{
 				Etag: "etag1",
@@ -238,15 +245,21 @@ func TestQueryDeleteRestrictWsAdminsSetting(t *testing.T) {
 		},
 		Resource: testRestrictWsAdminsSetting,
 		Delete:   true,
-		ID:       "etag1",
-	}.Apply(t)
-
-	assert.NoError(t, err)
-	assert.Equal(t, "etag2", d.Id())
+		HCL: `
+		restrict_workspace_admins {
+			status = "RESTRICT_TOKENS_AND_JOB_RUN_AS"
+		}
+		etag = "etag1"
+		`,
+		ID: defaultSettingId,
+	}.ApplyAndExpectData(t, map[string]any{
+		"id":   defaultSettingId,
+		"etag": "etag2",
+	})
 }
 
 func TestQueryDeleteRestrictWsAdminsSettingWithConflict(t *testing.T) {
-	d, err := qa.ResourceFixture{
+	qa.ResourceFixture{
 		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
 			w.GetMockSettingsAPI().EXPECT().DeleteRestrictWorkspaceAdminsSetting(mock.Anything, settings.DeleteRestrictWorkspaceAdminsSettingRequest{
 				Etag: "etag1",
@@ -268,10 +281,16 @@ func TestQueryDeleteRestrictWsAdminsSettingWithConflict(t *testing.T) {
 			}, nil)
 		},
 		Resource: testRestrictWsAdminsSetting,
-		Delete:   true,
-		ID:       "etag1",
-	}.Apply(t)
-
-	assert.NoError(t, err)
-	assert.Equal(t, "etag3", d.Id())
+		HCL: `
+		restrict_workspace_admins {
+			status = "RESTRICT_TOKENS_AND_JOB_RUN_AS"
+		}
+		etag = "etag1"
+		`,
+		Delete: true,
+		ID:     defaultSettingId,
+	}.ApplyAndExpectData(t, map[string]any{
+		"id":   defaultSettingId,
+		"etag": "etag3",
+	})
 }


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

Before this change, generated settings resource were using `etag` value as resource ID. This lead to a situation that importing of these resources was problematic because ID was changing all the time.

This PR introduces stable IDs for generated resources. By default it uses a constant ID: `global`, similar to other resources, like, `databricks_sql_global_config`, but the resource implementor may provide a function that will generate a resource ID from the settings' data.

This fixes #3270

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

