### PR TITLE
Make StructToSchema work for recursive data types

### DIFF
--- a/clusters/resource_cluster.go
+++ b/clusters/resource_cluster.go
@@ -155,6 +155,10 @@ func (ClusterSpec) CustomizeSchema(s map[string]*schema.Schema) map[string]*sche
 	return s
 }
 
+func (ClusterSpec) MaxDepthForTypes() map[string]int {
+	return map[string]int{}
+}
+
 func resourceClusterSchema() map[string]*schema.Schema {
 	return common.StructToSchema(ClusterSpec{}, nil)
 }

--- a/clusters/resource_cluster.go
+++ b/clusters/resource_cluster.go
@@ -155,10 +155,6 @@ func (ClusterSpec) CustomizeSchema(s map[string]*schema.Schema) map[string]*sche
 	return s
 }
 
-func (ClusterSpec) MaxDepthForTypes() map[string]int {
-	return map[string]int{}
-}
-
 func resourceClusterSchema() map[string]*schema.Schema {
 	return common.StructToSchema(ClusterSpec{}, nil)
 }

--- a/common/recursion_tracking.go
+++ b/common/recursion_tracking.go
@@ -48,7 +48,7 @@ func getEmptyRecursionTrackingContext() recursionTrackingContext {
 	}
 }
 
