### PR TITLE
Revert "Use stable IDs for settings resources (#3278)"

### DIFF
--- a/docs/resources/default_namespace_settings.md
+++ b/docs/resources/default_namespace_settings.md
@@ -29,11 +29,3 @@ The resource supports the following arguments:
 
 * `namespace` - (Required) The configuration details.
 * `value` - (Required) The value for the setting.
-
-## Import
-
-This resource can be imported by predefined name `global`:
-
-```bash
-terraform import databricks_default_namespace_setting.this global
-```

--- a/docs/resources/restrict_workspace_admins_setting.md
+++ b/docs/resources/restrict_workspace_admins_setting.md
@@ -38,11 +38,3 @@ The resource supports the following arguments:
 
 * `restrict_workspace_admins` - (Required) The configuration details.
 * `status` - (Required) The restrict workspace admins status for the workspace.
-
-## Import
-
-This resource can be imported by predefined name `global`:
-
-```bash
-terraform import databricks_restrict_workspace_admins_setting.this global
-```

--- a/settings/generic_setting.go
+++ b/settings/generic_setting.go
@@ -12,10 +12,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-var (
-	defaultSettingId = "global"
-)
-
 func retryOnEtagError[Req, Resp any](f func(req Req) (Resp, error), firstReq Req, updateReq func(req *Req, newEtag string), retriableErrors []error) (Resp, error) {
 	req := firstReq
 	// Retry once on etag error.
@@ -72,9 +68,6 @@ type genericSettingDefinition[T, U any] interface {
 
 	// Update the etag in the setting.
 	SetETag(t *T, newEtag string)
-
-	// Generate resource ID from settings instance
-	GetId(t *T) string
 }
 
 func getEtag[T any](t T) string {
@@ -111,9 +104,6 @@ type workspaceSetting[T any] struct {
 
 	// Delete the setting with the given etag, and return the new etag.
 	deleteFunc func(ctx context.Context, w *databricks.WorkspaceClient, etag string) (string, error)
-
-	// Optional function to generate resource ID from the settings
-	generateIdFunc func(setting *T) string
 }
 
 func (w workspaceSetting[T]) SettingStruct() T {
@@ -131,15 +121,6 @@ func (w workspaceSetting[T]) Delete(ctx context.Context, c *databricks.Workspace
 func (w workspaceSetting[T]) GetETag(t *T) string {
 	return getEtag(t)
 }
-
-func (w workspaceSetting[T]) GetId(t *T) string {
-	id := defaultSettingId
-	if w.generateIdFunc != nil {
-		id = w.generateIdFunc(t)
-	}
-	return id
-}
-
 func (w workspaceSetting[T]) SetETag(t *T, newEtag string) {
 	setEtag(t, newEtag)
 }
@@ -164,9 +145,6 @@ type accountSetting[T any] struct {
 
 	// Delete the setting with the given etag, and return the new etag.
 	deleteFunc func(ctx context.Context, w *databricks.AccountClient, etag string) (string, error)
-
-	// Optional function to generate resource ID from the settings
-	generateIdFunc func(setting *T) string
 }
 
 func (w accountSetting[T]) SettingStruct() T {
@@ -186,14 +164,6 @@ func (w accountSetting[T]) GetETag(t *T) string {
 }
 func (w accountSetting[T]) SetETag(t *T, newEtag string) {
 	setEtag(t, newEtag)
-}
-
-func (w accountSetting[T]) GetId(t *T) string {
-	id := defaultSettingId
-	if w.generateIdFunc != nil {
-		id = w.generateIdFunc(t)
-	}
-	return id
 }
 
 var _ accountSettingDefinition[struct{}] = accountSetting[struct{}]{}
@@ -247,8 +217,7 @@ func makeSettingResource[T, U any](defn genericSettingDefinition[T, U]) common.R
 		default:
 			return fmt.Errorf("unexpected setting type: %T", defn)
 		}
-		d.Set("etag", res)
-		d.SetId(defn.GetId(&setting))
+		d.SetId(res)
 		return nil
 	}
 
@@ -266,7 +235,7 @@ func makeSettingResource[T, U any](defn genericSettingDefinition[T, U]) common.R
 				if err != nil {
 					return err
 				}
-				res, err = defn.Read(ctx, w, d.Get("etag").(string))
+				res, err = defn.Read(ctx, w, d.Id())
 				if err != nil {
 					return err
 				}
@@ -275,7 +244,7 @@ func makeSettingResource[T, U any](defn genericSettingDefinition[T, U]) common.R
 				if err != nil {
 					return err
 				}
-				res, err = defn.Read(ctx, a, d.Get("etag").(string))
+				res, err = defn.Read(ctx, a, d.Id())
 				if err != nil {
 					return err
 				}
@@ -290,12 +259,12 @@ func makeSettingResource[T, U any](defn genericSettingDefinition[T, U]) common.R
 			// with a response which is at least as recent as the etag.
 			// Updating, while not always necessary, ensures that the
 			// server responds with an updated response.
-			d.Set("etag", defn.GetETag(res))
+			d.SetId(defn.GetETag(res))
 			return nil
 		},
 		Update: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
 			var setting T
-			defn.SetETag(&setting, d.Get("etag").(string))
+			defn.SetETag(&setting, d.Id())
 			return createOrUpdate(ctx, d, c, setting)
 		},
 		Delete: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
@@ -311,7 +280,7 @@ func makeSettingResource[T, U any](defn genericSettingDefinition[T, U]) common.R
 					func(etag string) (string, error) {
 						return defn.Delete(ctx, w, etag)
 					},
-					d.Get("etag").(string),
+					d.Id(),
 					updateETag,
 					deleteRetriableErrors)
 				if err != nil {
@@ -326,7 +295,7 @@ func makeSettingResource[T, U any](defn genericSettingDefinition[T, U]) common.R
 					func(etag string) (string, error) {
 						return defn.Delete(ctx, a, etag)
 					},
-					d.Get("etag").(string),
+					d.Id(),
 					updateETag,
 					deleteRetriableErrors)
 				if err != nil {
@@ -335,7 +304,7 @@ func makeSettingResource[T, U any](defn genericSettingDefinition[T, U]) common.R
 			default:
 				return fmt.Errorf("unexpected setting type: %T", defn)
 			}
