### PR TITLE
Fix `databricks_user` and `databricks_service_principal` integration tests

### DIFF
--- a/internal/acceptance/service_principal_test.go
+++ b/internal/acceptance/service_principal_test.go
@@ -3,7 +3,6 @@ package acceptance
 import (
 	"context"
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/databricks/databricks-sdk-go"
@@ -22,36 +21,37 @@ const awsSpn = `resource "databricks_service_principal" "this" {
 }`
 
 func TestAccServicePrincipalHomeDeleteSuccess(t *testing.T) {
-	GetEnvOrSkipTest(t, "ARM_CLIENT_ID")
+	loadWorkspaceEnv(t)
+	if !isAzure(t) {
+		skipf(t)("Test only valid for Azure")
+	}
+	uuid := createUuid()
+	var spId string
 	workspaceLevel(t, step{
 		Template: `
 			resource "databricks_service_principal" "a" {
-				application_id = "{var.RANDOM_UUID}"
+				application_id = "` + uuid + `"
 				force_delete_home_dir = true
 			}`,
 		Check: func(s *terraform.State) error {
-			appId := s.RootModule().Resources["databricks_service_principal.a"].Primary.Attributes["application_id"]
-			os.Setenv("application_id_a", appId)
+			spId = s.RootModule().Resources["databricks_service_principal.a"].Primary.Attributes["application_id"]
 			return nil
 		},
 	}, step{
 		Template: `
-			resource "databricks_service_principal" "b" {
-				application_id = "{var.RANDOM_UUID}"
-			}
-			`,
+			resource "databricks_service_principal" "a" {
+				application_id = "` + uuid + `"
+				force_delete_home_dir = true
+			}`,
+		Destroy: true,
 		Check: func(s *terraform.State) error {
 			w, err := databricks.NewWorkspaceClient()
 			if err != nil {
 				return err
 			}
 			ctx := context.Background()
-			_, err = w.Workspace.GetStatusByPath(ctx, fmt.Sprintf("/Users/%v", os.Getenv("application_id_a")))
-			os.Remove("application_id_a")
-			if err != nil {
-				if apierr.IsMissing(err) {
-					return nil
-				}
+			_, err = w.Workspace.GetStatusByPath(ctx, fmt.Sprintf("/Users/%v", spId))
+			if err != nil && !apierr.IsMissing(err) {
 				return err
 			}
 			return nil
@@ -60,7 +60,10 @@ func TestAccServicePrincipalHomeDeleteSuccess(t *testing.T) {
 }
 
 func TestAccServicePrinicpalHomeDeleteNotDeleted(t *testing.T) {
-	GetEnvOrSkipTest(t, "ARM_CLIENT_ID")
+	loadWorkspaceEnv(t)
+	if !isAzure(t) {
+		skipf(t)("Test only valid for Azure")
+	}
 	var appId string
 	workspaceLevel(t, step{
 		Template: `

--- a/internal/acceptance/user_test.go
+++ b/internal/acceptance/user_test.go
@@ -74,9 +74,11 @@ func TestAccUserHomeDelete(t *testing.T) {
 		}`,
 	}, step{
 		Template: `
-		resource "databricks_user" "second" {
-			user_name = "{var.RANDOM}@example.com"
+		resource "databricks_user" "first" {
+			user_name = "` + username + `"
+			force_delete_home_dir = true
 		}`,
+		Destroy: true,
 		Check: func(s *terraform.State) error {
 			w, err := databricks.NewWorkspaceClient()
 			if err != nil {

--- a/internal/acceptance/user_test.go
+++ b/internal/acceptance/user_test.go
@@ -66,19 +66,16 @@ func TestAccUserHomeDeleteHasNoEffectInAccount(t *testing.T) {
 
 func TestAccUserHomeDelete(t *testing.T) {
 	username := qa.RandomEmail()
+	template := `
+	resource "databricks_user" "first" {
+		user_name = "` + username + `"
+		force_delete_home_dir = true
+	}`
 	workspaceLevel(t, step{
-		Template: `
-		resource "databricks_user" "first" {
-			user_name = "` + username + `"
-			force_delete_home_dir = true
-		}`,
+		Template: template,
 	}, step{
-		Template: `
-		resource "databricks_user" "first" {
-			user_name = "` + username + `"
-			force_delete_home_dir = true
-		}`,
-		Destroy: true,
+		Template: template,
+		Destroy:  true,
 		Check: func(s *terraform.State) error {
 			w, err := databricks.NewWorkspaceClient()
 			if err != nil {
@@ -114,19 +111,18 @@ func provisionHomeFolder(ctx context.Context, s *terraform.State, tfAttribute, u
 
 func TestAccUserHomeDeleteNotDeleted(t *testing.T) {
 	username := qa.RandomEmail()
+	template := `
+	resource "databricks_user" "a" {
+		user_name = "` + username + `"
+	}`
 	workspaceLevel(t, step{
-		Template: `
-			resource "databricks_user" "a" {
-				user_name = "` + username + `"
-			}`,
+		Template: template,
 		Check: func(s *terraform.State) error {
 			return provisionHomeFolder(context.Background(), s, "databricks_user.a", username)
 		},
 	}, step{
-		Template: `
-			resource "databricks_user" "b" {
-				user_name = "{var.RANDOM}@example.com"
-			}`,
+		Template: template,
+		Destroy:  true,
 		Check: func(s *terraform.State) error {
 			w, err := databricks.NewWorkspaceClient()
 			if err != nil {

--- a/scim/resource_service_principal.go
+++ b/scim/resource_service_principal.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/databricks/databricks-sdk-go/apierr"
 	"github.com/databricks/terraform-provider-databricks/common"
 	"golang.org/x/exp/slices"
 
@@ -223,18 +224,18 @@ func ResourceServicePrincipal() common.Resource {
 			if !isAccount && !isDisable && err == nil {
 				if isForceDeleteRepos {
 					err = workspace.NewNotebooksAPI(ctx, c).Delete(fmt.Sprintf("/Repos/%v", appId), true)
-					if err != nil {
+					if err != nil && !apierr.IsMissing(err) {
 						return fmt.Errorf("force_delete_repos: %s", err.Error())
 					}
 				}
 				if isForceDeleteHomeDir {
 					err = workspace.NewNotebooksAPI(ctx, c).Delete(fmt.Sprintf("/Users/%v", appId), true)
-					if err != nil {
+					if err != nil && !apierr.IsMissing(err) {
 						return fmt.Errorf("force_delete_home_dir: %s", err.Error())
 					}
 				}
 			}
-			return err
+			return nil
 		},
 	}
 }

--- a/scim/resource_service_principal.go
+++ b/scim/resource_service_principal.go
@@ -220,6 +220,9 @@ func ResourceServicePrincipal() common.Resource {
 			} else {
 				err = spAPI.Delete(d.Id())
 			}
+			if err != nil {
+				return err
+			}
 			// Handle force delete flags
 			if !isAccount && !isDisable && err == nil {
 				if isForceDeleteRepos {

--- a/scim/resource_service_principal_test.go
+++ b/scim/resource_service_principal_test.go
@@ -451,7 +451,7 @@ func TestResourceServicePrinicpalforce_delete_reposError(t *testing.T) {
 }
 
 func TestResourceServicePrincipalDelete_NonExistingRepo(t *testing.T) {
-	_, err := qa.ResourceFixture{
+	qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   "DELETE",
@@ -478,8 +478,7 @@ func TestResourceServicePrincipalDelete_NonExistingRepo(t *testing.T) {
 			application_id = "abc"
 			force_delete_repos = true	
 		`,
-	}.Apply(t)
-	assert.EqualError(t, err, "force_delete_repos: Path (/Repos/abc) doesn't exist.")
+	}.ApplyNoError(t)
 }
 
 func TestResourceServicePrincipalDelete_DirError(t *testing.T) {
@@ -511,7 +510,7 @@ func TestResourceServicePrincipalDelete_DirError(t *testing.T) {
 }
 
 func TestResourceServicePrincipalDelete_NonExistingDir(t *testing.T) {
-	_, err := qa.ResourceFixture{
+	qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   "DELETE",
@@ -538,8 +537,7 @@ func TestResourceServicePrincipalDelete_NonExistingDir(t *testing.T) {
 		 	application_id = "abc"
 			force_delete_home_dir = true	
 		`,
-	}.Apply(t)
-	assert.EqualError(t, err, "force_delete_home_dir: Path (/Users/abc) doesn't exist.")
+	}.ApplyNoError(t)
 }
 
 func TestCreateForceOverridesManuallyAddedServicePrincipalErrorNotMatched(t *testing.T) {

--- a/scim/resource_user.go
+++ b/scim/resource_user.go
@@ -146,6 +146,9 @@ func ResourceUser() common.Resource {
 			} else {
 				err = user.Delete(d.Id())
 			}
+			if err != nil {
+				return err
+			}
 			// Handle force delete flags
 			if !isAccount && !isDisable && err == nil {
 				if isForceDeleteRepos {

--- a/scim/resource_user.go
+++ b/scim/resource_user.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/databricks/databricks-sdk-go/apierr"
 	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/databricks/terraform-provider-databricks/workspace"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -149,18 +150,18 @@ func ResourceUser() common.Resource {
 			if !isAccount && !isDisable && err == nil {
 				if isForceDeleteRepos {
 					err = workspace.NewNotebooksAPI(ctx, c).Delete(fmt.Sprintf("/Repos/%v", userName), true)
-					if err != nil {
+					if err != nil && !apierr.IsMissing(err) {
 						return fmt.Errorf("force_delete_repos: %s", err.Error())
 					}
 				}
 				if isForceDeleteHomeDir {
 					err = workspace.NewNotebooksAPI(ctx, c).Delete(fmt.Sprintf("/Users/%v", userName), true)
-					if err != nil {
+					if err != nil && !apierr.IsMissing(err) {
 						return fmt.Errorf("force_delete_home_dir: %s", err.Error())
 					}
 				}
 			}
-			return err
+			return nil
 		},
 	}
 }

--- a/scim/resource_user_test.go
+++ b/scim/resource_user_test.go
@@ -502,7 +502,7 @@ func TestResourceUserforce_delete_reposError(t *testing.T) {
 	require.Error(t, err, err)
 }
 func TestResourceUserDelete_NonExistingRepo(t *testing.T) {
-	_, err := qa.ResourceFixture{
+	qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   "DELETE",
@@ -529,8 +529,7 @@ func TestResourceUserDelete_NonExistingRepo(t *testing.T) {
 			user_name    = "abc"
 			force_delete_repos = true
 		`,
-	}.Apply(t)
-	assert.EqualError(t, err, "force_delete_repos: Path (/Repos/abc) doesn't exist.")
+	}.ApplyNoError(t)
 }
 
 func TestResourceUserDelete_DirError(t *testing.T) {
@@ -561,7 +560,7 @@ func TestResourceUserDelete_DirError(t *testing.T) {
 	require.Error(t, err, err)
 }
 func TestResourceUserDelete_NonExistingDir(t *testing.T) {
-	_, err := qa.ResourceFixture{
+	qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   "DELETE",
@@ -588,8 +587,7 @@ func TestResourceUserDelete_NonExistingDir(t *testing.T) {
 			user_name    = "abc"
 			force_delete_home_dir = true
 		`,
-	}.Apply(t)
-	assert.EqualError(t, err, "force_delete_home_dir: Path (/Users/abc) doesn't exist.")
+	}.ApplyNoError(t)
 }
 
 func TestResourceUserDelete_ForceDeleteHomeDir(t *testing.T) {


### PR DESCRIPTION
## Changes
The recent Go SDK upgrade caused a small regression for these test cases. If the home folder was never provisioned for the user/service principal, deleting with force_delete_home_dir should not cause deletion failures. Here, we only return the failure if the path deletion fails due to the folder not existing. The same logic is applied to repos.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