-func getRecursionTrackingContext(rp ResourceProvider) recursionTrackingContext {
+func getRecursionTrackingContext(rp RecursiveResourceProvider) recursionTrackingContext {
 	return recursionTrackingContext{
 		map[string]int{},
 		rp.MaxDepthForTypes(),

--- a/common/recursion_tracking.go
+++ b/common/recursion_tracking.go
@@ -1,0 +1,56 @@
+package common
+
+import (
+	"maps"
+	"reflect"
+	"strings"
+)
+
+type recursionTrackingContext struct {
+	timesVisited     map[string]int
+	maxDepthForTypes map[string]int
+}
+
+func (rt recursionTrackingContext) depthExceeded(typeField reflect.StructField) bool {
+	typeName := rt.getNameForTypeField(typeField)
+	if maxDepth, ok := rt.maxDepthForTypes[typeName]; ok {
+		return rt.timesVisited[typeName]+1 > maxDepth
+	}
+	return false
+}
+
+func (rt recursionTrackingContext) getNameForTypeField(typeField reflect.StructField) string {
+	return strings.TrimPrefix(typeField.Type.String(), "*")
+}
+
+func (rt recursionTrackingContext) getMaxDepthForTypeField(typeField reflect.StructField) int {
+	typeName := rt.getNameForTypeField(typeField)
+	return rt.maxDepthForTypes[typeName]
+}
+
+func (rt recursionTrackingContext) copy() recursionTrackingContext {
+	newTimesVisited := map[string]int{}
+	maps.Copy(newTimesVisited, rt.timesVisited)
+	return recursionTrackingContext{
+		timesVisited:     newTimesVisited,
+		maxDepthForTypes: rt.maxDepthForTypes,
+	}
+}
+
+func (rt recursionTrackingContext) visit(v reflect.Value) {
+	rt.timesVisited[strings.TrimPrefix(v.Type().String(), "*")] += 1
+}
+
+func getEmptyRecursionTrackingContext() recursionTrackingContext {
+	return recursionTrackingContext{
+		map[string]int{},
+		map[string]int{},
+	}
+}
+
+func getRecursionTrackingContext(rp ResourceProvider) recursionTrackingContext {
+	return recursionTrackingContext{
+		map[string]int{},
+		rp.MaxDepthForTypes(),
+	}
+}

--- a/common/reflect_resource.go
+++ b/common/reflect_resource.go
@@ -293,6 +293,7 @@ func typeToSchema(v reflect.Value, aliases map[string]string, rt recursionTracki
 	if rk != reflect.Struct {
 		panic(fmt.Errorf("Schema value of Struct is expected, but got %s: %#v", reflectKind(rk), v))
 	}
+	rt = rt.copy()
 	rt.visit(v)
 	fields := listAllFields(v)
 	for _, field := range fields {
@@ -368,7 +369,7 @@ func typeToSchema(v reflect.Value, aliases map[string]string, rt recursionTracki
 			scm[fieldName].Type = schema.TypeList
 			elem := typeField.Type.Elem()
 			sv := reflect.New(elem).Elem()
-			nestedSchema := typeToSchema(sv, unwrappedAliases, rt.copy())
+			nestedSchema := typeToSchema(sv, unwrappedAliases, rt)
 			if strings.Contains(tfTag, "suppress_diff") {
 				scm[fieldName].DiffSuppressFunc = diffSuppressor(scm[fieldName])
 				for _, v := range nestedSchema {
@@ -386,7 +387,7 @@ func typeToSchema(v reflect.Value, aliases map[string]string, rt recursionTracki
 			elem := typeField.Type  // changed from ptr
 			sv := reflect.New(elem) // changed from ptr
 
-			nestedSchema := typeToSchema(sv, unwrappedAliases, rt.copy())
+			nestedSchema := typeToSchema(sv, unwrappedAliases, rt)
 			if strings.Contains(tfTag, "suppress_diff") {
 				scm[fieldName].DiffSuppressFunc = diffSuppressor(scm[fieldName])
 				for _, v := range nestedSchema {
@@ -416,7 +417,7 @@ func typeToSchema(v reflect.Value, aliases map[string]string, rt recursionTracki
 			case reflect.Struct:
 				sv := reflect.New(elem).Elem()
 				scm[fieldName].Elem = &schema.Resource{
-					Schema: typeToSchema(sv, unwrappedAliases, rt.copy()),
+					Schema: typeToSchema(sv, unwrappedAliases, rt),
 				}
 			}
 		default:

--- a/common/reflect_resource.go
+++ b/common/reflect_resource.go
@@ -139,18 +139,18 @@ func MustSchemaPath(s map[string]*schema.Schema, path ...string) *schema.Schema 
 
 // StructToSchema makes schema from a struct type & applies customizations from callback given
 func StructToSchema(v any, customize func(map[string]*schema.Schema) map[string]*schema.Schema) map[string]*schema.Schema {
+	if rp, ok := v.(RecursiveResourceProvider); ok {
+		if customize != nil {
+			panic("customize should be nil if the input implements the RecursiveResourceProvider interface; use CustomizeSchema of ResourceProvider instead")
+		}
+		return recursiveResourceProviderStructToSchema(rp)
+	}
 	// If the input 'v' is an instance of ResourceProvider, call resourceProviderStructToSchema instead.
 	if rp, ok := v.(ResourceProvider); ok {
 		if customize != nil {
 			panic("customize should be nil if the input implements the ResourceProvider interface; use CustomizeSchema of ResourceProvider instead")
 		}
 		return resourceProviderStructToSchema(rp)
-	}
-	if rp, ok := v.(RecursiveResourceProvider); ok {
-		if customize != nil {
-			panic("customize should be nil if the input implements the RecursiveResourceProvider interface; use CustomizeSchema of ResourceProvider instead")
-		}
-		return recursiveResourceProviderStructToSchema(rp)
 	}
 	rv := reflect.ValueOf(v)
 	scm := typeToSchema(rv, map[string]string{}, getEmptyRecursionTrackingContext())

--- a/common/reflect_resource_test.go
+++ b/common/reflect_resource_test.go
@@ -283,10 +283,6 @@ func (DummyResourceProvider) CustomizeSchema(s map[string]*schema.Schema) map[st
 	return s
 }
 
-func (DummyResourceProvider) MaxDepthForTypes() map[string]int {
-	return map[string]int{}
-}
-
 var dummy = DummyNoTfTag{
 	Enabled:     true,
 	Workers:     1004,


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
- This is a prerequisite PR for onboarding jobs foreach task to terraform because it contains recursive reference
- Added `recursion_tracking` utility functions and `recursionTrackingContext` struct to track recursion depth
- Added `MaxDepthForTypes` into `ResourceProvider` to limit recursion depth per type
- Added unit test
- Updated `SchemaPath` helper function to fix a bug that could make this function return early

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [x] covered with integration tests in `internal/acceptance`
- [x] relevant acceptance tests are passing
- [x] using Go SDK
