### PR TITLE
[BUG] Remove set in job libraries

### DIFF
--- a/jobs/resource_job.go
+++ b/jobs/resource_job.go
@@ -218,7 +218,7 @@ type JobTaskSettings struct {
 	NewCluster        *clusters.Cluster   `json:"new_cluster,omitempty" tf:"group:cluster_type"`
 	JobClusterKey     string              `json:"job_cluster_key,omitempty" tf:"group:cluster_type"`
 	ComputeKey        string              `json:"compute_key,omitempty" tf:"group:cluster_type"`
-	Libraries         []libraries.Library `json:"libraries,omitempty" tf:"slice_set,alias:library"`
+	Libraries         []libraries.Library `json:"libraries,omitempty" tf:"slice,alias:library"`
 
 	NotebookTask    *NotebookTask       `json:"notebook_task,omitempty" tf:"group:task_type"`
 	SparkJarTask    *SparkJarTask       `json:"spark_jar_task,omitempty" tf:"group:task_type"`


### PR DESCRIPTION
Remove Set to revert to ordered List

## Changes
I have developed 2 libraries  (A and B) but B depend on A.
They are installed consecutively on my databricks cluster from a static S3 resource link, so order matter as it don't use registry to resolve dependencies in a single pass.

The TypeSet will ensure unicity but have drawback to introduce shifting in order of installation, so i have just fallback to default TypeList.

Actually it's custom python wheels.

Rgds

## Tests
I have tested to build my fork on my github action runner and successfully solved the deployment issue (order is preserved)

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
