### PR TITLE
Remove empty lines from view_definition to avoid unecessary recreation of resources

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Bug Fixes
 
+* Fixed `databricks_sql_table` view definitions being replaced due to whitespace-only changes.
 * Fixed `databricks_mws_workspaces` failing to update `private_access_settings_id` and other fields on GCP workspaces ([#5430](https://github.com/databricks/terraform-provider-databricks/issues/5430)).
 
 ### Documentation

--- a/catalog/resource_sql_table.go
+++ b/catalog/resource_sql_table.go
@@ -84,7 +84,7 @@ func (ti SqlTableInfo) CustomizeSchema(s *common.CustomizableSchema) *common.Cus
 		return strings.EqualFold(strings.ToLower(old), strings.ToLower(new))
 	})
 	s.SchemaPath("storage_location").SetCustomSuppressDiff(ucDirectoryPathSlashAndEmptySuppressDiff)
-	s.SchemaPath("view_definition").SetCustomSuppressDiff(common.SuppressDiffWhitespaceChange)
+	s.SchemaPath("view_definition").SetCustomSuppressDiff(common.SuppressDiffWhitespaceAndEmptyLines)
 
 	s.SchemaPath("cluster_id").SetConflictsWith([]string{"warehouse_id"})
 	s.SchemaPath("warehouse_id").SetConflictsWith([]string{"cluster_id"})

