### PR TITLE
Delete Vector Search Endpoint when we get an error while waiting for creation

### DIFF
--- a/vectorsearch/resource_vector_search_endpoint.go
+++ b/vectorsearch/resource_vector_search_endpoint.go
@@ -2,6 +2,7 @@ package vectorsearch
 
 import (
 	"context"
+	"log"
 	"time"
 
 	"github.com/databricks/terraform-provider-databricks/common"
@@ -47,6 +48,13 @@ func ResourceVectorSearchEndpoint() common.Resource {
 			}
 			endpoint, err := wait.GetWithTimeout(d.Timeout(schema.TimeoutCreate))
 			if err != nil {
+				ctx2, cancel := context.WithDeadline(context.Background(), time.Now().Add(10*time.Second))
+				log.Printf("[ERROR] Error waiting for endpoint to be created: %s", err.Error())
+				err2 := w.VectorSearchEndpoints.DeleteEndpointByEndpointName(ctx2, req.Name)
+				if err2 != nil {
+					log.Printf("[ERROR] Error cleaning up endpoint: %s", err2.Error())
+				}
+				cancel()
 				return err
 			}
 			d.SetId(endpoint.Name)

--- a/vectorsearch/resource_vector_search_endpoint.go
+++ b/vectorsearch/resource_vector_search_endpoint.go
@@ -47,15 +47,13 @@ func ResourceVectorSearchEndpoint() common.Resource {
 			if err != nil {
 				return err
 			}
-			endpoint, err := wait.GetWithTimeout(d.Timeout(schema.TimeoutCreate))
+			endpoint, err := wait.GetWithTimeout(d.Timeout(schema.TimeoutCreate) - deleteCallTimeout)
 			if err != nil {
-				nestedContext, cancel := context.WithDeadline(context.Background(), time.Now().Add(deleteCallTimeout))
 				log.Printf("[ERROR] Error waiting for endpoint to be created: %s", err.Error())
-				nestedErr := w.VectorSearchEndpoints.DeleteEndpointByEndpointName(nestedContext, req.Name)
+				nestedErr := w.VectorSearchEndpoints.DeleteEndpointByEndpointName(ctx, req.Name)
 				if nestedErr != nil {
 					log.Printf("[ERROR] Error cleaning up endpoint: %s", nestedErr.Error())
 				}
-				cancel()
 				return err
 			}
 			d.SetId(endpoint.Name)


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

If we get an error while waiting for the endpoint creation we simply return that error.  But when we got a timeout, we didn't clean the endpoint and this led to the resource not being destroyed in the tests as the backend continued to provision it.

This PR deletes the vector search endpoint when we get a creation error during the wait phase. This behaviour is similar to the current behaviour of clusters.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [x] using Go SDK
