### PR TITLE
Fix suppress_diff for webhook notifications at the task level in `databricks_job`

### DIFF
--- a/common/reflect_resource.go
+++ b/common/reflect_resource.go
@@ -172,8 +172,28 @@ func SchemaPath(s map[string]*schema.Schema, path ...string) (*schema.Schema, er
 	return nil, fmt.Errorf("%v does not compute", path)
 }
 
+func SchemaMap(s map[string]*schema.Schema, path ...string) (map[string]*schema.Schema, error) {
+	sch, err := SchemaPath(s, path...)
+	if err != nil {
+		return nil, err
+	}
+	cv, ok := sch.Elem.(*schema.Resource)
+	if !ok {
+		return nil, fmt.Errorf("%s is not nested resource", path[len(path)-1])
+	}
+	return cv.Schema, nil
+}
+
 func MustSchemaPath(s map[string]*schema.Schema, path ...string) *schema.Schema {
 	sch, err := SchemaPath(s, path...)
+	if err != nil {
+		panic(err)
+	}
+	return sch
+}
+
+func MustSchemaMap(s map[string]*schema.Schema, path ...string) map[string]*schema.Schema {
+	sch, err := SchemaMap(s, path...)
 	if err != nil {
 		panic(err)
 	}

--- a/jobs/resource_job.go
+++ b/jobs/resource_job.go
@@ -773,7 +773,7 @@ var jobSchema = common.StructToSchema(JobSettings{},
 
 		// Clear the implied diff suppression for the webhook notification lists
 		fixWebhookNotifications(s)
-		fixWebhookNotifications(common.MustSchemaMap(s, "tasks"))
+		fixWebhookNotifications(common.MustSchemaMap(s, "task"))
 
 		return s
 	})

--- a/pipelines/resource_pipeline.go
+++ b/pipelines/resource_pipeline.go
@@ -332,8 +332,7 @@ func suppressStorageDiff(k, old, new string, d *schema.ResourceData) bool {
 }
 
 func adjustPipelineResourceSchema(m map[string]*schema.Schema) map[string]*schema.Schema {
-	cluster, _ := m["cluster"].Elem.(*schema.Resource)
-	clustersSchema := cluster.Schema
+	clustersSchema := common.MustSchemaMap(m, "cluster")
 	clustersSchema["spark_conf"].DiffSuppressFunc = clusters.SparkConfDiffSuppressFunc
 	common.MustSchemaPath(clustersSchema,
 		"aws_attributes", "zone_id").DiffSuppressFunc = clusters.ZoneDiffSuppress
@@ -341,8 +340,7 @@ func adjustPipelineResourceSchema(m map[string]*schema.Schema) map[string]*schem
 
 	common.MustSchemaPath(clustersSchema, "init_scripts", "dbfs").Deprecated = clusters.DbfsDeprecationWarning
 
-	gcpAttributes, _ := clustersSchema["gcp_attributes"].Elem.(*schema.Resource)
-	gcpAttributesSchema := gcpAttributes.Schema
+	gcpAttributesSchema := common.MustSchemaMap(clustersSchema, "gcp_attributes")
 	delete(gcpAttributesSchema, "use_preemptible_executors")
 	delete(gcpAttributesSchema, "boot_disk_size")
 

--- a/sql/resource_sql_alerts.go
+++ b/sql/resource_sql_alerts.go
@@ -124,8 +124,7 @@ func (a *AlertEntity) fromAPIObject(apiAlert *sql.Alert, s map[string]*schema.Sc
 
 func ResourceSqlAlert() common.Resource {
 	s := common.StructToSchema(AlertEntity{}, func(m map[string]*schema.Schema) map[string]*schema.Schema {
-		options := m["options"].Elem.(*schema.Resource)
-		options.Schema["op"].ValidateFunc = validation.StringInSlice([]string{">", ">=", "<", "<=", "==", "!="}, true)
+		common.MustSchemaPath(m, "options", "op").ValidateFunc = validation.StringInSlice([]string{">", ">=", "<", "<=", "==", "!="}, true)
 		return m
 	})
 

--- a/sql/resource_sql_query.go
+++ b/sql/resource_sql_query.go
@@ -515,7 +515,7 @@ func ResourceSqlQuery() common.Resource {
 		QueryEntity{},
 		func(m map[string]*schema.Schema) map[string]*schema.Schema {
 			m["schedule"].Deprecated = "Operations on `databricks_sql_query` schedules are deprecated. Please use `databricks_job` resource to schedule a `sql_task`."
-			schedule := m["schedule"].Elem.(*schema.Resource)
+			schedule := common.MustSchemaMap(m, "schedule")
 
 			// Make different query schedule types mutually exclusive.
 			{
@@ -525,15 +525,15 @@ func ResourceSqlQuery() common.Resource {
 						if n1 == n2 {
 							continue
 						}
-						schedule.Schema[n1].ConflictsWith = append(schedule.Schema[n1].ConflictsWith, fmt.Sprintf("schedule.0.%s", n2))
+						schedule[n1].ConflictsWith = append(schedule[n1].ConflictsWith, fmt.Sprintf("schedule.0.%s", n2))
 					}
 				}
 			}
 
 			// Validate week of day in weekly schedule.
 			// Manually verified that this is case sensitive.
-			weekly := schedule.Schema["weekly"].Elem.(*schema.Resource)
-			weekly.Schema["day_of_week"].ValidateFunc = validation.StringInSlice([]string{
+			weekly := common.MustSchemaMap(schedule, "weekly")
+			weekly["day_of_week"].ValidateFunc = validation.StringInSlice([]string{
 				"Sunday",
 				"Monday",
 				"Tuesday",


### PR DESCRIPTION
## Changes
https://github.com/databricks/terraform-provider-databricks/commit/602bff98b6f80720927a145a82b8bc371b7a7cde fixed an issue in `webhook_notifications` where the provider would fail if a user removed the last webhook notification of a particular type. However, this only applied at the job level, not at the task level.

This PR removes diff suppression on the webhook notifications at the task level. As part of this, it introduces a new pair of helper methods, `SchemaMap` and `MustSchemaMap`. These behave similarly to `SchemaPath` and `MustSchemaPath`. The latter two return the entry in the `map[string]*schema.Schema` for a particular field recursively, but if you need to get that field's schema, you need to subsequently inspect the `Elem` field and assert that its type is `*schema.Resource` before reading its `Schema` field. `SchemaMap` handles this for you.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
