### PR TITLE
Support persisting empty fields in StructToData

### DIFF
--- a/common/reflect_resource.go
+++ b/common/reflect_resource.go
@@ -613,9 +613,6 @@ func collectionToMaps(v any, s *schema.Schema, aliases map[string]map[string]str
 		if err != nil {
 			return nil, err
 		}
-		if len(data) == 0 {
-			continue
-		}
 		resultList = append(resultList, data)
 	}
 	return resultList, nil

--- a/common/reflect_resource_test.go
+++ b/common/reflect_resource_test.go
@@ -502,6 +502,44 @@ func TestDataToStructPointerWithResourceProviderStruct(t *testing.T) {
 	DataToStructPointer(d, s, &dummyCopy)
 }
 
+func TestStructToData_EmptyField(t *testing.T) {
+	type EmptyField struct{}
+	type Container struct {
+		EmptyField *EmptyField `json:"empty_field,omitempty"`
+	}
+	s := StructToSchema(Container{}, nil)
+	assert.NotNil(t, s)
+
+	dummy := Container{
+		EmptyField: &EmptyField{},
+	}
+
+	d := schema.TestResourceDataRaw(t, s, map[string]any{})
+	d.MarkNewResource()
+	err := StructToData(dummy, s, d)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, d.Get("empty_field.#"))
+}
+
+func TestStructToData_EmptyFieldNil(t *testing.T) {
+	type EmptyField struct{}
+	type Container struct {
+		EmptyField *EmptyField `json:"empty_field,omitempty"`
+	}
+	s := StructToSchema(Container{}, nil)
+	assert.NotNil(t, s)
+
+	dummy := Container{
+		EmptyField: nil,
+	}
+
+	d := schema.TestResourceDataRaw(t, s, map[string]any{})
+	d.MarkNewResource()
+	err := StructToData(dummy, s, d)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, d.Get("empty_field.#"))
+}
+
 func TestStructToData(t *testing.T) {
 	s := StructToSchema(Dummy{}, func(s map[string]*schema.Schema) map[string]*schema.Schema {
 		return s


### PR DESCRIPTION
## Changes
Some APIs legitimately return empty objects in fields, but StructToData does not persist these objects (e.g. #3351). This is caused by a filter in collectionToMaps that removes data structures that don't have any non-optional fields or optional fields set to a non-empty/non-nil value.

This PR removes this check. I need to do a bit more work to verify the impact of removing this on the rest of the provider.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
