### PR TITLE
Exporter: change listing behavior for metastore and storage credentials

### DIFF
--- a/docs/guides/experimental-exporter.md
+++ b/docs/guides/experimental-exporter.md
@@ -136,7 +136,7 @@ Exporter aims to generate HCL code for most of the resources within the Databric
 | [databricks_ip_access_list](../resources/ip_access_list.md) | Yes | Yes | Yes | No |
 | [databricks_job](../resources/job.md) | Yes | No | Yes | No |
 | [databricks_library](../resources/library.md) | Yes\* | No | Yes | No |
-| [databricks_metastore](../resources/metastore.md) | Yes | Yes | Yes | Yes |
+| [databricks_metastore](../resources/metastore.md) | Yes | Yes | No | Yes |
 | [databricks_metastore_assignment](../resources/metastore_assignment.md) | Yes | No | No | Yes |
 | [databricks_mlflow_experiment](../resources/mlflow_experiment.md) | No | No | No | No |
 | [databricks_mlflow_model](../resources/mlflow_model.md) | No | No | No | No |
@@ -165,7 +165,7 @@ Exporter aims to generate HCL code for most of the resources within the Databric
 | [databricks_sql_table](../resources/sql_table.md) | Yes | Yes | Yes | No |
 | [databricks_sql_visualization](../resources/sql_visualization.md) | Yes | Yes | Yes | No |
 | [databricks_sql_widget](../resources/sql_widget.md) | Yes | Yes | Yes | No |
-| [databricks_storage_credential](../resources/storage_credential.md) | Yes | Yes | Yes | Yes |
+| [databricks_storage_credential](../resources/storage_credential.md) | Yes | Yes | Yes | No |
 | [databricks_system_schema](../resources/system_schema.md) | Yes | No | Yes | No |
 | [databricks_token](../resources/token.md) | Not Applicable | No | Yes | No |
 | [databricks_user](../resources/user.md) | Yes | No | Yes | Yes |

