### PR TITLE
Clean up integration tests and expose helper functions for identifying cloud

### DIFF
--- a/catalog/resource_sql_table.go
+++ b/catalog/resource_sql_table.go
@@ -87,6 +87,7 @@ func sqlTableIsManagedProperty(key string) bool {
 		"delta.columnMapping.maxColumnId":                          true,
 		"delta.enableDeletionVectors":                              true,
 		"delta.enableRowTracking":                                  true,
+		"delta.feature.clustering":                                 true,
 		"delta.feature.deletionVectors":                            true,
 		"delta.feature.domainMetadata":                             true,
 		"delta.feature.liquid":                                     true,

--- a/internal/acceptance/account_rule_set_test.go
+++ b/internal/acceptance/account_rule_set_test.go
@@ -2,8 +2,6 @@ package acceptance
 
 import (
 	"context"
-	"os"
-	"strings"
 	"testing"
 
 	"github.com/databricks/databricks-sdk-go/service/iam"
@@ -14,8 +12,8 @@ import (
 )
 
 // Application ID is mandatory in Azure today.
-func getServicePrincipalResource(cloudEnv string) string {
-	if strings.HasPrefix(cloudEnv, "azure") {
+func getServicePrincipalResource() string {
+	if isAzure() {
 		return `
 		resource "databricks_service_principal" "this" {
 			application_id = "{var.RANDOM_UUID}"
@@ -31,9 +29,8 @@ func getServicePrincipalResource(cloudEnv string) string {
 }
 
 func TestMwsAccAccountServicePrincipalRuleSetsFullLifeCycle(t *testing.T) {
-	loadDebugEnvIfRunsFromIDE(t, "account")
-	cloudEnv := os.Getenv("CLOUD_ENV")
-	spResource := getServicePrincipalResource(cloudEnv)
+	loadAccountEnv(t)
+	spResource := getServicePrincipalResource()
 	accountLevel(t, step{
 		Template: spResource + `
 		resource "databricks_group" "this" {

--- a/internal/acceptance/account_rule_set_test.go
+++ b/internal/acceptance/account_rule_set_test.go
@@ -12,8 +12,8 @@ import (
 )
 
 // Application ID is mandatory in Azure today.
-func getServicePrincipalResource() string {
-	if isAzure() {
+func getServicePrincipalResource(t *testing.T) string {
+	if isAzure(t) {
 		return `
 		resource "databricks_service_principal" "this" {
 			application_id = "{var.RANDOM_UUID}"
@@ -30,7 +30,7 @@ func getServicePrincipalResource() string {
 
 func TestMwsAccAccountServicePrincipalRuleSetsFullLifeCycle(t *testing.T) {
 	loadAccountEnv(t)
-	spResource := getServicePrincipalResource()
+	spResource := getServicePrincipalResource(t)
 	accountLevel(t, step{
 		Template: spResource + `
 		resource "databricks_group" "this" {

--- a/internal/acceptance/catalog_test.go
+++ b/internal/acceptance/catalog_test.go
@@ -16,7 +16,7 @@ func TestUcAccCatalog(t *testing.T) {
 				purpose = "testing"
 			}
 			%s
-		}`, getPredictiveOptimizationSetting(true)),
+		}`, getPredictiveOptimizationSetting(t, true)),
 	})
 }
 
@@ -64,7 +64,7 @@ func TestUcAccCatalogUpdate(t *testing.T) {
 				purpose = "testing"
 			}
 			%s
-		}`, getPredictiveOptimizationSetting(true)),
+		}`, getPredictiveOptimizationSetting(t, true)),
 	}, step{
 		Template: fmt.Sprintf(`
 		resource "databricks_catalog" "sandbox" {
@@ -75,7 +75,7 @@ func TestUcAccCatalogUpdate(t *testing.T) {
 			}
 			%s
 			owner = "account users"
-		}`, getPredictiveOptimizationSetting(true)),
+		}`, getPredictiveOptimizationSetting(t, true)),
 	}, step{
 		Template: fmt.Sprintf(`
 		resource "databricks_catalog" "sandbox" {
@@ -86,7 +86,7 @@ func TestUcAccCatalogUpdate(t *testing.T) {
 			}
 			%s
 			owner = "{env.TEST_DATA_ENG_GROUP}"
-		}`, getPredictiveOptimizationSetting(true)),
+		}`, getPredictiveOptimizationSetting(t, true)),
 	}, step{
 		Template: fmt.Sprintf(`
 		resource "databricks_catalog" "sandbox" {
@@ -97,6 +97,6 @@ func TestUcAccCatalogUpdate(t *testing.T) {
 			}
 			%s
 			owner = "{env.TEST_METASTORE_ADMIN_GROUP_NAME}"
-		}`, getPredictiveOptimizationSetting(false)),
+		}`, getPredictiveOptimizationSetting(t, false)),
 	})
 }

--- a/internal/acceptance/catalog_test.go
+++ b/internal/acceptance/catalog_test.go
@@ -1,20 +1,22 @@
 package acceptance
 
 import (
+	"fmt"
 	"testing"
 )
 
 func TestUcAccCatalog(t *testing.T) {
+	loadUcwsEnv(t)
 	unityWorkspaceLevel(t, step{
-		Template: `
+		Template: fmt.Sprintf(`
 		resource "databricks_catalog" "sandbox" {
 			name         = "sandbox{var.RANDOM}"
 			comment      = "this catalog is managed by terraform"
 			properties = {
 				purpose = "testing"
 			}
-			enable_predictive_optimization = "ENABLE"
-		}`,
+			%s
+		}`, getPredictiveOptimizationSetting(true)),
 	})
 }
 
@@ -52,48 +54,49 @@ func TestUcAccCatalogIsolated(t *testing.T) {
 }
 
 func TestUcAccCatalogUpdate(t *testing.T) {
+	loadUcwsEnv(t)
 	unityWorkspaceLevel(t, step{
-		Template: `
+		Template: fmt.Sprintf(`
 		resource "databricks_catalog" "sandbox" {
 			name           = "sandbox{var.STICKY_RANDOM}"
 			comment        = "this catalog is managed by terraform"
 			properties     = {
 				purpose = "testing"
 			}
-			enable_predictive_optimization = "ENABLE"
-		}`,
+			%s
+		}`, getPredictiveOptimizationSetting(true)),
 	}, step{
-		Template: `
+		Template: fmt.Sprintf(`
 		resource "databricks_catalog" "sandbox" {
 			name           = "sandbox{var.STICKY_RANDOM}"
 			comment        = "this catalog is managed by terraform"
 			properties     = {
 				purpose = "testing"
 			}
-			enable_predictive_optimization = "ENABLE"
+			%s
 			owner = "account users"
-		}`,
+		}`, getPredictiveOptimizationSetting(true)),
 	}, step{
-		Template: `
+		Template: fmt.Sprintf(`
 		resource "databricks_catalog" "sandbox" {
 			name           = "sandbox{var.STICKY_RANDOM}"
 			comment        = "this catalog is managed by terraform"
 			properties     = {
 				purpose = "testing"
 			}
-			enable_predictive_optimization = "ENABLE"
+			%s
 			owner = "{env.TEST_DATA_ENG_GROUP}"
-		}`,
+		}`, getPredictiveOptimizationSetting(true)),
 	}, step{
-		Template: `
+		Template: fmt.Sprintf(`
 		resource "databricks_catalog" "sandbox" {
 			name           = "sandbox{var.STICKY_RANDOM}"
 			comment        = "this catalog is managed by terraform - updated comment"
 			properties     = {
 				purpose = "testing"
 			}
-			enable_predictive_optimization = "DISABLE"
+			%s
 			owner = "{env.TEST_METASTORE_ADMIN_GROUP_NAME}"
-		}`,
+		}`, getPredictiveOptimizationSetting(false)),
 	})
 }

--- a/internal/acceptance/data_current_config_test.go
+++ b/internal/acceptance/data_current_config_test.go
@@ -23,17 +23,17 @@ func checkCurrentConfig(t *testing.T, cloudType string, isAccount string) func(s
 
 func TestAccDataCurrentConfig(t *testing.T) {
 	loadWorkspaceEnv(t)
-	if isAws() {
+	if isAws(t) {
 		workspaceLevel(t, step{
 			Template: `data "databricks_current_config" "this" {}`,
 			Check:    checkCurrentConfig(t, "aws", "false"),
 		})
-	} else if isAzure() {
+	} else if isAzure(t) {
 		workspaceLevel(t, step{
 			Template: `data "databricks_current_config" "this" {}`,
 			Check:    checkCurrentConfig(t, "azure", "false"),
 		})
-	} else if isGcp() {
+	} else if isGcp(t) {
 		workspaceLevel(t, step{
 			Template: `data "databricks_current_config" "this" {}`,
 			Check:    checkCurrentConfig(t, "gcp", "false"),
@@ -43,17 +43,17 @@ func TestAccDataCurrentConfig(t *testing.T) {
 
 func TestMwsAccDataCurrentConfig(t *testing.T) {
 	loadAccountEnv(t)
-	if isAws() {
+	if isAws(t) {
 		accountLevel(t, step{
 			Template: `data "databricks_current_config" "this" {}`,
 			Check:    checkCurrentConfig(t, "aws", "true"),
 		})
-	} else if isAzure() {
+	} else if isAzure(t) {
 		accountLevel(t, step{
 			Template: `data "databricks_current_config" "this" {}`,
 			Check:    checkCurrentConfig(t, "azure", "true"),
 		})
-	} else if isGcp() {
+	} else if isGcp(t) {
 		accountLevel(t, step{
 			Template: `data "databricks_current_config" "this" {}`,
 			Check:    checkCurrentConfig(t, "gcp", "true"),

--- a/internal/acceptance/data_current_config_test.go
+++ b/internal/acceptance/data_current_config_test.go
@@ -1,7 +1,6 @@
 package acceptance
 
 import (
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -23,19 +22,18 @@ func checkCurrentConfig(t *testing.T, cloudType string, isAccount string) func(s
 }
 
 func TestAccDataCurrentConfig(t *testing.T) {
-	cloudEnv := os.Getenv("CLOUD_ENV")
-	switch cloudEnv {
-	case "aws":
+	loadWorkspaceEnv(t)
+	if isAws() {
 		workspaceLevel(t, step{
 			Template: `data "databricks_current_config" "this" {}`,
 			Check:    checkCurrentConfig(t, "aws", "false"),
 		})
-	case "azure":
+	} else if isAzure() {
 		workspaceLevel(t, step{
 			Template: `data "databricks_current_config" "this" {}`,
 			Check:    checkCurrentConfig(t, "azure", "false"),
 		})
-	case "gcp":
+	} else if isGcp() {
 		workspaceLevel(t, step{
 			Template: `data "databricks_current_config" "this" {}`,
 			Check:    checkCurrentConfig(t, "gcp", "false"),
@@ -44,19 +42,18 @@ func TestAccDataCurrentConfig(t *testing.T) {
 }
 
 func TestMwsAccDataCurrentConfig(t *testing.T) {
-	cloudEnv := os.Getenv("CLOUD_ENV")
-	switch cloudEnv {
-	case "MWS":
+	loadAccountEnv(t)
+	if isAws() {
 		accountLevel(t, step{
 			Template: `data "databricks_current_config" "this" {}`,
 			Check:    checkCurrentConfig(t, "aws", "true"),
 		})
-	case "azure-ucacct":
+	} else if isAzure() {
 		accountLevel(t, step{
 			Template: `data "databricks_current_config" "this" {}`,
 			Check:    checkCurrentConfig(t, "azure", "true"),
 		})
-	case "gcp-accounts":
+	} else if isGcp() {
 		accountLevel(t, step{
 			Template: `data "databricks_current_config" "this" {}`,
 			Check:    checkCurrentConfig(t, "gcp", "true"),

--- a/internal/acceptance/init_test.go
+++ b/internal/acceptance/init_test.go
@@ -370,25 +370,25 @@ func loadUcacctEnv(t *testing.T) {
 	loadDebugEnvIfRunsFromIDE(t, "ucacct")
 }
 
-func isAws() bool {
+func isAws(t *testing.T) bool {
 	awsCloudEnvs := []string{"MWS", "aws", "ucws", "ucacct"}
-	return isCloudEnvInList(awsCloudEnvs)
+	return isCloudEnvInList(t, awsCloudEnvs)
 }
 
-func isAzure() bool {
+func isAzure(t *testing.T) bool {
 	azureCloudEnvs := []string{"azure", "azure-ucacct"}
-	return isCloudEnvInList(azureCloudEnvs)
+	return isCloudEnvInList(t, azureCloudEnvs)
 }
 
-func isGcp() bool {
+func isGcp(t *testing.T) bool {
 	gcpCloudEnvs := []string{"gcp-accounts", "gcp-ucacct", "gcp-ucws", "gcp"}
-	return isCloudEnvInList(gcpCloudEnvs)
+	return isCloudEnvInList(t, gcpCloudEnvs)
 }
 
-func isCloudEnvInList(cloudEnvs []string) bool {
+func isCloudEnvInList(t *testing.T, cloudEnvs []string) bool {
 	cloudEnv := os.Getenv("CLOUD_ENV")
 	if cloudEnv == "" {
-		panic("CLOUD_ENV is not set. When debugging, ensure that load*Env functions are called before referencing the environment")
+		skipf(t)("Acceptance tests skipped unless env 'CLOUD_ENV' is set")
 	}
 	return slices.Contains(cloudEnvs, cloudEnv)
 }

--- a/internal/acceptance/init_test.go
+++ b/internal/acceptance/init_test.go
@@ -386,7 +386,11 @@ func isGcp() bool {
 }
 
 func isCloudEnvInList(cloudEnvs []string) bool {
-	return slices.Contains(cloudEnvs, os.Getenv("CLOUD_ENV"))
+	cloudEnv := os.Getenv("CLOUD_ENV")
+	if cloudEnv == "" {
+		panic("CLOUD_ENV is not set. When debugging, ensure that load*Env functions are called before referencing the environment")
+	}
+	return slices.Contains(cloudEnvs, cloudEnv)
 }
 
 // loads debug environment from ~/.databricks/debug-env.json

--- a/internal/acceptance/init_test.go
+++ b/internal/acceptance/init_test.go
@@ -9,6 +9,7 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -36,7 +37,7 @@ func init() {
 }
 
 func workspaceLevel(t *testing.T, steps ...step) {
-	loadDebugEnvIfRunsFromIDE(t, "workspace")
+	loadWorkspaceEnv(t)
 	t.Log(GetEnvOrSkipTest(t, "CLOUD_ENV"))
 	if os.Getenv("DATABRICKS_ACCOUNT_ID") != "" {
 		skipf(t)("Skipping workspace test on account level")
@@ -46,7 +47,7 @@ func workspaceLevel(t *testing.T, steps ...step) {
 }
 
 func accountLevel(t *testing.T, steps ...step) {
-	loadDebugEnvIfRunsFromIDE(t, "account")
+	loadAccountEnv(t)
 	cfg := &config.Config{
 		AccountID: GetEnvOrSkipTest(t, "DATABRICKS_ACCOUNT_ID"),
 	}
@@ -63,7 +64,7 @@ func accountLevel(t *testing.T, steps ...step) {
 }
 
 func unityWorkspaceLevel(t *testing.T, steps ...step) {
-	loadDebugEnvIfRunsFromIDE(t, "ucws")
+	loadUcwsEnv(t)
 	GetEnvOrSkipTest(t, "TEST_METASTORE_ID")
 	if os.Getenv("DATABRICKS_ACCOUNT_ID") != "" {
 		skipf(t)("Skipping workspace test on account level")
@@ -73,7 +74,7 @@ func unityWorkspaceLevel(t *testing.T, steps ...step) {
 }
 
 func unityAccountLevel(t *testing.T, steps ...step) {
-	loadDebugEnvIfRunsFromIDE(t, "ucacct")
+	loadUcacctEnv(t)
 	GetEnvOrSkipTest(t, "DATABRICKS_ACCOUNT_ID")
 	GetEnvOrSkipTest(t, "TEST_METASTORE_ID")
 	t.Parallel()
@@ -351,6 +352,41 @@ func skipf(t *testing.T) func(format string, args ...any) {
 func isInDebug() bool {
 	ex, _ := os.Executable()
 	return strings.HasPrefix(path.Base(ex), "__debug_bin")
+}
+
+func loadWorkspaceEnv(t *testing.T) {
+	loadDebugEnvIfRunsFromIDE(t, "workspace")
+}
+
+func loadAccountEnv(t *testing.T) {
+	loadDebugEnvIfRunsFromIDE(t, "account")
+}
+
+func loadUcwsEnv(t *testing.T) {
+	loadDebugEnvIfRunsFromIDE(t, "ucws")
+}
+
+func loadUcacctEnv(t *testing.T) {
+	loadDebugEnvIfRunsFromIDE(t, "ucacct")
+}
+
+func isAws() bool {
+	awsCloudEnvs := []string{"MWS", "aws", "ucws", "ucacct"}
+	return isCloudEnvInList(awsCloudEnvs)
+}
+
+func isAzure() bool {
+	azureCloudEnvs := []string{"azure", "azure-ucacct"}
+	return isCloudEnvInList(azureCloudEnvs)
+}
+
+func isGcp() bool {
+	gcpCloudEnvs := []string{"gcp-accounts", "gcp-ucacct", "gcp-ucws", "gcp"}
+	return isCloudEnvInList(gcpCloudEnvs)
+}
+
+func isCloudEnvInList(cloudEnvs []string) bool {
+	return slices.Contains(cloudEnvs, os.Getenv("CLOUD_ENV"))
 }
 
 // loads debug environment from ~/.databricks/debug-env.json

--- a/internal/acceptance/job_test.go
+++ b/internal/acceptance/job_test.go
@@ -376,7 +376,7 @@ func TestUcAccJobRunAsMutations(t *testing.T) {
 }
 
 func TestAccRemoveWebhooks(t *testing.T) {
-	// skipf(t)("There is no API to create notification destinations. Once available, add here and enable this test.")
+	skipf(t)("There is no API to create notification destinations. Once available, add here and enable this test.")
 	workspaceLevel(t, step{
 		Template: `
 		resource databricks_job test {

--- a/internal/acceptance/job_test.go
+++ b/internal/acceptance/job_test.go
@@ -347,16 +347,16 @@ func TestAccJobRunAsUser(t *testing.T) {
 	})
 }
 
-func TestAccJobRunAsServicePrincipal(t *testing.T) {
-	loadDebugEnvIfRunsFromIDE(t, "ucws")
+func TestUcAccJobRunAsServicePrincipal(t *testing.T) {
+	loadUcwsEnv(t)
 	spId := GetEnvOrSkipTest(t, "ACCOUNT_LEVEL_SERVICE_PRINCIPAL_ID")
 	unityWorkspaceLevel(t, step{
 		Template: runAsTemplate(`service_principal_name = "` + spId + `"`),
 	})
 }
 
-func TestAccJobRunAsMutations(t *testing.T) {
-	loadDebugEnvIfRunsFromIDE(t, "ucws")
+func TestUcAccJobRunAsMutations(t *testing.T) {
+	loadUcwsEnv(t)
 	spId := GetEnvOrSkipTest(t, "ACCOUNT_LEVEL_SERVICE_PRINCIPAL_ID")
 	unityWorkspaceLevel(
 		t,
@@ -375,7 +375,7 @@ func TestAccJobRunAsMutations(t *testing.T) {
 	)
 }
 
-func TestRemoveWebhooks(t *testing.T) {
+func TestAccRemoveWebhooks(t *testing.T) {
 	// skipf(t)("There is no API to create notification destinations. Once available, add here and enable this test.")
 	workspaceLevel(t, step{
 		Template: `

--- a/internal/acceptance/metastore_test.go
+++ b/internal/acceptance/metastore_test.go
@@ -9,23 +9,23 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func getStorageRoot() string {
-	if isAws() {
+func getStorageRoot(t *testing.T) string {
+	if isAws(t) {
 		return "s3://{env.TEST_BUCKET}/test{var.RANDOM}"
-	} else if isAzure() {
+	} else if isAzure(t) {
 		return "abfss://{var.RANDOM}@{var.RANDOM}/"
-	} else if isGcp() {
+	} else if isGcp(t) {
 		return "gs://{var.RANDOM}/metastore"
 	}
 	return ""
 }
 
-func getRegion() string {
-	if isAws() {
+func getRegion(t *testing.T) string {
+	if isAws(t) {
 		return "us-east-1"
-	} else if isAzure() {
+	} else if isAzure(t) {
 		return "eastus"
-	} else if isGcp() {
+	} else if isGcp(t) {
 		return "us-east1"
 	}
 	return ""
@@ -34,23 +34,23 @@ func getRegion() string {
 func TestUcAccRootlessMetastore(t *testing.T) {
 	loadUcacctEnv(t)
 	runMetastoreTest(t, map[string]any{
-		"region": getRegion(),
+		"region": getRegion(t),
 	})
 }
 
 func TestUcAccMetastore(t *testing.T) {
 	loadUcacctEnv(t)
 	runMetastoreTest(t, map[string]any{
-		"storage_root": getStorageRoot(),
-		"region":       getRegion(),
+		"storage_root": getStorageRoot(t),
+		"region":       getRegion(t),
 	})
 }
 
 func TestUcAccMetastoreDeltaSharing(t *testing.T) {
 	loadUcacctEnv(t)
 	runMetastoreTest(t, map[string]any{
-		"storage_root":        getStorageRoot(),
-		"region":              getRegion(),
+		"storage_root":        getStorageRoot(t),
+		"region":              getRegion(t),
 		"delta_sharing_scope": "INTERNAL",
 		"delta_sharing_recipient_token_lifetime_in_seconds": 3600,
 		"delta_sharing_organization_name":                   "databricks-tf-provider-test",
@@ -60,8 +60,8 @@ func TestUcAccMetastoreDeltaSharing(t *testing.T) {
 func TestUcAccMetastoreDeltaSharingInfiniteLifetime(t *testing.T) {
 	loadUcacctEnv(t)
 	runMetastoreTest(t, map[string]any{
-		"storage_root":        getStorageRoot(),
-		"region":              getRegion(),
+		"storage_root":        getStorageRoot(t),
+		"region":              getRegion(t),
 		"delta_sharing_scope": "INTERNAL",
 		"delta_sharing_recipient_token_lifetime_in_seconds": 0,
 	})
@@ -70,8 +70,8 @@ func TestUcAccMetastoreDeltaSharingInfiniteLifetime(t *testing.T) {
 func TestUcAccMetastoreWithOwnerUpdates(t *testing.T) {
 	loadUcacctEnv(t)
 	runMetastoreTestWithOwnerUpdates(t, map[string]any{
-		"storage_root": getStorageRoot(),
-		"region":       getRegion(),
+		"storage_root": getStorageRoot(t),
+		"region":       getRegion(t),
 	})
 }
 

--- a/internal/acceptance/metastore_test.go
+++ b/internal/acceptance/metastore_test.go
@@ -3,59 +3,54 @@ package acceptance
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
-func getStorageRoot(cloudEnv string) string {
-	switch cloudEnv {
-	case "ucacct":
+func getStorageRoot() string {
+	if isAws() {
 		return "s3://{env.TEST_BUCKET}/test{var.RANDOM}"
-	case "azure-ucacct":
+	} else if isAzure() {
 		return "abfss://{var.RANDOM}@{var.RANDOM}/"
-	case "gcp-accounts":
+	} else if isGcp() {
 		return "gs://{var.RANDOM}/metastore"
-	default:
-		return ""
 	}
+	return ""
 }
 
-func getRegion(cloudEnv string) string {
-	switch cloudEnv {
-	case "ucacct":
+func getRegion() string {
+	if isAws() {
 		return "us-east-1"
-	case "azure-ucacct":
+	} else if isAzure() {
 		return "eastus"
-	case "gcp-accounts":
+	} else if isGcp() {
 		return "us-east1"
-	default:
-		return ""
 	}
+	return ""
 }
 
 func TestUcAccRootlessMetastore(t *testing.T) {
-	loadDebugEnvIfRunsFromIDE(t, "ucacct")
+	loadUcacctEnv(t)
 	runMetastoreTest(t, map[string]any{
-		"region": getRegion(os.Getenv("CLOUD_ENV")),
+		"region": getRegion(),
 	})
 }
 
 func TestUcAccMetastore(t *testing.T) {
-	loadDebugEnvIfRunsFromIDE(t, "ucacct")
+	loadUcacctEnv(t)
 	runMetastoreTest(t, map[string]any{
-		"storage_root": getStorageRoot(os.Getenv("CLOUD_ENV")),
-		"region":       getRegion(os.Getenv("CLOUD_ENV")),
+		"storage_root": getStorageRoot(),
+		"region":       getRegion(),
 	})
 }
 
 func TestUcAccMetastoreDeltaSharing(t *testing.T) {
-	loadDebugEnvIfRunsFromIDE(t, "ucacct")
+	loadUcacctEnv(t)
 	runMetastoreTest(t, map[string]any{
-		"storage_root":        getStorageRoot(os.Getenv("CLOUD_ENV")),
-		"region":              getRegion(os.Getenv("CLOUD_ENV")),
+		"storage_root":        getStorageRoot(),
+		"region":              getRegion(),
 		"delta_sharing_scope": "INTERNAL",
 		"delta_sharing_recipient_token_lifetime_in_seconds": 3600,
 		"delta_sharing_organization_name":                   "databricks-tf-provider-test",
@@ -63,20 +58,20 @@ func TestUcAccMetastoreDeltaSharing(t *testing.T) {
 }
 
 func TestUcAccMetastoreDeltaSharingInfiniteLifetime(t *testing.T) {
-	loadDebugEnvIfRunsFromIDE(t, "ucacct")
+	loadUcacctEnv(t)
 	runMetastoreTest(t, map[string]any{
-		"storage_root":        getStorageRoot(os.Getenv("CLOUD_ENV")),
-		"region":              getRegion(os.Getenv("CLOUD_ENV")),
+		"storage_root":        getStorageRoot(),
+		"region":              getRegion(),
 		"delta_sharing_scope": "INTERNAL",
 		"delta_sharing_recipient_token_lifetime_in_seconds": 0,
 	})
 }
 
 func TestUcAccMetastoreWithOwnerUpdates(t *testing.T) {
-	loadDebugEnvIfRunsFromIDE(t, "ucacct")
+	loadUcacctEnv(t)
 	runMetastoreTestWithOwnerUpdates(t, map[string]any{
-		"storage_root": getStorageRoot(os.Getenv("CLOUD_ENV")),
-		"region":       getRegion(os.Getenv("CLOUD_ENV")),
+		"storage_root": getStorageRoot(),
+		"region":       getRegion(),
 	})
 }
 

--- a/internal/acceptance/model_serving_test.go
+++ b/internal/acceptance/model_serving_test.go
@@ -13,11 +13,9 @@ import (
 )
 
 func TestAccModelServing(t *testing.T) {
-	cloudEnv := os.Getenv("CLOUD_ENV")
-	switch cloudEnv {
-	case "aws", "azure":
-	default:
-		t.Skipf("not available on %s", cloudEnv)
+	loadWorkspaceEnv(t)
+	if isGcp() {
+		skipf(t)("not available on GCP")
 	}
 
 	clusterID := os.Getenv("TEST_DEFAULT_CLUSTER_ID")

--- a/internal/acceptance/model_serving_test.go
+++ b/internal/acceptance/model_serving_test.go
@@ -3,7 +3,6 @@ package acceptance
 import (
 	"context"
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/databricks/databricks-sdk-go"
@@ -14,14 +13,11 @@ import (
 
 func TestAccModelServing(t *testing.T) {
 	loadWorkspaceEnv(t)
-	if isGcp() {
+	if isGcp(t) {
 		skipf(t)("not available on GCP")
 	}
 
-	clusterID := os.Getenv("TEST_DEFAULT_CLUSTER_ID")
-	if clusterID == "" {
-		t.Skipf("default cluster not available")
-	}
+	clusterID := GetEnvOrSkipTest(t, "TEST_DEFAULT_CLUSTER_ID")
 
 	name := fmt.Sprintf("terraform-test-model-serving-%[1]s",
 		acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum))

--- a/internal/acceptance/schema_test.go
+++ b/internal/acceptance/schema_test.go
@@ -84,12 +84,24 @@ func schemaTemplateWithOwner(comment string, owner string) string {
 			properties = {
 				kind = "various"
 			}
-			enable_predictive_optimization = "ENABLE"
+			%s
 			owner = "%s"
-		}`, comment, owner)
+		}`, comment, getPredictiveOptimizationSetting(true), owner)
+}
+
+func getPredictiveOptimizationSetting(enabled bool) string {
+	if isGcp() {
+		return ""
+	}
+	value := "ENABLE"
+	if !enabled {
+		value = "DISABLE"
+	}
+	return fmt.Sprintf(`enable_predictive_optimization = "%s"`, value)
 }
 
 func TestUcAccSchemaUpdate(t *testing.T) {
+	loadUcwsEnv(t)
 	unityWorkspaceLevel(t, step{
 		Template: catalogTemplate + schemaTemplateWithOwner("this database is managed by terraform", "account users"),
 	}, step{

--- a/internal/acceptance/schema_test.go
+++ b/internal/acceptance/schema_test.go
@@ -75,7 +75,7 @@ func TestUcAccSchema(t *testing.T) {
 	})
 }
 
-func schemaTemplateWithOwner(comment string, owner string) string {
+func schemaTemplateWithOwner(t *testing.T, comment string, owner string) string {
 	return fmt.Sprintf(`
 		resource "databricks_schema" "things" {
 			catalog_name = databricks_catalog.sandbox.id
@@ -86,11 +86,11 @@ func schemaTemplateWithOwner(comment string, owner string) string {
 			}
 			%s
 			owner = "%s"
-		}`, comment, getPredictiveOptimizationSetting(true), owner)
+		}`, comment, getPredictiveOptimizationSetting(t, true), owner)
 }
 
-func getPredictiveOptimizationSetting(enabled bool) string {
-	if isGcp() {
+func getPredictiveOptimizationSetting(t *testing.T, enabled bool) string {
+	if isGcp(t) {
 		return ""
 	}
 	value := "ENABLE"
@@ -103,12 +103,12 @@ func getPredictiveOptimizationSetting(enabled bool) string {
 func TestUcAccSchemaUpdate(t *testing.T) {
 	loadUcwsEnv(t)
 	unityWorkspaceLevel(t, step{
-		Template: catalogTemplate + schemaTemplateWithOwner("this database is managed by terraform", "account users"),
+		Template: catalogTemplate + schemaTemplateWithOwner(t, "this database is managed by terraform", "account users"),
 	}, step{
-		Template: catalogTemplate + schemaTemplateWithOwner("this database is managed by terraform -- updated comment", "account users"),
+		Template: catalogTemplate + schemaTemplateWithOwner(t, "this database is managed by terraform -- updated comment", "account users"),
 	}, step{
-		Template: catalogTemplate + schemaTemplateWithOwner("this database is managed by terraform -- updated comment", "{env.TEST_DATA_ENG_GROUP}"),
+		Template: catalogTemplate + schemaTemplateWithOwner(t, "this database is managed by terraform -- updated comment", "{env.TEST_DATA_ENG_GROUP}"),
 	}, step{
-		Template: catalogTemplate + schemaTemplateWithOwner("this database is managed by terraform -- updated comment 2", "{env.TEST_METASTORE_ADMIN_GROUP_NAME}"),
+		Template: catalogTemplate + schemaTemplateWithOwner(t, "this database is managed by terraform -- updated comment 2", "{env.TEST_METASTORE_ADMIN_GROUP_NAME}"),
 	})
 }

--- a/internal/acceptance/secret_acl_test.go
+++ b/internal/acceptance/secret_acl_test.go
@@ -71,6 +71,11 @@ func TestAccSecretAclResourceDefaultPrincipal(t *testing.T) {
 				require.NoError(t, err)
 				acls := acls_resp.Items
 				assert.Equal(t, 1, len(acls))
+				// assert does not stop execution on failure, but this test must stop if no
+				// ACLs are returned, otherwise it panics, stopping all other test executions.
+				if len(acls) == 0 {
+					t.FailNow()
+				}
 				assert.Equal(t, "users", acls[0].Principal)
 				assert.Equal(t, "READ", string(acls[0].Permission))
 				return nil

--- a/internal/acceptance/sql_global_config_test.go
+++ b/internal/acceptance/sql_global_config_test.go
@@ -3,7 +3,6 @@ package acceptance
 import (
 	"context"
 	"fmt"
-	"os"
 	"strconv"
 	"strings"
 	"testing"
@@ -38,7 +37,7 @@ resource "databricks_sql_global_config" "this" {
 }
 
 func TestAccSQLGlobalConfig(t *testing.T) {
-	loadDebugEnvIfRunsFromIDE(t, "workspace")
+	loadWorkspaceEnv(t)
 	workspaceLevel(t, step{
 		PreConfig: func() {
 			ctx := context.Background()
@@ -50,8 +49,8 @@ func TestAccSQLGlobalConfig(t *testing.T) {
 }
 
 func TestAccSQLGlobalConfigServerless(t *testing.T) {
-	loadDebugEnvIfRunsFromIDE(t, "workspace")
-	if strings.Contains(os.Getenv("CLOUD_ENV"), "gcp") {
+	loadWorkspaceEnv(t)
+	if isGcp() {
 		skipf(t)("GCP does not support serverless compute")
 	}
 

--- a/internal/acceptance/sql_global_config_test.go
+++ b/internal/acceptance/sql_global_config_test.go
@@ -50,7 +50,7 @@ func TestAccSQLGlobalConfig(t *testing.T) {
 
 func TestAccSQLGlobalConfigServerless(t *testing.T) {
 	loadWorkspaceEnv(t)
-	if isGcp() {
+	if isGcp(t) {
 		skipf(t)("GCP does not support serverless compute")
 	}
 

--- a/internal/acceptance/storage_credential_test.go
+++ b/internal/acceptance/storage_credential_test.go
@@ -1,14 +1,12 @@
 package acceptance
 
 import (
-	"os"
 	"testing"
 )
 
 func TestUcAccStorageCredential(t *testing.T) {
-	cloudEnv := os.Getenv("CLOUD_ENV")
-	switch cloudEnv {
-	case "ucws":
+	loadUcwsEnv(t)
+	if isAws() {
 		unityWorkspaceLevel(t, step{
 			Template: `
 				resource "databricks_storage_credential" "external" {
@@ -20,7 +18,7 @@ func TestUcAccStorageCredential(t *testing.T) {
 					comment = "Managed by TF"
 				}`,
 		})
-	case "gcp-ucws":
+	} else if isGcp() {
 		unityWorkspaceLevel(t, step{
 			Template: `
 				resource "databricks_storage_credential" "external" {

--- a/internal/acceptance/storage_credential_test.go
+++ b/internal/acceptance/storage_credential_test.go
@@ -6,7 +6,7 @@ import (
 
 func TestUcAccStorageCredential(t *testing.T) {
 	loadUcwsEnv(t)
-	if isAws() {
+	if isAws(t) {
 		unityWorkspaceLevel(t, step{
 			Template: `
 				resource "databricks_storage_credential" "external" {
@@ -18,7 +18,7 @@ func TestUcAccStorageCredential(t *testing.T) {
 					comment = "Managed by TF"
 				}`,
 		})
-	} else if isGcp() {
+	} else if isGcp(t) {
 		unityWorkspaceLevel(t, step{
 			Template: `
 				resource "databricks_storage_credential" "external" {

--- a/internal/acceptance/vector_search_test.go
+++ b/internal/acceptance/vector_search_test.go
@@ -2,18 +2,15 @@ package acceptance
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 )
 
 func TestUcAccVectorSearchEndpoint(t *testing.T) {
-	cloudEnv := os.Getenv("CLOUD_ENV")
-	switch cloudEnv {
-	case "ucws", "azure":
-	default:
-		t.Skipf("not available on %s", cloudEnv)
+	loadUcwsEnv(t)
+	if isGcp() {
+		skipf(t)("not available on GCP")
 	}
 
 	name := fmt.Sprintf("terraform-test-vector-search-%[1]s",

--- a/internal/acceptance/vector_search_test.go
+++ b/internal/acceptance/vector_search_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestUcAccVectorSearchEndpoint(t *testing.T) {
 	loadUcwsEnv(t)
-	if isGcp() {
+	if isGcp(t) {
 		skipf(t)("not available on GCP")
 	}
 


### PR DESCRIPTION
## Changes
This PR introduces two key improvements in the integration test library:
* `isAws()`, `isGcp()` and `isAzure()` can be used to determine whether the integration test runner is targeting a specific cloud.
* `loadWorkspaceEnv()`, `loadAccountEnv()`, `loadUcwsEnv()` and `loadUcacctEnv()` simplify loading a specific debug environment for integration tests that rely on environment variables before calling `workspaceLevel()`/`accountLevel()`/`unityWorkspaceLevel()`/`unityAccountLevel()` test helpers.

I've gone through the codebase and replaced usage of the confusing `CLOUD_ENV` variable with these helpers.

Additionally, I found several integration tests that are not running correctly due to their naming, which I've corrected. 

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
