### PR TITLE
Bump Go SDK to v0.38.0

### DIFF
--- a/catalog/data_storage_credential_test.go
+++ b/catalog/data_storage_credential_test.go
@@ -20,7 +20,7 @@ func TestStorageCredentialDataVerify(t *testing.T) {
 					AwsIamRole: &catalog.AwsIamRoleResponse{
 						RoleArn: "test",
 					},
-					AzureManagedIdentity: &catalog.AzureManagedIdentity{
+					AzureManagedIdentity: &catalog.AzureManagedIdentityResponse{
 						AccessConnectorId: "test",
 					},
 					DatabricksGcpServiceAccount: &catalog.DatabricksGcpServiceAccountResponse{

--- a/catalog/resource_lakehouse_monitor.go
+++ b/catalog/resource_lakehouse_monitor.go
@@ -16,7 +16,7 @@ const lakehouseMonitorDefaultProvisionTimeout = 15 * time.Minute
 
 func WaitForMonitor(w *databricks.WorkspaceClient, ctx context.Context, monitorName string) error {
 	return retry.RetryContext(ctx, lakehouseMonitorDefaultProvisionTimeout, func() *retry.RetryError {
-		endpoint, err := w.LakehouseMonitors.GetByFullName(ctx, monitorName)
+		endpoint, err := w.LakehouseMonitors.GetByTableName(ctx, monitorName)
 		if err != nil {
 			return retry.NonRetryableError(err)
 		}
@@ -66,13 +66,13 @@ func ResourceLakehouseMonitor() common.Resource {
 
 			var create catalog.CreateMonitor
 			common.DataToStructPointer(d, monitorSchema, &create)
-			create.FullName = d.Get("table_name").(string)
+			create.TableName = d.Get("table_name").(string)
 
 			endpoint, err := w.LakehouseMonitors.Create(ctx, create)
 			if err != nil {
 				return err
 			}
-			err = WaitForMonitor(w, ctx, create.FullName)
+			err = WaitForMonitor(w, ctx, create.TableName)
 			if err != nil {
 				return err
 			}
@@ -84,7 +84,7 @@ func ResourceLakehouseMonitor() common.Resource {
 			if err != nil {
 				return err
 			}
-			endpoint, err := w.LakehouseMonitors.GetByFullName(ctx, d.Id())
+			endpoint, err := w.LakehouseMonitors.GetByTableName(ctx, d.Id())
 			if err != nil {
 				return err
 
@@ -98,19 +98,19 @@ func ResourceLakehouseMonitor() common.Resource {
 			}
 			var update catalog.UpdateMonitor
 			common.DataToStructPointer(d, monitorSchema, &update)
-			update.FullName = d.Get("table_name").(string)
+			update.TableName = d.Get("table_name").(string)
 			_, err = w.LakehouseMonitors.Update(ctx, update)
 			if err != nil {
 				return err
 			}
-			return WaitForMonitor(w, ctx, update.FullName)
+			return WaitForMonitor(w, ctx, update.TableName)
 		},
 		Delete: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
 			w, err := c.WorkspaceClient()
 			if err != nil {
 				return err
 			}
-			return w.LakehouseMonitors.DeleteByFullName(ctx, d.Id())
+			return w.LakehouseMonitors.DeleteByTableName(ctx, d.Id())
 		},
 		Schema: monitorSchema,
 		Timeouts: &schema.ResourceTimeout{

--- a/catalog/resource_lakehouse_monitor_test.go
+++ b/catalog/resource_lakehouse_monitor_test.go
@@ -18,10 +18,10 @@ func TestLakehouseMonitorCreateTimeseries(t *testing.T) {
 		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
 			e := w.GetMockLakehouseMonitorsAPI().EXPECT()
 			e.Create(mock.Anything, catalog.CreateMonitor{
-				FullName:         "test_table",
+				TableName:         "test_table",
 				OutputSchemaName: "output.schema",
 				AssetsDir:        "sample.dir",
-				TimeSeries: &catalog.MonitorTimeSeriesProfileType{
+				TimeSeries: &catalog.MonitorTimeSeries{
 					Granularities: []string{"1 day"},
 					TimestampCol:  "timestamp",
 				},
@@ -32,7 +32,7 @@ func TestLakehouseMonitorCreateTimeseries(t *testing.T) {
 				Status:                catalog.MonitorInfoStatusMonitorStatusPending,
 				DriftMetricsTableName: "test_table_drift",
 			}, nil)
-			e.GetByFullName(mock.Anything, "test_table").Return(&catalog.MonitorInfo{
+			e.GetByTableName(mock.Anything, "test_table").Return(&catalog.MonitorInfo{
 				TableName:             "test_table",
 				Status:                catalog.MonitorInfoStatusMonitorStatusActive,
 				AssetsDir:             "sample.dir",
@@ -59,15 +59,15 @@ func TestLakehouseMonitorCreateInference(t *testing.T) {
 		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
 			e := w.GetMockLakehouseMonitorsAPI().EXPECT()
 			e.Create(mock.Anything, catalog.CreateMonitor{
-				FullName:         "test_table",
+				TableName:         "test_table",
 				OutputSchemaName: "output.schema",
 				AssetsDir:        "sample.dir",
-				InferenceLog: &catalog.MonitorInferenceLogProfileType{
+				InferenceLog: &catalog.MonitorInferenceLog{
 					Granularities: []string{"1 day"},
 					TimestampCol:  "timestamp",
 					PredictionCol: "prediction",
 					ModelIdCol:    "model_id",
-					ProblemType:   catalog.MonitorInferenceLogProfileTypeProblemTypeProblemTypeRegression,
+					ProblemType:   catalog.MonitorInferenceLogProblemTypeProblemTypeRegression,
 				},
 			}).Return(&catalog.MonitorInfo{
 				AssetsDir:        "sample.dir",
@@ -75,17 +75,17 @@ func TestLakehouseMonitorCreateInference(t *testing.T) {
 				TableName:        "test_table",
 				Status:           catalog.MonitorInfoStatusMonitorStatusActive,
 			}, nil)
-			e.GetByFullName(mock.Anything, "test_table").Return(&catalog.MonitorInfo{
+			e.GetByTableName(mock.Anything, "test_table").Return(&catalog.MonitorInfo{
 				TableName:        "test_table",
 				Status:           catalog.MonitorInfoStatusMonitorStatusActive,
 				AssetsDir:        "sample.dir",
 				OutputSchemaName: "output.schema",
-				InferenceLog: &catalog.MonitorInferenceLogProfileType{
+				InferenceLog: &catalog.MonitorInferenceLog{
 					Granularities: []string{"1 day"},
 					TimestampCol:  "timestamp",
 					PredictionCol: "prediction",
 					ModelIdCol:    "model_id",
-					ProblemType:   catalog.MonitorInferenceLogProfileTypeProblemTypeProblemTypeRegression,
+					ProblemType:   catalog.MonitorInferenceLogProblemTypeProblemTypeRegression,
 				},
 			}, nil)
 		},
@@ -111,22 +111,22 @@ func TestLakehouseMonitorCreateSnapshot(t *testing.T) {
 		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
 			e := w.GetMockLakehouseMonitorsAPI().EXPECT()
 			e.Create(mock.Anything, catalog.CreateMonitor{
-				FullName:         "test_table",
+				TableName:         "test_table",
 				OutputSchemaName: "output.schema",
 				AssetsDir:        "sample.dir",
-				Snapshot:         &catalog.MonitorSnapshotProfileType{},
+				Snapshot:         &catalog.MonitorSnapshot{},
 			}).Return(&catalog.MonitorInfo{
 				AssetsDir:        "sample.dir",
 				OutputSchemaName: "output.schema",
 				TableName:        "test_table",
 				Status:           catalog.MonitorInfoStatusMonitorStatusActive,
 			}, nil)
-			e.GetByFullName(mock.Anything, "test_table").Return(&catalog.MonitorInfo{
+			e.GetByTableName(mock.Anything, "test_table").Return(&catalog.MonitorInfo{
 				TableName:        "test_table",
 				Status:           catalog.MonitorInfoStatusMonitorStatusActive,
 				AssetsDir:        "sample.dir",
 				OutputSchemaName: "output.schema",
-				Snapshot:         &catalog.MonitorSnapshotProfileType{},
+				Snapshot:         &catalog.MonitorSnapshot{},
 			}, nil)
 		},
 		Resource: ResourceLakehouseMonitor(),
@@ -144,12 +144,12 @@ func TestLakehouseMonitorGet(t *testing.T) {
 	qa.ResourceFixture{
 		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
 			e := w.GetMockLakehouseMonitorsAPI().EXPECT()
-			e.GetByFullName(mock.Anything, "test_table").Return(&catalog.MonitorInfo{
+			e.GetByTableName(mock.Anything, "test_table").Return(&catalog.MonitorInfo{
 				TableName:        "test_table",
 				Status:           catalog.MonitorInfoStatusMonitorStatusActive,
 				AssetsDir:        "new_assets.dir",
 				OutputSchemaName: "output.schema",
-				InferenceLog: &catalog.MonitorInferenceLogProfileType{
+				InferenceLog: &catalog.MonitorInferenceLog{
 					Granularities: []string{"1 week"},
 					TimestampCol:  "timestamp",
 					PredictionCol: "prediction",
@@ -168,21 +168,21 @@ func TestLakehouseMonitorUpdate(t *testing.T) {
 		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
 			e := w.GetMockLakehouseMonitorsAPI().EXPECT()
 			e.Update(mock.Anything, catalog.UpdateMonitor{
-				FullName:         "test_table",
+				TableName:         "test_table",
 				OutputSchemaName: "output.schema",
-				InferenceLog: &catalog.MonitorInferenceLogProfileType{
+				InferenceLog: &catalog.MonitorInferenceLog{
 					Granularities: []string{"1 week"},
 					TimestampCol:  "timestamp",
 					PredictionCol: "prediction",
 					ModelIdCol:    "model_id",
-					ProblemType:   catalog.MonitorInferenceLogProfileTypeProblemTypeProblemTypeRegression,
+					ProblemType:   catalog.MonitorInferenceLogProblemTypeProblemTypeRegression,
 				},
 			}).Return(&catalog.MonitorInfo{
 				AssetsDir:        "new_assets.dir",
 				OutputSchemaName: "output.schema",
 				TableName:        "test_table",
 				Status:           catalog.MonitorInfoStatusMonitorStatusActive,
-				InferenceLog: &catalog.MonitorInferenceLogProfileType{
+				InferenceLog: &catalog.MonitorInferenceLog{
 					Granularities: []string{"1 week"},
 					TimestampCol:  "timestamp",
 					PredictionCol: "prediction",
@@ -190,12 +190,12 @@ func TestLakehouseMonitorUpdate(t *testing.T) {
 				},
 				DriftMetricsTableName: "test_table_drift",
 			}, nil)
-			e.GetByFullName(mock.Anything, "test_table").Return(&catalog.MonitorInfo{
+			e.GetByTableName(mock.Anything, "test_table").Return(&catalog.MonitorInfo{
 				TableName:        "test_table",
 				Status:           catalog.MonitorInfoStatusMonitorStatusActive,
 				AssetsDir:        "new_assets.dir",
 				OutputSchemaName: "output.schema",
-				InferenceLog: &catalog.MonitorInferenceLogProfileType{
+				InferenceLog: &catalog.MonitorInferenceLog{
 					Granularities: []string{"1 week"},
 					TimestampCol:  "timestamp",
 					PredictionCol: "prediction",
@@ -229,7 +229,7 @@ func TestLakehouseMonitorDelete(t *testing.T) {
 	qa.ResourceFixture{
 		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
 			e := w.GetMockLakehouseMonitorsAPI().EXPECT()
-			e.DeleteByFullName(mock.Anything, "test_table").Return(nil)
+			e.DeleteByTableName(mock.Anything, "test_table").Return(nil)
 		},
 		Resource: ResourceLakehouseMonitor(),
 		Delete:   true,

--- a/catalog/resource_metastore_data_access_test.go
+++ b/catalog/resource_metastore_data_access_test.go
@@ -74,7 +74,7 @@ func TestCreateDacWithAzMI(t *testing.T) {
 				Resource: "/api/2.1/unity-catalog/storage-credentials",
 				ExpectedRequest: catalog.CreateStorageCredential{
 					Name: "bcd",
-					AzureManagedIdentity: &catalog.AzureManagedIdentity{
+					AzureManagedIdentity: &catalog.AzureManagedIdentityRequest{
 						AccessConnectorId: "def",
 						ManagedIdentityId: "/..../subscription",
 					},
@@ -95,7 +95,7 @@ func TestCreateDacWithAzMI(t *testing.T) {
 				Resource: "/api/2.1/unity-catalog/storage-credentials/bcd?",
 				Response: catalog.StorageCredentialInfo{
 					Name: "bcd",
-					AzureManagedIdentity: &catalog.AzureManagedIdentity{
+					AzureManagedIdentity: &catalog.AzureManagedIdentityResponse{
 						AccessConnectorId: "def",
 						ManagedIdentityId: "/..../subscription",
 					},
@@ -253,7 +253,7 @@ func TestCreateAccountDacWithAzMI(t *testing.T) {
 					MetastoreId: "abc",
 					CredentialInfo: &catalog.CreateStorageCredential{
 						Name: "bcd",
-						AzureManagedIdentity: &catalog.AzureManagedIdentity{
+						AzureManagedIdentity: &catalog.AzureManagedIdentityRequest{
 							AccessConnectorId: "def",
 						},
 					},
@@ -280,7 +280,7 @@ func TestCreateAccountDacWithAzMI(t *testing.T) {
 				Response: catalog.AccountsStorageCredentialInfo{
 					CredentialInfo: &catalog.StorageCredentialInfo{
 						Name: "bcd",
-						AzureManagedIdentity: &catalog.AzureManagedIdentity{
+						AzureManagedIdentity: &catalog.AzureManagedIdentityResponse{
 							AccessConnectorId: "def",
 						},
 					},

--- a/catalog/resource_storage_credential.go
+++ b/catalog/resource_storage_credential.go
@@ -15,7 +15,7 @@ type StorageCredentialInfo struct {
 	Comment                     string                                       `json:"comment,omitempty"`
 	Aws                         *catalog.AwsIamRoleResponse                  `json:"aws_iam_role,omitempty" tf:"group:access"`
 	Azure                       *catalog.AzureServicePrincipal               `json:"azure_service_principal,omitempty" tf:"group:access"`
-	AzMI                        *catalog.AzureManagedIdentity                `json:"azure_managed_identity,omitempty" tf:"group:access"`
+	AzMI                        *catalog.AzureManagedIdentityResponse        `json:"azure_managed_identity,omitempty" tf:"group:access"`
 	GcpSAKey                    *GcpServiceAccountKey                        `json:"gcp_service_account_key,omitempty" tf:"group:access"`
 	DatabricksGcpServiceAccount *catalog.DatabricksGcpServiceAccountResponse `json:"databricks_gcp_service_account,omitempty" tf:"computed"`
 	MetastoreID                 string                                       `json:"metastore_id,omitempty" tf:"computed"`

--- a/catalog/resource_storage_credential_test.go
+++ b/catalog/resource_storage_credential_test.go
@@ -466,7 +466,7 @@ func TestCreateStorageCredentialWithAzMI(t *testing.T) {
 				Resource: "/api/2.1/unity-catalog/storage-credentials",
 				ExpectedRequest: catalog.CreateStorageCredential{
 					Name: "a",
-					AzureManagedIdentity: &catalog.AzureManagedIdentity{
+					AzureManagedIdentity: &catalog.AzureManagedIdentityRequest{
 						AccessConnectorId: "def",
 					},
 					Comment: "c",
@@ -479,7 +479,7 @@ func TestCreateStorageCredentialWithAzMI(t *testing.T) {
 				Method:   "PATCH",
 				Resource: "/api/2.1/unity-catalog/storage-credentials/a",
 				ExpectedRequest: catalog.UpdateStorageCredential{
-					AzureManagedIdentity: &catalog.AzureManagedIdentity{
+					AzureManagedIdentity: &catalog.AzureManagedIdentityResponse{
 						AccessConnectorId: "def",
 					},
 					Comment: "c",
@@ -493,7 +493,7 @@ func TestCreateStorageCredentialWithAzMI(t *testing.T) {
 				Resource: "/api/2.1/unity-catalog/storage-credentials/a?",
 				Response: catalog.StorageCredentialInfo{
 					Name: "a",
-					AzureManagedIdentity: &catalog.AzureManagedIdentity{
+					AzureManagedIdentity: &catalog.AzureManagedIdentityResponse{
 						AccessConnectorId: "def",
 					},
 					MetastoreId: "d",
@@ -621,7 +621,7 @@ func TestUpdateAzStorageCredentialMI(t *testing.T) {
 				Resource: "/api/2.1/unity-catalog/storage-credentials/a",
 				ExpectedRequest: catalog.UpdateStorageCredential{
 					Comment: "c",
-					AzureManagedIdentity: &catalog.AzureManagedIdentity{
+					AzureManagedIdentity: &catalog.AzureManagedIdentityResponse{
 						AccessConnectorId: "CHANGED",
 					},
 				},
@@ -631,7 +631,7 @@ func TestUpdateAzStorageCredentialMI(t *testing.T) {
 				Resource: "/api/2.1/unity-catalog/storage-credentials/a?",
 				Response: catalog.StorageCredentialInfo{
 					Name: "a",
-					AzureManagedIdentity: &catalog.AzureManagedIdentity{
+					AzureManagedIdentity: &catalog.AzureManagedIdentityResponse{
 						AccessConnectorId: "CHANGED",
 					},
 					MetastoreId: "d",

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/databricks/terraform-provider-databricks
 go 1.21
 
 require (
-	github.com/databricks/databricks-sdk-go v0.37.0
+	github.com/databricks/databricks-sdk-go v0.38.0
 	github.com/golang-jwt/jwt/v4 v4.5.0
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/hcl v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -24,8 +24,8 @@ github.com/cloudflare/circl v1.3.7/go.mod h1:sRTcRWXGLrKw6yIGJ+l7amYJFfAXbZG0kBS
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cyphar/filepath-securejoin v0.2.4 h1:Ugdm7cg7i6ZK6x3xDF1oEu1nfkyfH53EtKeQYTC3kyg=
 github.com/cyphar/filepath-securejoin v0.2.4/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxGGx79pTxQpKOJNYHHl4=
-github.com/databricks/databricks-sdk-go v0.37.0 h1:8ej3hNqfyfDNdV5YBjfLbq+p99JLu5NTtzwObbsIhRM=
-github.com/databricks/databricks-sdk-go v0.37.0/go.mod h1:Yjy1gREDLK65g4axpVbVNKYAHYE2Sqzj0AB9QWHCBVM=
+github.com/databricks/databricks-sdk-go v0.38.0 h1:MQhOCWTkdKItG+n6ZwcXQv9FWBVXq9fax8VSZns2e+0=
+github.com/databricks/databricks-sdk-go v0.38.0/go.mod h1:Yjy1gREDLK65g4axpVbVNKYAHYE2Sqzj0AB9QWHCBVM=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/jobs/resource_job.go
+++ b/jobs/resource_job.go
@@ -17,7 +17,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/databricks/databricks-sdk-go/apierr"
-	"github.com/databricks/databricks-sdk-go/service/compute"
 	"github.com/databricks/terraform-provider-databricks/clusters"
 	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/databricks/terraform-provider-databricks/libraries"
@@ -248,11 +247,6 @@ type JobCluster struct {
 	NewCluster    *clusters.Cluster `json:"new_cluster,omitempty" tf:"group:cluster_type"`
 }
 
-type JobCompute struct {
-	ComputeKey  string               `json:"compute_key,omitempty" tf:"group:cluster_type"`
-	ComputeSpec *compute.ComputeSpec `json:"spec,omitempty" tf:"group:cluster_type"`
-}
-
 type ContinuousConf struct {
 	PauseStatus string `json:"pause_status,omitempty" tf:"default:UNPAUSED"`
 }
@@ -308,7 +302,6 @@ type JobSettings struct {
 	Tasks       []JobTaskSettings `json:"tasks,omitempty" tf:"alias:task"`
 	Format      string            `json:"format,omitempty" tf:"computed"`
 	JobClusters []JobCluster      `json:"job_clusters,omitempty" tf:"alias:job_cluster"`
-	Compute     []JobCompute      `json:"compute,omitempty" tf:"alias:compute"`
 	// END Jobs API 2.1
 
 	// BEGIN Jobs + Repo integration preview

--- a/jobs/resource_job_test.go
+++ b/jobs/resource_job_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/databricks/databricks-sdk-go/apierr"
-	"github.com/databricks/databricks-sdk-go/service/compute"
 	"github.com/databricks/databricks-sdk-go/service/jobs"
 	"github.com/databricks/terraform-provider-databricks/clusters"
 	"github.com/databricks/terraform-provider-databricks/common"
@@ -897,78 +896,6 @@ func TestResourceJobCreate_JobClusters(t *testing.T) {
 	}.Apply(t)
 	assert.NoError(t, err)
 	assert.Equal(t, "17", d.Id())
-}
-
-func TestResourceJobCreate_JobCompute(t *testing.T) {
-	d, err := qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:   "POST",
-				Resource: "/api/2.1/jobs/create",
-				ExpectedRequest: JobSettings{
-					Name: "JobComputed",
-					Tasks: []JobTaskSettings{
-						{
-							TaskKey:    "b",
-							ComputeKey: "j",
-							NotebookTask: &NotebookTask{
-								NotebookPath: "/Stuff",
-							},
-						},
-					},
-					MaxConcurrentRuns: 1,
-					Compute: []JobCompute{
-						{
-							ComputeKey: "j",
-							ComputeSpec: &compute.ComputeSpec{
-								Kind: "t",
-							},
-						},
-					},
-				},
-				Response: Job{
-					JobID: 18,
-				},
-			},
-			{
-				Method:   "GET",
-				Resource: "/api/2.1/jobs/get?job_id=18",
-				Response: Job{
-					// good enough for mock
-					Settings: &JobSettings{
-						Tasks: []JobTaskSettings{
-							{
-								TaskKey: "b",
-							},
-						},
-					},
-				},
-			},
-		},
-		Create:   true,
-		Resource: ResourceJob(),
-		HCL: `
-		name = "JobComputed"
-
-		compute {
-			compute_key = "j"
-			spec {
-			  kind   	= "t"
-			}
-		}
-
-		task {
-			task_key = "b"
-
-			compute_key = "j"
-
-			notebook_task {
-				notebook_path = "/Stuff"
-			}
-		}`,
-	}.Apply(t)
-	assert.NoError(t, err)
-	assert.Equal(t, "18", d.Id())
 }
 
 func TestResourceJobCreate_SqlSubscriptions(t *testing.T) {


### PR DESCRIPTION
## Changes
Update the Databricks Go SDK dependency to v0.38.0.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
