### PR TITLE
Exporter: skip listing of jobs deployed with DABs

### DIFF
--- a/docs/guides/experimental-exporter.md
+++ b/docs/guides/experimental-exporter.md
@@ -67,7 +67,7 @@ Services are just logical groups of resources used for filtering and organizatio
 * `directories` - **listing** [databricks_directory](../resources/directory.md).
 * `dlt` - **listing** [databricks_pipeline](../resources/pipeline.md).
 * `groups` - **listing** [databricks_group](../data-sources/group.md) with [membership](../resources/group_member.md) and [data access](../resources/group_instance_profile.md).
-* `jobs` - **listing** [databricks_job](../resources/job.md). Usually, there are more automated jobs than interactive clusters, so they get their own file in this tool's output.
+* `jobs` - **listing** [databricks_job](../resources/job.md). Usually, there are more automated workflows than interactive clusters, so they get their own file in this tool's output.  *Please note that workflows deployed and maintained via [Databricks Asset Bundles](https://docs.databricks.com/en/dev-tools/bundles/index.html) aren't exported!*
 * `mlflow-webhooks` - **listing** [databricks_mlflow_webhook](../resources/mlflow_webhook.md).
 * `model-serving` - **listing** [databricks_model_serving](../resources/model_serving.md).
 * `mounts` - **listing** works only in combination with `-mounts` command-line option.

--- a/exporter/importables_test.go
+++ b/exporter/importables_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/databricks/databricks-sdk-go/service/catalog"
 	"github.com/databricks/databricks-sdk-go/service/compute"
 	"github.com/databricks/databricks-sdk-go/service/iam"
+	sdk_jobs "github.com/databricks/databricks-sdk-go/service/jobs"
 	"github.com/databricks/databricks-sdk-go/service/sharing"
 	sdk_workspace "github.com/databricks/databricks-sdk-go/service/workspace"
 	tfcatalog "github.com/databricks/terraform-provider-databricks/catalog"
@@ -434,13 +435,22 @@ func TestInstnacePoolsListWithMatch(t *testing.T) {
 	})
 }
 
-func TestJobListNoNameMatch(t *testing.T) {
+func TestJobListNoNameMatchOrFromBundles(t *testing.T) {
 	ic := importContextForTest()
 	ic.match = "bcd"
 	ic.importJobs([]jobs.Job{
 		{
 			Settings: &jobs.JobSettings{
 				Name: "abc",
+			},
+		},
+		{
+			Settings: &jobs.JobSettings{
+				Name:     "bcd",
+				EditMode: "UI_LOCKED",
+				Deployment: &sdk_jobs.JobDeployment{
+					Kind: "BUNDLE",
+				},
 			},
 		},
 	})

--- a/exporter/util.go
+++ b/exporter/util.go
@@ -822,6 +822,11 @@ func (ic *importContext) importJobs(l []jobs.Job) {
 			log.Printf("[INFO] Job name %s doesn't match selection %s", job.Settings.Name, ic.match)
 			continue
 		}
+		if job.Settings.Deployment != nil && job.Settings.Deployment.Kind == "BUNDLE" &&
+			job.Settings.EditMode == "UI_LOCKED" {
+			log.Printf("[INFO] Skipping job '%s' because it's deployed by DABs", job.Settings.Name)
+			continue
+		}
 		ic.Emit(&resource{
 			Resource: "databricks_job",
 			ID:       job.ID(),


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

Because these jobs could be deployed with DABs it makes little sense to export them into Terraform...

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
