### PR TITLE
add `IF NOT EXISTS` option to sql_table

### DIFF
--- a/catalog/resource_sql_table.go
+++ b/catalog/resource_sql_table.go
@@ -254,7 +254,7 @@ func (ti *SqlTableInfo) buildTableCreateStatement() string {
 
 	createType := ti.getTableTypeString()
 
-    createStatement := fmt.Sprintf("CREATE %s%s %s%s", externalFragment, createType, ifNotExistsClause, ti.SQLFullName())
+    createStatement := fmt.Sprintf("CREATE %s%s %s%s", externalFragment, createType, ifNotExistsFragment, ti.SQLFullName())
     statements = append(statements, createStatement)
 
 	if len(ti.ColumnInfos) > 0 {

--- a/catalog/resource_sql_table.go
+++ b/catalog/resource_sql_table.go
@@ -43,7 +43,7 @@ type SqlTableInfo struct {
 	Options               map[string]string `json:"options,omitempty" tf:"force_new"`
 	ClusterID             string            `json:"cluster_id,omitempty" tf:"computed"`
 	WarehouseID           string            `json:"warehouse_id,omitempty"`
-    CreateIfNotExists     bool              `json:"create_if_not_exists,omitempty"`
+	CreateIfNotExists     bool              `json:"create_if_not_exists,omitempty"`
 
 	exec    common.CommandExecutor
 	sqlExec sql.StatementExecutionInterface
@@ -247,15 +247,15 @@ func (ti *SqlTableInfo) buildTableCreateStatement() string {
 		externalFragment = "EXTERNAL "
 	}
 
-    ifNotExistsFragment := ""
-    if ti.CreateIfNotExists {
-        ifNotExistsFragment = "IF NOT EXISTS "
-    }
+	ifNotExistsFragment := ""
+	if ti.CreateIfNotExists {
+		ifNotExistsFragment = "IF NOT EXISTS "
+	}
 
 	createType := ti.getTableTypeString()
 
-    createStatement := fmt.Sprintf("CREATE %s%s %s%s", externalFragment, createType, ifNotExistsFragment, ti.SQLFullName())
-    statements = append(statements, createStatement)
+	createStatement := fmt.Sprintf("CREATE %s%s %s%s", externalFragment, createType, ifNotExistsFragment, ti.SQLFullName())
+	statements = append(statements, createStatement)
 
 	if len(ti.ColumnInfos) > 0 {
 		statements = append(statements, fmt.Sprintf(" (%s)", ti.serializeColumnInfos()))
@@ -408,11 +408,11 @@ func ResourceSqlTable() common.Resource {
 
 			s["partitions"].ConflictsWith = []string{"cluster_keys"}
 			s["cluster_keys"].ConflictsWith = []string{"partitions"}
-            s["create_if_not_exists"] = &schema.Schema{
-                Type:     schema.TypeBool,
-                Optional: true,
-                Default:  false,
-            }
+			s["create_if_not_exists"] = &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			}
 			return s
 		})
 	return common.Resource{

--- a/catalog/resource_sql_table_test.go
+++ b/catalog/resource_sql_table_test.go
@@ -53,22 +53,22 @@ func TestResourceSqlTableCreateStatement_View(t *testing.T) {
 }
 
 func TestResourceSqlTableCreateStatement_WithCreateIfNotExists(t *testing.T) {
-    ti := &SqlTableInfo{
-        Name:                  "bar",
-        CatalogName:           "main",
-        SchemaName:            "foo",
-        TableType:             "EXTERNAL",
-        DataSourceFormat:      "DELTA",
-        StorageLocation:       "s3://ext-main/foo/bar1",
-        StorageCredentialName: "somecred",
-        Comment:               "terraform managed",
-        CreateIfNotExists:     true,
-    }
-    stmt := ti.buildTableCreateStatement()
-    assert.Contains(t, stmt, "CREATE EXTERNAL TABLE IF NOT EXISTS `main`.`foo`.`bar`")
-    assert.Contains(t, stmt, "USING DELTA")
-    assert.Contains(t, stmt, "LOCATION 's3://ext-main/foo/bar1' WITH (CREDENTIAL `somecred`)")
-    assert.Contains(t, stmt, "COMMENT 'terraform managed'")
+	ti := &SqlTableInfo{
+		Name:                  "bar",
+		CatalogName:           "main",
+		SchemaName:            "foo",
+		TableType:             "EXTERNAL",
+		DataSourceFormat:      "DELTA",
+		StorageLocation:       "s3://ext-main/foo/bar1",
+		StorageCredentialName: "somecred",
+		Comment:               "terraform managed",
+		CreateIfNotExists:     true,
+	}
+	stmt := ti.buildTableCreateStatement()
+	assert.Contains(t, stmt, "CREATE EXTERNAL TABLE IF NOT EXISTS `main`.`foo`.`bar`")
+	assert.Contains(t, stmt, "USING DELTA")
+	assert.Contains(t, stmt, "LOCATION 's3://ext-main/foo/bar1' WITH (CREDENTIAL `somecred`)")
+	assert.Contains(t, stmt, "COMMENT 'terraform managed'")
 }
 
 func TestResourceSqlTableCreateStatement_ViewWithComments(t *testing.T) {

--- a/catalog/resource_sql_table_test.go
+++ b/catalog/resource_sql_table_test.go
@@ -52,6 +52,25 @@ func TestResourceSqlTableCreateStatement_View(t *testing.T) {
 	assert.Contains(t, stmt, "'one'='two'")
 }
 
+func TestResourceSqlTableCreateStatement_WithCreateIfNotExists(t *testing.T) {
+    ti := &SqlTableInfo{
+        Name:                  "bar",
+        CatalogName:           "main",
+        SchemaName:            "foo",
+        TableType:             "EXTERNAL",
+        DataSourceFormat:      "DELTA",
+        StorageLocation:       "s3://ext-main/foo/bar1",
+        StorageCredentialName: "somecred",
+        Comment:               "terraform managed",
+        CreateIfNotExists:     true,
+    }
+    stmt := ti.buildTableCreateStatement()
+    assert.Contains(t, stmt, "CREATE EXTERNAL TABLE IF NOT EXISTS `main`.`foo`.`bar`")
+    assert.Contains(t, stmt, "USING DELTA")
+    assert.Contains(t, stmt, "LOCATION 's3://ext-main/foo/bar1' WITH (CREDENTIAL `somecred`)")
+    assert.Contains(t, stmt, "COMMENT 'terraform managed'")
+}
+
 func TestResourceSqlTableCreateStatement_ViewWithComments(t *testing.T) {
 	ti := &SqlTableInfo{
 		Name:                  "bar",

--- a/docs/resources/sql_table.md
+++ b/docs/resources/sql_table.md
@@ -128,6 +128,7 @@ The following arguments are supported:
 * `options` - (Optional) Map of user defined table options. Change forces creation of a new resource.
 * `properties` - (Optional) Map of table properties.
 * `partitions` - (Optional) a subset of columns to partition the table by. Change forces creation of a new resource. Conflicts with `cluster_keys`.
+* `create_if_not_exists` - (Optional) Adds IF NOT EXISTS clause to avoid error in case resource already exists (Default: `false`).
 
 ### `column` configuration block
 


### PR DESCRIPTION
## Changes
Hello!
I was building a pipeline that manages views using the terraform `databricks_sql_table` resource and felt the need to use IF NOT EXISTS clause.


This pull request adds create_if_not_exists option to the `databricks_sql_table` resource.

#### Reasons:

- Running terraform apply will fail if the resource exists, which is not the expected behavior
- Adding the IF NOT EXISTS clause makes the operation idempotent, which is desirable
- Using  IF NOT EXISTS clause will cause less overhead of handling errors and less pollution of logging

My organization currently uses the  `databricks_sql_table` resource to manage view creation, and it would be nice to have the option to use the IF NOT EXISTS clause for the reasons above and to stop our CICD pipelines from failing.

#### Terraform State:
Because this is an optional input and defaults to false, it would not make any changes to the current state because it would not make any changes to the DDL, so this change should be backward-compatible

#### Testing:
I have added one case for testing the changes with `create_if_not_exists` and run `make test` and individual tests as well

![image](https://github.com/databricks/terraform-provider-databricks/assets/23335136/263b8158-32ba-42df-843e-d65edf4e6c9a)

![image](https://github.com/databricks/terraform-provider-databricks/assets/23335136/f79e5aa5-2c0b-495c-b2f6-55e693b18fe3)




## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
