### PR TITLE
Use stable IDs for settings resources (v2)

### DIFF
--- a/docs/resources/default_namespace_settings.md
+++ b/docs/resources/default_namespace_settings.md
@@ -29,3 +29,11 @@ The resource supports the following arguments:
 
 * `namespace` - (Required) The configuration details.
 * `value` - (Required) The value for the setting.
+
+## Import
+
+This resource can be imported by predefined name `global`:
+
+```bash
+terraform import databricks_default_namespace_setting.this global
+```

--- a/docs/resources/restrict_workspace_admins_setting.md
+++ b/docs/resources/restrict_workspace_admins_setting.md
@@ -38,3 +38,11 @@ The resource supports the following arguments:
 
 * `restrict_workspace_admins` - (Required) The configuration details.
 * `status` - (Required) The restrict workspace admins status for the workspace.
+
+## Import
+
+This resource can be imported by predefined name `global`:
+
+```bash
+terraform import databricks_restrict_workspace_admins_setting.this global
+```

--- a/internal/acceptance/default_namespace_test.go
+++ b/internal/acceptance/default_namespace_test.go
@@ -8,42 +8,44 @@ import (
 	"github.com/databricks/databricks-sdk-go/apierr"
 	"github.com/databricks/databricks-sdk-go/service/settings"
 	"github.com/databricks/terraform-provider-databricks/common"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAccDefaultNamespaceSetting(t *testing.T) {
-	workspaceLevel(t, step{
-		Template: `
-		resource "databricks_default_namespace_setting" "this" {
-			namespace {
-				value = "namespace_value"
-			}
+	template := `
+	resource "databricks_default_namespace_setting" "this" {
+		namespace {
+			value = "namespace_value"
 		}
-		`,
-		Check: resourceCheck("databricks_default_namespace_setting.this", func(ctx context.Context, client *common.DatabricksClient, id string) error {
-			ctx = context.WithValue(ctx, common.Api, common.API_2_1)
-			w, err := client.WorkspaceClient()
-			assert.NoError(t, err)
-			res, err := w.Settings.GetDefaultNamespaceSetting(ctx, settings.GetDefaultNamespaceSettingRequest{
-				Etag: id,
-			})
-			assert.NoError(t, err)
-			// Check that the resource has been created and that it has the correct value.
-			assert.Equal(t, res.Namespace.Value, "namespace_value")
-			return nil
-		}),
+	}
+	`
+	workspaceLevel(t, step{
+		Template: template,
+		Check: resourceCheckWithState("databricks_default_namespace_setting.this",
+			func(ctx context.Context, client *common.DatabricksClient, state *terraform.InstanceState) error {
+				ctx = context.WithValue(ctx, common.Api, common.API_2_1)
+				w, err := client.WorkspaceClient()
+				require.NoError(t, err)
+				etag := state.Attributes["etag"]
+				require.NotEmpty(t, etag)
+				res, err := w.Settings.GetDefaultNamespaceSetting(ctx, settings.GetDefaultNamespaceSettingRequest{
+					Etag: etag,
+				})
+				require.NoError(t, err)
+				// Check that the resource has been created and that it has the correct value.
+				assert.Equal(t, res.Namespace.Value, "namespace_value")
+				return nil
+			}),
 	},
 		step{
-			Template: `resource "databricks_default_namespace_setting" "this" {
-				namespace {
-					value = "namespace_value"
-				}
-			}`,
-			Destroy: true,
+			Template: template,
+			Destroy:  true,
 			Check: resourceCheck("databricks_default_namespace_setting.this", func(ctx context.Context, client *common.DatabricksClient, id string) error {
 				ctx = context.WithValue(ctx, common.Api, common.API_2_1)
 				w, err := client.WorkspaceClient()
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				// Terraform Check returns the latest resource status before it is destroyed, which has an outdated eTag.
 				// We are making an update call to get the correct eTag in the response error.
 				_, err = w.Settings.UpdateDefaultNamespaceSetting(ctx, settings.UpdateDefaultNamespaceSettingRequest{

--- a/internal/acceptance/restrict_workspace_admins_test.go
+++ b/internal/acceptance/restrict_workspace_admins_test.go
@@ -8,68 +8,71 @@ import (
 	"github.com/databricks/databricks-sdk-go/apierr"
 	"github.com/databricks/databricks-sdk-go/service/settings"
 	"github.com/databricks/terraform-provider-databricks/common"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAccRestrictWorkspaceAdminsSetting(t *testing.T) {
-	workspaceLevel(t, step{
-		Template: `
-		resource "databricks_restrict_workspace_admins_setting" "this" {
-			restrict_workspace_admins {
-				status = "RESTRICT_TOKENS_AND_JOB_RUN_AS"
-			}
+	template := `
+	resource "databricks_restrict_workspace_admins_setting" "this" {
+		restrict_workspace_admins {
+			status = "RESTRICT_TOKENS_AND_JOB_RUN_AS"
 		}
-		`,
-		Check: resourceCheck("databricks_restrict_workspace_admins_setting.this", func(ctx context.Context, client *common.DatabricksClient, id string) error {
-			ctx = context.WithValue(ctx, common.Api, common.API_2_1)
-			w, err := client.WorkspaceClient()
-			assert.NoError(t, err)
-			res, err := w.Settings.GetRestrictWorkspaceAdminsSetting(ctx, settings.GetRestrictWorkspaceAdminsSettingRequest{
-				Etag: id,
-			})
-			assert.NoError(t, err)
-			// Check that the resource has been created and that it has the correct value.
-			assert.Equal(t, res.RestrictWorkspaceAdmins.Status.String(), "RESTRICT_TOKENS_AND_JOB_RUN_AS")
-			return nil
-		}),
-	},
-		step{
-			Template: `resource "databricks_restrict_workspace_admins_setting" "this" {
-				restrict_workspace_admins {
-					status = "RESTRICT_TOKENS_AND_JOB_RUN_AS"
-				}
-			}`,
-			Destroy: true,
-			Check: resourceCheck("databricks_restrict_workspace_admins_setting.this", func(ctx context.Context, client *common.DatabricksClient, id string) error {
+	}
+	`
+	workspaceLevel(t, step{
+		Template: template,
+		Check: resourceCheckWithState("databricks_restrict_workspace_admins_setting.this",
+			func(ctx context.Context, client *common.DatabricksClient, state *terraform.InstanceState) error {
 				ctx = context.WithValue(ctx, common.Api, common.API_2_1)
 				w, err := client.WorkspaceClient()
-				assert.NoError(t, err)
-				// Terraform Check returns the latest resource status before it is destroyed, which has an outdated eTag.
-				// We are making an update call to get the correct eTag in the response error.
-				_, err = w.Settings.UpdateRestrictWorkspaceAdminsSetting(ctx, settings.UpdateRestrictWorkspaceAdminsSettingRequest{
-					AllowMissing: true,
-					Setting: settings.RestrictWorkspaceAdminsSetting{
-						RestrictWorkspaceAdmins: settings.RestrictWorkspaceAdminsMessage{
-							Status: "RESTRICT_TOKENS_AND_JOB_RUN_AS",
-						},
-					},
-					FieldMask: "restrict_workspace_admins.status",
-				})
-				assert.Error(t, err)
-				var aerr *apierr.APIError
-				if !errors.As(err, &aerr) {
-					assert.FailNow(t, "cannot parse error message %v", err)
-				}
-				etag := aerr.Details[0].Metadata["etag"]
+				require.NoError(t, err)
+				etag := state.Attributes["etag"]
+				require.NotEmpty(t, etag)
 				res, err := w.Settings.GetRestrictWorkspaceAdminsSetting(ctx, settings.GetRestrictWorkspaceAdminsSettingRequest{
 					Etag: etag,
 				})
-				// we should not be getting any error
 				assert.NoError(t, err)
-				// workspace should go back to default
-				assert.Equal(t, res.RestrictWorkspaceAdmins.Status.String(), "ALLOW_ALL")
+				// Check that the resource has been created and that it has the correct value.
+				assert.Equal(t, "RESTRICT_TOKENS_AND_JOB_RUN_AS", res.RestrictWorkspaceAdmins.Status.String())
 				return nil
 			}),
+	},
+		step{
+			Template: template,
+			Destroy:  true,
+			Check: resourceCheck("databricks_restrict_workspace_admins_setting.this",
+				func(ctx context.Context, client *common.DatabricksClient, id string) error {
+					ctx = context.WithValue(ctx, common.Api, common.API_2_1)
+					w, err := client.WorkspaceClient()
+					assert.NoError(t, err)
+					// Terraform Check returns the latest resource status before it is destroyed, which has an outdated eTag.
+					// We are making an update call to get the correct eTag in the response error.
+					_, err = w.Settings.UpdateRestrictWorkspaceAdminsSetting(ctx, settings.UpdateRestrictWorkspaceAdminsSettingRequest{
+						AllowMissing: true,
+						Setting: settings.RestrictWorkspaceAdminsSetting{
+							RestrictWorkspaceAdmins: settings.RestrictWorkspaceAdminsMessage{
+								Status: "RESTRICT_TOKENS_AND_JOB_RUN_AS",
+							},
+						},
+						FieldMask: "restrict_workspace_admins.status",
+					})
+					assert.Error(t, err)
+					var aerr *apierr.APIError
+					if !errors.As(err, &aerr) {
+						assert.FailNow(t, "cannot parse error message %v", err)
+					}
+					etag := aerr.Details[0].Metadata["etag"]
+					res, err := w.Settings.GetRestrictWorkspaceAdminsSetting(ctx, settings.GetRestrictWorkspaceAdminsSettingRequest{
+						Etag: etag,
+					})
+					// we should not be getting any error
+					assert.NoError(t, err)
+					// workspace should go back to default
+					assert.Equal(t, res.RestrictWorkspaceAdmins.Status.String(), "ALLOW_ALL")
+					return nil
+				}),
 		},
 	)
 }

--- a/settings/generic_setting.go
+++ b/settings/generic_setting.go
@@ -14,6 +14,7 @@ import (
 
 var (
 	defaultSettingId = "global"
+	etagAttrName     = "etag"
 )
 
 func retryOnEtagError[Req, Resp any](f func(req Req) (Resp, error), firstReq Req, updateReq func(req *Req, newEtag string), retriableErrors []error) (Resp, error) {
@@ -47,7 +48,7 @@ func getEtagFromError(err error) (string, error) {
 	errorInfos := apierr.GetErrorInfo(err)
 	if len(errorInfos) > 0 {
 		metadata := errorInfos[0].Metadata
-		if etag, ok := metadata["etag"]; ok {
+		if etag, ok := metadata[etagAttrName]; ok {
 			return etag, nil
 		}
 	}
@@ -112,7 +113,7 @@ type workspaceSetting[T any] struct {
 	// Delete the setting with the given etag, and return the new etag.
 	deleteFunc func(ctx context.Context, w *databricks.WorkspaceClient, etag string) (string, error)
 
-	// Optional function to generate resource ID from the settings
+	// Optional function to generate resource ID from the settings. If not provided, will use predefined value `global`
 	generateIdFunc func(setting *T) string
 }
 
@@ -165,7 +166,7 @@ type accountSetting[T any] struct {
 	// Delete the setting with the given etag, and return the new etag.
 	deleteFunc func(ctx context.Context, w *databricks.AccountClient, etag string) (string, error)
 
-	// Optional function to generate resource ID from the settings
+	// Optional function to generate resource ID from the settings. If not provided, will use predefined value `global`
 	generateIdFunc func(setting *T) string
 }
 
@@ -201,7 +202,7 @@ var _ accountSettingDefinition[struct{}] = accountSetting[struct{}]{}
 func makeSettingResource[T, U any](defn genericSettingDefinition[T, U]) common.Resource {
 	resourceSchema := common.StructToSchema(defn.SettingStruct(),
 		func(s map[string]*schema.Schema) map[string]*schema.Schema {
-			s["etag"].Computed = true
+			s[etagAttrName].Computed = true
 			// Note: this may not always be computed, but it is for the default namespace setting. If other settings
 			// are added for which setting_name is not computed, we'll need to expose this somehow as part of the setting
 			// definition.
@@ -247,7 +248,7 @@ func makeSettingResource[T, U any](defn genericSettingDefinition[T, U]) common.R
 		default:
 			return fmt.Errorf("unexpected setting type: %T", defn)
 		}
-		d.Set("etag", res)
+		d.Set(etagAttrName, res)
 		d.SetId(defn.GetId(&setting))
 		return nil
 	}
@@ -266,7 +267,7 @@ func makeSettingResource[T, U any](defn genericSettingDefinition[T, U]) common.R
 				if err != nil {
 					return err
 				}
-				res, err = defn.Read(ctx, w, d.Get("etag").(string))
+				res, err = defn.Read(ctx, w, d.Get(etagAttrName).(string))
 				if err != nil {
 					return err
 				}
@@ -275,7 +276,7 @@ func makeSettingResource[T, U any](defn genericSettingDefinition[T, U]) common.R
 				if err != nil {
 					return err
 				}
-				res, err = defn.Read(ctx, a, d.Get("etag").(string))
+				res, err = defn.Read(ctx, a, d.Get(etagAttrName).(string))
 				if err != nil {
 					return err
 				}
@@ -290,12 +291,12 @@ func makeSettingResource[T, U any](defn genericSettingDefinition[T, U]) common.R
 			// with a response which is at least as recent as the etag.
 			// Updating, while not always necessary, ensures that the
 			// server responds with an updated response.
-			d.Set("etag", defn.GetETag(res))
+			d.Set(etagAttrName, defn.GetETag(res))
 			return nil
 		},
 		Update: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
 			var setting T
-			defn.SetETag(&setting, d.Get("etag").(string))
+			defn.SetETag(&setting, d.Get(etagAttrName).(string))
 			return createOrUpdate(ctx, d, c, setting)
 		},
 		Delete: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
@@ -311,7 +312,7 @@ func makeSettingResource[T, U any](defn genericSettingDefinition[T, U]) common.R
 					func(etag string) (string, error) {
 						return defn.Delete(ctx, w, etag)
 					},
-					d.Get("etag").(string),
+					d.Get(etagAttrName).(string),
 					updateETag,
 					deleteRetriableErrors)
 				if err != nil {
@@ -326,7 +327,7 @@ func makeSettingResource[T, U any](defn genericSettingDefinition[T, U]) common.R
 					func(etag string) (string, error) {
 						return defn.Delete(ctx, a, etag)
 					},
-					d.Get("etag").(string),
+					d.Get(etagAttrName).(string),
 					updateETag,
 					deleteRetriableErrors)
 				if err != nil {
@@ -335,7 +336,7 @@ func makeSettingResource[T, U any](defn genericSettingDefinition[T, U]) common.R
 			default:
 				return fmt.Errorf("unexpected setting type: %T", defn)
 			}
-			d.Set("etag", etag)
+			d.Set(etagAttrName, etag)
 			return nil
 		},
 	}

--- a/settings/generic_setting.go
+++ b/settings/generic_setting.go
@@ -13,7 +13,7 @@ import (
 )
 
 var (
-	defaultSettingName = "global"
+	defaultSettingId = "global"
 )
 
 func retryOnEtagError[Req, Resp any](f func(req Req) (Resp, error), firstReq Req, updateReq func(req *Req, newEtag string), retriableErrors []error) (Resp, error) {
@@ -133,7 +133,7 @@ func (w workspaceSetting[T]) GetETag(t *T) string {
 }
 
 func (w workspaceSetting[T]) GetId(t *T) string {
-	id := defaultSettingName
+	id := defaultSettingId
 	if w.generateIdFunc != nil {
 		id = w.generateIdFunc(t)
 	}
@@ -189,7 +189,7 @@ func (w accountSetting[T]) SetETag(t *T, newEtag string) {
 }
 
 func (w accountSetting[T]) GetId(t *T) string {
-	id := defaultSettingName
+	id := defaultSettingId
 	if w.generateIdFunc != nil {
 		id = w.generateIdFunc(t)
 	}

--- a/settings/generic_setting_test.go
+++ b/settings/generic_setting_test.go
@@ -35,7 +35,7 @@ func TestQueryCreateDefaultNameSetting(t *testing.T) {
 				Details: []apierr.ErrorDetail{{
 					Type: "type.googleapis.com/google.rpc.ErrorInfo",
 					Metadata: map[string]string{
-						"etag": "etag1",
+						etagAttrName: "etag1",
 					},
 				}},
 			})
@@ -75,7 +75,7 @@ func TestQueryCreateDefaultNameSetting(t *testing.T) {
 		`,
 	}.ApplyAndExpectData(t, map[string]any{
 		"id":                defaultSettingId,
-		"etag":              "etag2",
+		etagAttrName:        "etag2",
 		"namespace.0.value": "namespace_value",
 	})
 }
@@ -104,7 +104,7 @@ func TestQueryReadDefaultNameSetting(t *testing.T) {
 		ID: defaultSettingId,
 	}.ApplyAndExpectData(t, map[string]any{
 		"id":                defaultSettingId,
-		"etag":              "etag2",
+		etagAttrName:        "etag2",
 		"namespace.0.value": "namespace_value",
 	})
 }
@@ -151,7 +151,7 @@ func TestQueryUpdateDefaultNameSetting(t *testing.T) {
 		ID: defaultSettingId,
 	}.ApplyAndExpectData(t, map[string]any{
 		"id":                defaultSettingId,
-		"etag":              "etag2",
+		etagAttrName:        "etag2",
 		"namespace.0.value": "new_namespace_value",
 	})
 }
@@ -177,7 +177,7 @@ func TestQueryUpdateDefaultNameSettingWithConflict(t *testing.T) {
 				Details: []apierr.ErrorDetail{{
 					Type: "type.googleapis.com/google.rpc.ErrorInfo",
 					Metadata: map[string]string{
-						"etag": "etag2",
+						etagAttrName: "etag2",
 					},
 				}},
 			})
@@ -219,7 +219,7 @@ func TestQueryUpdateDefaultNameSettingWithConflict(t *testing.T) {
 		ID: defaultSettingId,
 	}.ApplyAndExpectData(t, map[string]any{
 		"id":                defaultSettingId,
-		"etag":              "etag3",
+		etagAttrName:        "etag3",
 		"namespace.0.value": "new_namespace_value",
 	})
 }
@@ -245,7 +245,7 @@ func TestQueryDeleteDefaultNameSetting(t *testing.T) {
 	}.Apply(t)
 
 	assert.NoError(t, err)
-	assert.Equal(t, "etag2", d.Get("etag").(string))
+	assert.Equal(t, "etag2", d.Get(etagAttrName).(string))
 }
 
 func TestQueryDeleteDefaultNameSettingWithConflict(t *testing.T) {
@@ -260,7 +260,7 @@ func TestQueryDeleteDefaultNameSettingWithConflict(t *testing.T) {
 				Details: []apierr.ErrorDetail{{
 					Type: "type.googleapis.com/google.rpc.ErrorInfo",
 					Metadata: map[string]string{
-						"etag": "etag2",
+						etagAttrName: "etag2",
 					},
 				}},
 			})
@@ -282,5 +282,5 @@ func TestQueryDeleteDefaultNameSettingWithConflict(t *testing.T) {
 	}.Apply(t)
 
 	assert.NoError(t, err)
-	assert.Equal(t, "etag3", d.Get("etag").(string))
+	assert.Equal(t, "etag3", d.Get(etagAttrName).(string))
 }

--- a/settings/generic_setting_test.go
+++ b/settings/generic_setting_test.go
@@ -74,7 +74,7 @@ func TestQueryCreateDefaultNameSetting(t *testing.T) {
 			}
 		`,
 	}.ApplyAndExpectData(t, map[string]any{
-		"id":                defaultSettingName,
+		"id":                defaultSettingId,
 		"etag":              "etag2",
 		"namespace.0.value": "namespace_value",
 	})
@@ -101,9 +101,9 @@ func TestQueryReadDefaultNameSetting(t *testing.T) {
 			}
 			etag = "etag1"
 		`,
-		ID: defaultSettingName,
+		ID: defaultSettingId,
 	}.ApplyAndExpectData(t, map[string]any{
-		"id":                defaultSettingName,
+		"id":                defaultSettingId,
 		"etag":              "etag2",
 		"namespace.0.value": "namespace_value",
 	})
@@ -148,9 +148,9 @@ func TestQueryUpdateDefaultNameSetting(t *testing.T) {
 			}
 			etag = "etag1"
 		`,
-		ID: defaultSettingName,
+		ID: defaultSettingId,
 	}.ApplyAndExpectData(t, map[string]any{
-		"id":                defaultSettingName,
+		"id":                defaultSettingId,
 		"etag":              "etag2",
 		"namespace.0.value": "new_namespace_value",
 	})
@@ -216,9 +216,9 @@ func TestQueryUpdateDefaultNameSettingWithConflict(t *testing.T) {
 			}
 			etag = "etag1"
 		`,
-		ID: defaultSettingName,
+		ID: defaultSettingId,
 	}.ApplyAndExpectData(t, map[string]any{
-		"id":                defaultSettingName,
+		"id":                defaultSettingId,
 		"etag":              "etag3",
 		"namespace.0.value": "new_namespace_value",
 	})
@@ -241,7 +241,7 @@ func TestQueryDeleteDefaultNameSetting(t *testing.T) {
 			}
 			etag = "etag1"
 		`,
-		ID: defaultSettingName,
+		ID: defaultSettingId,
 	}.Apply(t)
 
 	assert.NoError(t, err)
@@ -278,7 +278,7 @@ func TestQueryDeleteDefaultNameSettingWithConflict(t *testing.T) {
 			}
 			etag = "etag1"
 		`,
-		ID: defaultSettingName,
+		ID: defaultSettingId,
 	}.Apply(t)
 
 	assert.NoError(t, err)

--- a/settings/resource_restrict_workspace_admins_setting_test.go
+++ b/settings/resource_restrict_workspace_admins_setting_test.go
@@ -34,7 +34,7 @@ func TestQueryCreateRestrictWsAdminsSetting(t *testing.T) {
 				Details: []apierr.ErrorDetail{{
 					Type: "type.googleapis.com/google.rpc.ErrorInfo",
 					Metadata: map[string]string{
-						"etag": "etag1",
+						etagAttrName: "etag1",
 					},
 				}},
 			})
@@ -77,7 +77,7 @@ func TestQueryCreateRestrictWsAdminsSetting(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, defaultSettingId, d.Id())
-	assert.Equal(t, "etag2", d.Get("etag").(string))
+	assert.Equal(t, "etag2", d.Get(etagAttrName).(string))
 	assert.Equal(t, "RESTRICT_TOKENS_AND_JOB_RUN_AS", d.Get("restrict_workspace_admins.0.status"))
 }
 
@@ -108,7 +108,7 @@ func TestQueryReadRestrictWsAdminsSetting(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, defaultSettingId, d.Id())
-	assert.Equal(t, "etag2", d.Get("etag").(string))
+	assert.Equal(t, "etag2", d.Get(etagAttrName).(string))
 	res := d.Get("restrict_workspace_admins").([]interface{})[0].(map[string]interface{})
 	assert.Equal(t, "RESTRICT_TOKENS_AND_JOB_RUN_AS", res["status"])
 }
@@ -158,7 +158,7 @@ func TestQueryUpdateRestrictWsAdminsSetting(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, defaultSettingId, d.Id())
-	assert.Equal(t, "etag2", d.Get("etag").(string))
+	assert.Equal(t, "etag2", d.Get(etagAttrName).(string))
 	res := d.Get("restrict_workspace_admins").([]interface{})[0].(map[string]interface{})
 	assert.Equal(t, "ALLOW_ALL", res["status"])
 }
@@ -184,7 +184,7 @@ func TestQueryUpdateRestrictWsAdminsSettingWithConflict(t *testing.T) {
 				Details: []apierr.ErrorDetail{{
 					Type: "type.googleapis.com/google.rpc.ErrorInfo",
 					Metadata: map[string]string{
-						"etag": "etag2",
+						etagAttrName: "etag2",
 					},
 				}},
 			})
@@ -229,7 +229,7 @@ func TestQueryUpdateRestrictWsAdminsSettingWithConflict(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, defaultSettingId, d.Id())
-	assert.Equal(t, "etag3", d.Get("etag").(string))
+	assert.Equal(t, "etag3", d.Get(etagAttrName).(string))
 	res := d.Get("restrict_workspace_admins").([]interface{})[0].(map[string]interface{})
 	assert.Equal(t, "RESTRICT_TOKENS_AND_JOB_RUN_AS", res["status"])
 }
@@ -253,8 +253,8 @@ func TestQueryDeleteRestrictWsAdminsSetting(t *testing.T) {
 		`,
 		ID: defaultSettingId,
 	}.ApplyAndExpectData(t, map[string]any{
-		"id":   defaultSettingId,
-		"etag": "etag2",
+		"id":         defaultSettingId,
+		etagAttrName: "etag2",
 	})
 }
 
@@ -270,7 +270,7 @@ func TestQueryDeleteRestrictWsAdminsSettingWithConflict(t *testing.T) {
 				Details: []apierr.ErrorDetail{{
 					Type: "type.googleapis.com/google.rpc.ErrorInfo",
 					Metadata: map[string]string{
-						"etag": "etag2",
+						etagAttrName: "etag2",
 					},
 				}},
 			})
@@ -290,7 +290,7 @@ func TestQueryDeleteRestrictWsAdminsSettingWithConflict(t *testing.T) {
 		Delete: true,
 		ID:     defaultSettingId,
 	}.ApplyAndExpectData(t, map[string]any{
-		"id":   defaultSettingId,
-		"etag": "etag3",
+		"id":         defaultSettingId,
+		etagAttrName: "etag3",
 	})
 }

--- a/settings/resource_restrict_workspace_admins_setting_test.go
+++ b/settings/resource_restrict_workspace_admins_setting_test.go
@@ -76,7 +76,8 @@ func TestQueryCreateRestrictWsAdminsSetting(t *testing.T) {
 
 	assert.NoError(t, err)
 
-	assert.Equal(t, "etag2", d.Id())
+	assert.Equal(t, defaultSettingId, d.Id())
+	assert.Equal(t, "etag2", d.Get("etag").(string))
 	assert.Equal(t, "RESTRICT_TOKENS_AND_JOB_RUN_AS", d.Get("restrict_workspace_admins.0.status"))
 }
 
@@ -99,13 +100,15 @@ func TestQueryReadRestrictWsAdminsSetting(t *testing.T) {
 			restrict_workspace_admins {
 				status = "RESTRICT_TOKENS_AND_JOB_RUN_AS"
 			}
+			etag = "etag1"
 		`,
-		ID: "etag1",
+		ID: defaultSettingId,
 	}.Apply(t)
 
 	assert.NoError(t, err)
 
-	assert.Equal(t, "etag2", d.Id())
+	assert.Equal(t, defaultSettingId, d.Id())
+	assert.Equal(t, "etag2", d.Get("etag").(string))
 	res := d.Get("restrict_workspace_admins").([]interface{})[0].(map[string]interface{})
 	assert.Equal(t, "RESTRICT_TOKENS_AND_JOB_RUN_AS", res["status"])
 }
@@ -147,13 +150,15 @@ func TestQueryUpdateRestrictWsAdminsSetting(t *testing.T) {
 			restrict_workspace_admins {
 				status = "ALLOW_ALL"
 			}
+			etag = "etag1"
 		`,
-		ID: "etag1",
+		ID: defaultSettingId,
 	}.Apply(t)
 
 	assert.NoError(t, err)
 
-	assert.Equal(t, "etag2", d.Id())
+	assert.Equal(t, defaultSettingId, d.Id())
+	assert.Equal(t, "etag2", d.Get("etag").(string))
 	res := d.Get("restrict_workspace_admins").([]interface{})[0].(map[string]interface{})
 	assert.Equal(t, "ALLOW_ALL", res["status"])
 }
@@ -216,19 +221,21 @@ func TestQueryUpdateRestrictWsAdminsSettingWithConflict(t *testing.T) {
 			restrict_workspace_admins {
 				status = "RESTRICT_TOKENS_AND_JOB_RUN_AS"
 			}
+			etag = "etag1"
 		`,
-		ID: "etag1",
+		ID: defaultSettingId,
 	}.Apply(t)
 
 	assert.NoError(t, err)
 
-	assert.Equal(t, "etag3", d.Id())
+	assert.Equal(t, defaultSettingId, d.Id())
+	assert.Equal(t, "etag3", d.Get("etag").(string))
 	res := d.Get("restrict_workspace_admins").([]interface{})[0].(map[string]interface{})
 	assert.Equal(t, "RESTRICT_TOKENS_AND_JOB_RUN_AS", res["status"])
 }
 
 func TestQueryDeleteRestrictWsAdminsSetting(t *testing.T) {
-	d, err := qa.ResourceFixture{
+	qa.ResourceFixture{
 		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
 			w.GetMockSettingsAPI().EXPECT().DeleteRestrictWorkspaceAdminsSetting(mock.Anything, settings.DeleteRestrictWorkspaceAdminsSettingRequest{
 				Etag: "etag1",
@@ -238,15 +245,21 @@ func TestQueryDeleteRestrictWsAdminsSetting(t *testing.T) {
 		},
 		Resource: testRestrictWsAdminsSetting,
 		Delete:   true,
-		ID:       "etag1",
-	}.Apply(t)
-
-	assert.NoError(t, err)
-	assert.Equal(t, "etag2", d.Id())
+		HCL: `
+		restrict_workspace_admins {
+			status = "RESTRICT_TOKENS_AND_JOB_RUN_AS"
+		}
+		etag = "etag1"
+		`,
+		ID: defaultSettingId,
+	}.ApplyAndExpectData(t, map[string]any{
+		"id":   defaultSettingId,
+		"etag": "etag2",
+	})
 }
 
 func TestQueryDeleteRestrictWsAdminsSettingWithConflict(t *testing.T) {
-	d, err := qa.ResourceFixture{
+	qa.ResourceFixture{
 		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
 			w.GetMockSettingsAPI().EXPECT().DeleteRestrictWorkspaceAdminsSetting(mock.Anything, settings.DeleteRestrictWorkspaceAdminsSettingRequest{
 				Etag: "etag1",
@@ -268,10 +281,16 @@ func TestQueryDeleteRestrictWsAdminsSettingWithConflict(t *testing.T) {
 			}, nil)
 		},
 		Resource: testRestrictWsAdminsSetting,
-		Delete:   true,
-		ID:       "etag1",
-	}.Apply(t)
-
-	assert.NoError(t, err)
-	assert.Equal(t, "etag3", d.Id())
+		HCL: `
+		restrict_workspace_admins {
+			status = "RESTRICT_TOKENS_AND_JOB_RUN_AS"
+		}
+		etag = "etag1"
+		`,
+		Delete: true,
+		ID:     defaultSettingId,
+	}.ApplyAndExpectData(t, map[string]any{
+		"id":   defaultSettingId,
+		"etag": "etag3",
+	})
 }


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

Before this change, generated settings resource were using etag value as resource ID. This lead to a situation that importing of these resources was problematic because ID was changing all the time.

This PR introduces stable IDs for generated resources. By default it uses a constant ID: global, similar to other resources, like, databricks_sql_global_config, but the resource implementor may provide a function that will generate a resource ID from the settings' data.

This fixes #3270

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [x] covered with integration tests in `internal/acceptance`
- [x] relevant acceptance tests are passing
- [x] using Go SDK
