### PR TITLE
Perform case-insensitive error message checking when using `force` in `databricks_user`

### DIFF
--- a/scim/resource_user.go
+++ b/scim/resource_user.go
@@ -12,9 +12,9 @@ import (
 
 func userExistsErrorMessage(userName string, isAccount bool) string {
 	if isAccount {
-		return fmt.Sprintf("User with email %s already exists in this account", userName)
+		return strings.ToLower(fmt.Sprintf("User with email %s already exists in this account", userName))
 	} else {
-		return fmt.Sprintf("User with username %s already exists.", userName)
+		return strings.ToLower(fmt.Sprintf("User with username %s already exists.", userName))
 	}
 }
 
@@ -172,8 +172,9 @@ func createForceOverridesManuallyAddedUser(err error, d *schema.ResourceData, us
 	}
 	// corner-case for overriding manually provisioned users
 	userName := strings.ReplaceAll(u.UserName, "'", "")
-	if (!strings.HasPrefix(err.Error(), userExistsErrorMessage(userName, false))) &&
-		(!strings.HasPrefix(err.Error(), userExistsErrorMessage(userName, true))) {
+	errStr := strings.ToLower(err.Error())
+	if (!strings.HasPrefix(errStr, userExistsErrorMessage(userName, false))) &&
+		(!strings.HasPrefix(errStr, userExistsErrorMessage(userName, true))) {
 		return err
 	}
 	userList, err := usersAPI.Filter(fmt.Sprintf(`userName eq "%s"`, userName), true)

--- a/scim/resource_user_test.go
+++ b/scim/resource_user_test.go
@@ -704,7 +704,7 @@ func TestCreateForceOverwriteFindsAndSetsID(t *testing.T) {
 		d.Set("force", true)
 		d.Set("user_name", "me@example.com")
 		err := createForceOverridesManuallyAddedUser(
-			fmt.Errorf(userExistsErrorMessage("me@example.com", false)),
+			fmt.Errorf(userExistsErrorMessage("Me@Example.Com", false)),
 			d, NewUsersAPI(ctx, client), User{
 				UserName: "me@example.com",
 			})


### PR DESCRIPTION
The support team has reported that there are cases when users are created with the lower-case name, and the user already exists in the account but has the user name in another case, then the `force` option doesn't work correctly.

The fix is to compare error messages and emails in a case-insensitive manner.

Unfortunately, it's hard to test now as our backend now lower-case user names automatically...

## Changes
<!-- Summary of your changes that are easy to understand -->

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
