### PR TITLE
Fix `databricks_entitlement` Update & Delete

### DIFF
--- a/internal/acceptance/entitlements_test.go
+++ b/internal/acceptance/entitlements_test.go
@@ -3,11 +3,14 @@ package acceptance
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/databricks/databricks-sdk-go"
+	"github.com/databricks/databricks-sdk-go/httpclient"
 	"github.com/databricks/databricks-sdk-go/service/iam"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -101,51 +104,123 @@ func TestAccServicePrincipalEntitlementsResourceOnAws(t *testing.T) {
 	})
 }
 
-func TestAccIssue1860(t *testing.T) {
+type entitlement struct {
+	name  string
+	value bool
+}
+
+func (e entitlement) String() string {
+	return fmt.Sprintf("%s = %t", e.name, e.value)
+}
+
+func entitlementsStepBuilder(t *testing.T, c **httpclient.ApiClient, groupName string) func(entitlements []entitlement) step {
+	return func(entitlements []entitlement) step {
+		entitlementsBuf := strings.Builder{}
+		for _, entitlement := range entitlements {
+			entitlementsBuf.WriteString(fmt.Sprintf("%s\n", entitlement.String()))
+		}
+		return step{
+			Template: fmt.Sprintf(`
+			data "databricks_group" "example" {
+				display_name = "%s"
+			}
+			
+			resource "databricks_entitlements" "entitlements_users" {
+				group_id              = data.databricks_group.example.id
+				%s
+			}
+		`, groupName, entitlementsBuf.String()),
+			Check: func(s *terraform.State) error {
+				groupId := s.RootModule().Resources["data.databricks_group.example"].Primary.ID
+				var res iam.Group
+				ctx := context.Background()
+				err := (*c).Do(ctx, "GET", fmt.Sprintf("/api/2.0/preview/scim/v2/Groups/%s?attributes=entitlements", groupId),
+					httpclient.WithResponseUnmarshal(&res))
+				assert.NoError(t, err)
+				receivedEntitlements := make([]string, 0, len(res.Entitlements))
+				for _, entitlement := range res.Entitlements {
+					receivedEntitlements = append(receivedEntitlements, entitlement.Value)
+				}
+				expectedEntitlements := make([]string, 0, len(entitlements))
+				for _, entitlement := range entitlements {
+					if entitlement.value {
+						expectedEntitlements = append(expectedEntitlements, strings.ReplaceAll(entitlement.name, "_", "-"))
+					}
+				}
+				assert.ElementsMatch(t, expectedEntitlements, receivedEntitlements)
+				return nil
+			},
+		}
+
+	}
+}
+
+func makeEntitlementsSteps(t *testing.T, entitlementsSteps [][]entitlement) []step {
 	groupName := RandomName("entitlements-")
-	workspaceLevel(t, step{
-		PreConfig: func() {
-			w := databricks.Must(databricks.NewWorkspaceClient())
-			ctx := context.Background()
-			_, err := w.Groups.Create(ctx, iam.Group{
-				DisplayName: groupName,
-			})
+	var c *httpclient.ApiClient
+	makeEntitlementsStep := entitlementsStepBuilder(t, &c, groupName)
+	steps := make([]step, len(entitlementsSteps))
+	for i, entitlements := range entitlementsSteps {
+		steps[i] = makeEntitlementsStep(entitlements)
+	}
+	steps[0].PreConfig = makePreconfig(t, &c, groupName)
+	return steps
+}
+
+func makePreconfig(t *testing.T, c **httpclient.ApiClient, groupName string) func() {
+	return func() {
+		w := databricks.Must(databricks.NewWorkspaceClient())
+		var err error
+		*c, err = w.Config.NewApiClient()
+		assert.NoError(t, err)
+		ctx := context.Background()
+		group, err := w.Groups.Create(ctx, iam.Group{
+			DisplayName: groupName,
+		})
+		assert.NoError(t, err)
+		t.Cleanup(func() {
+			err := w.Groups.DeleteById(ctx, group.Id)
 			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestAccEntitlementsAddToEmpty(t *testing.T) {
+	steps := makeEntitlementsSteps(t, [][]entitlement{
+		{},
+		{
+			{"allow_cluster_create", true},
+			{"allow_instance_pool_create", true},
+			{"workspace_access", true},
+			{"databricks_sql_access", true},
 		},
-		Template: fmt.Sprintf(`
-		  data "databricks_group" "example" {
-			display_name = "%s"
-		  }
-		  
-		  resource "databricks_entitlements" "entitlements_users" {
-			group_id              = data.databricks_group.example.id
-		  }
-		`, groupName),
-	}, step{
-		Template: fmt.Sprintf(`
-		  data "databricks_group" "example" {
-			display_name = "%s"
-		  }
-		  resource "databricks_entitlements" "entitlements_users" {
-			group_id                   = data.databricks_group.example.id
-			allow_cluster_create       = true
-			allow_instance_pool_create = true
-			workspace_access           = true
-			databricks_sql_access      = true
-		  }
-		  `, groupName),
-	}, step{
-		Template: fmt.Sprintf(`
-		  data "databricks_group" "example" {
-			display_name = "%s"
-		  }
-		  resource "databricks_entitlements" "entitlements_users" {
-			group_id                   = data.databricks_group.example.id
-			allow_cluster_create       = false
-			allow_instance_pool_create = false
-			workspace_access           = true
-			databricks_sql_access      = true
-		  }
-		  `, groupName),
 	})
+	workspaceLevel(t, steps...)
+}
+
+func TestAccEntitlementsRemoveExisting(t *testing.T) {
+	steps := makeEntitlementsSteps(t, [][]entitlement{
+		{
+			{"allow_cluster_create", true},
+			{"allow_instance_pool_create", true},
+			{"workspace_access", true},
+			{"databricks_sql_access", true},
+		},
+		{},
+	})
+
+	workspaceLevel(t, steps...)
+}
+
+func TestAccEntitlementsSomeTrueSomeFalse(t *testing.T) {
+	steps := makeEntitlementsSteps(t, [][]entitlement{
+		{
+			{"allow_cluster_create", false},
+			{"allow_instance_pool_create", false},
+			{"workspace_access", true},
+			{"databricks_sql_access", true},
+		},
+	})
+
+	workspaceLevel(t, steps...)
 }

--- a/internal/acceptance/entitlements_test.go
+++ b/internal/acceptance/entitlements_test.go
@@ -198,6 +198,25 @@ func TestAccEntitlementsAddToEmpty(t *testing.T) {
 	workspaceLevel(t, steps...)
 }
 
+func TestAccEntitlementsSetExplicitlyToFalse(t *testing.T) {
+	steps := makeEntitlementsSteps(t, [][]entitlement{
+		{
+			{"allow_cluster_create", false},
+			{"allow_instance_pool_create", false},
+			{"workspace_access", false},
+			{"databricks_sql_access", false},
+		},
+		{},
+		{
+			{"allow_cluster_create", false},
+			{"allow_instance_pool_create", false},
+			{"workspace_access", false},
+			{"databricks_sql_access", false},
+		},
+	})
+	workspaceLevel(t, steps...)
+}
+
 func TestAccEntitlementsRemoveExisting(t *testing.T) {
 	steps := makeEntitlementsSteps(t, [][]entitlement{
 		{

--- a/internal/acceptance/entitlements_test.go
+++ b/internal/acceptance/entitlements_test.go
@@ -208,7 +208,6 @@ func TestAccEntitlementsRemoveExisting(t *testing.T) {
 		},
 		{},
 	})
-
 	workspaceLevel(t, steps...)
 }
 
@@ -221,6 +220,5 @@ func TestAccEntitlementsSomeTrueSomeFalse(t *testing.T) {
 			{"databricks_sql_access", true},
 		},
 	})
-
 	workspaceLevel(t, steps...)
 }

--- a/scim/data_group.go
+++ b/scim/data_group.go
@@ -32,7 +32,7 @@ func DataSourceGroup() common.Resource {
 		s["display_name"].ValidateFunc = validation.StringIsNotEmpty
 		s["recursive"].Default = true
 		s["members"].Deprecated = "Please use `users`, `service_principals`, and `child_groups` instead"
-		addEntitlementsToSchema(&s)
+		addEntitlementsToSchema(s)
 		return s
 	})
 

--- a/scim/resource_entitlement.go
+++ b/scim/resource_entitlement.go
@@ -75,11 +75,16 @@ func patchEntitlements(ctx context.Context, d *schema.ResourceData, c *common.Da
 	userId := d.Get("user_id").(string)
 	spnId := d.Get("service_principal_id").(string)
 	noEntitlementMessage := "invalidPath No such attribute with the name : entitlements in the current resource"
+	entitlements := readEntitlementsFromData(d)
+	if entitlements == nil {
+		// No updates are needed, so return early
+		return nil
+	}
 	request := PatchRequestComplexValue([]patchOperation{
 		{
 			op,
 			"entitlements",
-			readEntitlementsFromData(d),
+			entitlements,
 		},
 	})
 	if groupId != "" {

--- a/scim/resource_entitlement.go
+++ b/scim/resource_entitlement.go
@@ -28,6 +28,9 @@ func ResourceEntitlements() common.Resource {
 	addEntitlementsToSchema(entitlementSchema)
 	return common.Resource{
 		Create: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
+			if c.Config.IsAccountClient() {
+				return fmt.Errorf("entitlements can only be managed with a provider configured at the workspace-level")
+			}
 			err := patchEntitlements(ctx, d, c, "replace")
 			if err != nil {
 				return err

--- a/scim/resource_entitlement_test.go
+++ b/scim/resource_entitlement_test.go
@@ -71,23 +71,7 @@ var emptyAddRequest = PatchRequestComplexValue([]patchOperation{
 
 var updateRequest = PatchRequestComplexValue([]patchOperation{
 	{
-		"remove", "entitlements", []ComplexValue{
-			{
-				Value: "allow-cluster-create",
-			},
-			{
-				Value: "allow-instance-pool-create",
-			},
-			{
-				Value: "databricks-sql-access",
-			},
-			{
-				Value: "workspace-access",
-			},
-		},
-	},
-	{
-		"add", "entitlements", []ComplexValue{
+		"replace", "entitlements", []ComplexValue{
 			{
 				Value: "allow-cluster-create",
 			},

--- a/scim/resource_entitlement_test.go
+++ b/scim/resource_entitlement_test.go
@@ -747,3 +747,13 @@ func TestResourceEntitlementsGroupCreateEmpty(t *testing.T) {
 	assert.Equal(t, false, d.Get("databricks_sql_access"))
 	assert.Equal(t, false, d.Get("workspace_access"))
 }
+
+func TestResourceEntitlementsCreate_AccountLevelShouldError(t *testing.T) {
+	_, err := qa.ResourceFixture{
+		Resource:  ResourceEntitlements(),
+		HCL:       `group_id = "abc"`,
+		Create:    true,
+		AccountID: "abc-123",
+	}.Apply(t)
+	assert.Contains(t, "entitlements can only be managed with a provider configured at the workspace-level", err.Error())
+}

--- a/scim/resource_group.go
+++ b/scim/resource_group.go
@@ -19,7 +19,7 @@ func ResourceGroup() common.Resource {
 	}
 	groupSchema := common.StructToSchema(entity{},
 		func(m map[string]*schema.Schema) map[string]*schema.Schema {
-			addEntitlementsToSchema(&m)
+			addEntitlementsToSchema(m)
 			// https://github.com/databricks/terraform-provider-databricks/issues/1089
 			m["display_name"].ValidateDiagFunc = validation.ToDiagFunc(
 				validation.StringNotInSlice([]string{"users", "admins"}, false))
@@ -34,7 +34,7 @@ func ResourceGroup() common.Resource {
 			}
 			return m
 		})
-	addEntitlementsToSchema(&groupSchema)
+	addEntitlementsToSchema(groupSchema)
 	return common.Resource{
 		Create: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
 			g := Group{

--- a/scim/resource_service_principal.go
+++ b/scim/resource_service_principal.go
@@ -104,7 +104,7 @@ func ResourceServicePrincipal() common.Resource {
 	}
 	servicePrincipalSchema := common.StructToSchema(entity{},
 		func(m map[string]*schema.Schema) map[string]*schema.Schema {
-			addEntitlementsToSchema(&m)
+			addEntitlementsToSchema(m)
 			m["active"].Default = true
 			m["force"] = &schema.Schema{
 				Type:     schema.TypeBool,

--- a/scim/resource_user.go
+++ b/scim/resource_user.go
@@ -32,7 +32,7 @@ func ResourceUser() common.Resource {
 	}
 	userSchema := common.StructToSchema(entity{},
 		func(m map[string]*schema.Schema) map[string]*schema.Schema {
-			addEntitlementsToSchema(&m)
+			addEntitlementsToSchema(m)
 			m["user_name"].DiffSuppressFunc = common.EqualFoldDiffSuppress
 			m["active"].Default = true
 			m["force"] = &schema.Schema{

--- a/scim/scim.go
+++ b/scim/scim.go
@@ -101,10 +101,10 @@ func readEntitlementsFromData(d *schema.ResourceData) entitlements {
 	return e
 }
 
-func addEntitlementsToSchema(s *map[string]*schema.Schema) {
+func addEntitlementsToSchema(s map[string]*schema.Schema) {
 	for _, entitlement := range possibleEntitlements {
 		field_name := entitlementMapping[entitlement]
-		(*s)[field_name] = &schema.Schema{
+		s[field_name] = &schema.Schema{
 			Type:     schema.TypeBool,
 			Optional: true,
 			Default:  false,

--- a/scim/scim.go
+++ b/scim/scim.go
@@ -72,16 +72,6 @@ func (e entitlements) readIntoData(d *schema.ResourceData) error {
 	return nil
 }
 
-func generateFullEntitlements() entitlements {
-	var e entitlements
-	for _, entitlement := range possibleEntitlements {
-		e = append(e, ComplexValue{
-			Value: entitlement,
-		})
-	}
-	return e
-}
-
 func readEntitlementsFromData(d *schema.ResourceData) entitlements {
 	var e entitlements
 	for _, entitlement := range possibleEntitlements {
@@ -91,12 +81,6 @@ func readEntitlementsFromData(d *schema.ResourceData) entitlements {
 				Value: entitlement,
 			})
 		}
-	}
-	// if there is no nil value
-	if e == nil {
-		e = append(e, ComplexValue{
-			Value: "",
-		})
 	}
 	return e
 }

--- a/scim/scim.go
+++ b/scim/scim.go
@@ -82,6 +82,12 @@ func readEntitlementsFromData(d *schema.ResourceData) entitlements {
 			})
 		}
 	}
+	// if there is no nil value
+	if e == nil {
+		e = append(e, ComplexValue{
+			Value: "",
+		})
+	}
 	return e
 }
 


### PR DESCRIPTION
## Changes
It seems that updating entitlements may not be working properly, see #1840. I think there might be some issue with the way that updates are being sent to Databricks. Here's an example from a test I've written in this PR:
```
024-04-04T18:39:26.412+0200 [DEBUG] databricks: PATCH /api/2.0/preview/scim/v2/Groups/234408399693172
> {
>   "Operations": [
>     {
>       "op": "remove",
>       "path": "entitlements",
>       "value": [
>         {
>           "value": "allow-cluster-create"
>         },
>         {
>           "value": "allow-instance-pool-create"
>         },
>         {
>           "value": "databricks-sql-access"
>         },
>         {
>           "value": "workspace-access"
>         }
>       ]
>     },
>     {
>       "op": "add",
>       "path": "entitlements",
>       "value": [
>         {
>           "value": "allow-cluster-create"
>         },
>         {
>           "value": "allow-instance-pool-create"
>         },
>         {
>           "value": "databricks-sql-access"
>         },
>         {
>           "value": "workspace-access"
>         }
>       ]
>     }
>   ],
>   "schemas": [
>     "urn:ietf:params:scim:api:messages:2.0:PatchOp"
>   ]
> }
< HTTP/2.0 400 Bad Request
< {
<   "detail": "No such attribute with the name : entitlements in the current resource",
<   "schemas": [
<     "urn:ietf:params:scim:api:messages:2.0:Error"
<   ],
<   "scimType": "invalidPath",
<   "status": "400"
< }
```

I've modified the update implementation to more closely resemble the create implementation, using SCIM's `replace` operation to reset entitlements to the desired values. The only difference between the create and update pathways is that the ID is set in the create pathway. With additional testing added in this PR, this seems to address the issues users have been facing with entitlements.

Other cleanup in this PR:
* Change `addEntitlementsToSchema()` to accept `map[string]*schema.Schema`. `map`s are mutable so you don't need a pointer to update them.
* Only call `d.SetId()` in `Create`. This is save as changes to the user/group/SP will cause the resource to be recreated, so this doesn't need to be called in the update pathway.
* If no entitlements are set, deleting `databricks_entitlement` is a no-op, so exit early. This is the cause of the `No such attribute with the name : entitlements in the current resource` message when deleting a `databricks_entitlement` resource with no entitlements set.

## Tests
Added an integration test fixture harness to easily test entitlements. In particular, `databricks_entitlement` needs to be tested without a corresponding `databricks_user`/`databricks_group`/`databricks_service_principal` resource to ensure that its create/update/delete methods work properly. The test is written in a way where the first step's `PreConfig` creates a group, and then all steps' `databricks_entitlement` resources refer to that group. The group is cleaned up at the end of the test. I test three combinations:
* Create an empty databricks_entitlement, then add all of the allowed entitlements.
* Create a full databricks_entitlement, then remove all of the entitlements.
* Create a partial databricks_entitlement with some entitlements set to false.

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
