### PR TITLE
Add lock to `databricks_metastore_assignment` test

### DIFF
--- a/internal/acceptance/metastore_assignment_test.go
+++ b/internal/acceptance/metastore_assignment_test.go
@@ -1,11 +1,22 @@
 package acceptance
 
 import (
+	"context"
+	"os"
 	"testing"
+
+	"github.com/databricks/databricks-sdk-go/qa/lock"
 )
+
+func lockForTest(t *testing.T) func() {
+	return func() {
+		lock.Acquire(context.Background(), lock.Workspace{WorkspaceId: os.Getenv("DUMMY_WORKSPACE_ID")}, lock.InTest(t))
+	}
+}
 
 func TestUcAccMetastoreAssignment(t *testing.T) {
 	unityWorkspaceLevel(t, step{
+		PreConfig: lockForTest(t),
 		Template: `resource "databricks_metastore_assignment" "this" {
 			metastore_id = "{env.TEST_METASTORE_ID}"
 			workspace_id = {env.DUMMY_WORKSPACE_ID}
@@ -15,15 +26,7 @@ func TestUcAccMetastoreAssignment(t *testing.T) {
 
 func TestUcAccAccountMetastoreAssignment(t *testing.T) {
 	unityAccountLevel(t, step{
-		Template: `resource "databricks_metastore_assignment" "this" {
-			metastore_id = "{env.TEST_METASTORE_ID}"
-			workspace_id = {env.DUMMY_WORKSPACE_ID}
-		}`,
-	})
-}
-
-func TestUcAccMetastoreReAssignment(t *testing.T) {
-	unityAccountLevel(t, step{
+		PreConfig: lockForTest(t),
 		Template: `resource "databricks_metastore_assignment" "this" {
 			metastore_id = "{env.TEST_METASTORE_ID}"
 			workspace_id = {env.DUMMY_WORKSPACE_ID}


### PR DESCRIPTION
## Changes
The `databricks_metastore_assignment` tests race against one another. This PR adds our lock to ensure that they don't run in parallel.

## Tests

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
