### PR TITLE
Exporter: modify grants for some UC objects to allow handling of other owners

### DIFF
--- a/docs/guides/experimental-exporter.md
+++ b/docs/guides/experimental-exporter.md
@@ -84,7 +84,7 @@ Services are just logical groups of resources used for filtering and organizatio
 * `uc-catalogs` - **listing** [databricks_catalog](../resources/catalog.md) and [databricks_catalog_workspace_binding](../resources/catalog_workspace_binding.md)
 * `uc-connections` - **listing** [databricks_connection](../resources/connection.md).  *Please note that because API doesn't return sensitive fields, such as, passwords, tokens, ..., the generated `options` block could be incomplete!*
 * `uc-external-locations` - **listing** exports [databricks_external_location](../resources/external_location.md) resource.
-* `uc-grants` -  [databricks_grants](../resources/grants.md)
+* `uc-grants` -  [databricks_grants](../resources/grants.md). *Please note that during export the list of grants is expanded to include the identity that does the export! This is done to allow to create objects in case when catalogs/schemas have different owners than current identity.*.
 * `uc-metastores` - **listing** [databricks_metastore](../resources/metastore.md) and [databricks_metastore_assignment](../resource/metastore_assignment.md) (only on account-level).  *Please note that when using workspace-level configuration, only metastores from the workspace's region are listed!*
 * `uc-models` - [databricks_registered_model](../resources/registered_model.md)
 * `uc-schemas` -  [databricks_schema](../resources/schema.md)

