### PR TITLE
Fix `databricks_mws_private_access_settings` creation

### DIFF
--- a/docs/resources/mws_private_access_settings.md
+++ b/docs/resources/mws_private_access_settings.md
@@ -29,7 +29,6 @@ The `databricks_mws_private_access_settings.pas.private_access_settings_id` can 
 ```hcl
 resource "databricks_mws_workspaces" "this" {
   provider                   = databricks.mws
-  account_id                 = var.databricks_account_id
   aws_region                 = var.region
   workspace_name             = local.prefix
   credentials_id             = databricks_mws_credentials.this.credentials_id
@@ -48,7 +47,6 @@ resource "databricks_mws_workspaces" "this" {
 ```hcl
 resource "databricks_mws_workspaces" "this" {
   provider       = databricks.mws
-  account_id     = var.databricks_account_id
   workspace_name = "gcp-workspace"
   location       = var.subnet_region
   cloud_resource_container {
@@ -71,7 +69,6 @@ resource "databricks_mws_workspaces" "this" {
 
 The following arguments are available:
 
-* `account_id` - Account Id that could be found in the Accounts Console for [AWS](https://accounts.cloud.databricks.com/) or [GCP](https://accounts.gcp.databricks.com/)
 * `private_access_settings_name` - Name of Private Access Settings in Databricks Account
 * `public_access_enabled` (Boolean, Optional, `false` by default on AWS, `true` by default on GCP) - If `true`, the [databricks_mws_workspaces](mws_workspaces.md) can be accessed over the [databricks_mws_vpc_endpoint](mws_vpc_endpoint.md) as well as over the public network. In such a case, you could also configure an [databricks_ip_access_list](ip_access_list.md) for the workspace, to restrict the source networks that could be used to access it over the public network. If `false`, the workspace can be accessed only over VPC endpoints, and not over the public network. Once explicitly set, this field becomes mandatory.
 * `region` - Region of AWS VPC or the Google Cloud VPC network

--- a/mws/resource_mws_private_access_settings.go
+++ b/mws/resource_mws_private_access_settings.go
@@ -15,9 +15,9 @@ func ResourceMwsPrivateAccessSettings() common.Resource {
 	pasSchema := common.StructToSchema(provisioning.PrivateAccessSettings{}, func(m map[string]*schema.Schema) map[string]*schema.Schema {
 		common.CustomizeSchemaPath(m, "private_access_settings_name").SetValidateFunc(validation.StringLenBetween(4, 256))
 		common.CustomizeSchemaPath(m, "private_access_settings_name").SetRequired()
+
 		common.CustomizeSchemaPath(m, "region").SetRequired()
 
-		common.CustomizeSchemaPath(m, "private_access_level").SetValidateFunc(validation.StringInSlice([]string{"ACCOUNT", "ENDPOINT"}, true))
 		common.CustomizeSchemaPath(m, "private_access_settings_id").SetComputed()
 
 		common.CustomizeSchemaPath(m, "private_access_level").SetValidateFunc(validation.StringInSlice([]string{"ACCOUNT", "ENDPOINT"}, true))

--- a/mws/resource_mws_private_access_settings.go
+++ b/mws/resource_mws_private_access_settings.go
@@ -42,6 +42,7 @@ func ResourceMwsPrivateAccessSettings() common.Resource {
 				return err
 			}
 			d.Set("private_access_settings_id", res.PrivateAccessSettingsId)
+			d.Set("account_id", res.AccountId)
 			p.Pack(d)
 			return nil
 		},

--- a/mws/resource_mws_private_access_settings.go
+++ b/mws/resource_mws_private_access_settings.go
@@ -12,30 +12,30 @@ import (
 )
 
 func ResourceMwsPrivateAccessSettings() common.Resource {
-	s := common.StructToSchema(provisioning.PrivateAccessSettings{}, func(s map[string]*schema.Schema) map[string]*schema.Schema {
-		// nolint
-		s["private_access_settings_name"].ValidateFunc = validation.StringLenBetween(4, 256)
-		common.SetRequired(s["private_access_settings_name"])
-		common.SetRequired(s["region"])
+	pasSchema := common.StructToSchema(provisioning.PrivateAccessSettings{}, func(m map[string]*schema.Schema) map[string]*schema.Schema {
+		common.CustomizeSchemaPath(m, "private_access_settings_name").SetValidateFunc(validation.StringLenBetween(4, 256))
+		common.CustomizeSchemaPath(m, "private_access_settings_name").SetRequired()
+		common.CustomizeSchemaPath(m, "region").SetRequired()
 
-		s["private_access_level"].ValidateFunc = validation.StringInSlice([]string{"ACCOUNT", "ENDPOINT"}, true)
-		common.SetDefault(s["private_access_level"], "ACCOUNT")
+		common.CustomizeSchemaPath(m, "private_access_level").SetValidateFunc(validation.StringInSlice([]string{"ACCOUNT", "ENDPOINT"}, true))
+		common.CustomizeSchemaPath(m, "private_access_settings_id").SetComputed()
 
-		s["private_access_settings_id"].Computed = true
+		common.CustomizeSchemaPath(m, "private_access_level").SetValidateFunc(validation.StringInSlice([]string{"ACCOUNT", "ENDPOINT"}, true))
+		common.CustomizeSchemaPath(m, "private_access_level").SetDefault("ACCOUNT")
 
-		common.AddAccountIdField(s)
-		return s
+		common.AddAccountIdField(m)
+		return m
 	})
 	p := common.NewPairSeparatedID("account_id", "private_access_settings_id", "/")
 	return common.Resource{
-		Schema: s,
+		Schema: pasSchema,
 		Create: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
 			a, err := c.AccountClientWithAccountIdFromConfig(d)
 			if err != nil {
 				return err
 			}
 			var pas provisioning.UpsertPrivateAccessSettingsRequest
-			common.DataToStructPointer(d, s, &pas)
+			common.DataToStructPointer(d, pasSchema, &pas)
 			common.SetForceSendFields(&pas, d, []string{"public_access_enabled"})
 			res, err := a.PrivateAccess.Create(ctx, pas)
 			if err != nil {
@@ -55,7 +55,7 @@ func ResourceMwsPrivateAccessSettings() common.Resource {
 			if err != nil {
 				return err
 			}
-			return common.StructToData(pas, s, d)
+			return common.StructToData(pas, pasSchema, d)
 		},
 		Update: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
 			a, pasID, err := c.AccountClientWithAccountIdFromPair(d, p)
@@ -63,7 +63,7 @@ func ResourceMwsPrivateAccessSettings() common.Resource {
 				return err
 			}
 			var pas provisioning.UpsertPrivateAccessSettingsRequest
-			common.DataToStructPointer(d, s, &pas)
+			common.DataToStructPointer(d, pasSchema, &pas)
 			common.SetForceSendFields(&pas, d, []string{"public_access_enabled"})
 			pas.PrivateAccessSettingsId = pasID
 			return a.PrivateAccess.Replace(ctx, pas)

--- a/mws/resource_mws_private_access_settings_test.go
+++ b/mws/resource_mws_private_access_settings_test.go
@@ -24,6 +24,7 @@ func TestResourcePASCreate(t *testing.T) {
 				PrivateAccessLevel:        "ACCOUNT",
 			}).Return(&provisioning.PrivateAccessSettings{
 				PrivateAccessSettingsId: "pas_id",
+				AccountId:               "abc",
 			}, nil)
 			e.GetByPrivateAccessSettingsId(mock.Anything, "pas_id").Return(&provisioning.PrivateAccessSettings{
 				PrivateAccessSettingsId:   "pas_id",
@@ -85,6 +86,7 @@ func TestResourcePASCreate_PublicAccessDisabled(t *testing.T) {
 				ForceSendFields:           []string{"PublicAccessEnabled"},
 			}).Return(&provisioning.PrivateAccessSettings{
 				PrivateAccessSettingsId: "pas_id",
+				AccountId:               "abc",
 			}, nil)
 			e.GetByPrivateAccessSettingsId(mock.Anything, "pas_id").Return(&provisioning.PrivateAccessSettings{
 				PrivateAccessSettingsId:   "pas_id",
@@ -93,7 +95,8 @@ func TestResourcePASCreate_PublicAccessDisabled(t *testing.T) {
 				ForceSendFields:           []string{"PublicAccessEnabled"},
 			}, nil)
 		},
-		Resource: ResourceMwsPrivateAccessSettings(),
+		Resource:  ResourceMwsPrivateAccessSettings(),
+		AccountID: "abc",
 		HCL: `
 		account_id = "abc"
 		private_access_settings_name = "pas_name"


### PR DESCRIPTION
## Changes
- `account_id` was not set correctly during creation, leading to failure during read
Closes #3409

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [x] using Go SDK
