### PR TITLE
Exporter: don't generate references to ignored resources

### DIFF
--- a/exporter/context_test.go
+++ b/exporter/context_test.go
@@ -42,6 +42,25 @@ func TestImportContextFindSkips(t *testing.T) {
 	assert.Nil(t, traversal)
 }
 
+func TestFindRefIgnoredResource(t *testing.T) {
+	ic := &importContext{
+		Importables: map[string]importable{
+			"a": {
+				Ignore: func(ic *importContext, r *resource) bool {
+					return true
+				},
+			},
+			"b": {},
+		},
+	}
+	ra := &resourceApproximation{
+		Type:     "a",
+		Resource: &resource{},
+	}
+	assert.True(t, ic.isIgnoredResourceApproximation(ra))
+	assert.False(t, ic.isIgnoredResourceApproximation(&resourceApproximation{Type: "b"}))
+}
+
 func TestImportContextFindNoDirectLookup(t *testing.T) {
 	state := newStateApproximation([]string{"a"})
 	state.Append(resourceApproximation{

--- a/exporter/model.go
+++ b/exporter/model.go
@@ -30,10 +30,9 @@ type instanceApproximation struct {
 type resourceApproximation struct {
 	Type      string                  `json:"type"`
 	Name      string                  `json:"name"`
-	Provider  string                  `json:"provider"`
 	Mode      string                  `json:"mode"`
-	Module    string                  `json:"module,omitempty"`
 	Instances []instanceApproximation `json:"instances"`
+	Resource  *resource
 }
 
 func (ra *resourceApproximation) Get(attr string) (any, bool) {


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

Before this PR, exporter generated references to resources that are ignored (deleted DLT pipelines in jobs, for example) - this happens because such object is still in the state, so we can find it by ID, and generate a reference to it.  This PR adds a check if resource is ignored or not, and if it's ignored, then don't generate a reference.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