--- a/catalog/resource_sql_table.go
+++ b/catalog/resource_sql_table.go
@@ -436,7 +436,7 @@ func (ti *SqlTableInfo) diff(oldti *SqlTableInfo) ([]string, error) {
 	if ti.TableType == "VIEW" {
 		// View only attributes
 		ti.formatViewDefinition()
-		if ti.ViewDefinition != oldti.ViewDefinition {
+		if common.NormalizeWhitespaceAndEmptyLines(ti.ViewDefinition) != common.NormalizeWhitespaceAndEmptyLines(oldti.ViewDefinition) {
 			statements = append(statements, fmt.Sprintf("ALTER VIEW %s AS %s", ti.SQLFullName(), ti.ViewDefinition))
 		}
 	} else {

--- a/catalog/resource_sql_table_test.go
+++ b/catalog/resource_sql_table_test.go
@@ -892,6 +892,56 @@ func TestResourceSqlTableUpdateView_Definition(t *testing.T) {
 	}.ApplyNoError(t)
 }
 
+func TestResourceSqlTableUpdateView_IgnoreNewlineInDefinition(t *testing.T) {
+	commandExecuted := false
+
+	_, err := qa.ResourceFixture{
+		CommandMock: func(commandStr string) common.CommandResults {
+			commandExecuted = true
+			return common.CommandResults{
+				ResultType: "",
+				Data:       nil,
+			}
+		},
+		HCL: `
+        resource "databricks_sql_table" "test" {
+            name            = "barview"
+            catalog_name    = "main"
+            schema_name     = "foo"
+            table_type      = "VIEW"
+            cluster_id      = "existingcluster"
+            view_definition = "SELECT * FROM main.foo.bar\n\n"
+        }`,
+		InstanceState: map[string]string{
+			"name":            "barview",
+			"catalog_name":    "main",
+			"schema_name":     "foo",
+			"table_type":      "VIEW",
+			"cluster_id":      "existingcluster",
+			"view_definition": "SELECT * FROM main.foo.bar",
+		},
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "GET",
+				Resource: "/api/2.1/unity-catalog/tables/main.foo.barview",
+				Response: SqlTableInfo{
+					Name:           "barview",
+					CatalogName:    "main",
+					SchemaName:     "foo",
+					TableType:      "VIEW",
+					ViewDefinition: "SELECT * FROM main.foo.bar",
+				},
+			},
+		},
+		Resource: ResourceSqlTable(),
+		Update:   true,
+		ID:       "main.foo.barview",
+	}.Apply(t)
+
+	assert.NoError(t, err)
+	assert.False(t, commandExecuted, "No update command should be executed for only newline changes in view_definition")
+}
+
 func TestResourceSqlTableUpdateView_Comments(t *testing.T) {
 	d, err := qa.ResourceFixture{
 		CommandMock: func(commandStr string) common.CommandResults {

--- a/catalog/resource_sql_table_test.go
+++ b/catalog/resource_sql_table_test.go
@@ -894,21 +894,6 @@ func TestResourceSqlTableUpdateView_Definition(t *testing.T) {
 
 func TestResourceSqlTableUpdateView_IgnoreNewlineInDefinition(t *testing.T) {
 	qa.ResourceFixture{
-		CommandMock: func(commandStr string) common.CommandResults {
-			assert.NotContains(t, commandStr, "ALTERR VIEW `main`.`foo`.`barview`", "New lines should not recreate the resource")
-			return common.CommandResults{
-				ResultType: "",
-				Data:       nil,
-			}
-		},
-		HCL: `
-		name               = "barview"
-		catalog_name       = "main"
-		schema_name        = "foo"
-		table_type         = "VIEW"
-		cluster_id         = "existingcluster"
-		view_definition    = "SELECT * FROM main.foo.bar \n\n"
-		`,
 		InstanceState: map[string]string{
 			"name":            "barview",
 			"catalog_name":    "main",
@@ -917,42 +902,132 @@ func TestResourceSqlTableUpdateView_IgnoreNewlineInDefinition(t *testing.T) {
 			"cluster_id":      "existingcluster",
 			"view_definition": "SELECT * FROM main.foo.bar",
 		},
-		Fixtures: append([]qa.HTTPFixture{
-			{
-				Method:   "GET",
-				Resource: "/api/2.1/unity-catalog/tables/main.foo.barview",
-				Response: SqlTableInfo{
-					Name:           "barview",
-					CatalogName:    "main",
-					SchemaName:     "foo",
-					TableType:      "VIEW",
-					ViewDefinition: "SELECT * FROM main.foo.bar",
-				},
+		ExpectedDiff: map[string]*terraform.ResourceAttrDiff{
+			"catalog_name": {
+				Old:         "main",
+				New:         "main",
+				RequiresNew: false,
 			},
-			{
-				Method:   "GET",
-				Resource: "/api/2.1/unity-catalog/tables/main.foo.barview",
-				Response: SqlTableInfo{
-					Name:           "barview",
-					CatalogName:    "main",
-					SchemaName:     "foo",
-					TableType:      "VIEW",
-					ViewDefinition: "SELECT * FROM main.foo.bar",
-				},
+			"cluster_id": {
+				Old:         "existingcluster",
+				New:         "existingcluster",
+				RequiresNew: false,
 			},
-			{
-				Method:   "POST",
-				Resource: "/api/2.0/clusters/start",
-				ExpectedRequest: clusters.ClusterID{
-					ClusterID: "existingcluster",
-				},
-				Status: 404,
+			"name": {
+				Old:         "barview",
+				New:         "barview",
+				RequiresNew: false,
 			},
-		}, createClusterForSql...),
+			"schema_name": {
+				Old:         "foo",
+				New:         "foo",
+				RequiresNew: false,
+			},
+			"table_type": {
+				Old:         "VIEW",
+				New:         "VIEW",
+				RequiresNew: false,
+			},
+			"view_definition": {
+				Old:         "SELECT * FROM main.foo.bar",
+				New:         "SELECT * FROM main.foo.bar ",
+				NewComputed: false,
+				RequiresNew: false,
+				NewRemoved:  false,
+				Sensitive:   false,
+			},
+			"column.#": {
+				Old:         "",
+				New:         "",
+				NewComputed: true,
+				RequiresNew: false,
+			},
+			"effective_properties.%": {
+				Old:         "",
+				New:         "",
+				NewComputed: true,
+				RequiresNew: false,
+			},
+			"owner": {
+				Old:         "",
+				New:         "",
+				NewComputed: true,
+				RequiresNew: false,
+			},
+			"partitions.#": {
+				Old:         "",
+				New:         "",
+				NewComputed: true,
+				RequiresNew: true,
+			},
+			"provider_config.#": {
+				Old:         "",
+				New:         "",
+				NewComputed: true,
+				RequiresNew: false,
+			},
+			"table_id": {
+				Old:         "",
+				New:         "",
+				NewComputed: true,
+				RequiresNew: false,
+			},
+		},
+		HCL: `
+		name               = "barview"
+		catalog_name       = "main"
+		schema_name        = "foo"
+		table_type         = "VIEW"
+		cluster_id         = "existingcluster"
+		view_definition    = "SELECT * FROM main.foo.bar "
+		`,
 		Resource: ResourceSqlTable(),
-		Update:   true,
 		ID:       "main.foo.barview",
 	}.ApplyNoError(t)
+}
+
+func TestResourceSqlTableDiff_ViewDefinitionWhitespaceOnly(t *testing.T) {
+	oldTable := &SqlTableInfo{
+		Name:           "barview",
+		CatalogName:    "main",
+		SchemaName:     "foo",
+		TableType:      "VIEW",
+		ViewDefinition: "SELECT id, name FROM somewhere WHERE condition = true",
+	}
+	newTable := &SqlTableInfo{
+		Name:           "barview",
+		CatalogName:    "main",
+		SchemaName:     "foo",
+		TableType:      "VIEW",
+		ViewDefinition: "SELECT  id, name \r\n\r\n FROM  somewhere\tWHERE  condition = true  ",
+	}
+
+	statements, err := newTable.diff(oldTable)
+
+	assert.NoError(t, err)
+	assert.Empty(t, statements)
+}
+
+func TestResourceSqlTableDiff_ViewDefinitionSemanticChange(t *testing.T) {
+	oldTable := &SqlTableInfo{
+		Name:           "barview",
+		CatalogName:    "main",
+		SchemaName:     "foo",
+		TableType:      "VIEW",
+		ViewDefinition: "SELECT id, name FROM somewhere WHERE condition = true",
+	}
+	newTable := &SqlTableInfo{
+		Name:           "barview",
+		CatalogName:    "main",
+		SchemaName:     "foo",
+		TableType:      "VIEW",
+		ViewDefinition: "SELECT id, name FROM somewhere WHERE condition = false",
+	}
+
+	statements, err := newTable.diff(oldTable)
+
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"ALTER VIEW `main`.`foo`.`barview` AS SELECT id, name FROM somewhere WHERE condition = false"}, statements)
 }
 
 func TestResourceSqlTableUpdateView_Comments(t *testing.T) {

--- a/catalog/resource_sql_table_test.go
+++ b/catalog/resource_sql_table_test.go
@@ -893,25 +893,22 @@ func TestResourceSqlTableUpdateView_Definition(t *testing.T) {
 }
 
 func TestResourceSqlTableUpdateView_IgnoreNewlineInDefinition(t *testing.T) {
-	commandExecuted := false
-
-	_, err := qa.ResourceFixture{
+	qa.ResourceFixture{
 		CommandMock: func(commandStr string) common.CommandResults {
-			commandExecuted = true
+			assert.NotContains(t, commandStr, "ALTERR VIEW `main`.`foo`.`barview`", "New lines should not recreate the resource")
 			return common.CommandResults{
 				ResultType: "",
 				Data:       nil,
 			}
 		},
 		HCL: `
-        resource "databricks_sql_table" "test" {
-            name            = "barview"
-            catalog_name    = "main"
-            schema_name     = "foo"
-            table_type      = "VIEW"
-            cluster_id      = "existingcluster"
-            view_definition = "SELECT * FROM main.foo.bar\n\n"
-        }`,
+		name               = "barview"
+		catalog_name       = "main"
+		schema_name        = "foo"
+		table_type         = "VIEW"
+		cluster_id         = "existingcluster"
+		view_definition    = "SELECT * FROM main.foo.bar \n\n"
+		`,
 		InstanceState: map[string]string{
 			"name":            "barview",
 			"catalog_name":    "main",
@@ -920,7 +917,7 @@ func TestResourceSqlTableUpdateView_IgnoreNewlineInDefinition(t *testing.T) {
 			"cluster_id":      "existingcluster",
 			"view_definition": "SELECT * FROM main.foo.bar",
 		},
-		Fixtures: []qa.HTTPFixture{
+		Fixtures: append([]qa.HTTPFixture{
 			{
 				Method:   "GET",
 				Resource: "/api/2.1/unity-catalog/tables/main.foo.barview",
@@ -932,14 +929,30 @@ func TestResourceSqlTableUpdateView_IgnoreNewlineInDefinition(t *testing.T) {
 					ViewDefinition: "SELECT * FROM main.foo.bar",
 				},
 			},
-		},
+			{
+				Method:   "GET",
+				Resource: "/api/2.1/unity-catalog/tables/main.foo.barview",
+				Response: SqlTableInfo{
+					Name:           "barview",
+					CatalogName:    "main",
+					SchemaName:     "foo",
+					TableType:      "VIEW",
+					ViewDefinition: "SELECT * FROM main.foo.bar",
+				},
+			},
+			{
+				Method:   "POST",
+				Resource: "/api/2.0/clusters/start",
+				ExpectedRequest: clusters.ClusterID{
+					ClusterID: "existingcluster",
+				},
+				Status: 404,
+			},
+		}, createClusterForSql...),
 		Resource: ResourceSqlTable(),
 		Update:   true,
 		ID:       "main.foo.barview",
-	}.Apply(t)
-
-	assert.NoError(t, err)
-	assert.False(t, commandExecuted, "No update command should be executed for only newline changes in view_definition")
+	}.ApplyNoError(t)
 }
 
 func TestResourceSqlTableUpdateView_Comments(t *testing.T) {

--- a/common/util.go
+++ b/common/util.go
@@ -46,6 +46,27 @@ func SuppressDiffWhitespaceChange(k, old, new string, d *schema.ResourceData) bo
 	return strings.TrimSpace(old) == strings.TrimSpace(new)
 }
 
+func SuppressDiffWhitespaceAndEmptyLines(k, old, new string, d *schema.ResourceData) bool {
+	log.Printf("[DEBUG] Suppressing diff for %v due to potential whitespace and empty line differences: old=%#v new=%#v", k, old, new)
+
+	cleanString := func(input string) string {
+		lines := strings.Split(input, "\n")
+		processedLines := []string{}
+		for _, line := range lines {
+			trimmedLine := strings.TrimSpace(line)
+			if trimmedLine != "" {
+				processedLines = append(processedLines, trimmedLine)
+			}
+		}
+		return strings.Join(processedLines, " ")
+	}
+
+	cleanedOld := cleanString(old)
+	cleanedNew := cleanString(new)
+
+	return cleanedOld == cleanedNew
+}
+
 func MustInt64(s string) int64 {
 	n, err := strconv.ParseInt(s, 10, 64)
 	if err != nil {

--- a/common/util.go
+++ b/common/util.go
@@ -64,7 +64,7 @@ func SuppressDiffWhitespaceAndEmptyLines(k, old, new string, d *schema.ResourceD
 	cleanedOld := cleanString(old)
 	cleanedNew := cleanString(new)
 
-	return cleanedOld == cleanedNew
+	return strings.TrimSpace(cleanedOld) == strings.TrimSpace(cleanedNew)
 }
 
 func MustInt64(s string) int64 {

--- a/common/util.go
+++ b/common/util.go
@@ -13,6 +13,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"unicode"
 
 	"github.com/databricks/databricks-sdk-go/apierr"
 
@@ -46,25 +47,45 @@ func SuppressDiffWhitespaceChange(k, old, new string, d *schema.ResourceData) bo
 	return strings.TrimSpace(old) == strings.TrimSpace(new)
 }
 
-func SuppressDiffWhitespaceAndEmptyLines(k, old, new string, d *schema.ResourceData) bool {
-	log.Printf("[DEBUG] Suppressing diff for %v due to potential whitespace and empty line differences: old=%#v new=%#v", k, old, new)
+func NormalizeWhitespaceAndEmptyLines(s string) string {
+	var b strings.Builder
+	var quote rune
+	pendingSpace := false
 
-	cleanString := func(input string) string {
-		lines := strings.Split(input, "\n")
-		processedLines := []string{}
-		for _, line := range lines {
-			trimmedLine := strings.TrimSpace(line)
-			if trimmedLine != "" {
-				processedLines = append(processedLines, trimmedLine)
+	for _, r := range s {
+		if quote != 0 {
+			b.WriteRune(r)
+			if r == quote {
+				quote = 0
 			}
+			continue
 		}
-		return strings.Join(processedLines, " ")
+
+		switch {
+		case r == '\'' || r == '"' || r == '`':
+			if pendingSpace && b.Len() > 0 {
+				b.WriteRune(' ')
+			}
+			pendingSpace = false
+			quote = r
+			b.WriteRune(r)
+		case unicode.IsSpace(r):
+			pendingSpace = b.Len() > 0
+		default:
+			if pendingSpace {
+				b.WriteRune(' ')
+			}
+			pendingSpace = false
+			b.WriteRune(r)
+		}
 	}
 
-	cleanedOld := cleanString(old)
-	cleanedNew := cleanString(new)
+	return b.String()
+}
 
-	return strings.TrimSpace(cleanedOld) == strings.TrimSpace(cleanedNew)
+func SuppressDiffWhitespaceAndEmptyLines(k, old, new string, d *schema.ResourceData) bool {
+	log.Printf("[DEBUG] Suppressing diff for %v due to potential whitespace and empty line differences: old=%#v new=%#v", k, old, new)
+	return NormalizeWhitespaceAndEmptyLines(old) == NormalizeWhitespaceAndEmptyLines(new)
 }
 
 func MustInt64(s string) int64 {

--- a/common/util_test.go
+++ b/common/util_test.go
@@ -43,6 +43,11 @@ func TestSuppressDiffWhitespaceAndEmptyLines(t *testing.T) {
 	assert.False(t, SuppressDiffWhitespaceAndEmptyLines("k", "line1\nline2", "line1line2", nil))
 	assert.True(t, SuppressDiffWhitespaceAndEmptyLines("k", " line1\n\n\nline2 ", "\nline1\nline2\n", nil))
 	assert.True(t, SuppressDiffWhitespaceAndEmptyLines("k", "line1\n\nline2", "   line1\nline2   ", nil))
+	assert.True(t, SuppressDiffWhitespaceAndEmptyLines("k", "SELECT id, name FROM somewhere", "SELECT  id, name \n\n FROM  somewhere", nil))
+	assert.True(t, SuppressDiffWhitespaceAndEmptyLines("k", "SELECT\tid\r\nFROM table", "SELECT id FROM table", nil))
+	assert.False(t, SuppressDiffWhitespaceAndEmptyLines("k", "SELECT id FROM table", "SELECT name FROM table", nil))
+	assert.False(t, SuppressDiffWhitespaceAndEmptyLines("k", "SELECT 'a  b'", "SELECT 'a b'", nil))
+	assert.False(t, SuppressDiffWhitespaceAndEmptyLines("k", "SELECT `a  b`", "SELECT `a b`", nil))
 }
 
 func TestMustInt64(t *testing.T) {

--- a/common/util_test.go
+++ b/common/util_test.go
@@ -36,6 +36,15 @@ func TestSuppressDiffWhitespaceChange(t *testing.T) {
 	assert.False(t, SuppressDiffWhitespaceChange("k", "value", "new_value", nil))
 }
 
+func TestSuppressDiffWhitespaceAndEmptyLines(t *testing.T) {
+	assert.True(t, SuppressDiffWhitespaceAndEmptyLines("k", "value", "  value  ", nil))
+	assert.False(t, SuppressDiffWhitespaceAndEmptyLines("k", "value", "new_value", nil))
+	assert.True(t, SuppressDiffWhitespaceAndEmptyLines("k", "  value\n", "\nvalue  ", nil))
+	assert.False(t, SuppressDiffWhitespaceAndEmptyLines("k", "line1\nline2", "line1line2", nil))
+	assert.True(t, SuppressDiffWhitespaceAndEmptyLines("k", " line1\n\n\nline2 ", "\nline1\nline2\n", nil))
+	assert.True(t, SuppressDiffWhitespaceAndEmptyLines("k", "line1\n\nline2", "   line1\nline2   ", nil))
+}
+
 func TestMustInt64(t *testing.T) {
 	assert.Equal(t, int64(123), MustInt64("123"))
 }

--- a/sql/sql_table_test.go
+++ b/sql/sql_table_test.go
@@ -235,6 +235,56 @@ func TestUcAccResourceSqlTable_View(t *testing.T) {
 	})
 }
 
+func TestUcAccResourceSqlTable_ViewDefinitionChange(t *testing.T) {
+	acceptance.UnityWorkspaceLevel(t, acceptance.Step{
+		Template: `
+		resource "databricks_schema" "this" {
+			name         = "{var.STICKY_RANDOM}"
+			catalog_name = "main"
+		}
+
+		resource "databricks_sql_table" "this" {
+			name               = "bar"
+			catalog_name       = "main"
+			schema_name        = databricks_schema.this.name
+			table_type         = "VIEW"
+			view_definition    = "SELECT id, name FROM somewhere WHERE condition = true"
+			warehouse_id       = "{env.TEST_DEFAULT_WAREHOUSE_ID}"
+
+			column {
+				name      = "id"
+			}
+
+			column {
+				name      = "name"
+			}
+		}`,
+	}, acceptance.Step{
+		Template: `
+		resource "databricks_schema" "this" {
+			name         = "{var.STICKY_RANDOM}"
+			catalog_name = "main"
+		}
+
+		resource "databricks_sql_table" "this" {
+			name               = "bar"
+			catalog_name       = "main"
+			schema_name        = databricks_schema.this.name
+			table_type         = "VIEW"
+			view_definition    = "SELECT  id, name \n\n FROM  somewhere  WHERE  condition = true  "
+			warehouse_id       = "{env.TEST_DEFAULT_WAREHOUSE_ID}"
+
+			column {
+				name      = "id"
+			}
+
+			column {
+				name      = "name"
+			}
+		}`,
+	})
+}
+
 func TestUcAccResourceSqlTable_WarehousePartition(t *testing.T) {
 	acceptance.UnityWorkspaceLevel(t, acceptance.Step{
 		Template: `


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

This PR solves the problem described here: https://github.com/databricks/terraform-provider-databricks/pull/3330

empty new lines on view_definition cause terraform to plan to change the view definition.
This PR adds the removal of empty lines to `DiffSuppressFunc` to avoid this problem

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [x] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

![image](https://github.com/databricks/terraform-provider-databricks/assets/23335136/5f4a6192-cdf3-43b5-93ae-1a81850445f5)

![image](https://github.com/databricks/terraform-provider-databricks/assets/23335136/f664acb6-5012-4b24-8b04-c0d07353bea9)
