### PR TITLE
Docs: Improve description of depends_on block

### DIFF
--- a/docs/resources/job.md
+++ b/docs/resources/job.md
@@ -130,7 +130,7 @@ This block describes individual tasks:
 
 ### depends_on Configuration Block
 
-This block describes dependencies of a given task:
+This block describes upstream dependencies of a given task. For multiple upstream dependencies, use multiple blocks.
 
 * `task_key` - (Required) The name of the task this task depends on.
 * `outcome` - (Optional, string) Can only be specified on condition task dependencies. The outcome of the dependent task that must be met for this task to run. Possible values are `"true"` or `"false"`.


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
Documentation change only. Improves the documentation regarding multiple upstream dependencies. This confused me as well as [my google result](https://community.databricks.com/t5/community-discussions/terraform-provider-problemi-in-creating-dependant-task/m-p/46515/highlight/true#M2145).
## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->
N/A
- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
