### PR TITLE
Set `Computed` field to `true` for `common.Resource` `account_id` attribute

### DIFF
--- a/common/resource.go
+++ b/common/resource.go
@@ -443,6 +443,7 @@ var NoAuth string = "default auth: cannot configure default credentials, " +
 func AddAccountIdField(s map[string]*schema.Schema) map[string]*schema.Schema {
 	s["account_id"] = &schema.Schema{
 		Type:       schema.TypeString,
+		Computed:   true,
 		Optional:   true,
 		Deprecated: "Configuring `account_id` at the resource-level is deprecated; please specify it in the `provider {}` configuration block instead",
 	}

--- a/mws/resource_mws_private_access_settings_test.go
+++ b/mws/resource_mws_private_access_settings_test.go
@@ -3,6 +3,8 @@ package mws
 import (
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
 	"github.com/databricks/databricks-sdk-go/apierr"
 	"github.com/databricks/databricks-sdk-go/experimental/mocks"
 	"github.com/databricks/databricks-sdk-go/service/provisioning"
@@ -246,4 +248,27 @@ func TestResourcePASDelete_Error(t *testing.T) {
 	}.Apply(t)
 	qa.AssertErrorStartsWith(t, err, "Internal error happened")
 	assert.Equal(t, "abc/pas_id", d.Id())
+}
+
+func TestResourcePASUpdateAccountIdNoDiff(t *testing.T) {
+	qa.ResourceFixture{
+		Resource: ResourceMwsPrivateAccessSettings(),
+		ID:       "abc",
+		InstanceState: map[string]string{
+			"account_id":                   "foo",
+			"private_access_settings_name": "pas_name",
+			"public_access_enabled":        "false",
+			"region":                       "eu-west-1",
+			"private_access_level":         "ENDPOINT",
+		},
+		ExpectedDiff: map[string]*terraform.ResourceAttrDiff{
+			"private_access_settings_id": {Old: "", New: "", NewComputed: true, NewRemoved: false, RequiresNew: false, Sensitive: false},
+		},
+		HCL: `
+		private_access_settings_name = "pas_name"
+		public_access_enabled = false
+		region = "eu-west-1"
+		private_access_level = "ENDPOINT"
+		`,
+	}.ApplyNoError(t)
 }


### PR DESCRIPTION
In #3135, the `account_id` resource field is deprecated in favour of the provider level `account_id` attribute. However, it was reported that for the `databricks_mws_private_access_settings` resource, this could lead to a diff for every apply since the API returns the `account_id`. 

The API returns `account_id`, putting the attribute back in the state. But since it is removed in the resource, it will try to set it back to null.

Setting the `account_id` field to `Computed` will use the API provided `account_id` which should not result in diffs.

Resolves #3223 

## Changes
Set `Computed` field to `true` for `common.Resource` `account_id` attribute.

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
