### PR TITLE
Update Aliases function for ResourceProvider to handle recursive structures more gracefully

### DIFF
--- a/clusters/resource_cluster.go
+++ b/clusters/resource_cluster.go
@@ -62,8 +62,8 @@ type ClusterSpec struct {
 	compute.ClusterSpec
 }
 
-func (ClusterSpec) Aliases() map[string]string {
-	return map[string]string{}
+func (ClusterSpec) Aliases() map[string]map[string]string {
+	return map[string]map[string]string{}
 }
 
 func (ClusterSpec) CustomizeSchema(s map[string]*schema.Schema) map[string]*schema.Schema {

--- a/clusters/resource_cluster.go
+++ b/clusters/resource_cluster.go
@@ -62,10 +62,6 @@ type ClusterSpec struct {
 	compute.ClusterSpec
 }
 
-func (ClusterSpec) Aliases() map[string]map[string]string {
-	return map[string]map[string]string{}
-}
-
 func (ClusterSpec) CustomizeSchema(s map[string]*schema.Schema) map[string]*schema.Schema {
 	common.CustomizeSchemaPath(s, "cluster_source").SetReadOnly()
 	common.CustomizeSchemaPath(s, "enable_elastic_disk").SetComputed()

--- a/common/recursion_tracking.go
+++ b/common/recursion_tracking.go
@@ -14,7 +14,6 @@ type recursionTrackingContext struct {
 func (rt recursionTrackingContext) depthExceeded(typeField reflect.StructField) bool {
 	typeName := getNameForType(typeField.Type)
 	if maxDepth, ok := rt.maxDepthForTypes[typeName]; ok {
-		println("in if!!")
 		return rt.timesVisited[typeName]+1 > maxDepth
 	}
 	return false

--- a/common/recursion_tracking.go
+++ b/common/recursion_tracking.go
@@ -34,7 +34,7 @@ func (rt recursionTrackingContext) copy() recursionTrackingContext {
 }
 
 func (rt recursionTrackingContext) visit(v reflect.Value) {
-	rt.timesVisited[strings.TrimPrefix(v.Type().String(), "*")] += 1
+	rt.timesVisited[getNameForType(v.Type())] += 1
 }
 
 func getEmptyRecursionTrackingContext() recursionTrackingContext {

--- a/common/recursion_tracking.go
+++ b/common/recursion_tracking.go
@@ -13,8 +13,6 @@ type recursionTrackingContext struct {
 
 func (rt recursionTrackingContext) depthExceeded(typeField reflect.StructField) bool {
 	typeName := getNameForType(typeField.Type)
-	println("========")
-	println(typeName)
 	if maxDepth, ok := rt.maxDepthForTypes[typeName]; ok {
 		println("in if!!")
 		return rt.timesVisited[typeName]+1 > maxDepth

--- a/common/recursion_tracking.go
+++ b/common/recursion_tracking.go
@@ -12,19 +12,15 @@ type recursionTrackingContext struct {
 }
 
 func (rt recursionTrackingContext) depthExceeded(typeField reflect.StructField) bool {
-	typeName := rt.getNameForTypeField(typeField)
+	typeName := getNameForType(typeField.Type)
 	if maxDepth, ok := rt.maxDepthForTypes[typeName]; ok {
 		return rt.timesVisited[typeName]+1 > maxDepth
 	}
 	return false
 }
 
-func (rt recursionTrackingContext) getNameForTypeField(typeField reflect.StructField) string {
-	return strings.TrimPrefix(typeField.Type.String(), "*")
-}
-
 func (rt recursionTrackingContext) getMaxDepthForTypeField(typeField reflect.StructField) int {
-	typeName := rt.getNameForTypeField(typeField)
+	typeName := getNameForType(typeField.Type)
 	return rt.maxDepthForTypes[typeName]
 }
 
@@ -53,4 +49,8 @@ func getRecursionTrackingContext(rp RecursiveResourceProvider) recursionTracking
 		map[string]int{},
 		rp.MaxDepthForTypes(),
 	}
+}
+
+func getNameForType(t reflect.Type) string {
+	return strings.TrimPrefix(t.String(), "*")
 }

--- a/common/recursion_tracking.go
+++ b/common/recursion_tracking.go
@@ -13,7 +13,10 @@ type recursionTrackingContext struct {
 
 func (rt recursionTrackingContext) depthExceeded(typeField reflect.StructField) bool {
 	typeName := getNameForType(typeField.Type)
+	println("========")
+	println(typeName)
 	if maxDepth, ok := rt.maxDepthForTypes[typeName]; ok {
+		println("in if!!")
 		return rt.timesVisited[typeName]+1 > maxDepth
 	}
 	return false

--- a/common/reflect_resource.go
+++ b/common/reflect_resource.go
@@ -475,26 +475,6 @@ func isGoSdk(v reflect.Value) bool {
 	return false
 }
 
-// Unwraps aliases map given a fieldname. Should be called everytime we recursively call iterFields.
-//
-// NOTE: If the target field has an alias, we expect `fieldname` argument to be the alias.
-// For example
-//
-//	fieldName = "cluster"
-//	aliases = {"cluster.clusterName": "name", "libraries": "library"}
-//	would return: {"clusterName": "name"}
-func unwrapAliasesMap(fieldName string, aliases map[string]string) map[string]string {
-	result := make(map[string]string)
-	prefix := fieldName + "."
-	for key, value := range aliases {
-		// Only keep the keys that have the prefix.
-		if strings.HasPrefix(key, prefix) && key != prefix {
-			result[key] = value
-		}
-	}
-	return result
-}
-
 // Iterate through each field of the given reflect.Value object and execute a callback function with the corresponding
 // terraform schema object as the input.
 func iterFields(rv reflect.Value, path []string, s map[string]*schema.Schema, aliases map[string]map[string]string,

--- a/common/reflect_resource.go
+++ b/common/reflect_resource.go
@@ -38,21 +38,26 @@ var kindMap = map[reflect.Kind]string{
 	reflect.UnsafePointer: "UnsafePointer",
 }
 
-// Generic interface for ResourceProvider. Using CustomizeSchema and Aliases functions to keep track of additional information
-// on top of the generated go-sdk struct. This is used to replace manually maintained structs with `tf` tags.
-//
-// Aliases() returns a two dimensional map where the top level key is the name of the struct, the second level key is the name of the field,
-// the values are the alias for the corresponding field under the specified struct.
-// Example:
-//
-//	{
-//	    "compute.ClusterSpec": {
-//	        "libraries": "library"
-//	    }
-//	}
+// Generic interface for ResourceProvider. Using CustomizeSchema function to keep track of additional information
+// on top of the generated go-sdk struct.
 type ResourceProvider interface {
-	Aliases() map[string]map[string]string
 	CustomizeSchema(map[string]*schema.Schema) map[string]*schema.Schema
+}
+
+// Interface for ResourceProvider instances that need aliases for fields.
+// The function MaxDepthForTypes allows us to specify the max number of recursive depth for a specific field
+type ResourceProviderWithAlias interface {
+	ResourceProvider
+	// Aliases() returns a two dimensional map where the top level key is the name of the struct, the second level key is the name of the field,
+	// the values are the alias for the corresponding field under the specified struct.
+	// Example:
+	//
+	//	{
+	//	    "compute.ClusterSpec": {
+	//	        "libraries": "library"
+	//	    }
+	//	}
+	Aliases() map[string]map[string]string
 }
 
 // Interface for ResourceProvider instances that have recursive references in its schema.
@@ -72,10 +77,14 @@ type RecursiveResourceProvider interface {
 func resourceProviderStructToSchema(v ResourceProvider) map[string]*schema.Schema {
 	rv := reflect.ValueOf(v)
 	var scm map[string]*schema.Schema
+	aliases := map[string]map[string]string{}
+	if rpwa, ok := v.(ResourceProviderWithAlias); ok {
+		aliases = rpwa.Aliases()
+	}
 	if rrp, ok := v.(RecursiveResourceProvider); ok {
-		scm = typeToSchema(rv, v.Aliases(), getRecursionTrackingContext(rrp))
+		scm = typeToSchema(rv, aliases, getRecursionTrackingContext(rrp))
 	} else {
-		scm = typeToSchema(rv, v.Aliases(), getEmptyRecursionTrackingContext())
+		scm = typeToSchema(rv, aliases, getEmptyRecursionTrackingContext())
 	}
 	scm = v.CustomizeSchema(scm)
 	return scm

--- a/common/reflect_resource.go
+++ b/common/reflect_resource.go
@@ -41,7 +41,7 @@ var kindMap = map[reflect.Kind]string{
 // Generic interface for ResourceProvider. Using CustomizeSchema and Aliases functions to keep track of additional information
 // on top of the generated go-sdk struct. This is used to replace manually maintained structs with `tf` tags.
 type ResourceProvider interface {
-	Aliases() map[string]string
+	Aliases() map[string]map[string]string
 	CustomizeSchema(map[string]*schema.Schema) map[string]*schema.Schema
 }
 
@@ -79,10 +79,11 @@ func reflectKind(k reflect.Kind) string {
 	return n
 }
 
-func chooseFieldNameWithAliases(typeField reflect.StructField, aliases map[string]string) string {
+func chooseFieldNameWithAliases(typeField reflect.StructField, parentTypeName string, aliases map[string]map[string]string) string {
+	fieldNameWithAliasTag := chooseFieldName(typeField)
 	// If nothing in the aliases map, return the field name from plain chooseFieldName method.
 	if len(aliases) == 0 {
-		return chooseFieldName(typeField)
+		return fieldNameWithAliasTag
 	}
 
 	jsonFieldName := getJsonFieldName(typeField)
@@ -90,10 +91,12 @@ func chooseFieldNameWithAliases(typeField reflect.StructField, aliases map[strin
 		return "-"
 	}
 
-	if value, ok := aliases[jsonFieldName]; ok {
-		return value
+	if parentMap, ok := aliases[parentTypeName]; ok {
+		if value, ok := parentMap[jsonFieldName]; ok {
+			return value
+		}
 	}
-	return jsonFieldName
+	return fieldNameWithAliasTag
 }
 
 func getJsonFieldName(typeField reflect.StructField) string {
@@ -144,7 +147,7 @@ func StructToSchema(v any, customize func(map[string]*schema.Schema) map[string]
 		return resourceProviderStructToSchema(rp)
 	}
 	rv := reflect.ValueOf(v)
-	scm := typeToSchema(rv, map[string]string{}, getEmptyRecursionTrackingContext())
+	scm := typeToSchema(rv, map[string]map[string]string{}, getEmptyRecursionTrackingContext())
 	if customize != nil {
 		scm = customize(scm)
 	}
@@ -295,7 +298,8 @@ func listAllFields(v reflect.Value) []field {
 	return fields
 }
 
-func typeToSchema(v reflect.Value, aliases map[string]string, rt recursionTrackingContext) map[string]*schema.Schema {
+func typeToSchema(v reflect.Value, aliases map[string]map[string]string, rt recursionTrackingContext) map[string]*schema.Schema {
+	typeName := getNameForType(v.Type())
 	scm := map[string]*schema.Schema{}
 	rk := v.Kind()
 	if rk == reflect.Ptr {
@@ -312,13 +316,12 @@ func typeToSchema(v reflect.Value, aliases map[string]string, rt recursionTracki
 		typeField := field.sf
 		if rt.depthExceeded(typeField) {
 			// Skip the field if recursion depth is over the limit.
-			log.Printf("[TRACE] over recursion limit, skipping field: %s, max depth: %d", rt.getNameForTypeField(typeField), rt.getMaxDepthForTypeField(typeField))
+			log.Printf("[TRACE] over recursion limit, skipping field: %s, max depth: %d", getNameForType(typeField.Type), rt.getMaxDepthForTypeField(typeField))
 			continue
 		}
 		tfTag := typeField.Tag.Get("tf")
 
-		fieldName := chooseFieldNameWithAliases(typeField, aliases)
-		unwrappedAliases := unwrapAliasesMap(fieldName, aliases)
+		fieldName := chooseFieldNameWithAliases(typeField, typeName, aliases)
 		if fieldName == "-" {
 			continue
 		}
@@ -381,7 +384,7 @@ func typeToSchema(v reflect.Value, aliases map[string]string, rt recursionTracki
 			scm[fieldName].Type = schema.TypeList
 			elem := typeField.Type.Elem()
 			sv := reflect.New(elem).Elem()
-			nestedSchema := typeToSchema(sv, unwrappedAliases, rt)
+			nestedSchema := typeToSchema(sv, aliases, rt)
 			if strings.Contains(tfTag, "suppress_diff") {
 				scm[fieldName].DiffSuppressFunc = diffSuppressor(fieldName, scm[fieldName])
 				for k, v := range nestedSchema {
@@ -398,7 +401,7 @@ func typeToSchema(v reflect.Value, aliases map[string]string, rt recursionTracki
 			elem := typeField.Type  // changed from ptr
 			sv := reflect.New(elem) // changed from ptr
 
-			nestedSchema := typeToSchema(sv, unwrappedAliases, rt)
+			nestedSchema := typeToSchema(sv, aliases, rt)
 			if strings.Contains(tfTag, "suppress_diff") {
 				scm[fieldName].DiffSuppressFunc = diffSuppressor(fieldName, scm[fieldName])
 				for k, v := range nestedSchema {
@@ -427,7 +430,7 @@ func typeToSchema(v reflect.Value, aliases map[string]string, rt recursionTracki
 			case reflect.Struct:
 				sv := reflect.New(elem).Elem()
 				scm[fieldName].Elem = &schema.Resource{
-					Schema: typeToSchema(sv, unwrappedAliases, rt),
+					Schema: typeToSchema(sv, aliases, rt),
 				}
 			}
 		default:
@@ -446,7 +449,7 @@ func IsRequestEmpty(v any) (bool, error) {
 		return false, fmt.Errorf("value of Struct is expected, but got %s: %#v", reflectKind(rv.Kind()), rv)
 	}
 	var isNotEmpty bool
-	err := iterFields(rv, []string{}, StructToSchema(v, nil), map[string]string{}, func(fieldSchema *schema.Schema, path []string, valueField *reflect.Value) error {
+	err := iterFields(rv, []string{}, StructToSchema(v, nil), map[string]map[string]string{}, func(fieldSchema *schema.Schema, path []string, valueField *reflect.Value) error {
 		if isNotEmpty {
 			return nil
 		}
@@ -494,7 +497,7 @@ func unwrapAliasesMap(fieldName string, aliases map[string]string) map[string]st
 
 // Iterate through each field of the given reflect.Value object and execute a callback function with the corresponding
 // terraform schema object as the input.
-func iterFields(rv reflect.Value, path []string, s map[string]*schema.Schema, aliases map[string]string,
+func iterFields(rv reflect.Value, path []string, s map[string]*schema.Schema, aliases map[string]map[string]string,
 	cb func(fieldSchema *schema.Schema, path []string, valueField *reflect.Value) error) error {
 	rk := rv.Kind()
 	if rk != reflect.Struct {
@@ -505,9 +508,10 @@ func iterFields(rv reflect.Value, path []string, s map[string]*schema.Schema, al
 	}
 	isGoSDK := isGoSdk(rv)
 	fields := listAllFields(rv)
+	parentTypeName := getNameForType(rv.Type())
 	for _, field := range fields {
 		typeField := field.sf
-		fieldName := chooseFieldNameWithAliases(typeField, aliases)
+		fieldName := chooseFieldNameWithAliases(typeField, parentTypeName, aliases)
 		if fieldName == "-" {
 			continue
 		}
@@ -533,7 +537,7 @@ func iterFields(rv reflect.Value, path []string, s map[string]*schema.Schema, al
 	return nil
 }
 
-func collectionToMaps(v any, s *schema.Schema, aliases map[string]string) ([]any, error) {
+func collectionToMaps(v any, s *schema.Schema, aliases map[string]map[string]string) ([]any, error) {
 	resultList := []any{}
 	if sl, ok := v.([]string); ok {
 		// most likely list of parameters to job task
@@ -568,12 +572,11 @@ func collectionToMaps(v any, s *schema.Schema, aliases map[string]string) ([]any
 		err := iterFields(v, []string{}, r.Schema, aliases, func(fieldSchema *schema.Schema,
 			path []string, valueField *reflect.Value) error {
 			fieldName := path[len(path)-1]
-			newAliases := unwrapAliasesMap(fieldName, aliases)
 			fieldValue := valueField.Interface()
 			fieldPath := strings.Join(path, ".")
 			switch fieldSchema.Type {
 			case schema.TypeList, schema.TypeSet:
-				nv, err := collectionToMaps(fieldValue, fieldSchema, newAliases)
+				nv, err := collectionToMaps(fieldValue, fieldSchema, aliases)
 				if err != nil {
 					return fmt.Errorf("%s: %v", path, err)
 				}
@@ -704,25 +707,23 @@ func DataToStructPointer(d *schema.ResourceData, scm map[string]*schema.Schema, 
 // DataToReflectValue reads reflect value from data
 func DataToReflectValue(d *schema.ResourceData, s map[string]*schema.Schema, rv reflect.Value) error {
 	// TODO: Pass in the right aliases map.
-	return readReflectValueFromData([]string{}, d, rv, s, map[string]string{})
+	return readReflectValueFromData([]string{}, d, rv, s, map[string]map[string]string{})
 }
 
 // Get the aliases map from the given struct if it is an instance of ResourceProvider.
 // NOTE: This does not return aliases defined on `tf` tags.
-func getAliasesMapFromStruct(s any) map[string]string {
+func getAliasesMapFromStruct(s any) map[string]map[string]string {
 	if v, ok := s.(ResourceProvider); ok {
 		return v.Aliases()
 	}
-	return map[string]string{}
+	return map[string]map[string]string{}
 }
 
 func readReflectValueFromData(path []string, d attributeGetter,
-	rv reflect.Value, s map[string]*schema.Schema, aliases map[string]string) error {
+	rv reflect.Value, s map[string]*schema.Schema, aliases map[string]map[string]string) error {
 	return iterFields(rv, path, s, aliases, func(fieldSchema *schema.Schema,
 		path []string, valueField *reflect.Value) error {
 		fieldPath := strings.Join(path, ".")
-		fieldName := path[len(path)-1]
-		newAliases := unwrapAliasesMap(fieldName, aliases)
 		raw, ok := d.GetOk(fieldPath)
 		if !ok {
 			return nil
@@ -759,13 +760,13 @@ func readReflectValueFromData(path []string, d attributeGetter,
 			rawSet := raw.(*schema.Set)
 			rawList := rawSet.List()
 			return readListFromData(path, d, rawList, valueField,
-				fieldSchema, newAliases, func(i int) string {
+				fieldSchema, aliases, func(i int) string {
 					return strconv.Itoa(rawSet.F(rawList[i]))
 				})
 		case schema.TypeList:
 			// here we rely on Terraform SDK to perform validation, so we don't to it twice
 			rawList := raw.([]any)
-			return readListFromData(path, d, rawList, valueField, fieldSchema, newAliases, strconv.Itoa)
+			return readListFromData(path, d, rawList, valueField, fieldSchema, aliases, strconv.Itoa)
 		default:
 			return fmt.Errorf("%s[%v] unsupported field type", fieldPath, raw)
 		}
@@ -818,7 +819,7 @@ func primitiveReflectValueFromInterface(rk reflect.Kind,
 }
 
 func readListFromData(path []string, d attributeGetter,
-	rawList []any, valueField *reflect.Value, fieldSchema *schema.Schema, aliases map[string]string,
+	rawList []any, valueField *reflect.Value, fieldSchema *schema.Schema, aliases map[string]map[string]string,
 	offsetConverter func(i int) string) error {
 	if len(rawList) == 0 {
 		return nil

--- a/common/reflect_resource.go
+++ b/common/reflect_resource.go
@@ -711,7 +711,7 @@ func DataToReflectValue(d *schema.ResourceData, s map[string]*schema.Schema, rv 
 // Get the aliases map from the given struct if it is an instance of ResourceProvider.
 // NOTE: This does not return aliases defined on `tf` tags.
 func getAliasesMapFromStruct(s any) map[string]map[string]string {
-	if v, ok := s.(ResourceProvider); ok {
+	if v, ok := s.(ResourceProviderWithAlias); ok {
 		return v.Aliases()
 	}
 	return map[string]map[string]string{}

--- a/common/reflect_resource.go
+++ b/common/reflect_resource.go
@@ -40,6 +40,16 @@ var kindMap = map[reflect.Kind]string{
 
 // Generic interface for ResourceProvider. Using CustomizeSchema and Aliases functions to keep track of additional information
 // on top of the generated go-sdk struct. This is used to replace manually maintained structs with `tf` tags.
+//
+// Aliases() returns a two dimensional map where the top level key is the name of the struct, the second level key is the name of the field,
+// the values are the alias for the corresponding field under the specified struct.
+// Example:
+//
+//	{
+//	    "compute.ClusterSpec": {
+//	        "libraries": "library"
+//	    }
+//	}
 type ResourceProvider interface {
 	Aliases() map[string]map[string]string
 	CustomizeSchema(map[string]*schema.Schema) map[string]*schema.Schema

--- a/common/reflect_resource.go
+++ b/common/reflect_resource.go
@@ -45,7 +45,6 @@ type ResourceProvider interface {
 }
 
 // Interface for ResourceProvider instances that need aliases for fields.
-// The function MaxDepthForTypes allows us to specify the max number of recursive depth for a specific field
 type ResourceProviderWithAlias interface {
 	ResourceProvider
 	// Aliases() returns a two dimensional map where the top level key is the name of the struct, the second level key is the name of the field,

--- a/common/reflect_resource.go
+++ b/common/reflect_resource.go
@@ -79,7 +79,8 @@ func reflectKind(k reflect.Kind) string {
 	return n
 }
 
-func chooseFieldNameWithAliases(typeField reflect.StructField, parentTypeName string, aliases map[string]map[string]string) string {
+func chooseFieldNameWithAliases(typeField reflect.StructField, parentType reflect.Type, aliases map[string]map[string]string) string {
+	parentTypeName := getNameForType(parentType)
 	fieldNameWithAliasTag := chooseFieldName(typeField)
 	// If nothing in the aliases map, return the field name from plain chooseFieldName method.
 	if len(aliases) == 0 {
@@ -299,7 +300,6 @@ func listAllFields(v reflect.Value) []field {
 }
 
 func typeToSchema(v reflect.Value, aliases map[string]map[string]string, rt recursionTrackingContext) map[string]*schema.Schema {
-	typeName := getNameForType(v.Type())
 	scm := map[string]*schema.Schema{}
 	rk := v.Kind()
 	if rk == reflect.Ptr {
@@ -321,7 +321,7 @@ func typeToSchema(v reflect.Value, aliases map[string]map[string]string, rt recu
 		}
 		tfTag := typeField.Tag.Get("tf")
 
-		fieldName := chooseFieldNameWithAliases(typeField, typeName, aliases)
+		fieldName := chooseFieldNameWithAliases(typeField, v.Type(), aliases)
 		if fieldName == "-" {
 			continue
 		}
@@ -488,10 +488,9 @@ func iterFields(rv reflect.Value, path []string, s map[string]*schema.Schema, al
 	}
 	isGoSDK := isGoSdk(rv)
 	fields := listAllFields(rv)
-	parentTypeName := getNameForType(rv.Type())
 	for _, field := range fields {
 		typeField := field.sf
-		fieldName := chooseFieldNameWithAliases(typeField, parentTypeName, aliases)
+		fieldName := chooseFieldNameWithAliases(typeField, rv.Type(), aliases)
 		if fieldName == "-" {
 			continue
 		}

--- a/common/reflect_resource_test.go
+++ b/common/reflect_resource_test.go
@@ -270,7 +270,7 @@ type DummyResourceProvider struct {
 }
 
 func (DummyResourceProvider) Aliases() map[string]map[string]string {
-	return map[string]map[string]string{"common.DummyNoTfTag": {"enabled": "enabled_alias"},
+	return map[string]map[string]string{"common.DummyResourceProvider": {"enabled": "enabled_alias"},
 		"common.AddressNoTfTag": {"primary": "primary_alias"}}
 }
 

--- a/common/reflect_resource_test.go
+++ b/common/reflect_resource_test.go
@@ -48,7 +48,7 @@ func TestChooseFieldNameWithAliasesMap(t *testing.T) {
 	}
 	assert.Equal(t, "foo", chooseFieldNameWithAliases(reflect.StructField{
 		Tag: `json:"bar"`,
-	}, reflect.ValueOf(Bar{}).Type(), map[string]map[string]string{"Bar": {"bar": "foo"}}))
+	}, reflect.ValueOf(Bar{}).Type(), map[string]map[string]string{"common.Bar": {"bar": "foo"}}))
 }
 
 type testSliceItem struct {

--- a/common/reflect_resource_test.go
+++ b/common/reflect_resource_test.go
@@ -96,10 +96,6 @@ type testForEachTask struct {
 	Extra string       `json:"extra,omitempty"`
 }
 
-func (testRecursiveStruct) Aliases() map[string]map[string]string {
-	return map[string]map[string]string{}
-}
-
 func (testRecursiveStruct) CustomizeSchema(s map[string]*schema.Schema) map[string]*schema.Schema {
 	return s
 }

--- a/common/reflect_resource_test.go
+++ b/common/reflect_resource_test.go
@@ -269,9 +269,9 @@ type DummyResourceProvider struct {
 	DummyNoTfTag
 }
 
-func (DummyResourceProvider) Aliases() map[string]string {
-	return map[string]string{"enabled": "enabled_alias",
-		"addresses.primary": "primary_alias"}
+func (DummyResourceProvider) Aliases() map[string]map[string]string {
+	return map[string]map[string]string{"common.DummyNoTfTag": {"enabled": "enabled_alias"},
+		"common.AddressNoTfTag": {"primary": "primary_alias"}}
 }
 
 func (DummyResourceProvider) CustomizeSchema(s map[string]*schema.Schema) map[string]*schema.Schema {

--- a/common/reflect_resource_test.go
+++ b/common/reflect_resource_test.go
@@ -43,9 +43,12 @@ func TestChooseFieldName(t *testing.T) {
 }
 
 func TestChooseFieldNameWithAliasesMap(t *testing.T) {
+	type Bar struct {
+		Foo string `json:"foo,omitempty"`
+	}
 	assert.Equal(t, "foo", chooseFieldNameWithAliases(reflect.StructField{
 		Tag: `json:"bar"`,
-	}, "Bar", map[string]map[string]string{"Bar": {"bar": "foo"}}))
+	}, reflect.ValueOf(Bar{}).Type(), map[string]map[string]string{"Bar": {"bar": "foo"}}))
 }
 
 type testSliceItem struct {

--- a/common/reflect_resource_test.go
+++ b/common/reflect_resource_test.go
@@ -45,7 +45,7 @@ func TestChooseFieldName(t *testing.T) {
 func TestChooseFieldNameWithAliasesMap(t *testing.T) {
 	assert.Equal(t, "foo", chooseFieldNameWithAliases(reflect.StructField{
 		Tag: `json:"bar"`,
-	}, map[string]string{"bar": "foo"}))
+	}, "Bar", map[string]map[string]string{"Bar": {"bar": "foo"}}))
 }
 
 type testSliceItem struct {

--- a/common/reflect_resource_test.go
+++ b/common/reflect_resource_test.go
@@ -93,8 +93,8 @@ type testForEachTask struct {
 	Extra string       `json:"extra,omitempty"`
 }
 
-func (testRecursiveStruct) Aliases() map[string]string {
-	return map[string]string{}
+func (testRecursiveStruct) Aliases() map[string]map[string]string {
+	return map[string]map[string]string{}
 }
 
 func (testRecursiveStruct) CustomizeSchema(s map[string]*schema.Schema) map[string]*schema.Schema {


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
- This is a sub PR of https://github.com/databricks/terraform-provider-databricks/pull/3320
- Make `Aliases` function return a map of map which can derive aliases from the parent type name and field name.
- The goal is to avoid redundantly specifying the aliases in recursive data types such as the jobs for_each_task
- Also updating the `recursion_tracking.go` functions to make `getNameForType` more sharable 

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [x] covered with integration tests in `internal/acceptance`
- [x] relevant acceptance tests are passing
- [x] using Go SDK