-			d.Set("etag", etag)
+			d.SetId(etag)
 			return nil
 		},
 	}

--- a/settings/generic_setting_test.go
+++ b/settings/generic_setting_test.go
@@ -15,7 +15,7 @@ import (
 var testSetting = AllSettingsResources()["default_namespace"]
 
 func TestQueryCreateDefaultNameSetting(t *testing.T) {
-	qa.ResourceFixture{
+	d, err := qa.ResourceFixture{
 		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
 			e := w.GetMockSettingsAPI().EXPECT()
 			e.UpdateDefaultNamespaceSetting(mock.Anything, settings.UpdateDefaultNamespaceSettingRequest{
@@ -73,15 +73,16 @@ func TestQueryCreateDefaultNameSetting(t *testing.T) {
 				value = "namespace_value"
 			}
 		`,
-	}.ApplyAndExpectData(t, map[string]any{
-		"id":                defaultSettingId,
-		"etag":              "etag2",
-		"namespace.0.value": "namespace_value",
-	})
+	}.Apply(t)
+
+	assert.NoError(t, err)
+
+	assert.Equal(t, "etag2", d.Id())
+	assert.Equal(t, "namespace_value", d.Get("namespace.0.value"))
 }
 
 func TestQueryReadDefaultNameSetting(t *testing.T) {
-	qa.ResourceFixture{
+	d, err := qa.ResourceFixture{
 		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
 			w.GetMockSettingsAPI().EXPECT().GetDefaultNamespaceSetting(mock.Anything, settings.GetDefaultNamespaceSettingRequest{
 				Etag: "etag1",
@@ -99,18 +100,19 @@ func TestQueryReadDefaultNameSetting(t *testing.T) {
 			namespace {
 				value = "namespace_value"
 			}
-			etag = "etag1"
 		`,
-		ID: defaultSettingId,
-	}.ApplyAndExpectData(t, map[string]any{
-		"id":                defaultSettingId,
-		"etag":              "etag2",
-		"namespace.0.value": "namespace_value",
-	})
+		ID: "etag1",
+	}.Apply(t)
+
+	assert.NoError(t, err)
+
+	assert.Equal(t, "etag2", d.Id())
+	res := d.Get("namespace").([]interface{})[0].(map[string]interface{})
+	assert.Equal(t, "namespace_value", res["value"])
 }
 
 func TestQueryUpdateDefaultNameSetting(t *testing.T) {
-	qa.ResourceFixture{
+	d, err := qa.ResourceFixture{
 		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
 			e := w.GetMockSettingsAPI().EXPECT()
 			e.UpdateDefaultNamespaceSetting(mock.Anything, settings.UpdateDefaultNamespaceSettingRequest{
@@ -146,18 +148,19 @@ func TestQueryUpdateDefaultNameSetting(t *testing.T) {
 			namespace {
 				value = "new_namespace_value"
 			}
-			etag = "etag1"
 		`,
-		ID: defaultSettingId,
-	}.ApplyAndExpectData(t, map[string]any{
-		"id":                defaultSettingId,
-		"etag":              "etag2",
-		"namespace.0.value": "new_namespace_value",
-	})
+		ID: "etag1",
+	}.Apply(t)
+
+	assert.NoError(t, err)
+
+	assert.Equal(t, "etag2", d.Id())
+	res := d.Get("namespace").([]interface{})[0].(map[string]interface{})
+	assert.Equal(t, "new_namespace_value", res["value"])
 }
 
 func TestQueryUpdateDefaultNameSettingWithConflict(t *testing.T) {
-	qa.ResourceFixture{
+	d, err := qa.ResourceFixture{
 		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
 			e := w.GetMockSettingsAPI().EXPECT()
 			e.UpdateDefaultNamespaceSetting(mock.Anything, settings.UpdateDefaultNamespaceSettingRequest{
@@ -214,14 +217,15 @@ func TestQueryUpdateDefaultNameSettingWithConflict(t *testing.T) {
 			namespace {
 				value = "new_namespace_value"
 			}
-			etag = "etag1"
 		`,
-		ID: defaultSettingId,
-	}.ApplyAndExpectData(t, map[string]any{
-		"id":                defaultSettingId,
-		"etag":              "etag3",
-		"namespace.0.value": "new_namespace_value",
-	})
+		ID: "etag1",
+	}.Apply(t)
+
+	assert.NoError(t, err)
+
+	assert.Equal(t, "etag3", d.Id())
+	res := d.Get("namespace").([]interface{})[0].(map[string]interface{})
+	assert.Equal(t, "new_namespace_value", res["value"])
 }
 
 func TestQueryDeleteDefaultNameSetting(t *testing.T) {
@@ -235,17 +239,11 @@ func TestQueryDeleteDefaultNameSetting(t *testing.T) {
 		},
 		Resource: testSetting,
 		Delete:   true,
-		HCL: `
-			namespace {
-				value = "new_namespace_value"
-			}
-			etag = "etag1"
-		`,
-		ID: defaultSettingId,
+		ID:       "etag1",
 	}.Apply(t)
 
 	assert.NoError(t, err)
-	assert.Equal(t, "etag2", d.Get("etag").(string))
+	assert.Equal(t, "etag2", d.Id())
 }
 
 func TestQueryDeleteDefaultNameSettingWithConflict(t *testing.T) {
@@ -272,15 +270,9 @@ func TestQueryDeleteDefaultNameSettingWithConflict(t *testing.T) {
 		},
 		Resource: testSetting,
 		Delete:   true,
-		HCL: `
-			namespace {
-				value = "new_namespace_value"
-			}
-			etag = "etag1"
-		`,
-		ID: defaultSettingId,
+		ID:       "etag1",
 	}.Apply(t)
 
 	assert.NoError(t, err)
-	assert.Equal(t, "etag3", d.Get("etag").(string))
+	assert.Equal(t, "etag3", d.Id())
 }

--- a/settings/resource_restrict_workspace_admins_setting_test.go
+++ b/settings/resource_restrict_workspace_admins_setting_test.go
@@ -76,8 +76,7 @@ func TestQueryCreateRestrictWsAdminsSetting(t *testing.T) {
 
 	assert.NoError(t, err)
 
-	assert.Equal(t, defaultSettingId, d.Id())
-	assert.Equal(t, "etag2", d.Get("etag").(string))
+	assert.Equal(t, "etag2", d.Id())
 	assert.Equal(t, "RESTRICT_TOKENS_AND_JOB_RUN_AS", d.Get("restrict_workspace_admins.0.status"))
 }
 
@@ -100,15 +99,13 @@ func TestQueryReadRestrictWsAdminsSetting(t *testing.T) {
 			restrict_workspace_admins {
 				status = "RESTRICT_TOKENS_AND_JOB_RUN_AS"
 			}
-			etag = "etag1"
 		`,
-		ID: defaultSettingId,
+		ID: "etag1",
 	}.Apply(t)
 
 	assert.NoError(t, err)
 
-	assert.Equal(t, defaultSettingId, d.Id())
-	assert.Equal(t, "etag2", d.Get("etag").(string))
+	assert.Equal(t, "etag2", d.Id())
 	res := d.Get("restrict_workspace_admins").([]interface{})[0].(map[string]interface{})
 	assert.Equal(t, "RESTRICT_TOKENS_AND_JOB_RUN_AS", res["status"])
 }
@@ -150,15 +147,13 @@ func TestQueryUpdateRestrictWsAdminsSetting(t *testing.T) {
 			restrict_workspace_admins {
 				status = "ALLOW_ALL"
 			}
-			etag = "etag1"
 		`,
-		ID: defaultSettingId,
+		ID: "etag1",
 	}.Apply(t)
 
 	assert.NoError(t, err)
 
-	assert.Equal(t, defaultSettingId, d.Id())
-	assert.Equal(t, "etag2", d.Get("etag").(string))
+	assert.Equal(t, "etag2", d.Id())
 	res := d.Get("restrict_workspace_admins").([]interface{})[0].(map[string]interface{})
 	assert.Equal(t, "ALLOW_ALL", res["status"])
 }
@@ -221,21 +216,19 @@ func TestQueryUpdateRestrictWsAdminsSettingWithConflict(t *testing.T) {
 			restrict_workspace_admins {
 				status = "RESTRICT_TOKENS_AND_JOB_RUN_AS"
 			}
-			etag = "etag1"
 		`,
-		ID: defaultSettingId,
+		ID: "etag1",
 	}.Apply(t)
 
 	assert.NoError(t, err)
 
-	assert.Equal(t, defaultSettingId, d.Id())
-	assert.Equal(t, "etag3", d.Get("etag").(string))
+	assert.Equal(t, "etag3", d.Id())
 	res := d.Get("restrict_workspace_admins").([]interface{})[0].(map[string]interface{})
 	assert.Equal(t, "RESTRICT_TOKENS_AND_JOB_RUN_AS", res["status"])
 }
 
 func TestQueryDeleteRestrictWsAdminsSetting(t *testing.T) {
-	qa.ResourceFixture{
+	d, err := qa.ResourceFixture{
 		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
 			w.GetMockSettingsAPI().EXPECT().DeleteRestrictWorkspaceAdminsSetting(mock.Anything, settings.DeleteRestrictWorkspaceAdminsSettingRequest{
 				Etag: "etag1",
@@ -245,21 +238,15 @@ func TestQueryDeleteRestrictWsAdminsSetting(t *testing.T) {
 		},
 		Resource: testRestrictWsAdminsSetting,
 		Delete:   true,
-		HCL: `
-		restrict_workspace_admins {
-			status = "RESTRICT_TOKENS_AND_JOB_RUN_AS"
-		}
-		etag = "etag1"
-		`,
-		ID: defaultSettingId,
-	}.ApplyAndExpectData(t, map[string]any{
-		"id":   defaultSettingId,
-		"etag": "etag2",
-	})
+		ID:       "etag1",
+	}.Apply(t)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "etag2", d.Id())
 }
 
 func TestQueryDeleteRestrictWsAdminsSettingWithConflict(t *testing.T) {
-	qa.ResourceFixture{
+	d, err := qa.ResourceFixture{
 		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
 			w.GetMockSettingsAPI().EXPECT().DeleteRestrictWorkspaceAdminsSetting(mock.Anything, settings.DeleteRestrictWorkspaceAdminsSettingRequest{
 				Etag: "etag1",
@@ -281,16 +268,10 @@ func TestQueryDeleteRestrictWsAdminsSettingWithConflict(t *testing.T) {
 			}, nil)
 		},
 		Resource: testRestrictWsAdminsSetting,
-		HCL: `
-		restrict_workspace_admins {
-			status = "RESTRICT_TOKENS_AND_JOB_RUN_AS"
-		}
-		etag = "etag1"
-		`,
-		Delete: true,
-		ID:     defaultSettingId,
-	}.ApplyAndExpectData(t, map[string]any{
-		"id":   defaultSettingId,
-		"etag": "etag3",
-	})
+		Delete:   true,
+		ID:       "etag1",
+	}.Apply(t)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "etag3", d.Id())
 }


### PR DESCRIPTION
This reverts commit 054371306bf6ca0e99889017c3bbd738b5e27fb1.

## Changes
<!-- Summary of your changes that are easy to understand -->

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
