### PR TITLE
Fix storage credential doc guide

### DIFF
--- a/docs/guides/unity-catalog.md
+++ b/docs/guides/unity-catalog.md
@@ -30,7 +30,7 @@ To get started with Unity Catalog, this guide takes you through the following hi
   - [Create users and groups](#create-users-and-groups)
   - [Create a Unity Catalog metastore and link it to workspaces](#create-a-unity-catalog-metastore-and-link-it-to-workspaces)
   - [Configure external locations and credentials](#configure-external-locations-and-credentials)
-  - [Create Unity Catalog objects in the metastore](#create-unity-catalog-objects-in-the-metastore)  
+  - [Create Unity Catalog objects in the metastore](#create-unity-catalog-objects-in-the-metastore)
   - [Configure Unity Catalog clusters](#configure-unity-catalog-clusters)
 
 ## Provider initialization
@@ -315,7 +315,7 @@ resource "aws_iam_policy" "external_data_access" {
 }
 
 resource "aws_iam_role" "external_data_access" {
-  name                = "${local.prefix}-external-access"
+  name                = "${local.prefix}-uc-access"
   assume_role_policy  = data.aws_iam_policy_document.passrole_for_uc.json
   managed_policy_arns = [aws_iam_policy.external_data_access.arn]
   tags = merge(local.tags, {


### PR DESCRIPTION
## Changes
Updated the role created in the example to have the same name as referenced to in the self-assume policies and the storage credential. Also saw that the linter removed some white space in the MD file.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
