### PR TITLE
Add lookup by name or region to `databricks_metastore` data source

### DIFF
--- a/catalog/data_metastore.go
+++ b/catalog/data_metastore.go
@@ -2,6 +2,8 @@ package catalog
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
 	"github.com/databricks/databricks-sdk-go"
 	"github.com/databricks/databricks-sdk-go/service/catalog"
@@ -10,15 +12,54 @@ import (
 
 func DataSourceMetastore() common.Resource {
 	type AccountMetastoreByID struct {
-		Id        string                 `json:"metastore_id"`
+		Id        string                 `json:"metastore_id,omitempty" tf:"computed"`
+		Name      string                 `json:"name,omitempty" tf:"computed"`
+		Region    string                 `json:"region,omitempty" tf:"computed"`
 		Metastore *catalog.MetastoreInfo `json:"metastore_info,omitempty" tf:"computed" `
 	}
 	return common.AccountData(func(ctx context.Context, data *AccountMetastoreByID, acc *databricks.AccountClient) error {
-		metastore, err := acc.Metastores.GetByMetastoreId(ctx, data.Id)
-		if err != nil {
-			return err
+		if data.Id == "" && data.Name == "" && data.Region == "" {
+			return fmt.Errorf("one of metastore_id, name or region must be provided")
 		}
-		data.Metastore = metastore.MetastoreInfo
+		if (data.Id != "" && data.Name != "") || (data.Region != "" && data.Id != "") || (data.Region != "" && data.Name != "") {
+			return fmt.Errorf("only one of metastore_id, name or region must be provided")
+		}
+		if data.Id != "" {
+			minfo, err := acc.Metastores.GetByMetastoreId(ctx, data.Id)
+			if err != nil {
+				return err
+			}
+			data.Metastore = minfo.MetastoreInfo
+		} else {
+			metastores, err := acc.Metastores.ListAll(ctx)
+			if err != nil {
+				return err
+			}
+			minfos := []catalog.MetastoreInfo{}
+			if data.Name != "" {
+				for _, v := range metastores {
+					if v.Name == data.Name {
+						minfos = append(minfos, v)
+					}
+				}
+			} else {
+				for _, v := range metastores {
+					if strings.EqualFold(v.Region, data.Region) {
+						minfos = append(minfos, v)
+					}
+				}
+			}
+			if len(minfos) == 0 {
+				return fmt.Errorf("a metastore with name '%s' or in region '%s' is not found", data.Name, data.Region)
+			}
+			if len(minfos) > 1 {
+				return fmt.Errorf("there are %d metastores with name '%s' in region '%s'", len(minfos), data.Name, data.Region)
+			}
+			data.Metastore = &minfos[0]
+		}
+		data.Id = data.Metastore.MetastoreId
+		data.Name = data.Metastore.Name
+		data.Region = data.Metastore.Region
 		return nil
 	})
 }

--- a/catalog/data_metastore.go
+++ b/catalog/data_metastore.go
@@ -38,7 +38,7 @@ func DataSourceMetastore() common.Resource {
 			minfos := []catalog.MetastoreInfo{}
 			if data.Name != "" {
 				for _, v := range metastores {
-					if v.Name == data.Name {
+					if strings.EqualFold(v.Name, data.Name) {
 						minfos = append(minfos, v)
 					}
 				}

--- a/catalog/data_metastore_test.go
+++ b/catalog/data_metastore_test.go
@@ -1,26 +1,27 @@
 package catalog
 
 import (
+	"fmt"
 	"testing"
 
+	"github.com/databricks/databricks-sdk-go/experimental/mocks"
 	"github.com/databricks/databricks-sdk-go/service/catalog"
 	"github.com/databricks/terraform-provider-databricks/qa"
+	"github.com/stretchr/testify/mock"
 )
 
-func TestMetastoreDataVerify(t *testing.T) {
+func TestMetastoreDataById(t *testing.T) {
 	qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:   "GET",
-				Resource: "/api/2.0/accounts/testaccount/metastores/abc?",
-				Response: catalog.AccountsMetastoreInfo{
-					MetastoreInfo: &catalog.MetastoreInfo{
-						Name:        "xyz",
-						MetastoreId: "abc",
-						Owner:       "pqr",
-					},
+		MockAccountClientFunc: func(m *mocks.MockAccountClient) {
+			e := m.GetMockAccountMetastoresAPI().EXPECT()
+			e.GetByMetastoreId(mock.Anything, "abc").Return(&catalog.AccountsMetastoreInfo{
+				MetastoreInfo: &catalog.MetastoreInfo{
+					Name:        "xyz",
+					MetastoreId: "abc",
+					Owner:       "pqr",
+					Region:      "unknown",
 				},
-			},
+			}, nil)
 		},
 		Resource:    DataSourceMetastore(),
 		Read:        true,
@@ -31,10 +32,36 @@ func TestMetastoreDataVerify(t *testing.T) {
 		metastore_id = "abc"
 		`,
 	}.ApplyAndExpectData(t, map[string]any{
+		"name":                          "xyz",
+		"region":                        "unknown",
 		"metastore_info.0.name":         "xyz",
 		"metastore_info.0.owner":        "pqr",
 		"metastore_info.0.metastore_id": "abc",
 	})
+}
+
+func TestMetastoreDataErrorNoParams(t *testing.T) {
+	qa.ResourceFixture{
+		Resource:    DataSourceMetastore(),
+		Read:        true,
+		NonWritable: true,
+		ID:          "_",
+		AccountID:   "_",
+	}.ExpectError(t, "one of metastore_id, name or region must be provided")
+}
+
+func TestMetastoreDataErrorMultipleParams(t *testing.T) {
+	qa.ResourceFixture{
+		Resource:    DataSourceMetastore(),
+		Read:        true,
+		NonWritable: true,
+		ID:          "_",
+		AccountID:   "_",
+		HCL: `
+		metastore_id = "abc"
+		name         = "abc"
+		`,
+	}.ExpectError(t, "only one of metastore_id, name or region must be provided")
 }
 
 func TestMetastoreDataError(t *testing.T) {
@@ -43,7 +70,134 @@ func TestMetastoreDataError(t *testing.T) {
 		Resource:    DataSourceMetastore(),
 		Read:        true,
 		NonWritable: true,
-		ID:          "_",
+		ID:          "id",
 		AccountID:   "_",
+		HCL: `
+		metastore_id = "abc"
+		`,
 	}.ExpectError(t, "i'm a teapot")
+}
+
+func TestMetastoreByName(t *testing.T) {
+	qa.ResourceFixture{
+		MockAccountClientFunc: func(m *mocks.MockAccountClient) {
+			e := m.GetMockAccountMetastoresAPI().EXPECT()
+			e.ListAll(mock.Anything).Return([]catalog.MetastoreInfo{
+				{
+					Name:        "xyz",
+					MetastoreId: "abc",
+					Owner:       "pqr",
+					Region:      "unknown",
+				},
+			}, nil)
+		},
+		Resource:    DataSourceMetastore(),
+		Read:        true,
+		NonWritable: true,
+		ID:          "_",
+		AccountID:   "testaccount",
+		HCL: `
+		name = "xyz"
+		`,
+	}.ApplyAndExpectData(t, map[string]any{
+		"name":                          "xyz",
+		"region":                        "unknown",
+		"metastore_info.0.name":         "xyz",
+		"metastore_info.0.owner":        "pqr",
+		"metastore_info.0.metastore_id": "abc",
+	})
+}
+
+func TestMetastoreByRegion(t *testing.T) {
+	qa.ResourceFixture{
+		MockAccountClientFunc: func(m *mocks.MockAccountClient) {
+			e := m.GetMockAccountMetastoresAPI().EXPECT()
+			e.ListAll(mock.Anything).Return([]catalog.MetastoreInfo{
+				{
+					Name:        "xyz",
+					MetastoreId: "abc",
+					Owner:       "pqr",
+					Region:      "westus",
+				},
+			}, nil)
+		},
+		Resource:    DataSourceMetastore(),
+		Read:        true,
+		NonWritable: true,
+		ID:          "_",
+		AccountID:   "testaccount",
+		HCL: `
+		region = "westus"
+		`,
+	}.ApplyAndExpectData(t, map[string]any{
+		"name":                          "xyz",
+		"region":                        "westus",
+		"metastore_info.0.name":         "xyz",
+		"metastore_info.0.owner":        "pqr",
+		"metastore_info.0.metastore_id": "abc",
+	})
+}
+
+func TestMetastoreByNameNoData(t *testing.T) {
+	qa.ResourceFixture{
+		MockAccountClientFunc: func(m *mocks.MockAccountClient) {
+			e := m.GetMockAccountMetastoresAPI().EXPECT()
+			e.ListAll(mock.Anything).Return([]catalog.MetastoreInfo{}, nil)
+		},
+		Resource:    DataSourceMetastore(),
+		Read:        true,
+		NonWritable: true,
+		ID:          "_",
+		AccountID:   "testaccount",
+		HCL: `
+		name = "test"
+		`,
+	}.ExpectError(t, "a metastore with name 'test' or in region '' is not found")
+}
+
+func TestMetastoreByNameListError(t *testing.T) {
+	qa.ResourceFixture{
+		MockAccountClientFunc: func(m *mocks.MockAccountClient) {
+			e := m.GetMockAccountMetastoresAPI().EXPECT()
+			e.ListAll(mock.Anything).Return([]catalog.MetastoreInfo{}, fmt.Errorf("i'm a teapot"))
+		},
+		Resource:    DataSourceMetastore(),
+		Read:        true,
+		NonWritable: true,
+		ID:          "_",
+		AccountID:   "testaccount",
+		HCL: `
+		name = "test"
+		`,
+	}.ExpectError(t, "i'm a teapot")
+}
+
+func TestMetastoreByRegionMultipleEntries(t *testing.T) {
+	qa.ResourceFixture{
+		MockAccountClientFunc: func(m *mocks.MockAccountClient) {
+			e := m.GetMockAccountMetastoresAPI().EXPECT()
+			e.ListAll(mock.Anything).Return([]catalog.MetastoreInfo{
+				{
+					Name:        "xyz",
+					MetastoreId: "abc",
+					Owner:       "pqr",
+					Region:      "westus",
+				},
+				{
+					Name:        "xyz2",
+					MetastoreId: "abc2",
+					Owner:       "pqr",
+					Region:      "westus",
+				},
+			}, nil)
+		},
+		Resource:    DataSourceMetastore(),
+		Read:        true,
+		NonWritable: true,
+		ID:          "_",
+		AccountID:   "testaccount",
+		HCL: `
+		region = "westus"
+		`,
+	}.ExpectError(t, "there are 2 metastores with name '' in region 'westus'")
 }

--- a/docs/data-sources/metastore.md
+++ b/docs/data-sources/metastore.md
@@ -34,7 +34,12 @@ output "some_metastore" {
 
 ## Argument Reference
 
-* `metastore_id` - Id of the metastore to be fetched
+Provide one of the arguments to get information about a metastore:
+
+* `metastore_id` - Id of the metastore
+* `name` - Name of the metastore
+* `region` - Region of the metastore
+
 
 ## Attribute Reference
 


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

Sometimes it would be easier to fetch metastore information by a workspace region or by a metastore name compared to fetching metastore information by ID.  This PR adds ability to specify either `name` or `region` to perform a metastore lookup.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [x] relevant acceptance tests are passing
- [x] using Go SDK
