### PR TITLE
Add deployment field to the databricks_pipeline resource

### DIFF
--- a/pipelines/resource_pipeline.go
+++ b/pipelines/resource_pipeline.go
@@ -97,23 +97,24 @@ type Notification struct {
 }
 
 type PipelineSpec struct {
-	ID                  string            `json:"id,omitempty" tf:"computed"`
-	Name                string            `json:"name,omitempty"`
-	Storage             string            `json:"storage,omitempty" tf:"force_new"`
-	Catalog             string            `json:"catalog,omitempty" tf:"force_new"`
-	Configuration       map[string]string `json:"configuration,omitempty"`
-	Clusters            []pipelineCluster `json:"clusters,omitempty" tf:"alias:cluster"`
-	Libraries           []PipelineLibrary `json:"libraries,omitempty" tf:"slice_set,alias:library"`
-	Filters             *filters          `json:"filters,omitempty"`
-	Continuous          bool              `json:"continuous,omitempty"`
-	Development         bool              `json:"development,omitempty"`
-	AllowDuplicateNames bool              `json:"allow_duplicate_names,omitempty"`
-	Target              string            `json:"target,omitempty"`
-	Photon              bool              `json:"photon,omitempty"`
-	Edition             string            `json:"edition,omitempty" tf:"suppress_diff,default:ADVANCED"`
-	Channel             string            `json:"channel,omitempty" tf:"suppress_diff,default:CURRENT"`
-	Notifications       []Notification    `json:"notifications,omitempty" tf:"alias:notification"`
-	Serverless          bool              `json:"serverless" tf:"optional"`
+	ID                  string             `json:"id,omitempty" tf:"computed"`
+	Name                string             `json:"name,omitempty"`
+	Storage             string             `json:"storage,omitempty" tf:"force_new"`
+	Catalog             string             `json:"catalog,omitempty" tf:"force_new"`
+	Configuration       map[string]string  `json:"configuration,omitempty"`
+	Clusters            []pipelineCluster  `json:"clusters,omitempty" tf:"alias:cluster"`
+	Libraries           []PipelineLibrary  `json:"libraries,omitempty" tf:"slice_set,alias:library"`
+	Filters             *filters           `json:"filters,omitempty"`
+	Continuous          bool               `json:"continuous,omitempty"`
+	Development         bool               `json:"development,omitempty"`
+	AllowDuplicateNames bool               `json:"allow_duplicate_names,omitempty"`
+	Target              string             `json:"target,omitempty"`
+	Photon              bool               `json:"photon,omitempty"`
+	Edition             string             `json:"edition,omitempty" tf:"suppress_diff,default:ADVANCED"`
+	Channel             string             `json:"channel,omitempty" tf:"suppress_diff,default:CURRENT"`
+	Notifications       []Notification     `json:"notifications,omitempty" tf:"alias:notification"`
+	Serverless          bool               `json:"serverless" tf:"optional"`
+	Deployment          *PipelineDeployment `json:"deployment,omitempty"`
 }
 
 type createPipelineResponse struct {
@@ -183,6 +184,17 @@ type PipelineListResponse struct {
 type PipelinesAPI struct {
 	client *common.DatabricksClient
 	ctx    context.Context
+}
+
+type DeploymentKind string
+
+const (
+	DeploymentKindBundle DeploymentKind = "BUNDLE"
+)
+
+type PipelineDeployment struct {
+	Kind             DeploymentKind `json:"kind,omitempty"`
+	MetadataFilePath string         `json:"metadata_file_path,omitempty"`
 }
 
 func NewPipelinesAPI(ctx context.Context, m any) PipelinesAPI {

--- a/pipelines/resource_pipeline.go
+++ b/pipelines/resource_pipeline.go
@@ -97,23 +97,23 @@ type Notification struct {
 }
 
 type PipelineSpec struct {
-	ID                  string             `json:"id,omitempty" tf:"computed"`
-	Name                string             `json:"name,omitempty"`
-	Storage             string             `json:"storage,omitempty" tf:"force_new"`
-	Catalog             string             `json:"catalog,omitempty" tf:"force_new"`
-	Configuration       map[string]string  `json:"configuration,omitempty"`
-	Clusters            []pipelineCluster  `json:"clusters,omitempty" tf:"alias:cluster"`
-	Libraries           []PipelineLibrary  `json:"libraries,omitempty" tf:"slice_set,alias:library"`
-	Filters             *filters           `json:"filters,omitempty"`
-	Continuous          bool               `json:"continuous,omitempty"`
-	Development         bool               `json:"development,omitempty"`
-	AllowDuplicateNames bool               `json:"allow_duplicate_names,omitempty"`
-	Target              string             `json:"target,omitempty"`
-	Photon              bool               `json:"photon,omitempty"`
-	Edition             string             `json:"edition,omitempty" tf:"suppress_diff,default:ADVANCED"`
-	Channel             string             `json:"channel,omitempty" tf:"suppress_diff,default:CURRENT"`
-	Notifications       []Notification     `json:"notifications,omitempty" tf:"alias:notification"`
-	Serverless          bool               `json:"serverless" tf:"optional"`
+	ID                  string              `json:"id,omitempty" tf:"computed"`
+	Name                string              `json:"name,omitempty"`
+	Storage             string              `json:"storage,omitempty" tf:"force_new"`
+	Catalog             string              `json:"catalog,omitempty" tf:"force_new"`
+	Configuration       map[string]string   `json:"configuration,omitempty"`
+	Clusters            []pipelineCluster   `json:"clusters,omitempty" tf:"alias:cluster"`
+	Libraries           []PipelineLibrary   `json:"libraries,omitempty" tf:"slice_set,alias:library"`
+	Filters             *filters            `json:"filters,omitempty"`
+	Continuous          bool                `json:"continuous,omitempty"`
+	Development         bool                `json:"development,omitempty"`
+	AllowDuplicateNames bool                `json:"allow_duplicate_names,omitempty"`
+	Target              string              `json:"target,omitempty"`
+	Photon              bool                `json:"photon,omitempty"`
+	Edition             string              `json:"edition,omitempty" tf:"suppress_diff,default:ADVANCED"`
+	Channel             string              `json:"channel,omitempty" tf:"suppress_diff,default:CURRENT"`
+	Notifications       []Notification      `json:"notifications,omitempty" tf:"alias:notification"`
+	Serverless          bool                `json:"serverless" tf:"optional"`
 	Deployment          *PipelineDeployment `json:"deployment,omitempty"`
 }
 

--- a/pipelines/resource_pipeline_test.go
+++ b/pipelines/resource_pipeline_test.go
@@ -36,14 +36,21 @@ var basicPipelineSpec = PipelineSpec{
 		Include: []string{"com.databricks.include"},
 		Exclude: []string{"com.databricks.exclude"},
 	},
+	Deployment: &PipelineDeployment{
+		Kind:             "BUNDLE",
+		MetadataFilePath: "/foo/bar",
+	},
+	Edition: "ADVANCED",
+	Channel: "CURRENT",
 }
 
 func TestResourcePipelineCreate(t *testing.T) {
 	d, err := qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
 			{
-				Method:   "POST",
-				Resource: "/api/2.0/pipelines",
+				Method:          "POST",
+				Resource:        "/api/2.0/pipelines",
+				ExpectedRequest: basicPipelineSpec,
 				Response: createPipelineResponse{
 					PipelineID: "abcd",
 				},
@@ -103,6 +110,10 @@ func TestResourcePipelineCreate(t *testing.T) {
 		  exclude = ["com.databricks.exclude"]
 		}
 		continuous = false
+		deployment {
+			kind = "BUNDLE"
+			metadata_file_path = "/foo/bar"
+		}
 		`,
 	}.Apply(t)
 	assert.NoError(t, err)


### PR DESCRIPTION
## Changes
This PR adds the `deployment` field to DABs. This will be used for DBU attribution and at some point in the future break-glass UI for DABs and Terraform.

OpenAPI changes are yet to go in, thus the structs are handwritten. Since this field is only meant for internal use we will not document it.

## Tests
Unit test and manually.

For manual testing I created a pipeline with `deployment` set:
```
resource "databricks_pipeline" this {
  name = "test-deployment"
  library {
    notebook {
      path = "/abc"
    }
  }
  deployment {
    kind = "BUNDLE"
    metadata_file_path = "/def/ghi"
  }
}
```

And checked it's `GET` output:
```
shreyas.goenka@THW32HFW6T terraform-playground % curl --request GET "https://e2-dogfood.staging.cloud.databricks.com/api/2.0/pipelines/0bc2bb77-7a32-44ff-99e4-129c0245f158" \
     --header "Authorization: Bearer ***" | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   564  100   564    0     0    716      0 --:--:-- --:--:-- --:--:--   716
{
  "pipeline_id": "0bc2bb77-7a32-44ff-99e4-129c0245f158",
  "spec": {
    "id": "0bc2bb77-7a32-44ff-99e4-129c0245f158",
    "pipeline_type": "WORKSPACE",
    "name": "test-deployment",
    "storage": "dbfs:/pipelines/0bc2bb77-7a32-44ff-99e4-129c0245f158",
    "libraries": [
      {
        "notebook": {
          "path": "/abc"
        }
      }
    ],
    "edition": "ADVANCED",
    "channel": "CURRENT",
    "serverless": false,
    "deployment": {
      "kind": "BUNDLE",
      "metadata_file_path": "/def/ghi"
    }
  },
  "state": "IDLE",
  "name": "test-deployment",
  "creator_user_name": "shreyas.goenka@databricks.com",
  "last_modified": 1712147638499,
  "run_as_user_name": "shreyas.goenka@databricks.com"
}
```