### PR TITLE
Allow changes to `display_name` of `databricks_group` resource without recreating a group

### DIFF
--- a/internal/acceptance/group_test.go
+++ b/internal/acceptance/group_test.go
@@ -2,6 +2,7 @@ package acceptance
 
 import (
 	"context"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/databricks/terraform-provider-databricks/qa"
@@ -66,5 +67,84 @@ func TestAccGroupsExternalIdAndScimProvisioning(t *testing.T) {
 			display_name = "` + name + `"
 			allow_cluster_create = true
 		}`,
+	})
+}
+
+func TestMwsAccGroupsUpdateDisplayName(t *testing.T) {
+	nameInit := qa.RandomName("tfgroup")
+	nameUpdate := qa.RandomName("tfgroup")
+	accountLevel(t, step{
+		Template: `resource "databricks_group" "this" {
+			display_name = "` + nameInit + `"
+		}`,
+		Check: resource.ComposeAggregateTestCheckFunc(
+			resource.TestCheckResourceAttr("databricks_group.this", "display_name", nameInit),
+			resourceCheck("databricks_group.this",
+				func(ctx context.Context, client *common.DatabricksClient, id string) error {
+					groupsAPI := scim.NewGroupsAPI(ctx, client)
+					group, err := groupsAPI.Read(id, "displayName,entitlements")
+					if err != nil {
+						return err
+					}
+					assert.Equal(t, group.DisplayName, nameInit)
+					return nil
+				}),
+		),
+	}, step{
+		Template: `resource "databricks_group" "this" {
+			display_name = "` + nameUpdate + `"
+		}`,
+		Check: resource.ComposeAggregateTestCheckFunc(
+			resource.TestCheckResourceAttr("databricks_group.this", "display_name", nameUpdate),
+			resourceCheck("databricks_group.this",
+				func(ctx context.Context, client *common.DatabricksClient, id string) error {
+					groupsAPI := scim.NewGroupsAPI(ctx, client)
+					group, err := groupsAPI.Read(id, "displayName,entitlements")
+					if err != nil {
+						return err
+					}
+					assert.Equal(t, group.DisplayName, nameUpdate)
+					return nil
+				}),
+		),
+	})
+}
+func TestAccGroupsUpdateDisplayName(t *testing.T) {
+	nameInit := qa.RandomName("tfgroup")
+	nameUpdate := qa.RandomName("tfgroup")
+	workspaceLevel(t, step{
+		Template: `resource "databricks_group" "this" {
+			display_name = "` + nameInit + `"
+		}`,
+		Check: resource.ComposeAggregateTestCheckFunc(
+			resource.TestCheckResourceAttr("databricks_group.this", "display_name", nameInit),
+			resourceCheck("databricks_group.this",
+				func(ctx context.Context, client *common.DatabricksClient, id string) error {
+					groupsAPI := scim.NewGroupsAPI(ctx, client)
+					group, err := groupsAPI.Read(id, "displayName,entitlements")
+					if err != nil {
+						return err
+					}
+					assert.Equal(t, group.DisplayName, nameInit)
+					return nil
+				}),
+		),
+	}, step{
+		Template: `resource "databricks_group" "this" {
+			display_name = "` + nameUpdate + `"
+		}`,
+		Check: resource.ComposeAggregateTestCheckFunc(
+			resource.TestCheckResourceAttr("databricks_group.this", "display_name", nameUpdate),
+			resourceCheck("databricks_group.this",
+				func(ctx context.Context, client *common.DatabricksClient, id string) error {
+					groupsAPI := scim.NewGroupsAPI(ctx, client)
+					group, err := groupsAPI.Read(id, "displayName,entitlements")
+					if err != nil {
+						return err
+					}
+					assert.Equal(t, group.DisplayName, nameUpdate)
+					return nil
+				}),
+		),
 	})
 }

--- a/scim/resource_group.go
+++ b/scim/resource_group.go
@@ -13,7 +13,7 @@ import (
 // ResourceGroup manages user groups
 func ResourceGroup() common.Resource {
 	type entity struct {
-		DisplayName string `json:"display_name" tf:"force_new"`
+		DisplayName string `json:"display_name"`
 		ExternalID  string `json:"external_id,omitempty" tf:"force_new,suppress_diff"`
 		URL         string `json:"url,omitempty" tf:"computed"`
 	}

--- a/scim/resource_group_test.go
+++ b/scim/resource_group_test.go
@@ -282,7 +282,7 @@ func TestResourceGroupUpdate(t *testing.T) {
 		allow_cluster_create = true
 		databricks_sql_access = true
 		`,
-		RequiresNew: true,
+		RequiresNew: false,
 		Update:      true,
 		ID:          "abc",
 	}.Apply(t)


### PR DESCRIPTION
Existing group names can now be modified via API without forcing new creation.

Closes #2578

## Changes
Update data model for group's display_name to longer `force_new`. Modify corresponding unit tests and add acceptance tests. 

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [x] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [x] using Go SDK
