### PR TITLE
Fix TestUcAccJobRunAsMutations

### DIFF
--- a/internal/acceptance/job_test.go
+++ b/internal/acceptance/job_test.go
@@ -358,6 +358,13 @@ func TestUcAccJobRunAsServicePrincipal(t *testing.T) {
 func TestUcAccJobRunAsMutations(t *testing.T) {
 	loadUcwsEnv(t)
 	spId := GetEnvOrSkipTest(t, "ACCOUNT_LEVEL_SERVICE_PRINCIPAL_ID")
+	// Note: the attribute must match the type of principal that the test is run as.
+	// Today, Azure tests are run using a service principal and AWS tests using a user.
+	// When AWS tests are run using a service principal, the attribute must be updated.
+	attribute := "user_name"
+	if isAzure(t) {
+		attribute = "service_principal_name"
+	}
 	unityWorkspaceLevel(
 		t,
 		// Provision job with service principal `run_as`
@@ -366,7 +373,7 @@ func TestUcAccJobRunAsMutations(t *testing.T) {
 		},
 		// Update job to a user `run_as`
 		step{
-			Template: runAsTemplate(`user_name = data.databricks_current_user.me.user_name`),
+			Template: runAsTemplate(attribute + ` = data.databricks_current_user.me.user_name`),
 		},
 		// Update job back to a service principal `run_as`
 		step{


### PR DESCRIPTION
## Changes
TestUcAccJobRunAsMutations fails today in Azure because the run_as field must use the attribute matching the principal type. Azure tests are run using a service principal, and AWS tests are run using a user. Thus, we need to change the attribute accordingly.

This PR adds some helper method for determining whether we are authenticated as an SP or user, then uses that to choose the correct attribute to set when constructing the template for `run_as` in `databricks_job`.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
