### PR TITLE
Disable Lakehouse Monitoring integration tests on GCP

### DIFF
--- a/internal/acceptance/lakehouse_monitor_test.go
+++ b/internal/acceptance/lakehouse_monitor_test.go
@@ -1,6 +1,7 @@
 package acceptance
 
 import (
+	"os"
 	"testing"
 )
 
@@ -46,6 +47,9 @@ resource "databricks_sql_table" "myInferenceTable" {
 `
 
 func TestUcAccLakehouseMonitor(t *testing.T) {
+	if os.Getenv("GOOGLE_CREDENTIALS") != "" {
+		t.Skipf("databricks_lakehouse_monitor resource is not available on GCP")
+	}
 	unityWorkspaceLevel(t, step{
 		Template: commonPartLakehouseMonitoring + `
 
@@ -110,6 +114,9 @@ func TestUcAccLakehouseMonitor(t *testing.T) {
 }
 
 func TestUcAccUpdateLakehouseMonitor(t *testing.T) {
+	if os.Getenv("GOOGLE_CREDENTIALS") != "" {
+		t.Skipf("databricks_lakehouse_monitor resource is not available on GCP")
+	}
 	unityWorkspaceLevel(t, step{
 		Template: commonPartLakehouseMonitoring + `
 			resource "databricks_lakehouse_monitor" "testMonitorInference" {


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

LM isn't available on GCP yet

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [x] covered with integration tests in `internal/acceptance`
- [x] relevant acceptance tests are passing
- [ ] using Go SDK
