### PR TITLE
Added support for SQL Notebooks execution in `databricks_job`

### DIFF
--- a/docs/resources/job.md
+++ b/docs/resources/job.md
@@ -324,6 +324,7 @@ You can invoke Spark submit tasks only on new clusters. **In the `new_cluster` s
 * `notebook_path` - (Required) The path of the [databricks_notebook](notebook.md#path) to be run in the Databricks workspace or remote repository. For notebooks stored in the Databricks workspace, the path must be absolute and begin with a slash. For notebooks stored in a remote repository, the path must be relative. This field is required.
 * `source` - (Optional) Location type of the notebook, can only be `WORKSPACE` or `GIT`. When set to `WORKSPACE`, the notebook will be retrieved from the local Databricks workspace. When set to `GIT`, the notebook will be retrieved from a Git repository defined in `git_source`. If the value is empty, the task will use `GIT` if `git_source` is defined and `WORKSPACE` otherwise.
 * `base_parameters` - (Optional) (Map) Base parameters to be used for each run of this job. If the run is initiated by a call to run-now with parameters specified, the two parameters maps will be merged. If the same key is specified in base_parameters and in run-now, the value from run-now will be used. If the notebook takes a parameter that is not specified in the job’s base_parameters or the run-now override parameters, the default value from the notebook will be used. Retrieve these parameters in a notebook using `dbutils.widgets.get`.
+* `warehouse_id` - (Optional) ID of the (the [databricks_sql_endpoint](sql_endpoint.md)) that will be used to execute the task with SQL notebook.
 
 ### pipeline_task Configuration Block
 

--- a/exporter/importables.go
+++ b/exporter/importables.go
@@ -403,6 +403,7 @@ var resourcesMap map[string]importable = map[string]importable{
 			{Path: "task.notebook_task.base_parameters", Resource: "databricks_file"},
 			{Path: "task.notebook_task.base_parameters", Resource: "databricks_workspace_file", Match: "workspace_path"},
 			{Path: "task.notebook_task.notebook_path", Resource: "databricks_notebook"},
+			{Path: "task.notebook_task.warehouse_id", Resource: "databricks_sql_endpoint"},
 			{Path: "task.pipeline_task.pipeline_id", Resource: "databricks_pipeline"},
 			{Path: "task.python_wheel_task.named_parameters", Resource: "databricks_dbfs_file", Match: "dbfs_path"},
 			{Path: "task.python_wheel_task.named_parameters", Resource: "databricks_file"},
@@ -480,6 +481,12 @@ var resourcesMap map[string]importable = map[string]importable{
 						ic.emitNotebookOrRepo(task.NotebookTask.NotebookPath)
 					}
 					ic.emitFilesFromMap(task.NotebookTask.BaseParameters)
+					if task.NotebookTask.WarehouseId != "" {
+						ic.Emit(&resource{
+							Resource: "databricks_sql_endpoint",
+							ID:       task.NotebookTask.WarehouseId,
+						})
+					}
 				}
 				if task.PipelineTask != nil {
 					ic.Emit(&resource{

--- a/jobs/resource_job.go
+++ b/jobs/resource_job.go
@@ -29,6 +29,7 @@ type NotebookTask struct {
 	NotebookPath   string            `json:"notebook_path"`
 	Source         string            `json:"source,omitempty" tf:"suppress_diff"`
 	BaseParameters map[string]string `json:"base_parameters,omitempty"`
+	WarehouseId    string            `json:"warehouse_id,omitempty"`
 }
 
 // SparkPythonTask contains the information for python jobs


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

For notebook tasks it's now possible to specify `warehouse_id` to execute SQL notebooks on SQL warehouses.

This fixes #3414

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [x] relevant acceptance tests are passing
- [ ] using Go SDK
