### PR TITLE
Exporter: add support for `databricks_file` resource

### DIFF
--- a/docs/guides/experimental-exporter.md
+++ b/docs/guides/experimental-exporter.md
@@ -79,7 +79,7 @@ Services are just logical groups of resources used for filtering and organizatio
 * `sql-dashboards` - **listing** [databricks_sql_dashboard](../resources/sql_dashboard.md) along with associated [databricks_sql_widget](../resources/sql_widget.md) and [databricks_sql_visualization](../resources/sql_visualization.md).
 * `sql-endpoints` - **listing** [databricks_sql_endpoint](../resources/sql_endpoint.md) along with [databricks_sql_global_config](../resources/sql_global_config.md).
 * `sql-queries` - **listing** [databricks_sql_query](../resources/sql_query.md).
-* `storage` - only [databricks_dbfs_file](../resources/dbfs_file.md) referenced in other resources (libraries, init scripts, ...) will be downloaded locally and properly arranged into terraform state.
+* `storage` - only [databricks_dbfs_file](../resources/dbfs_file.md) and [databricks_file](../resources/file.md) referenced in other resources (libraries, init scripts, ...) will be downloaded locally and properly arranged into terraform state.
 * `uc-artifact-allowlist` - **listing** exports [databricks_artifact_allowlist](../resources/artifact_allowlist.md) resources for Unity Catalog Allow Lists attached to the current metastore.
 * `uc-catalogs` - **listing** [databricks_catalog](../resources/catalog.md) and [databricks_catalog_workspace_binding](../resources/catalog_workspace_binding.md)
 * `uc-connections` - **listing** [databricks_connection](../resources/connection.md).  *Please note that because API doesn't return sensitive fields, such as, passwords, tokens, ..., the generated `options` block could be incomplete!*
@@ -124,6 +124,7 @@ Exporter aims to generate HCL code for most of the resources within the Databric
 | [databricks_connection](../resources/connection.md) | Yes | Yes | Yes | No |
 | [databricks_dbfs_file](../resources/dbfs_file.md) | Yes | No | Yes | No |
 | [databricks_external_location](../resources/external_location.md) | Yes | Yes | Yes | No |
+| [databricks_file](../resources/file.md) | Yes | No | Yes | No |
 | [databricks_global_init_script](../resources/global_init_script.md) | Yes | Yes | Yes | No |
 | [databricks_grants](../resources/grants.md) | Yes | No | Yes | No |
 | [databricks_group](../resources/group.md) | Yes | No | Yes | Yes |

--- a/exporter/importables_test.go
+++ b/exporter/importables_test.go
@@ -1231,7 +1231,7 @@ func TestGlobalInitScriptGeneration(t *testing.T) {
 		ic.generateAndWriteResources(nil)
 		assert.Equal(t, commands.TrimLeadingWhitespace(`
 		resource "databricks_global_init_script" "new_importing_things" {
-		  source  = "${path.module}/files/new_importing_things.sh"
+		  source  = "${path.module}/global_init_scripts/new_importing_things.sh"
 		  name    = "New: Importing ^ Things"
 		  enabled = true
 		}`), getGeneratedFile(ic, "workspace"))
@@ -1298,7 +1298,7 @@ func TestDbfsFileGeneration(t *testing.T) {
 		ic.generateAndWriteResources(nil)
 		assert.Equal(t, commands.TrimLeadingWhitespace(`
 		resource "databricks_dbfs_file" "_0cc175b9c0f1b6a831c399e269772661_a" {
-		  source = "${path.module}/files/_0cc175b9c0f1b6a831c399e269772661_a"
+		  source = "${path.module}/dbfs_files/_0cc175b9c0f1b6a831c399e269772661_a"
 		  path   = "a"
 		}`), getGeneratedFile(ic, "storage"))
 	})
