### PR TITLE
Exporter: Remove too aggressive omitting for `volume_type` attribute of `databricks_volume` resource

### DIFF
--- a/exporter/importables.go
+++ b/exporter/importables.go
@@ -2522,8 +2522,7 @@ var resourcesMap map[string]importable = map[string]importable{
 			return nil
 		},
 		ShouldOmitField: func(ic *importContext, pathString string, as *schema.Schema, d *schema.ResourceData) bool {
-			switch pathString {
-			case "storage_location", "volume_type":
+			if pathString == "storage_location" {
 				return d.Get("volume_type").(string) == "MANAGED"
 			}
 			return shouldOmitForUnityCatalog(ic, pathString, as, d)

--- a/exporter/importables_test.go
+++ b/exporter/importables_test.go
@@ -1985,8 +1985,7 @@ func TestVolumes(t *testing.T) {
 	assert.False(t, shouldOmitFunc(nil, "name", scm["name"], d))
 	d.Set("volume_type", "MANAGED")
 	d.Set("storage_location", "s3://abc/")
-	assert.True(t, shouldOmitFunc(nil, "volume_type", scm["volume_type"], d))
-	assert.True(t, shouldOmitFunc(nil, "storage_location", scm["storage_location"], d))
+	assert.False(t, shouldOmitFunc(nil, "volume_type", scm["volume_type"], d))
 	assert.True(t, shouldOmitFunc(nil, "storage_location", scm["storage_location"], d))
 }
 


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
