### PR TITLE
Exporter: add generation of import blocks for easier importing existing resources in Terraform 1.5+

### DIFF
--- a/docs/guides/experimental-exporter.md
+++ b/docs/guides/experimental-exporter.md
@@ -52,6 +52,7 @@ All arguments are optional, and they tune what code is being generated.
 * `-noformat` - optionally turn off the execution of `terraform fmt` on the exported files (enabled by default).
 * `-debug` - turn on debug output.
 * `-trace` - turn on trace output (includes debug level as well).
+* `-native-import` - turns on generation of [native import blocks](https://developer.hashicorp.com/terraform/language/import) (requires Terraform 1.5+).  This option is recommended for cases when you want to start to manage existing workspace.
 
 ## Services
 

--- a/exporter/command.go
+++ b/exporter/command.go
@@ -117,6 +117,7 @@ func Run(args ...string) error {
 		"Items with older than activity specified won't be imported.")
 	flags.BoolVar(&ic.incremental, "incremental", false, "Incremental export of the data. Requires -updated-since parameter")
 	flags.BoolVar(&ic.noFormat, "noformat", false, "Don't run `terraform fmt` on exported files")
+	flags.BoolVar(&ic.nativeImportSupported, "native-import", false, "Generate native import blocks (requires Terraform 1.5+)")
 	flags.StringVar(&ic.updatedSinceStr, "updated-since", "",
 		"Include only resources updated since a given timestamp (in ISO8601 format, i.e. 2023-07-01T00:00:00Z)")
 	flags.BoolVar(&debug, "debug", false, "Print extra debug information.")

--- a/exporter/context_test.go
+++ b/exporter/context_test.go
@@ -433,3 +433,22 @@ func TestDeletedWsObjectsDetection(t *testing.T) {
 	ic.loadOldWorkspaceObjects(fname)
 	require.Equal(t, 0, len(ic.oldWorkspaceObjects))
 }
+
+func TestExtractResourceIdFromImportBlockString(t *testing.T) {
+	id := extractResourceIdFromImportBlockString(`import {
+		id = "64ed13ad-5772-4871-b23d-660ad014ea1e"
+		to = databricks_pipeline.test_pipeline
+	  }`)
+	assert.Equal(t, "databricks_pipeline.test_pipeline", id)
+
+	id = extractResourceIdFromImportBlockString(``)
+	assert.Equal(t, "", id)
+
+	id = extractResourceIdFromImportBlockString(`aaaa`)
+	assert.Equal(t, "", id)
+
+	id = extractResourceIdFromImportBlockString(`import {
+		id = "64ed13ad-5772-4871-b23d-660ad014ea1e"
+	  }`)
+	assert.Equal(t, "", id)
+}


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

Since version 1.5, Terraform has supported use of the [import blocks](https://developer.hashicorp.com/terraform/language/import) that simplify the importing of existing resources into the state during the plan instead of importing one by one.

fixes #2780

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