@@ -2127,4 +2127,42 @@ func TestAuxUcFunctions(t *testing.T) {
 	d.Set("isolation_mode", "ISOLATED")
 	assert.False(t, shouldOmitFunc(nil, "isolation_mode", scm["isolation_mode"], d))
 	assert.False(t, shouldOmitFunc(nil, "name", scm["name"], d))
+}
+
+func TestImportUcVolumeFile(t *testing.T) {
+	qa.HTTPFixturesApply(t, []qa.HTTPFixture{
+		{
+			ReuseRequest: true,
+			Method:       "GET",
+			Resource:     "/api/2.0/fs/files/Volumes/main/default/wheels/some.whl?",
+			Response:     "test",
+		},
+	}, func(ctx context.Context, client *common.DatabricksClient) {
+		ic := importContextForTestWithClient(ctx, client)
+		tmpDir := fmt.Sprintf("/tmp/tf-%s", qa.RandomName())
+		defer os.RemoveAll(tmpDir)
+		os.Mkdir(tmpDir, 0700)
+		ic.Directory = tmpDir
+		ic.enableServices("storage")
+		ic.currentMetastore = currentMetastoreResponse
+
+		file_path := "/Volumes/main/default/wheels/some.whl"
+		d := storage.ResourceFile().ToResource().TestResourceData()
+		d.SetId(file_path)
+		err := resourcesMap["databricks_file"].Import(ic, &resource{
+			ID:   file_path,
+			Data: d,
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, file_path, d.Get("path"))
+		assert.Equal(t, "uc_files/main/default/wheels/some.whl", d.Get("source"))
+		// Testing auxiliary functions
+		shouldOmitFunc := resourcesMap["databricks_file"].ShouldOmitField
+		require.NotNil(t, shouldOmitFunc)
+		scm := storage.ResourceFile().Schema
+		assert.True(t, shouldOmitFunc(ic, "md5", scm["md5"], d))
+		assert.False(t, shouldOmitFunc(ic, "path", scm["path"], d))
+
+		assert.Equal(t, "main/default/wheels/some.whl_f27badf8", resourcesMap["databricks_file"].Name(nil, d))
+	})
 }

--- a/exporter/util.go
+++ b/exporter/util.go
@@ -44,6 +44,9 @@ func (ic *importContext) emitInitScripts(initScripts []clusters.InitScriptStorag
 		if is.Workspace != nil {
 			ic.emitWorkspaceFileOrRepo(is.Workspace.Destination)
 		}
+		if is.Volumes != nil {
+			ic.emitIfVolumeFile(is.Volumes.Destination)
+		}
 	}
 }
 
@@ -51,6 +54,7 @@ func (ic *importContext) emitFilesFromSlice(slice []string) {
 	for _, p := range slice {
 		ic.emitIfDbfsFile(p)
 		ic.emitIfWsfsFile(p)
+		ic.emitIfVolumeFile(p)
 	}
 }
 
@@ -58,6 +62,7 @@ func (ic *importContext) emitFilesFromMap(m map[string]string) {
 	for _, p := range m {
 		ic.emitIfDbfsFile(p)
 		ic.emitIfWsfsFile(p)
+		ic.emitIfVolumeFile(p)
 	}
 }
 
@@ -349,6 +354,9 @@ func (ic *importContext) emitLibraries(libs []libraries.Library) {
 		ic.emitIfWsfsFile(lib.Whl)
 		ic.emitIfWsfsFile(lib.Jar)
 		ic.emitIfWsfsFile(lib.Egg)
+		// Files on UC Volumes
+		ic.emitIfVolumeFile(lib.Whl)
+		ic.emitIfVolumeFile(lib.Jar)
 	}
 
 }
@@ -366,11 +374,15 @@ func (ic *importContext) importClusterLibraries(d *schema.ResourceData, s map[st
 		return err
 	}
 	for _, lib := range cll.LibraryStatuses {
-		// Emit workspace file libraries if necessary
-		// Emit Volume libraries when resource is available
 		ic.emitIfDbfsFile(lib.Library.Egg)
 		ic.emitIfDbfsFile(lib.Library.Jar)
 		ic.emitIfDbfsFile(lib.Library.Whl)
+		// Files on UC Volumes
+		ic.emitIfVolumeFile(lib.Library.Whl)
+		ic.emitIfVolumeFile(lib.Library.Jar)
+		// Files on WSFS
+		ic.emitIfWsfsFile(lib.Library.Whl)
+		ic.emitIfWsfsFile(lib.Library.Jar)
 	}
 	return nil
 }
@@ -591,10 +603,14 @@ func (ic *importContext) findSpnByAppID(applicationID string, fastCheck bool) (u
 
 func (ic *importContext) emitIfDbfsFile(path string) {
 	if strings.HasPrefix(path, "dbfs:") {
-		ic.Emit(&resource{
-			Resource: "databricks_dbfs_file",
-			ID:       path,
-		})
+		if strings.HasPrefix(path, "dbfs:/Volumes/") {
+			ic.emitIfVolumeFile(path[5:])
+		} else {
+			ic.Emit(&resource{
+				Resource: "databricks_dbfs_file",
+				ID:       path,
+			})
+		}
 	}
 }
 
@@ -602,6 +618,15 @@ func (ic *importContext) emitIfWsfsFile(path string) {
 	if strings.HasPrefix(path, "/Workspace/") {
 		normalPath := strings.TrimPrefix(path, "/Workspace")
 		ic.emitWorkspaceFileOrRepo(normalPath)
+	}
+}
+
+func (ic *importContext) emitIfVolumeFile(path string) {
+	if strings.HasPrefix(path, "/Volumes/") {
+		ic.Emit(&resource{
+			Resource: "databricks_file",
+			ID:       path,
+		})
 	}
 }
 
@@ -828,7 +853,7 @@ func (ic *importContext) createFileIn(dir, name string, content []byte) (string,
 	if err != nil {
 		return "", err
 	}
-	relativeName := strings.Replace(localFileName, ic.Directory+"/", "", 1)
+	relativeName := strings.TrimPrefix(localFileName, ic.Directory+"/")
 	return relativeName, nil
 }
 


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

Only files explicitly referenced as init scripts & libraries are exported.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
