### PR TITLE
Only suppress diff for `run_if` when it is `ALL_SUCCESS`

### DIFF
--- a/common/customizable_schema.go
+++ b/common/customizable_schema.go
@@ -90,7 +90,7 @@ func (s *CustomizableSchema) SetSuppressDiff() *CustomizableSchema {
 // the old value (ie value from state / platform) is equal to the default value.
 //
 // Often Databricks HTTP APIs will return values for fields that were not set by
-// the author in their terraform configuration This function allows us to suppress
+// the author in their terraform configuration. This function allows us to suppress
 // the diff in these cases.
 func (s *CustomizableSchema) SetSuppressDiffWithDefault(dv any) *CustomizableSchema {
 	primitiveTypes := []schema.ValueType{schema.TypeBool, schema.TypeString, schema.TypeInt, schema.TypeFloat}

--- a/common/customizable_schema.go
+++ b/common/customizable_schema.go
@@ -85,10 +85,13 @@ func (s *CustomizableSchema) SetSuppressDiff() *CustomizableSchema {
 	return s
 }
 
-// SetSuppressDiffWithDefault suppresses the diff if the new value (ie value from HCL config) is not set and
-// the old value (ie value from state / platform) is equal to the default value. Often Databricks HTTP APIs
-// will return values for fields that were not set by the author in their terraform configuration This function
-// allows us to suppress the diff in these cases.
+// SetSuppressDiffWithDefault suppresses the diff if the
+// new value (ie value from HCL config) is not set and
+// the old value (ie value from state / platform) is equal to the default value.
+//
+// Often Databricks HTTP APIs will return values for fields that were not set by
+// the author in their terraform configuration This function allows us to suppress
+// the diff in these cases.
 func (s *CustomizableSchema) SetSuppressDiffWithDefault(dv any) *CustomizableSchema {
 	primitiveTypes := []schema.ValueType{schema.TypeBool, schema.TypeString, schema.TypeInt, schema.TypeFloat}
 	if !slices.Contains(primitiveTypes, s.Schema.Type) {

--- a/common/customizable_schema_test.go
+++ b/common/customizable_schema_test.go
@@ -43,6 +43,99 @@ func TestCustomizableSchemaSetSuppressDiff(t *testing.T) {
 	assert.Truef(t, testCustomizableSchemaScm["non_optional"].DiffSuppressFunc != nil, "DiffSuppressfunc should be set in field: non_optional")
 }
 
+func TestCustomizableSchemaSetCustomSuppressDiffWithDefault(t *testing.T) {
+	tc := []struct {
+		name      string
+		fieldName string
+		dv        any
+		old       string
+		new       string
+		result    bool
+	}{
+		{
+			name:      "default string",
+			fieldName: "string",
+			dv:        "foobar",
+			old:       "foobar",
+			new:       "",
+			result:    true,
+		},
+		{
+			name:      "default int",
+			fieldName: "integer",
+			dv:        123,
+			old:       "123",
+			new:       "0",
+			result:    true,
+		},
+		{
+			name:      "default bool",
+			fieldName: "bool",
+			dv:        true,
+			old:       "true",
+			new:       "false",
+			result:    true,
+		},
+		{
+			name:      "default float",
+			fieldName: "float",
+			dv:        123.456,
+			old:       "123.456",
+			new:       "0",
+			result:    true,
+		},
+		{
+			name:      "non default string",
+			fieldName: "string",
+			dv:        "foobar",
+			old:       "non-default-val",
+			new:       "",
+			result:    false,
+		},
+		{
+			name:      "non default int",
+			fieldName: "integer",
+			dv:        123,
+			old:       "non-default-val",
+			new:       "0",
+			result:    false,
+		},
+		{
+			name:      "non default bool",
+			fieldName: "bool",
+			dv:        true,
+			old:       "non-default-val",
+			new:       "false",
+			result:    false,
+		},
+		{
+			name:      "non default float",
+			fieldName: "float",
+			dv:        123.456,
+			old:       "non-default-val",
+			new:       "0",
+			result:    false,
+		},
+		{
+			name:      "override in config",
+			fieldName: "string",
+			dv:        "foobar",
+			old:       "foobar",
+			new:       "new-val-in-config",
+			result:    false,
+		},
+	}
+
+	for _, tt := range tc {
+		t.Run(tt.name, func(t *testing.T) {
+			CustomizeSchemaPath(testCustomizableSchemaScm, tt.fieldName).SetSuppressDiffWithDefault(tt.dv)
+			assert.Truef(t, testCustomizableSchemaScm[tt.fieldName].DiffSuppressFunc != nil, "DiffSuppressFunc should be set in field: %s", tt.fieldName)
+
+			assert.Equal(t, tt.result, testCustomizableSchemaScm[tt.fieldName].DiffSuppressFunc("", tt.old, tt.new, nil))
+		})
+	}
+}
+
 func TestCustomizableSchemaSetCustomSuppressDiff(t *testing.T) {
 	CustomizeSchemaPath(testCustomizableSchemaScm, "non_optional").SetCustomSuppressDiff(diffSuppressor("test", CustomizeSchemaPath(testCustomizableSchemaScm, "non_optional").Schema))
 	assert.Truef(t, testCustomizableSchemaScm["non_optional"].DiffSuppressFunc != nil, "DiffSuppressfunc should be set in field: non_optional")

--- a/jobs/resource_job.go
+++ b/jobs/resource_job.go
@@ -695,7 +695,15 @@ func jobSettingsSchema(s map[string]*schema.Schema, prefix string) {
 	// the platform returns ALL_SUCCESS.
 	if v, err := common.SchemaPath(s, "task", "run_if"); err == nil {
 		v.DiffSuppressFunc = func(k, old, new string, d *schema.ResourceData) bool {
-			if old == "ALL_SUCCESS" && new == "" {
+			if old == string(jobs.RunIfAllSuccess) && new == "" {
+				return true
+			}
+			return false
+		}
+	}
+	if v, err := common.SchemaPath(s, "task", "for_each_task", "task", "run_if"); err == nil {
+		v.DiffSuppressFunc = func(k, old, new string, d *schema.ResourceData) bool {
+			if old == string(jobs.RunIfAllSuccess) && new == "" {
 				return true
 			}
 			return false

--- a/jobs/resource_job.go
+++ b/jobs/resource_job.go
@@ -690,25 +690,6 @@ func jobSettingsSchema(s map[string]*schema.Schema, prefix string) {
 			return false
 		}
 	}
-	// The default value for run_if for a task is ALL_SUCCESS. We only want
-	// to suppress the diff if user has not provided a value for run_if and
-	// the platform returns ALL_SUCCESS.
-	if v, err := common.SchemaPath(s, "task", "run_if"); err == nil {
-		v.DiffSuppressFunc = func(k, old, new string, d *schema.ResourceData) bool {
-			if old == string(jobs.RunIfAllSuccess) && new == "" {
-				return true
-			}
-			return false
-		}
-	}
-	if v, err := common.SchemaPath(s, "task", "for_each_task", "task", "run_if"); err == nil {
-		v.DiffSuppressFunc = func(k, old, new string, d *schema.ResourceData) bool {
-			if old == string(jobs.RunIfAllSuccess) && new == "" {
-				return true
-			}
-			return false
-		}
-	}
 }
 
 func gitSourceSchema(s map[string]*schema.Schema, prefix string) {
@@ -793,6 +774,10 @@ var jobSchema = common.StructToSchema(JobSettings{},
 		// Clear the implied diff suppression for the webhook notification lists
 		fixWebhookNotifications(s)
 		fixWebhookNotifications(common.MustSchemaMap(s, "task"))
+
+		// Suppress diff if the platform returns ALL_SUCCESS for run_if in a task
+		common.CustomizeSchemaPath(s, "task", "run_if").SetSuppressDiffWithDefault(jobs.RunIfAllSuccess)
+		common.CustomizeSchemaPath(s, "task", "for_each_task", "task", "run_if").SetSuppressDiffWithDefault(jobs.RunIfAllSuccess)
 
 		return s
 	})


### PR DESCRIPTION
## Changes
This PR introduces the `SetSuppressDiffWithDefault` which allows us to suppress diff in one of the most common cases. The first use of it is for `run_if`.

When a `run_if` is not defined for a task, the platform assigns it a default of `ALL_SUCCESS`. This PR fixes the suppress diff behaviour to only suppress the diff if the platform returns the default value, and not suppress it in all cases.

This PR treats one of the symptoms of job tasks being reordered during diff computation, and tasks that do not have a run_if defined ending up with one in the final job.

## Tests
Unit tests and manually. Task reordering during diff computation no longer incorrectly sets run_if.
