### PR TITLE
Exporter: Don't generate resources with empty names

### DIFF
--- a/exporter/context.go
+++ b/exporter/context.go
@@ -1185,6 +1185,7 @@ func (ic *importContext) Find(value, attr string, ref reference, origResource *r
 		if sr != nil && (ref.IsValidApproximation == nil || ref.IsValidApproximation(ic, origResource, sr, origPath)) {
 			log.Printf("[DEBUG] Finished direct lookup for reference for resource %s, attr='%s', value='%s', ref=%v. Found: type=%s name=%s",
 				ref.Resource, attr, value, ref, sr.Type, sr.Name)
+			// TODO: we need to not generate traversals resources for which their Ignore function returns true...
 			return matchValue, genTraversalTokens(sr, attr), sr.Mode == "data"
 		}
 		if ref.MatchType != MatchCaseInsensitive { // for case-insensitive matching we'll try iteration

--- a/exporter/importables.go
+++ b/exporter/importables.go
@@ -1657,6 +1657,7 @@ var resourcesMap map[string]importable = map[string]importable{
 			}
 			return nil
 		},
+		Ignore: generateIgnoreObjectWithoutName("databricks_sql_query"),
 		Depends: []reference{
 			{Path: "data_source_id", Resource: "databricks_sql_endpoint", Match: "data_source_id"},
 			{Path: "parameter.query.query_id", Resource: "databricks_sql_query", Match: "id"},
@@ -1705,6 +1706,7 @@ var resourcesMap map[string]importable = map[string]importable{
 			}
 			return nil
 		},
+		Ignore: generateIgnoreObjectWithoutName("databricks_sql_endpoint"),
 	},
 	"databricks_sql_global_config": {
 		WorkspaceLevel: true,
@@ -1896,6 +1898,7 @@ var resourcesMap map[string]importable = map[string]importable{
 			}
 			return nil
 		},
+		Ignore: generateIgnoreObjectWithoutName("databricks_sql_alert"),
 		Depends: []reference{
 			{Path: "query_id", Resource: "databricks_sql_query", Match: "id"},
 			{Path: "parent", Resource: "databricks_directory", Match: "object_id",
@@ -2418,6 +2421,7 @@ var resourcesMap map[string]importable = map[string]importable{
 			}
 			return shouldOmitForUnityCatalog(ic, pathString, as, d)
 		},
+		Ignore: generateIgnoreObjectWithoutName("databricks_catalog"),
 		Depends: []reference{
 			{Path: "connection_name", Resource: "databricks_connection", Match: "name"},
 			{Path: "storage_root", Resource: "databricks_external_location", Match: "url", MatchType: MatchLongestPrefix},
@@ -2495,6 +2499,7 @@ var resourcesMap map[string]importable = map[string]importable{
 			return nil
 		},
 		ShouldOmitField: shouldOmitForUnityCatalog,
+		Ignore:          generateIgnoreObjectWithoutName("databricks_schema"),
 		Depends: []reference{
 			{Path: "catalog_name", Resource: "databricks_catalog"},
 			{Path: "storage_root", Resource: "databricks_external_location", Match: "url", MatchType: MatchLongestPrefix},
@@ -2527,6 +2532,7 @@ var resourcesMap map[string]importable = map[string]importable{
 			}
 			return shouldOmitForUnityCatalog(ic, pathString, as, d)
 		},
+		Ignore: generateIgnoreObjectWithoutName("databricks_volume"),
 		Depends: []reference{
 			{Path: "catalog_name", Resource: "databricks_catalog"},
 			{Path: "schema_name", Resource: "databricks_schema", Match: "name",
@@ -2556,6 +2562,7 @@ var resourcesMap map[string]importable = map[string]importable{
 			// TODO: emit owner? See comment in catalog resource
 			return nil
 		},
+		Ignore: generateIgnoreObjectWithoutName("databricks_sql_table"),
 		ShouldOmitField: func(ic *importContext, pathString string, as *schema.Schema, d *schema.ResourceData) bool {
 			switch pathString {
 			case "storage_location":
@@ -2838,6 +2845,7 @@ var resourcesMap map[string]importable = map[string]importable{
 			}
 			return shouldOmitForUnityCatalog(ic, pathString, as, d)
 		},
+		Ignore: generateIgnoreObjectWithoutName("databricks_registered_model"),
 		Depends: []reference{
 			{Path: "catalog_name", Resource: "databricks_catalog"},
 			{Path: "schema_name", Resource: "databricks_schema", Match: "name",

--- a/exporter/util.go
+++ b/exporter/util.go
@@ -1327,3 +1327,13 @@ func isMatchingAllowListArtifact(ic *importContext, res *resource, ra *resourceA
 
 	return ok && matchType.(string) == "PREFIX_MATCH" && (artifactType == "LIBRARY_JAR" || artifactType == "INIT_SCRIPT")
 }
+
+func generateIgnoreObjectWithoutName(resourceType string) func(ic *importContext, r *resource) bool {
+	return func(ic *importContext, r *resource) bool {
+		res := (r.Data != nil && r.Data.Get("name").(string) == "")
+		if res {
+			ic.addIgnoredResource(fmt.Sprintf("%s. ID=%s", resourceType, r.ID))
+		}
+		return res
+	}
+}

--- a/exporter/util_test.go
+++ b/exporter/util_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/databricks/databricks-sdk-go/service/iam"
+	tfcatalog "github.com/databricks/terraform-provider-databricks/catalog"
 	"github.com/databricks/terraform-provider-databricks/clusters"
 	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/databricks/terraform-provider-databricks/qa"
@@ -389,4 +390,25 @@ func TestParallelListing(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 4, len(objects))
 
+}
+
+func TestIgnoreObjectWithEmptyName(t *testing.T) {
+	ic := importContextForTest()
+	// Test importing
+	d := tfcatalog.ResourceVolume().ToResource().TestResourceData()
+	d.SetId("vtest")
+	r := &resource{
+		ID:   "vtest",
+		Data: d,
+	}
+	//
+	ignoreFunc := resourcesMap["databricks_volume"].Ignore
+	require.NotNil(t, ignoreFunc)
+	assert.True(t, ignoreFunc(ic, r))
+	require.Equal(t, 1, len(ic.ignoredResources))
+	assert.Contains(t, ic.ignoredResources, "databricks_volume. ID=vtest")
+
+	d.Set("name", "test")
+	assert.False(t, ignoreFunc(ic, r))
+	assert.Equal(t, 1, len(ic.ignoredResources))
 }


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

Very often we emit resources that don't exist on the backend, and this creates incorrect resources without actual data. Typically this happens when objects are deleted but still referenced from jobs, dashboards, etc.

This PR skips the generation of resources where the `name` is the required attribute but it's empty in the state, meaning that resource doesn't exist on the backend.  This is done for the following resources:

* `databricks_sql_query`
* `databricks_sql_endpoint`
* `databricks_sql_alert
* `databricks_catalog`
* `databricks_schema`
* `databricks_volume`
* `databricks_sql_table`
* `databricks_registered_model`

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