--- a/exporter/context.go
+++ b/exporter/context.go
@@ -99,6 +99,7 @@ type importContext struct {
 	lastActiveMs             int64
 	generateDeclaration      bool
 	meAdmin                  bool
+	meUserName               string
 	prefix                   string
 	accountLevel             bool
 	shImports                map[string]bool
@@ -339,6 +340,7 @@ func (ic *importContext) Run() error {
 	ic.accountLevel = ic.Client.Config.IsAccountClient()
 	if ic.accountLevel {
 		ic.meAdmin = true
+		// TODO: check if we can get the current user from the account client
 		ic.accountClient, err = ic.Client.AccountClient()
 		if err != nil {
 			return err
@@ -355,6 +357,7 @@ func (ic *importContext) Run() error {
 		for _, g := range me.Groups {
 			if g.Display == "admins" {
 				ic.meAdmin = true
+				ic.meUserName = me.UserName
 				break
 			}
 		}

--- a/exporter/importables_test.go
+++ b/exporter/importables_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"sort"
 	"sync"
 	"testing"
 
@@ -2164,4 +2165,61 @@ func TestImportUcVolumeFile(t *testing.T) {
 
 		assert.Equal(t, "main/default/wheels/some.whl_f27badf8", resourcesMap["databricks_file"].Name(nil, d))
 	})
+}
+
+func sortStringsCopy(s []string) []string {
+	c := make([]string, len(s))
+	copy(c, s)
+	sort.Strings(c)
+	return c
+}
+
+func TestImportGrants(t *testing.T) {
+	ic := importContextForTest()
+
+	s := ic.Resources["databricks_grants"].Schema
+	d := tfcatalog.ResourceGrants().ToResource().TestResourceData()
+	id := "metastore/1234"
+	d.SetId(id)
+	d.MarkNewResource()
+	r := &resource{ID: id, Data: d}
+	err := resourcesMap["databricks_grants"].Import(ic, r)
+	assert.NoError(t, err)
+
+	// Test ignore function
+	assert.True(t, resourcesMap["databricks_grants"].Ignore(ic, r))
+
+	var pList tfcatalog.PermissionsList
+	common.DataToStructPointer(r.Data, s, &pList)
+	assert.Empty(t, pList.Assignments)
+
+	// Test with a filled user name and no permissions
+	ic.meUserName = "user@domain.com"
+	d.Set("metastore", "1234")
+	err = resourcesMap["databricks_grants"].Import(ic, r)
+	assert.NoError(t, err)
+	common.DataToStructPointer(r.Data, s, &pList)
+	require.Equal(t, 1, len(pList.Assignments))
+	assert.Equal(t, ic.meUserName, pList.Assignments[0].Principal)
+	assert.Equal(t, sortStringsCopy(metastorePrivilegesToAdd), sortStringsCopy(pList.Assignments[0].Privileges))
+
+	// Test with a filled user name and permissions
+	d.Set("metastore", "")
+	d.Set("catalog", "test")
+	pList.Assignments = []tfcatalog.PrivilegeAssignment{
+		{Principal: ic.meUserName, Privileges: []string{"USE_CATALOG", "USE_SCHEMA"}},
+	}
+	common.StructToData(pList, s, d)
+	err = resourcesMap["databricks_grants"].Import(ic, r)
+	assert.NoError(t, err)
+	common.DataToStructPointer(r.Data, s, &pList)
+	require.Equal(t, 1, len(pList.Assignments))
+	assert.Equal(t, ic.meUserName, pList.Assignments[0].Principal)
+	assert.Equal(t, sortStringsCopy(defaultPrivilegesToAdd), sortStringsCopy(pList.Assignments[0].Privileges))
+
+	// Test with a filled user name and unsupported objects
+	d.Set("catalog", "")
+	d.Set("model", "test")
+	err = resourcesMap["databricks_grants"].Import(ic, r)
+	assert.NoError(t, err)
 }

--- a/exporter/model.go
+++ b/exporter/model.go
@@ -236,6 +236,23 @@ type resource struct {
 	Incremental bool
 	// Actual Terraform data
 	Data *schema.ResourceData
+	// Arbitrary data to be used by importable
+	ExtraData map[string]any
+}
+
+func (r *resource) AddExtraData(key string, value any) {
+	if r.ExtraData == nil {
+		r.ExtraData = map[string]any{}
+	}
+	r.ExtraData[key] = value
+}
+
+func (r *resource) GetExtraData(key string) (any, bool) {
+	if r.ExtraData == nil {
+		return nil, false
+	}
+	v, ok := r.ExtraData[key]
+	return v, ok
 }
 
 func (r *resource) MatchPair() (string, string) {

--- a/exporter/model_test.go
+++ b/exporter/model_test.go
@@ -19,3 +19,14 @@ func TestResourceApproaximationGet(t *testing.T) {
 	require.True(t, found)
 	assert.Equal(t, "42", v.(string))
 }
+
+func TestExtraDataGet(t *testing.T) {
+	r := &resource{}
+	_, found := r.GetExtraData("test")
+	assert.False(t, found)
+
+	r.AddExtraData("test", "42")
+	v, found := r.GetExtraData("test")
+	require.True(t, found)
+	assert.Equal(t, "42", v.(string))
+}

--- a/exporter/util.go
+++ b/exporter/util.go
@@ -1337,3 +1337,16 @@ func generateIgnoreObjectWithoutName(resourceType string) func(ic *importContext
 		return res
 	}
 }
+
+func (ic *importContext) emitUCGrantsWithOwner(id string, parentResource *resource) {
+	gr := &resource{
+		Resource: "databricks_grants",
+		ID:       id,
+	}
+	if parentResource.Data != nil {
+		if owner, ok := parentResource.Data.GetOk("owner"); ok {
+			gr.AddExtraData("owner", owner)
+		}
+	}
+	ic.Emit(gr)
+}


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->


If UC objects, such as metastore, catalogs, schemas, volumes, etc. have an owner other than the current user, then it's impossible to create child objects during apply.  To mitigate this, the list of grants is expanded/changed to allow the creation of child objects by the identity who does the export (it's done only on the workspace level, and the same identity must be used when doing import).

TODOs:
- we need to discuss if we should use `ALL_PRIVILEGES` for catalogs/schemas/... vs. specific permissions like, `CREATE_SCHEMA` for catalogs, etc. @nkvuong What do you think?
- investigate if we can get the owner of the object, and don't add permissions if it's the current user - this may lead to increased API calls

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
