### PR TITLE
Exporter: More work on Unity Catalog support

### DIFF
--- a/docs/guides/experimental-exporter.md
+++ b/docs/guides/experimental-exporter.md
@@ -82,14 +82,15 @@ Services are just logical groups of resources used for filtering and organizatio
 * `uc-artifact-allowlist` - **listing** exports [databricks_artifact_allowlist](../resources/artifact_allowlist.md) resources for Unity Catalog Allow Lists attached to the current metastore.
 * `uc-catalogs` - **listing** [databricks_catalog](../resources/catalog.md) and [databricks_catalog_workspace_binding](../resources/catalog_workspace_binding.md)
 * `uc-connections` - **listing** [databricks_connection](../resources/connection.md).  *Please note that because API doesn't return sensitive fields, such as, passwords, tokens, ..., the generated `options` block could be incomplete!*
+* `uc-external-locations` - **listing** exports [databricks_external_location](../resources/external_location.md) resource.
 * `uc-grants` -  [databricks_grants](../resources/grants.md)
 * `uc-metastores` - **listing** [databricks_metastore](../resources/metastore.md) and [databricks_metastore_assignment](../resource/metastore_assignment.md) (only on account-level).  *Please note that when using workspace-level configuration, only metastores from the workspace's region are listed!*
 * `uc-models` - [databricks_registered_model](../resources/registered_model.md)
 * `uc-schemas` -  [databricks_schema](../resources/schema.md)
 * `uc-shares` - **listing** [databricks_share](../resources/share.md) and [databricks_recipient](../resources/recipient.md)
+* `uc-storage-credentials` - **listing** exports [databricks_storage_credential](../resources/storage_credential.md) resources on workspace or account level.
 * `uc-system-schemas` - **listing** exports [databricks_system_schema](../resources/system_schema.md) resources for the UC metastore of the current workspace.
