### PR TITLE
Fix integration tests for `databricks_entitlements`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -343,3 +343,6 @@ scripts/tt
 .metals
 
 provider/completeness.md
+
+# VS Code debugging binaries
+__debug_bin*

--- a/internal/acceptance/entitlements_base_resources.go
+++ b/internal/acceptance/entitlements_base_resources.go
@@ -5,13 +5,16 @@ import (
 	"fmt"
 
 	"github.com/databricks/databricks-sdk-go"
+	"github.com/databricks/databricks-sdk-go/httpclient"
 	"github.com/databricks/databricks-sdk-go/service/iam"
 )
 
 type entitlementResource interface {
+	resourceType() string
 	setDisplayName(string)
 	setWorkspaceClient(*databricks.WorkspaceClient)
 	create(context.Context) error
+	getEntitlements(context.Context) ([]iam.ComplexValue, error)
 	cleanUp(context.Context) error
 	dataSourceTemplate() string
 	tfReference() string
@@ -21,6 +24,10 @@ type userResource struct {
 	email string
 	id    string
 	w     *databricks.WorkspaceClient
+}
+
+func (u *userResource) resourceType() string {
+	return "user"
 }
 
 func (u *userResource) setDisplayName(displayName string) {
@@ -42,6 +49,20 @@ func (u *userResource) create(ctx context.Context) error {
 	return nil
 }
 
+func (u *userResource) getEntitlements(ctx context.Context) ([]iam.ComplexValue, error) {
+	c, err := u.w.Config.NewApiClient()
+	if err != nil {
+		return nil, err
+	}
+	res := iam.User{}
+	err = c.Do(ctx, "GET", fmt.Sprintf("/api/2.0/preview/scim/v2/Users/%s?attributes=entitlements", u.id),
+		httpclient.WithResponseUnmarshal(&res))
+	if err != nil {
+		return nil, err
+	}
+	return res.Entitlements, nil
+}
+
 func (u *userResource) cleanUp(ctx context.Context) error {
 	return u.w.Users.DeleteById(ctx, u.id)
 }
@@ -54,13 +75,17 @@ func (u *userResource) dataSourceTemplate() string {
 }
 
 func (u *userResource) tfReference() string {
-	return fmt.Sprintf("data.databricks_user.example.id")
+	return "user_id = data.databricks_user.example.id"
 }
 
 type groupResource struct {
 	displayName string
 	id          string
 	w           *databricks.WorkspaceClient
+}
+
+func (g *groupResource) resourceType() string {
+	return "group"
 }
 
 func (g *groupResource) setDisplayName(displayName string) {
@@ -82,6 +107,20 @@ func (g *groupResource) create(ctx context.Context) error {
 	return nil
 }
 
+func (g *groupResource) getEntitlements(ctx context.Context) ([]iam.ComplexValue, error) {
+	c, err := g.w.Config.NewApiClient()
+	if err != nil {
+		return nil, err
+	}
+	res := iam.Group{}
+	err = c.Do(ctx, "GET", fmt.Sprintf("/api/2.0/preview/scim/v2/Groups/%s?attributes=entitlements", g.id),
+		httpclient.WithResponseUnmarshal(&res))
+	if err != nil {
+		return nil, err
+	}
+	return res.Entitlements, nil
+}
+
 func (g *groupResource) cleanUp(ctx context.Context) error {
 	return g.w.Groups.DeleteById(ctx, g.id)
 }
@@ -94,13 +133,19 @@ func (g *groupResource) dataSourceTemplate() string {
 }
 
 func (g *groupResource) tfReference() string {
-	return fmt.Sprintf("data.databricks_group.example.id")
+	return "group_id = data.databricks_group.example.id"
 }
 
 type servicePrincipalResource struct {
 	applicationId string
+	cleanup       bool
 	displayName   string
+	id            string
 	w             *databricks.WorkspaceClient
+}
+
+func (s *servicePrincipalResource) resourceType() string {
+	return "service_principal"
 }
 
 func (s *servicePrincipalResource) setDisplayName(displayName string) {
@@ -112,28 +157,65 @@ func (s *servicePrincipalResource) setWorkspaceClient(w *databricks.WorkspaceCli
 }
 
 func (s *servicePrincipalResource) create(ctx context.Context) error {
-	sp, err := s.w.ServicePrincipals.Create(ctx, iam.ServicePrincipal{
-		ApplicationId: s.applicationId,
-		DisplayName:   s.displayName,
-	})
+	sp, err := s.create0(ctx)
 	if err != nil {
 		return err
 	}
-	s.applicationId = sp.ApplicationId
+	if s.applicationId == "" {
+		s.applicationId = sp.ApplicationId
+	}
+	s.id = sp.Id
 	return nil
 }
 
+func (s *servicePrincipalResource) create0(ctx context.Context) (iam.ServicePrincipal, error) {
+	if s.applicationId != "" {
+		sps := s.w.ServicePrincipals.List(ctx, iam.ListServicePrincipalsRequest{
+			Filter: fmt.Sprintf(`applicationId eq "%s"`, s.applicationId),
+		})
+		if !sps.HasNext(ctx) {
+			return iam.ServicePrincipal{}, fmt.Errorf("service principal with applicationId %s not found", s.applicationId)
+		}
+		return sps.Next(ctx)
+	}
+	sp, err := s.w.ServicePrincipals.Create(ctx, iam.ServicePrincipal{
+		DisplayName: s.displayName,
+	})
+	return *sp, err
+}
+
+func (s *servicePrincipalResource) getEntitlements(ctx context.Context) ([]iam.ComplexValue, error) {
+	c, err := s.w.Config.NewApiClient()
+	if err != nil {
+		return nil, err
+	}
+	res := iam.ServicePrincipal{}
+	err = c.Do(ctx, "GET", fmt.Sprintf("/api/2.0/preview/scim/v2/ServicePrincipals/%s?attributes=entitlements", s.id),
+		httpclient.WithResponseUnmarshal(&res))
+	if err != nil {
+		return nil, err
+	}
+	return res.Entitlements, nil
+}
+
 func (s *servicePrincipalResource) cleanUp(ctx context.Context) error {
+	if !s.cleanup {
+		return nil
+	}
 	return s.w.ServicePrincipals.DeleteById(ctx, s.applicationId)
 }
 
 func (s *servicePrincipalResource) dataSourceTemplate() string {
+	fragment := fmt.Sprintf(`display_name = "%s"`, s.displayName)
+	if s.applicationId != "" {
+		fragment = fmt.Sprintf(`application_id = "%s"`, s.applicationId)
+	}
 	return fmt.Sprintf(`
 		data "databricks_service_principal" "example" {
-			display_name = "%s"
-		}`, s.displayName)
+			%s
+		}`, fragment)
 }
 
 func (s *servicePrincipalResource) tfReference() string {
-	return fmt.Sprintf("data.databricks_service_principal.example.id")
+	return "service_principal_id = data.databricks_service_principal.example.id"
 }

--- a/internal/acceptance/entitlements_base_resources.go
+++ b/internal/acceptance/entitlements_base_resources.go
@@ -1,0 +1,139 @@
+package acceptance
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/databricks/databricks-sdk-go"
+	"github.com/databricks/databricks-sdk-go/service/iam"
+)
+
+type entitlementResource interface {
+	setDisplayName(string)
+	setWorkspaceClient(*databricks.WorkspaceClient)
+	create(context.Context) error
+	cleanUp(context.Context) error
+	dataSourceTemplate() string
+	tfReference() string
+}
+
+type userResource struct {
+	email string
+	id    string
+	w     *databricks.WorkspaceClient
+}
+
+func (u *userResource) setDisplayName(displayName string) {
+	u.email = displayName + "@example.com"
+}
+
+func (u *userResource) setWorkspaceClient(w *databricks.WorkspaceClient) {
+	u.w = w
+}
+
+func (u *userResource) create(ctx context.Context) error {
+	user, err := u.w.Users.Create(ctx, iam.User{
+		UserName: u.email,
+	})
+	if err != nil {
+		return err
+	}
+	u.id = user.Id
+	return nil
+}
+
+func (u *userResource) cleanUp(ctx context.Context) error {
+	return u.w.Users.DeleteById(ctx, u.id)
+}
+
+func (u *userResource) dataSourceTemplate() string {
+	return fmt.Sprintf(`
+		data "databricks_user" "example" {
+			user_name = "%s"
+		}`, u.email)
+}
+
+func (u *userResource) tfReference() string {
+	return fmt.Sprintf("data.databricks_user.example.id")
+}
+
+type groupResource struct {
+	displayName string
+	id          string
+	w           *databricks.WorkspaceClient
+}
+
+func (g *groupResource) setDisplayName(displayName string) {
+	g.displayName = displayName
+}
+
+func (g *groupResource) setWorkspaceClient(w *databricks.WorkspaceClient) {
+	g.w = w
+}
+
+func (g *groupResource) create(ctx context.Context) error {
+	group, err := g.w.Groups.Create(ctx, iam.Group{
+		DisplayName: g.displayName,
+	})
+	if err != nil {
+		return err
+	}
+	g.id = group.Id
+	return nil
+}
+
+func (g *groupResource) cleanUp(ctx context.Context) error {
+	return g.w.Groups.DeleteById(ctx, g.id)
+}
+
+func (g *groupResource) dataSourceTemplate() string {
+	return fmt.Sprintf(`
+		data "databricks_group" "example" {
+			display_name = "%s"
+		}`, g.displayName)
+}
+
+func (g *groupResource) tfReference() string {
+	return fmt.Sprintf("data.databricks_group.example.id")
+}
+
+type servicePrincipalResource struct {
+	applicationId string
+	displayName   string
+	w             *databricks.WorkspaceClient
+}
+
+func (s *servicePrincipalResource) setDisplayName(displayName string) {
+	s.displayName = displayName
+}
+
+func (s *servicePrincipalResource) setWorkspaceClient(w *databricks.WorkspaceClient) {
+	s.w = w
+}
+
+func (s *servicePrincipalResource) create(ctx context.Context) error {
+	sp, err := s.w.ServicePrincipals.Create(ctx, iam.ServicePrincipal{
+		ApplicationId: s.applicationId,
+		DisplayName:   s.displayName,
+	})
+	if err != nil {
+		return err
+	}
+	s.applicationId = sp.ApplicationId
+	return nil
+}
+
+func (s *servicePrincipalResource) cleanUp(ctx context.Context) error {
+	return s.w.ServicePrincipals.DeleteById(ctx, s.applicationId)
+}
+
+func (s *servicePrincipalResource) dataSourceTemplate() string {
+	return fmt.Sprintf(`
+		data "databricks_service_principal" "example" {
+			display_name = "%s"
+		}`, s.displayName)
+}
+
+func (s *servicePrincipalResource) tfReference() string {
+	return fmt.Sprintf("data.databricks_service_principal.example.id")
+}

--- a/internal/acceptance/entitlements_test.go
+++ b/internal/acceptance/entitlements_test.go
@@ -8,101 +8,11 @@ import (
 
 	"github.com/databricks/databricks-sdk-go"
 	"github.com/databricks/databricks-sdk-go/httpclient"
+	"github.com/databricks/databricks-sdk-go/logger"
 	"github.com/databricks/databricks-sdk-go/service/iam"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/stretchr/testify/assert"
 )
-
-func TestAccEntitlementResource(t *testing.T) {
-	var conf = `
-	resource "databricks_user" "first" {
-		user_name = "tf-eerste+{var.RANDOM}@example.com"
-		display_name = "Eerste {var.RANDOM}"
-		allow_cluster_create       = true
-		allow_instance_pool_create = true		
-	}
-
-	resource "databricks_group" "second" {
-		display_name = "{var.RANDOM} group"
-		allow_cluster_create       = true
-		allow_instance_pool_create = true		
-	}
-
-	resource "databricks_group" "third" {
-		display_name = "{var.RANDOM} group 2"
-	}	
-	
-	resource "databricks_entitlements" "first_entitlements" {
-		user_id                    = databricks_user.first.id
-		allow_cluster_create       = true
-		allow_instance_pool_create = true
-	}	
-
-	resource "databricks_entitlements" "second_entitlements" {
-		group_id                   = databricks_group.second.id
-		allow_cluster_create       = true
-		allow_instance_pool_create = true
-	}
-	
-	resource "databricks_entitlements" "third_entitlements" {
-		group_id                   = databricks_group.third.id
-		allow_cluster_create       = false
-		allow_instance_pool_create = false
-		databricks_sql_access      = false
-		workspace_access           = false
-	}`
-	workspaceLevel(t, step{
-		Template: conf,
-		Check: resource.ComposeTestCheckFunc(
-			resource.TestCheckResourceAttr("databricks_entitlements.first_entitlements", "allow_cluster_create", "true"),
-			resource.TestCheckResourceAttr("databricks_entitlements.first_entitlements", "allow_instance_pool_create", "true"),
-			resource.TestCheckResourceAttr("databricks_entitlements.second_entitlements", "allow_cluster_create", "true"),
-			resource.TestCheckResourceAttr("databricks_entitlements.second_entitlements", "allow_instance_pool_create", "true"),
-		),
-	}, step{
-		Template: conf,
-	})
-}
-
-func TestAccServicePrincipalEntitlementsResourceOnAzure(t *testing.T) {
-	// this test should run only on Azure, so just expect SPN config to be there or fail
-	// TODO: change to SDK so that we can be explicit if we want to fetch entitlements
-	GetEnvOrSkipTest(t, "ARM_CLIENT_ID")
-	workspaceLevel(t, step{
-		Template: `resource "databricks_service_principal" "this" {
-			application_id = "{var.RANDOM_UUID}"
-			allow_cluster_create       = true
-			allow_instance_pool_create = true
-			display_name = "SPN {var.RANDOM}"
-			force = true			
-		}
-
-		resource "databricks_entitlements" "service_principal" {
-			service_principal_id       = databricks_service_principal.this.id
-			allow_cluster_create       = true
-			allow_instance_pool_create = true
-		}`,
-	})
-}
-
-func TestAccServicePrincipalEntitlementsResourceOnAws(t *testing.T) {
-	GetEnvOrSkipTest(t, "TEST_EC2_INSTANCE_PROFILE")
-	workspaceLevel(t, step{
-		Template: `
-		resource "databricks_service_principal" "this" {
-			display_name = "SPN {var.RANDOM}"
-			allow_cluster_create       = true
-			allow_instance_pool_create = true				
-		}
-
-		resource "databricks_entitlements" "service_principal" {
-			service_principal_id       = databricks_service_principal.this.id
-			allow_cluster_create       = true
-			allow_instance_pool_create = true
-		}`,
-	})
-}
 
 type entitlement struct {
 	name  string
@@ -113,7 +23,7 @@ func (e entitlement) String() string {
 	return fmt.Sprintf("%s = %t", e.name, e.value)
 }
 
-func entitlementsStepBuilder(t *testing.T, c **httpclient.ApiClient, groupName string) func(entitlements []entitlement) step {
+func entitlementsStepBuilder(t *testing.T, c **httpclient.ApiClient, r entitlementResource) func(entitlements []entitlement) step {
 	return func(entitlements []entitlement) step {
 		entitlementsBuf := strings.Builder{}
 		for _, entitlement := range entitlements {
@@ -121,15 +31,12 @@ func entitlementsStepBuilder(t *testing.T, c **httpclient.ApiClient, groupName s
 		}
 		return step{
 			Template: fmt.Sprintf(`
-			data "databricks_group" "example" {
-				display_name = "%s"
-			}
-			
+			%s
 			resource "databricks_entitlements" "entitlements_users" {
-				group_id              = data.databricks_group.example.id
+				group_id = %s
 				%s
 			}
-		`, groupName, entitlementsBuf.String()),
+		`, r.dataSourceTemplate(), r.tfReference(), entitlementsBuf.String()),
 			Check: func(s *terraform.State) error {
 				groupId := s.RootModule().Resources["data.databricks_group.example"].Primary.ID
 				var res iam.Group
@@ -155,89 +62,116 @@ func entitlementsStepBuilder(t *testing.T, c **httpclient.ApiClient, groupName s
 	}
 }
 
-func makeEntitlementsSteps(t *testing.T, entitlementsSteps [][]entitlement) []step {
-	groupName := RandomName("entitlements-")
+func makeEntitlementsSteps(t *testing.T, r entitlementResource, entitlementsSteps [][]entitlement) []step {
+	r.setDisplayName(RandomName("entitlements-"))
 	var c *httpclient.ApiClient
-	makeEntitlementsStep := entitlementsStepBuilder(t, &c, groupName)
+	makeEntitlementsStep := entitlementsStepBuilder(t, &c, r)
 	steps := make([]step, len(entitlementsSteps))
 	for i, entitlements := range entitlementsSteps {
 		steps[i] = makeEntitlementsStep(entitlements)
 	}
-	steps[0].PreConfig = makePreconfig(t, &c, groupName)
+	steps[0].PreConfig = makePreconfig(t, &c, r)
 	return steps
 }
 
-func makePreconfig(t *testing.T, c **httpclient.ApiClient, groupName string) func() {
+func makePreconfig(t *testing.T, c **httpclient.ApiClient, r entitlementResource) func() {
+	logger.DefaultLogger = &logger.SimpleLogger{
+		Level: logger.LevelDebug,
+	}
 	return func() {
 		w := databricks.Must(databricks.NewWorkspaceClient())
+		r.setWorkspaceClient(w)
 		var err error
 		*c, err = w.Config.NewApiClient()
 		assert.NoError(t, err)
 		ctx := context.Background()
-		group, err := w.Groups.Create(ctx, iam.Group{
-			DisplayName: groupName,
-		})
+		err = r.create(ctx)
 		assert.NoError(t, err)
 		t.Cleanup(func() {
-			err := w.Groups.DeleteById(ctx, group.Id)
-			assert.NoError(t, err)
+			r.cleanUp(ctx)
+		})
+	}
+}
+
+func entitlementsTest(t *testing.T, f func(*testing.T, entitlementResource)) {
+	loadWorkspaceEnv(t)
+	sp := &servicePrincipalResource{}
+	if isAzure(t) {
+		sp.applicationId = GetEnvOrSkipTest(t, "ACCOUNT_LEVEL_SERVICE_PRINCIPAL_ID")
+	}
+	resources := []entitlementResource{
+		// &groupResource{},
+		&userResource{},
+		// sp,
+	}
+	for _, r := range resources {
+		t.Run(fmt.Sprintf("%T", r), func(t *testing.T) {
+			f(t, r)
 		})
 	}
 }
 
 func TestAccEntitlementsAddToEmpty(t *testing.T) {
-	steps := makeEntitlementsSteps(t, [][]entitlement{
-		{},
-		{
-			{"allow_cluster_create", true},
-			{"allow_instance_pool_create", true},
-			{"workspace_access", true},
-			{"databricks_sql_access", true},
-		},
+	entitlementsTest(t, func(t *testing.T, r entitlementResource) {
+		steps := makeEntitlementsSteps(t, r, [][]entitlement{
+			{},
+			{
+				{"allow_cluster_create", true},
+				{"allow_instance_pool_create", true},
+				{"workspace_access", true},
+				{"databricks_sql_access", true},
+			},
+		})
+		workspaceLevel(t, steps...)
 	})
-	workspaceLevel(t, steps...)
 }
 
 func TestAccEntitlementsSetExplicitlyToFalse(t *testing.T) {
-	steps := makeEntitlementsSteps(t, [][]entitlement{
-		{
-			{"allow_cluster_create", false},
-			{"allow_instance_pool_create", false},
-			{"workspace_access", false},
-			{"databricks_sql_access", false},
-		},
-		{},
-		{
-			{"allow_cluster_create", false},
-			{"allow_instance_pool_create", false},
-			{"workspace_access", false},
-			{"databricks_sql_access", false},
-		},
+	entitlementsTest(t, func(t *testing.T, r entitlementResource) {
+		steps := makeEntitlementsSteps(t, r, [][]entitlement{
+			{
+				{"allow_cluster_create", false},
+				{"allow_instance_pool_create", false},
+				{"workspace_access", false},
+				{"databricks_sql_access", false},
+			},
+			{},
+			{
+				{"allow_cluster_create", false},
+				{"allow_instance_pool_create", false},
+				{"workspace_access", false},
+				{"databricks_sql_access", false},
+			},
+		})
+		workspaceLevel(t, steps...)
 	})
-	workspaceLevel(t, steps...)
 }
 
 func TestAccEntitlementsRemoveExisting(t *testing.T) {
-	steps := makeEntitlementsSteps(t, [][]entitlement{
-		{
-			{"allow_cluster_create", true},
-			{"allow_instance_pool_create", true},
-			{"workspace_access", true},
-			{"databricks_sql_access", true},
-		},
-		{},
+	entitlementsTest(t, func(t *testing.T, r entitlementResource) {
+		steps := makeEntitlementsSteps(t, r, [][]entitlement{
+			{
+				{"allow_cluster_create", true},
+				{"allow_instance_pool_create", true},
+				{"workspace_access", true},
+				{"databricks_sql_access", true},
+			},
+			{},
+		})
+		workspaceLevel(t, steps...)
 	})
-	workspaceLevel(t, steps...)
 }
 
 func TestAccEntitlementsSomeTrueSomeFalse(t *testing.T) {
-	steps := makeEntitlementsSteps(t, [][]entitlement{
-		{
-			{"allow_cluster_create", false},
-			{"allow_instance_pool_create", false},
-			{"workspace_access", true},
-			{"databricks_sql_access", true},
-		},
+	entitlementsTest(t, func(t *testing.T, r entitlementResource) {
+		steps := makeEntitlementsSteps(t, r, [][]entitlement{
+			{
+				{"allow_cluster_create", false},
+				{"allow_instance_pool_create", false},
+				{"workspace_access", true},
+				{"databricks_sql_access", true},
+			},
+		})
+		workspaceLevel(t, steps...)
 	})
-	workspaceLevel(t, steps...)
 }


### PR DESCRIPTION
## Changes
The integration tests for `databricks_entitlements` are now failing. I believe this is caused by a race condition between `databricks_group` and `databricks_entitlements` resources. In practice, these resources should not be used at the same time; instead, you should the former when you need to define the group in TF and the latter if the group is defined externally to TF.

First, I've improved the test coverage for entitlements to cover all resource types (user, group, service principal). As part of this, I've rewritten the tests to manage the resources externally from Terraform's perspective, so there are no more race conditions. Because of this, I'm able to remove the other integration tests, including the flaky one.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
