### PR TITLE
Docs: Use correct provider alias in AWS E2 provisioning guide

### DIFF
--- a/docs/guides/aws-workspace.md
+++ b/docs/guides/aws-workspace.md
@@ -83,6 +83,7 @@ Cross-account IAM role is registered with [databricks_mws_credentials](../resour
 
 ```hcl
 data "databricks_aws_assume_role_policy" "this" {
+  provider    = databricks.mws
   external_id = var.databricks_account_id
 }
 
@@ -93,6 +94,7 @@ resource "aws_iam_role" "cross_account_role" {
 }
 
 data "databricks_aws_crossaccount_policy" "this" {
+  provider    = databricks.mws
   policy_type = "customer"
 }
 


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

We didn't declare the default `databricks` provider, so the code from the guide won't work until we add explicit aliases to data sources

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
