### PR TITLE
Remove unnecessary alias from cluster resource

### DIFF
--- a/clusters/resource_cluster.go
+++ b/clusters/resource_cluster.go
@@ -63,7 +63,7 @@ type ClusterSpec struct {
 }
 
 func (ClusterSpec) Aliases() map[string]string {
-	return map[string]string{"cluster_mount_infos": "cluster_mount_info"}
+	return map[string]string{}
 }
 
 func (ClusterSpec) CustomizeSchema(s map[string]*schema.Schema) map[string]*schema.Schema {


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
- Turns out that we don't need the `cluster_mount_info` alias because it is added only in `customize_schema`

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [x] covered with integration tests in `internal/acceptance`
- [x] relevant acceptance tests are passing
- [x] using Go SDK
