### PR TITLE
Exporter: generate resource data from the object status obtained during the listing operation

### DIFF
--- a/exporter/importables.go
+++ b/exporter/importables.go
@@ -555,7 +555,7 @@ var resourcesMap map[string]importable = map[string]importable{
 									if object.ObjectType != workspace.File {
 										continue
 									}
-									ic.maybeEmitWorkspaceObject("databricks_workspace_file", object.Path)
+									ic.maybeEmitWorkspaceObject("databricks_workspace_file", object.Path, &object)
 								}
 							} else {
 								log.Printf("[WARN] Can't list directory %s for DBT task in job %s (id: %s)", directory, job.Name, r.ID)
@@ -2053,7 +2053,7 @@ var resourcesMap map[string]importable = map[string]importable{
 				if res := ignoreIdeFolderRegex.FindStringSubmatch(directory.Path); res != nil {
 					continue
 				}
-				ic.maybeEmitWorkspaceObject("databricks_directory", directory.Path)
+				ic.maybeEmitWorkspaceObject("databricks_directory", directory.Path, &directory)
 
 				if offset%50 == 0 {
 					log.Printf("[INFO] Scanned %d of %d directories", offset+1, len(directoryList))

--- a/exporter/importables_test.go
+++ b/exporter/importables_test.go
@@ -1017,20 +1017,11 @@ func TestNotebookGeneration(t *testing.T) {
 					{
 						Path:       "/First/Second",
 						ObjectType: "NOTEBOOK",
+						ObjectID:   123,
+						Language:   "PYTHON",
 					},
 				},
 			},
-		},
-		{
-			Method:   "GET",
-			Resource: "/api/2.0/workspace/get-status?path=%2FFirst%2FSecond",
-			Response: workspace.ObjectStatus{
-				ObjectID:   123,
-				ObjectType: "NOTEBOOK",
-				Path:       "/First/Second",
-				Language:   "PYTHON",
-			},
-			ReuseRequest: true,
 		},
 		{
 			Method:   "GET",
@@ -1067,22 +1058,13 @@ func TestNotebookGenerationJupyter(t *testing.T) {
 						ObjectType: "NOTEBOOK",
 					},
 					{
-						Path:       "/First/Second",
+						ObjectID:   123,
 						ObjectType: "NOTEBOOK",
+						Path:       "/First/Second",
+						Language:   "PYTHON",
 					},
 				},
 			},
-		},
-		{
-			Method:   "GET",
-			Resource: "/api/2.0/workspace/get-status?path=%2FFirst%2FSecond",
-			Response: workspace.ObjectStatus{
-				ObjectID:   123,
-				ObjectType: "NOTEBOOK",
-				Path:       "/First/Second",
-				Language:   "PYTHON",
-			},
-			ReuseRequest: true,
 		},
 		{
 			Method:   "GET",
@@ -1121,8 +1103,10 @@ func TestNotebookGenerationBadCharacters(t *testing.T) {
 						ObjectType: "NOTEBOOK",
 					},
 					{
-						Path:       "/Fir\"st\\/Second",
+						ObjectID:   123,
 						ObjectType: "NOTEBOOK",
+						Path:       "/Fir\"st\\/Second",
+						Language:   "PYTHON",
 					},
 				},
 			},
@@ -1135,17 +1119,6 @@ func TestNotebookGenerationBadCharacters(t *testing.T) {
 				ObjectID:   124,
 				ObjectType: "DIRECTORY",
 				Path:       "/Fir\"st\\",
-			},
-			ReuseRequest: true,
-		},
-		{
-			Method:   "GET",
-			Resource: "/api/2.0/workspace/get-status?path=%2FFir%22st%5C%2FSecond",
-			Response: workspace.ObjectStatus{
-				ObjectID:   123,
-				ObjectType: "NOTEBOOK",
-				Path:       "/Fir\"st\\/Second",
-				Language:   "PYTHON",
 			},
 			ReuseRequest: true,
 		},
@@ -1823,7 +1796,6 @@ func TestImportShare(t *testing.T) {
 		},
 	}
 	d.MarkNewResource()
-	common.StructToData(share, scm, d)
 	err := common.StructToData(share, scm, d)
 	require.NoError(t, err)
 	err = resourcesMap["databricks_share"].Import(ic, &resource{

--- a/exporter/util.go
+++ b/exporter/util.go
@@ -256,7 +256,7 @@ func (ic *importContext) emitNotebookOrRepo(path string) {
 		ic.emitRepoByPath(path)
 	} else {
 		// TODO: strip /Workspace prefix if it's provided
-		ic.maybeEmitWorkspaceObject("databricks_notebook", path)
+		ic.maybeEmitWorkspaceObject("databricks_notebook", path, nil)
 	}
 }
 
@@ -962,11 +962,33 @@ func (ic *importContext) shouldEmitForPath(path string) bool {
 	return true
 }
 
-func (ic *importContext) maybeEmitWorkspaceObject(resourceType, path string) {
+func (ic *importContext) maybeEmitWorkspaceObject(resourceType, path string, obj *workspace.ObjectStatus) {
 	if ic.shouldEmitForPath(path) {
+		var data *schema.ResourceData
+		if obj != nil {
+			switch resourceType {
+			case "databricks_notebook":
+				data = workspace.ResourceNotebook().ToResource().TestResourceData()
+			case "databricks_workspace_file":
+				data = workspace.ResourceWorkspaceFile().ToResource().TestResourceData()
+			case "databricks_directory":
+				data = workspace.ResourceDirectory().ToResource().TestResourceData()
+			}
+			if data != nil {
+				scm := ic.Resources[resourceType].Schema
+				data.MarkNewResource()
+				data.SetId(path)
+				err := common.StructToData(obj, scm, data)
+				if err != nil {
+					log.Printf("[ERROR] can't convert %s object to data: %v. obj=%v", resourceType, err, obj)
+					data = nil
+				}
+			}
+		}
 		ic.Emit(&resource{
 			Resource:    resourceType,
 			ID:          path,
+			Data:        data,
 			Incremental: ic.incremental,
 		})
 	} else {
@@ -1043,9 +1065,9 @@ func emitWorkpaceObject(ic *importContext, object workspace.ObjectStatus) {
 	}
 	switch object.ObjectType {
 	case workspace.Notebook:
-		ic.maybeEmitWorkspaceObject("databricks_notebook", object.Path)
+		ic.maybeEmitWorkspaceObject("databricks_notebook", object.Path, &object)
 	case workspace.File:
-		ic.maybeEmitWorkspaceObject("databricks_workspace_file", object.Path)
+		ic.maybeEmitWorkspaceObject("databricks_workspace_file", object.Path, &object)
 	default:
 		log.Printf("[WARN] unknown type %s for path %s", object.ObjectType, object.Path)
 	}


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->


Before this PR, when we list workspace objects we just emitted the corresponding object with just ID (path) -> this led to the need to call the `Read` operation on the resource that led to an additional `get-status` REST API call.  But `get-status` returns the same data that are returned by the `list` operation.  With this PR we generate resource data from object status data returned by the `list` - this decreases the number of REST API calls necessary to import a notebook (this is critical for handling workspaces with a huge number of notebooks and workspace files).


## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
