### PR TITLE
Use Account client in the `databricks_aws_crossaccount_policy` data source

### DIFF
--- a/aws/data_aws_crossaccount_policy.go
+++ b/aws/data_aws_crossaccount_policy.go
@@ -22,7 +22,7 @@ func DataAwsCrossaccountPolicy() common.Resource {
 		Region          string   `json:"region,omitempty"`
 		SecurityGroupId string   `json:"security_group_id,omitempty"`
 	}
-	return common.WorkspaceData(func(ctx context.Context, data *AwsCrossAccountPolicy, w *databricks.WorkspaceClient) error {
+	return common.AccountData(func(ctx context.Context, data *AwsCrossAccountPolicy, w *databricks.AccountClient) error {
 		if !slices.Contains([]string{"managed", "customer", "restricted"}, data.PolicyType) {
 			return fmt.Errorf("policy_type must be either 'managed', 'customer' or 'restricted'")
 		}

--- a/docs/data-sources/aws_crossaccount_policy.md
+++ b/docs/data-sources/aws_crossaccount_policy.md
@@ -3,6 +3,8 @@ subcategory: "Deployment"
 ---
 # databricks_aws_crossaccount_policy Data Source
 
+-> **Note** This data source could be only used with account-level provider!
+
 This data source constructs necessary AWS cross-account policy for you, which is based on [official documentation](https://docs.databricks.com/administration-guide/account-api/iam-role.html#language-Your%C2%A0VPC,%C2%A0default).
 
 ## Example Usage

--- a/internal/acceptance/data_aws_crossaccount_policy_test.go
+++ b/internal/acceptance/data_aws_crossaccount_policy_test.go
@@ -1,0 +1,28 @@
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestUcAccDataSourceAwsCrossaccountPolicy(t *testing.T) {
+	GetEnvOrSkipTest(t, "TEST_ROOT_BUCKET") // marker for AWS test env
+	accountLevel(t, step{
+		Template: `
+		data "databricks_aws_crossaccount_policy" "this" {
+		}`,
+		Check: func(s *terraform.State) error {
+			r, ok := s.RootModule().Resources["data.databricks_aws_crossaccount_policy.this"]
+			if !ok {
+				return fmt.Errorf("data not found in state")
+			}
+			policy := r.Primary.Attributes["json"]
+			if policy == "" {
+				return fmt.Errorf("CrossAccount Policy JSON is empty: %v", r.Primary.Attributes)
+			}
+			return nil
+		},
+	})
+}

--- a/internal/acceptance/data_aws_crossaccount_policy_test.go
+++ b/internal/acceptance/data_aws_crossaccount_policy_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
-func TestUcAccDataSourceAwsCrossaccountPolicy(t *testing.T) {
+func TestMwsAccDataSourceAwsCrossaccountPolicy(t *testing.T) {
 	GetEnvOrSkipTest(t, "TEST_ROOT_BUCKET") // marker for AWS test env
 	accountLevel(t, step{
 		Template: `


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

This data source is typically run in context of the account provider, so it couldn't instantiate a workspace client

This fixes #3421

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [x] covered with integration tests in `internal/acceptance`
- [x] relevant acceptance tests are passing
- [ ] using Go SDK