--- a/exporter/importables.go
+++ b/exporter/importables.go
@@ -2605,7 +2605,6 @@ var resourcesMap map[string]importable = map[string]importable{
 	},
 	"databricks_storage_credential": {
 		WorkspaceLevel: true,
-		AccountLevel:   true,
 		Service:        "uc-storage-credentials",
 		Import: func(ic *importContext, r *resource) error {
 			ic.Emit(&resource{
@@ -2615,24 +2614,10 @@ var resourcesMap map[string]importable = map[string]importable{
 			return nil
 		},
 		List: func(ic *importContext) error {
-			var objList []catalog.StorageCredentialInfo
-			var err error
-
-			if ic.accountLevel {
-				if ic.currentMetastore == nil {
-					return fmt.Errorf("there is no UC metastore information")
-				}
-				currentMetastore := ic.currentMetastore.MetastoreId
-				objList, err = ic.accountClient.StorageCredentials.List(ic.Context, catalog.ListAccountStorageCredentialsRequest{
-					MetastoreId: currentMetastore,
-				})
-			} else {
-				objList, err = ic.workspaceClient.StorageCredentials.ListAll(ic.Context, catalog.ListStorageCredentialsRequest{})
-			}
+			objList, err := ic.workspaceClient.StorageCredentials.ListAll(ic.Context, catalog.ListStorageCredentialsRequest{})
 			if err != nil {
 				return err
 			}
-
 			for _, v := range objList {
 				ic.EmitIfUpdatedAfterMillisAndNameMatches(&resource{
 					Resource: "databricks_storage_credential",
@@ -2854,9 +2839,8 @@ var resourcesMap map[string]importable = map[string]importable{
 		},
 	},
 	"databricks_metastore": {
-		WorkspaceLevel: true,
-		AccountLevel:   true,
-		Service:        "uc-metastores",
+		AccountLevel: true,
+		Service:      "uc-metastores",
 		Name: func(ic *importContext, d *schema.ResourceData) string {
 			name := d.Get("name").(string)
 			if name == "" {
@@ -2865,13 +2849,7 @@ var resourcesMap map[string]importable = map[string]importable{
 			return name
 		},
 		List: func(ic *importContext) error {
-			var err error
-			var metastores []catalog.MetastoreInfo
-			if ic.accountLevel {
-				metastores, err = ic.accountClient.Metastores.ListAll(ic.Context)
-			} else {
-				metastores, err = ic.workspaceClient.Metastores.ListAll(ic.Context)
-			}
+			metastores, err := ic.accountClient.Metastores.ListAll(ic.Context)
 			if err != nil {
 				return err
 			}
@@ -2889,7 +2867,8 @@ var resourcesMap map[string]importable = map[string]importable{
 				ID:       "metastore/" + r.ID,
 			})
 			// TODO: emit owner? See comment in catalog resource
-			if ic.accountLevel { // emit metastore assignments
+			if ic.accountLevel {
+				// emit metastore assignments
 				assignments, err := ic.accountClient.MetastoreAssignments.ListByMetastoreId(ic.Context, r.ID)
 				if err == nil {
 					for _, workspaceID := range assignments.WorkspaceIds {
@@ -2901,6 +2880,8 @@ var resourcesMap map[string]importable = map[string]importable{
 				} else {
 					log.Printf("[ERROR] listing metastore assignments: %s", err.Error())
 				}
+				// TODO: emit storage credentials associated with specific metastores, but we'll need to solve
+				// a problem of importing a resource... This will require to changing ID from name to metastore ID + name.
 			}
 			return nil
 		},

--- a/exporter/importables_test.go
+++ b/exporter/importables_test.go
@@ -1564,30 +1564,31 @@ func TestImportExternalLocationGrants(t *testing.T) {
 	})
 }
 
-func TestListMetastores(t *testing.T) {
-	qa.HTTPFixturesApply(t, []qa.HTTPFixture{
-		{
-			ReuseRequest: true,
-			Method:       "GET",
-			Resource:     "/api/2.1/unity-catalog/metastores",
-			Response: catalog.ListMetastoresResponse{
-				Metastores: []catalog.MetastoreInfo{
-					{
-						Name:        "test",
-						MetastoreId: "1234",
-					},
-				},
-			},
-		},
-	}, func(ctx context.Context, client *common.DatabricksClient) {
-		ic := importContextForTestWithClient(ctx, client)
-		ic.enableServices("uc-metastores")
-		err := resourcesMap["databricks_metastore"].List(ic)
-		assert.NoError(t, err)
-		require.Equal(t, 1, len(ic.testEmits))
-		assert.True(t, ic.testEmits["databricks_metastore[<unknown>] (id: 1234)"])
-	})
-}
+// TODO: restore it when support for Account-level tests is added
+// func TestListMetastores(t *testing.T) {
+// 	qa.HTTPFixturesApply(t, []qa.HTTPFixture{
+// 		{
+// 			ReuseRequest: true,
+// 			Method:       "GET",
+// 			Resource:     "/api/2.1/unity-catalog/metastores",
+// 			Response: catalog.ListMetastoresResponse{
+// 				Metastores: []catalog.MetastoreInfo{
+// 					{
+// 						Name:        "test",
+// 						MetastoreId: "1234",
+// 					},
+// 				},
+// 			},
+// 		},
+// 	}, func(ctx context.Context, client *common.DatabricksClient) {
+// 		ic := importContextForTestWithClient(ctx, client)
+// 		ic.enableServices("uc-metastores")
+// 		err := resourcesMap["databricks_metastore"].List(ic)
+// 		assert.NoError(t, err)
+// 		require.Equal(t, 1, len(ic.testEmits))
+// 		assert.True(t, ic.testEmits["databricks_metastore[<unknown>] (id: 1234)"])
+// 	})
+// }
 
 func TestListCatalogs(t *testing.T) {
 	qa.HTTPFixturesApply(t, []qa.HTTPFixture{


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

Changes include:

* `databricks_metastore` will be listed and emitted only on the account-level - it makes little sense to list metastores on the workspace level.
* `databricks_storage_credential` is listed only on the workspace level as we don't have a specific metastore ID on the account level.  Also, we don't have a simple way of importing new storage credentials on the account level - we need to have `metastore_id` as a part of the storage credential ID.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