-* `uc-storage-credentials` - **listing** exports [databricks_storage_credential](../resources/storage_credential) resources on workspace or account level.
-* `uc-external-locations` - **listing** exports [databricks_external_location[(../resources/external_location) resource.
+* `uc-tables` - [databricks_sql_table](../resources/sql_table.md) resource.
 * `uc-volumes` -  [databricks_volume](../resources/volume.md)
 * `users` - [databricks_user](../resources/user.md) and [databricks_service_principal](../resources/service_principal.md) are written to their own file, simply because of their amount. If you use SCIM provisioning, migrating workspaces is the only use case for importing `users` service.
 * `workspace` - **listing** [databricks_workspace_conf](../resources/workspace_conf.md) and [databricks_global_init_script](../resources/global_init_script.md)
@@ -113,64 +114,65 @@ To speed up export, Terraform Exporter performs many operations, such as listing
 
 Exporter aims to generate HCL code for most of the resources within the Databricks workspace:
 
-| Resource | Generated code | Incremental |
-| --- | --- | --- |
-| [databricks_access_control_rule_set](../resources/access_control_rule_set.md) | Yes | No |
-| [databricks_artifact_allowlist](../resources/artifact_allowlist.md) | Yes | No |
-| [databricks_catalog](../resources/catalog.md) | Yes | Yes |
-| [databricks_cluster](../resources/cluster.md) | Yes | No |
-| [databricks_cluster_policy](../resources/cluster_policy.md) | Yes | No |
-| [databricks_connection](../resources/connection.md) | Yes | Yes |
-| [databricks_dbfs_file](../resources/dbfs_file.md) | Yes | No |
-| [databricks_external_location](../resources/external_location.md) | Yes | Yes |
-| [databricks_global_init_script](../resources/global_init_script.md) | Yes | Yes |
-| [databricks_grants](../resources/grants.md) | Yes | No |
-| [databricks_group](../resources/group.md) | Yes | No |
-| [databricks_group_instance_profile](../resources/group_instance_profile.md) | Yes | No |
-| [databricks_group_member](../resources/group_member.md) | Yes | No |
-| [databricks_group_role](../resources/group_role.md) | Yes | No |
-| [databricks_instance_pool](../resources/instance_pool.md) | Yes | No |
-| [databricks_instance_profile](../resources/instance_profile.md) | Yes | No |
-| [databricks_ip_access_list](../resources/ip_access_list.md) | Yes | Yes |
-| [databricks_job](../resources/job.md) | Yes | No |
-| [databricks_library](../resources/library.md) | Yes\* | No |
-| [databricks_metastore](../resources/metastore.md) | Yes | Yes |
-| [databricks_metastore_assignment](../resources/metastore_assignment.md) | Yes | No |
-| [databricks_mlflow_experiment](../resources/mlflow_experiment.md) | No | No |
-| [databricks_mlflow_model](../resources/mlflow_model.md) | No | No |
-| [databricks_mlflow_webhook](../resources/mlflow_webhook.md) | Yes | Yes |
-| [databricks_model_serving](../resources/model_serving) | Yes | Yes |
-| [databricks_notebook](../resources/notebook.md) | Yes | Yes |
-| [databricks_obo_token](../resources/obo_token.md) | Not Applicable | No |
-| [databricks_permissions](../resources/permissions.md) | Yes | No |
-| [databricks_pipeline](../resources/pipeline.md) | Yes | Yes |
-| [databricks_recipient](../resources/recipient.md) | Yes | Yes |
-| [databricks_registered_model](../resources/registered.md) | Yes | Yes |
-| [databricks_repo](../resources/repo.md) | Yes | No |
-| [databricks_schema](../resources/schema.md) | Yes | Yes |
-| [databricks_secret](../resources/secret.md) | Yes | No |
-| [databricks_secret_acl](../resources/secret_acl.md) | Yes | No |
-| [databricks_secret_scope](../resources/secret_scope.md) | Yes | No |
-| [databricks_service_principal](../resources/service_principal.md) | Yes | No |
-| [databricks_service_principal_role](../resources/service_principal_role.md) | Yes | No |
-| [databricks_share](../resources/share.md) | Yes | Yes |
-| [databricks_sql_alert](../resources/sql_alert.md) | Yes | Yes |
-| [databricks_sql_dashboard](../resources/sql_dashboard.md) | Yes | Yes |
-| [databricks_sql_endpoint](../resources/sql_endpoint.md) | Yes | No |
-| [databricks_sql_global_config](../resources/sql_global_config.md) | Yes | No |
-| [databricks_sql_permissions](../resources/sql_permissions.md) | No | No |
-| [databricks_sql_query](../resources/sql_query.md) | Yes | Yes |
-| [databricks_sql_visualization](../resources/sql_visualization.md) | Yes | Yes |
-| [databricks_sql_widget](../resources/sql_widget.md) | Yes | Yes |
-| [databricks_storage_credential](../resources/storage_credential.md) | Yes | Yes |
-| [databricks_system_schema](../resources/system_schema.md) | Yes | No |
-| [databricks_token](../resources/token.md) | Not Applicable | No |
-| [databricks_user](../resources/user.md) | Yes | No |
-| [databricks_user_instance_profile](../resources/user_instance_profile.md) | No (Deprecated) | No |
-| [databricks_user_role](../resources/user_role.md) | Yes | No |
-| [databricks_volume](../resources/volume.md) | Yes | Yes |
-| [databricks_workspace_conf](../resources/workspace_conf.md) | Yes (partial) | No |
-| [databricks_workspace_file](../resources/workspace_file.md) | Yes | Yes |
+| Resource | Supported | Incremental | Workspace | Account |
+| --- | --- | --- | --- | --- |
+| [databricks_access_control_rule_set](../resources/access_control_rule_set.md) | Yes | No | No | Yes |
+| [databricks_artifact_allowlist](../resources/artifact_allowlist.md) | Yes | No | Yes | No |
+| [databricks_catalog](../resources/catalog.md) | Yes | Yes | Yes | No |
+| [databricks_cluster](../resources/cluster.md) | Yes | No | Yes | No |
+| [databricks_cluster_policy](../resources/cluster_policy.md) | Yes | No | Yes | No |
+| [databricks_connection](../resources/connection.md) | Yes | Yes | Yes | No |
+| [databricks_dbfs_file](../resources/dbfs_file.md) | Yes | No | Yes | No |
+| [databricks_external_location](../resources/external_location.md) | Yes | Yes | Yes | No |
+| [databricks_global_init_script](../resources/global_init_script.md) | Yes | Yes | Yes | No |
+| [databricks_grants](../resources/grants.md) | Yes | No | Yes | No |
+| [databricks_group](../resources/group.md) | Yes | No | Yes | Yes |
+| [databricks_group_instance_profile](../resources/group_instance_profile.md) | Yes | No | Yes | No |
+| [databricks_group_member](../resources/group_member.md) | Yes | No | Yes | Yes |
+| [databricks_group_role](../resources/group_role.md) | Yes | No | Yes | Yes |
+| [databricks_instance_pool](../resources/instance_pool.md) | Yes | No | Yes | No |
+| [databricks_instance_profile](../resources/instance_profile.md) | Yes | No | Yes | No |
+| [databricks_ip_access_list](../resources/ip_access_list.md) | Yes | Yes | Yes | No |
+| [databricks_job](../resources/job.md) | Yes | No | Yes | No |
+| [databricks_library](../resources/library.md) | Yes\* | No | Yes | No |
+| [databricks_metastore](../resources/metastore.md) | Yes | Yes | Yes | Yes |
+| [databricks_metastore_assignment](../resources/metastore_assignment.md) | Yes | No | No | Yes |
+| [databricks_mlflow_experiment](../resources/mlflow_experiment.md) | No | No | No | No |
+| [databricks_mlflow_model](../resources/mlflow_model.md) | No | No | No | No |
+| [databricks_mlflow_webhook](../resources/mlflow_webhook.md) | Yes | Yes | Yes | No |
+| [databricks_model_serving](../resources/model_serving) | Yes | Yes | Yes | No |
+| [databricks_notebook](../resources/notebook.md) | Yes | Yes | Yes | No |
+| [databricks_obo_token](../resources/obo_token.md) | Not Applicable | No | No | No |
+| [databricks_permissions](../resources/permissions.md) | Yes | No | Yes | No |
+| [databricks_pipeline](../resources/pipeline.md) | Yes | Yes | Yes | No |
+| [databricks_recipient](../resources/recipient.md) | Yes | Yes | Yes | No |
+| [databricks_registered_model](../resources/registered.md) | Yes | Yes | Yes | No |
+| [databricks_repo](../resources/repo.md) | Yes | No | Yes | No |
+| [databricks_schema](../resources/schema.md) | Yes | Yes | Yes | No |
+| [databricks_secret](../resources/secret.md) | Yes | No | Yes | No |
+| [databricks_secret_acl](../resources/secret_acl.md) | Yes | No | Yes | No |
+| [databricks_secret_scope](../resources/secret_scope.md) | Yes | No | Yes | No |
+| [databricks_service_principal](../resources/service_principal.md) | Yes | No | Yes | Yes |
+| [databricks_service_principal_role](../resources/service_principal_role.md) | Yes | No | Yes | Yes |
+| [databricks_share](../resources/share.md) | Yes | Yes | Yes | No |
+| [databricks_sql_alert](../resources/sql_alert.md) | Yes | Yes | Yes | No |
+| [databricks_sql_dashboard](../resources/sql_dashboard.md) | Yes | Yes | Yes | No |
+| [databricks_sql_endpoint](../resources/sql_endpoint.md) | Yes | No | Yes | No |
+| [databricks_sql_global_config](../resources/sql_global_config.md) | Yes | No | Yes | No |
+| [databricks_sql_permissions](../resources/sql_permissions.md) | No | No | Yes | No |
+| [databricks_sql_query](../resources/sql_query.md) | Yes | Yes | Yes | No |
+| [databricks_sql_table](../resources/sql_table.md) | Yes | Yes | Yes | No |
+| [databricks_sql_visualization](../resources/sql_visualization.md) | Yes | Yes | Yes | No |
+| [databricks_sql_widget](../resources/sql_widget.md) | Yes | Yes | Yes | No |
+| [databricks_storage_credential](../resources/storage_credential.md) | Yes | Yes | Yes | Yes |
+| [databricks_system_schema](../resources/system_schema.md) | Yes | No | Yes | No |
+| [databricks_token](../resources/token.md) | Not Applicable | No | Yes | No |
+| [databricks_user](../resources/user.md) | Yes | No | Yes | Yes |
+| [databricks_user_instance_profile](../resources/user_instance_profile.md) | No | No | No | No |
+| [databricks_user_role](../resources/user_role.md) | Yes | No | Yes | Yes |
+| [databricks_volume](../resources/volume.md) | Yes | Yes | Yes | No |
+| [databricks_workspace_conf](../resources/workspace_conf.md) | Yes (partial) | No | Yes | No |
+| [databricks_workspace_file](../resources/workspace_file.md) | Yes | Yes | Yes | No |
 
 Notes:
 

--- a/exporter/util.go
+++ b/exporter/util.go
@@ -1288,3 +1288,14 @@ func isMatchignShareObject(obj string) isValidAproximationFunc {
 		return ok && objType.(string) == obj
 	}
 }
+
+func isMatchingAllowListArtifact(ic *importContext, res *resource, ra *resourceApproximation, origPath string) bool {
+	objPath := strings.Replace(origPath, ".artifact", ".match_type", 1)
+	matchType, ok := res.Data.GetOk(objPath)
+	artifactType := res.Data.Get("artifact_type").(string)
+	// artifact := res.Data.Get(origPath)
+	// log.Printf("[DEBUG] isMatchingAllowListArtifact: origPath='%s', ra.Type='%s', artifactType='%v' artifact='%v', objPath='%s' matchType='%v' ok? %v",
+	// 	origPath, ra.Type, artifactType, artifact, objPath, matchType, ok)
+
+	return ok && matchType.(string) == "PREFIX_MATCH" && (artifactType == "LIBRARY_JAR" || artifactType == "INIT_SCRIPT")
+}


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

This includes:

- added support for `databricks_sql_table`
- switch to use longest prefix match when generating references to `databricks_external_location`
- added suppression for `storage_location` of managed `databricks_registered_model`
- added references to `databricks_volume` from `databricks_artifact_allowlist`
- updated resources table in documentation to include information on which level (workspace or account) the given resource is handled

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

