### PR TITLE
Make CustomizeSchemaPath able to pass information to skip unfeasible customizations

### DIFF
--- a/catalog/resource_catalog.go
+++ b/catalog/resource_catalog.go
@@ -50,9 +50,10 @@ func ResourceCatalog() common.Resource {
 				Optional: true,
 				Default:  false,
 			}
-			common.CustomizeSchemaPath(s, "storage_root").SetCustomSuppressDiff(ucDirectoryPathSlashOnlySuppressDiff)
-			common.CustomizeSchemaPath(s, "name").SetCustomSuppressDiff(common.EqualFoldDiffSuppress)
-			common.CustomizeSchemaPath(s, "enable_predictive_optimization").SetValidateFunc(
+			emptyCtx := common.SchemaPathContext{}
+			common.CustomizeSchemaPath(emptyCtx, s, "storage_root").SetCustomSuppressDiff(ucDirectoryPathSlashOnlySuppressDiff)
+			common.CustomizeSchemaPath(emptyCtx, s, "name").SetCustomSuppressDiff(common.EqualFoldDiffSuppress)
+			common.CustomizeSchemaPath(emptyCtx, s, "enable_predictive_optimization").SetValidateFunc(
 				validation.StringInSlice([]string{"DISABLE", "ENABLE", "INHERIT"}, false),
 			)
 			return s

--- a/catalog/resource_lakehouse_monitor.go
+++ b/catalog/resource_lakehouse_monitor.go
@@ -35,24 +35,25 @@ func ResourceLakehouseMonitor() common.Resource {
 	monitorSchema := common.StructToSchema(
 		catalog.MonitorInfo{},
 		func(m map[string]*schema.Schema) map[string]*schema.Schema {
-			common.CustomizeSchemaPath(m, "assets_dir").SetRequired()
-			common.CustomizeSchemaPath(m, "output_schema_name").SetRequired()
-			common.CustomizeSchemaPath(m, "table_name").SetRequired()
-			common.CustomizeSchemaPath(m).AddNewField("skip_builtin_dashboard", &schema.Schema{
+			emptyCtx := common.SchemaPathContext{}
+			common.CustomizeSchemaPath(emptyCtx, m, "assets_dir").SetRequired()
+			common.CustomizeSchemaPath(emptyCtx, m, "output_schema_name").SetRequired()
+			common.CustomizeSchemaPath(emptyCtx, m, "table_name").SetRequired()
+			common.CustomizeSchemaPath(emptyCtx, m).AddNewField("skip_builtin_dashboard", &schema.Schema{
 				Type:     schema.TypeBool,
 				Optional: true,
 				Required: false,
 			})
-			common.CustomizeSchemaPath(m).AddNewField("warehouse_id", &schema.Schema{
+			common.CustomizeSchemaPath(emptyCtx, m).AddNewField("warehouse_id", &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
 				Required: false,
 			})
-			common.CustomizeSchemaPath(m, "monitor_version").SetReadOnly()
-			common.CustomizeSchemaPath(m, "drift_metrics_table_name").SetReadOnly()
-			common.CustomizeSchemaPath(m, "profile_metrics_table_name").SetReadOnly()
-			common.CustomizeSchemaPath(m, "status").SetReadOnly()
-			common.CustomizeSchemaPath(m, "dashboard_id").SetReadOnly()
+			common.CustomizeSchemaPath(emptyCtx, m, "monitor_version").SetReadOnly()
+			common.CustomizeSchemaPath(emptyCtx, m, "drift_metrics_table_name").SetReadOnly()
+			common.CustomizeSchemaPath(emptyCtx, m, "profile_metrics_table_name").SetReadOnly()
+			common.CustomizeSchemaPath(emptyCtx, m, "status").SetReadOnly()
+			common.CustomizeSchemaPath(emptyCtx, m, "dashboard_id").SetReadOnly()
 			return m
 		},
 	)

--- a/catalog/resource_online_table.go
+++ b/catalog/resource_online_table.go
@@ -56,14 +56,15 @@ func ResourceOnlineTable() common.Resource {
 	s := common.StructToSchema(catalog.OnlineTable{},
 		func(m map[string]*schema.Schema) map[string]*schema.Schema {
 			m["name"].DiffSuppressFunc = common.EqualFoldDiffSuppress
-			common.CustomizeSchemaPath(m, "spec", "source_table_full_name").SetCustomSuppressDiff(common.EqualFoldDiffSuppress)
-			common.CustomizeSchemaPath(m, "name").SetRequired().SetForceNew()
-			common.CustomizeSchemaPath(m, "status").SetReadOnly()
-			common.CustomizeSchemaPath(m, "spec", "pipeline_id").SetReadOnly()
+			emptyCtx := common.SchemaPathContext{}
+			common.CustomizeSchemaPath(emptyCtx, m, "spec", "source_table_full_name").SetCustomSuppressDiff(common.EqualFoldDiffSuppress)
+			common.CustomizeSchemaPath(emptyCtx, m, "name").SetRequired().SetForceNew()
+			common.CustomizeSchemaPath(emptyCtx, m, "status").SetReadOnly()
+			common.CustomizeSchemaPath(emptyCtx, m, "spec", "pipeline_id").SetReadOnly()
 
 			runTypes := []string{"spec.0.run_triggered", "spec.0.run_continuously"}
-			common.CustomizeSchemaPath(m, "spec", "run_triggered").SetAtLeastOneOf(runTypes).SetSuppressDiff()
-			common.CustomizeSchemaPath(m, "spec", "run_continuously").SetAtLeastOneOf(runTypes).SetSuppressDiff()
+			common.CustomizeSchemaPath(emptyCtx, m, "spec", "run_triggered").SetAtLeastOneOf(runTypes).SetSuppressDiff()
+			common.CustomizeSchemaPath(emptyCtx, m, "spec", "run_continuously").SetAtLeastOneOf(runTypes).SetSuppressDiff()
 			return m
 		})
 

--- a/catalog/resource_schema.go
+++ b/catalog/resource_schema.go
@@ -31,11 +31,12 @@ func ResourceSchema() common.Resource {
 				Optional: true,
 				Default:  false,
 			}
-			common.CustomizeSchemaPath(s, "storage_root").SetCustomSuppressDiff(ucDirectoryPathSlashOnlySuppressDiff)
+			emptyCtx := common.SchemaPathContext{}
+			common.CustomizeSchemaPath(emptyCtx, s, "storage_root").SetCustomSuppressDiff(ucDirectoryPathSlashOnlySuppressDiff)
 			s["storage_root"].DiffSuppressFunc = ucDirectoryPathSlashOnlySuppressDiff
-			common.CustomizeSchemaPath(s, "name").SetCustomSuppressDiff(common.EqualFoldDiffSuppress)
-			common.CustomizeSchemaPath(s, "catalog_name").SetCustomSuppressDiff(common.EqualFoldDiffSuppress)
-			common.CustomizeSchemaPath(s, "enable_predictive_optimization").SetValidateFunc(
+			common.CustomizeSchemaPath(emptyCtx, s, "name").SetCustomSuppressDiff(common.EqualFoldDiffSuppress)
+			common.CustomizeSchemaPath(emptyCtx, s, "catalog_name").SetCustomSuppressDiff(common.EqualFoldDiffSuppress)
+			common.CustomizeSchemaPath(emptyCtx, s, "enable_predictive_optimization").SetValidateFunc(
 				validation.StringInSlice([]string{"DISABLE", "ENABLE", "INHERIT"}, false),
 			)
 			return s

--- a/clusters/resource_cluster.go
+++ b/clusters/resource_cluster.go
@@ -123,62 +123,62 @@ type ClusterSpec struct {
 	Libraries []compute.Library `json:"libraries,omitempty" tf:"slice_set,alias:library"`
 }
 
-func (ClusterSpec) CustomizeSchema(s map[string]*schema.Schema) map[string]*schema.Schema {
-	common.CustomizeSchemaPath(s, "cluster_source").SetReadOnly()
-	common.CustomizeSchemaPath(s, "enable_elastic_disk").SetComputed()
-	common.CustomizeSchemaPath(s, "enable_local_disk_encryption").SetComputed()
-	common.CustomizeSchemaPath(s, "node_type_id").SetComputed().SetConflictsWith([]string{"driver_instance_pool_id", "instance_pool_id"})
-	common.CustomizeSchemaPath(s, "driver_node_type_id").SetComputed().SetConflictsWith([]string{"driver_instance_pool_id", "instance_pool_id"})
-	common.CustomizeSchemaPath(s, "driver_instance_pool_id").SetComputed().SetConflictsWith([]string{"driver_node_type_id", "node_type_id"})
-	common.CustomizeSchemaPath(s, "ssh_public_keys").SetMaxItems(10)
-	common.CustomizeSchemaPath(s, "init_scripts").SetMaxItems(10)
-	common.CustomizeSchemaPath(s, "init_scripts", "dbfs").SetDeprecated(DbfsDeprecationWarning)
-	common.CustomizeSchemaPath(s, "init_scripts", "dbfs", "destination").SetRequired()
-	common.CustomizeSchemaPath(s, "init_scripts", "s3", "destination").SetRequired()
-	common.CustomizeSchemaPath(s, "init_scripts", "volumes", "destination").SetRequired()
-	common.CustomizeSchemaPath(s, "init_scripts", "workspace", "destination").SetRequired()
-	common.CustomizeSchemaPath(s, "workload_type", "clients").SetRequired()
-	common.CustomizeSchemaPath(s, "workload_type", "clients", "notebooks").SetDefault(true)
-	common.CustomizeSchemaPath(s, "workload_type", "clients", "jobs").SetDefault(true)
+func (ClusterSpec) CustomizeSchema(s map[string]*schema.Schema, ctx common.SchemaPathContext) map[string]*schema.Schema {
+	common.CustomizeSchemaPath(ctx, s, "cluster_source").SetReadOnly()
+	common.CustomizeSchemaPath(ctx, s, "enable_elastic_disk").SetComputed()
+	common.CustomizeSchemaPath(ctx, s, "enable_local_disk_encryption").SetComputed()
+	common.CustomizeSchemaPath(ctx, s, "node_type_id").SetComputed().SetConflictsWith([]string{"driver_instance_pool_id", "instance_pool_id"})
+	common.CustomizeSchemaPath(ctx, s, "driver_node_type_id").SetComputed().SetConflictsWith([]string{"driver_instance_pool_id", "instance_pool_id"})
+	common.CustomizeSchemaPath(ctx, s, "driver_instance_pool_id").SetComputed().SetConflictsWith([]string{"driver_node_type_id", "node_type_id"})
+	common.CustomizeSchemaPath(ctx, s, "ssh_public_keys").SetMaxItems(10)
+	common.CustomizeSchemaPath(ctx, s, "init_scripts").SetMaxItems(10)
+	common.CustomizeSchemaPath(ctx, s, "init_scripts", "dbfs").SetDeprecated(DbfsDeprecationWarning)
+	common.CustomizeSchemaPath(ctx, s, "init_scripts", "dbfs", "destination").SetRequired()
+	common.CustomizeSchemaPath(ctx, s, "init_scripts", "s3", "destination").SetRequired()
+	common.CustomizeSchemaPath(ctx, s, "init_scripts", "volumes", "destination").SetRequired()
+	common.CustomizeSchemaPath(ctx, s, "init_scripts", "workspace", "destination").SetRequired()
+	common.CustomizeSchemaPath(ctx, s, "workload_type", "clients").SetRequired()
+	common.CustomizeSchemaPath(ctx, s, "workload_type", "clients", "notebooks").SetDefault(true)
+	common.CustomizeSchemaPath(ctx, s, "workload_type", "clients", "jobs").SetDefault(true)
 	s["library"].Set = func(i any) int {
 		lib := libraries.NewLibraryFromInstanceState(i)
 		return schema.HashString(lib.String())
 	}
-	common.CustomizeSchemaPath(s).AddNewField("idempotency_token", &schema.Schema{
+	common.CustomizeSchemaPath(ctx, s).AddNewField("idempotency_token", &schema.Schema{
 		Type:     schema.TypeString,
 		Optional: true,
 		ForceNew: true,
 	})
-	common.CustomizeSchemaPath(s, "data_security_mode").SetSuppressDiff()
-	common.CustomizeSchemaPath(s, "docker_image", "url").SetRequired()
-	common.CustomizeSchemaPath(s, "docker_image", "basic_auth", "password").SetRequired().SetSensitive()
-	common.CustomizeSchemaPath(s, "docker_image", "basic_auth", "username").SetRequired()
-	common.CustomizeSchemaPath(s, "spark_conf").SetCustomSuppressDiff(SparkConfDiffSuppressFunc)
-	common.CustomizeSchemaPath(s, "aws_attributes").SetSuppressDiff().SetConflictsWith([]string{"azure_attributes", "gcp_attributes"})
-	common.CustomizeSchemaPath(s, "aws_attributes", "zone_id").SetCustomSuppressDiff(ZoneDiffSuppress)
-	common.CustomizeSchemaPath(s, "azure_attributes").SetSuppressDiff().SetConflictsWith([]string{"aws_attributes", "gcp_attributes"})
-	common.CustomizeSchemaPath(s, "gcp_attributes").SetSuppressDiff().SetConflictsWith([]string{"aws_attributes", "azure_attributes"})
-	common.CustomizeSchemaPath(s, "autotermination_minutes").SetDefault(60)
-	common.CustomizeSchemaPath(s, "autoscale", "max_workers").SetOptional()
-	common.CustomizeSchemaPath(s, "autoscale", "min_workers").SetOptional()
-	common.CustomizeSchemaPath(s, "cluster_log_conf", "dbfs", "destination").SetRequired()
-	common.CustomizeSchemaPath(s, "cluster_log_conf", "s3", "destination").SetRequired()
-	common.CustomizeSchemaPath(s, "spark_version").SetRequired()
-	common.CustomizeSchemaPath(s).AddNewField("cluster_id", &schema.Schema{
+	common.CustomizeSchemaPath(ctx, s, "data_security_mode").SetSuppressDiff()
+	common.CustomizeSchemaPath(ctx, s, "docker_image", "url").SetRequired()
+	common.CustomizeSchemaPath(ctx, s, "docker_image", "basic_auth", "password").SetRequired().SetSensitive()
+	common.CustomizeSchemaPath(ctx, s, "docker_image", "basic_auth", "username").SetRequired()
+	common.CustomizeSchemaPath(ctx, s, "spark_conf").SetCustomSuppressDiff(SparkConfDiffSuppressFunc)
+	common.CustomizeSchemaPath(ctx, s, "aws_attributes").SetSuppressDiff().SetConflictsWith([]string{"azure_attributes", "gcp_attributes"})
+	common.CustomizeSchemaPath(ctx, s, "aws_attributes", "zone_id").SetCustomSuppressDiff(ZoneDiffSuppress)
+	common.CustomizeSchemaPath(ctx, s, "azure_attributes").SetSuppressDiff().SetConflictsWith([]string{"aws_attributes", "gcp_attributes"})
+	common.CustomizeSchemaPath(ctx, s, "gcp_attributes").SetSuppressDiff().SetConflictsWith([]string{"aws_attributes", "azure_attributes"})
+	common.CustomizeSchemaPath(ctx, s, "autotermination_minutes").SetDefault(60)
+	common.CustomizeSchemaPath(ctx, s, "autoscale", "max_workers").SetOptional()
+	common.CustomizeSchemaPath(ctx, s, "autoscale", "min_workers").SetOptional()
+	common.CustomizeSchemaPath(ctx, s, "cluster_log_conf", "dbfs", "destination").SetRequired()
+	common.CustomizeSchemaPath(ctx, s, "cluster_log_conf", "s3", "destination").SetRequired()
+	common.CustomizeSchemaPath(ctx, s, "spark_version").SetRequired()
+	common.CustomizeSchemaPath(ctx, s).AddNewField("cluster_id", &schema.Schema{
 		Type:     schema.TypeString,
 		Computed: true,
 	})
-	common.CustomizeSchemaPath(s).AddNewField("default_tags", &schema.Schema{
+	common.CustomizeSchemaPath(ctx, s).AddNewField("default_tags", &schema.Schema{
 		Type:     schema.TypeMap,
 		Computed: true,
 	})
-	common.CustomizeSchemaPath(s).AddNewField("state", &schema.Schema{
+	common.CustomizeSchemaPath(ctx, s).AddNewField("state", &schema.Schema{
 		Type:     schema.TypeString,
 		Computed: true,
 	})
-	common.CustomizeSchemaPath(s, "instance_pool_id").SetConflictsWith([]string{"driver_node_type_id", "node_type_id"})
-	common.CustomizeSchemaPath(s, "runtime_engine").SetValidateFunc(validation.StringInSlice([]string{"PHOTON", "STANDARD"}, false))
-	common.CustomizeSchemaPath(s).AddNewField("is_pinned", &schema.Schema{
+	common.CustomizeSchemaPath(ctx, s, "instance_pool_id").SetConflictsWith([]string{"driver_node_type_id", "node_type_id"})
+	common.CustomizeSchemaPath(ctx, s, "runtime_engine").SetValidateFunc(validation.StringInSlice([]string{"PHOTON", "STANDARD"}, false))
+	common.CustomizeSchemaPath(ctx, s).AddNewField("is_pinned", &schema.Schema{
 		Type:     schema.TypeBool,
 		Optional: true,
 		Default:  false,
@@ -189,12 +189,12 @@ func (ClusterSpec) CustomizeSchema(s map[string]*schema.Schema) map[string]*sche
 			return old == new
 		},
 	})
-	common.CustomizeSchemaPath(s).AddNewField("url", &schema.Schema{
+	common.CustomizeSchemaPath(ctx, s).AddNewField("url", &schema.Schema{
 		Type:     schema.TypeString,
 		Computed: true,
 	})
-	common.CustomizeSchemaPath(s, "num_workers").SetDefault(0).SetValidateDiagFunc(validation.ToDiagFunc(validation.IntAtLeast(0)))
-	common.CustomizeSchemaPath(s).AddNewField("cluster_mount_info", &schema.Schema{
+	common.CustomizeSchemaPath(ctx, s, "num_workers").SetDefault(0).SetValidateDiagFunc(validation.ToDiagFunc(validation.IntAtLeast(0)))
+	common.CustomizeSchemaPath(ctx, s).AddNewField("cluster_mount_info", &schema.Schema{
 		Type:     schema.TypeList,
 		Optional: true,
 		Elem: &schema.Resource{

--- a/clusters/resource_library.go
+++ b/clusters/resource_library.go
@@ -16,8 +16,8 @@ type LibraryResource struct {
 	compute.Library
 }
 
-func (LibraryResource) CustomizeSchema(s map[string]*schema.Schema) map[string]*schema.Schema {
-	common.CustomizeSchemaPath(s).AddNewField("cluster_id", &schema.Schema{
+func (LibraryResource) CustomizeSchema(s map[string]*schema.Schema, ctx common.SchemaPathContext) map[string]*schema.Schema {
+	common.CustomizeSchemaPath(ctx, s).AddNewField("cluster_id", &schema.Schema{
 		Type:     schema.TypeString,
 		Required: true,
 	})

--- a/common/customizable_schema_test.go
+++ b/common/customizable_schema_test.go
@@ -172,7 +172,7 @@ func TestCustomizableSchemaSetConflictsWith_PathInContext(t *testing.T) {
 		schemaPath: []*schema.Schema{},
 	}
 	CustomizeSchemaPath(fakeContextWithPath, testCustomizableSchemaScm, "float").SetConflictsWith([]string{"abc"})
-	assert.Truef(t, len(testCustomizableSchemaScm["flat"].ConflictsWith) == 1, "conflictsWith should be set in field: float")
+	assert.Truef(t, len(testCustomizableSchemaScm["float"].ConflictsWith) == 1, "conflictsWith should be set in field: float")
 	assert.Truef(t, CustomizeSchemaPath(fakeContextWithPath, testCustomizableSchemaScm, "float").Schema.ConflictsWith[0] == "a.0.b.abc", "conflictsWith should be set with the correct prefix")
 }
 

--- a/common/customizable_schema_test.go
+++ b/common/customizable_schema_test.go
@@ -11,17 +11,17 @@ import (
 var testCustomizableSchemaScm = StructToSchema(testStruct{}, nil)
 
 func TestCustomizableSchemaSetOptional(t *testing.T) {
-	CustomizeSchemaPath(testCustomizableSchemaScm, "non_optional").SetOptional()
+	CustomizeSchemaPath(getEmptySchemaPathContext(), testCustomizableSchemaScm, "non_optional").SetOptional()
 	assert.Truef(t, testCustomizableSchemaScm["non_optional"].Optional, "optional should be overriden to true in field: non-optional")
 }
 
 func TestCustomizableSchemaSetRequired(t *testing.T) {
-	CustomizeSchemaPath(testCustomizableSchemaScm, "float").SetRequired()
+	CustomizeSchemaPath(getEmptySchemaPathContext(), testCustomizableSchemaScm, "float").SetRequired()
 	assert.Truef(t, testCustomizableSchemaScm["float"].Required, "required should be overriden to true in field: float")
 }
 
 func TestCustomizableSchemaSetReadOnly(t *testing.T) {
-	CustomizeSchemaPath(testCustomizableSchemaScm, "bool").SetReadOnly()
+	CustomizeSchemaPath(getEmptySchemaPathContext(), testCustomizableSchemaScm, "bool").SetReadOnly()
 	assert.Truef(t, testCustomizableSchemaScm["bool"].Computed, "computed should be overriden to true in field: bool")
 	assert.Falsef(t, testCustomizableSchemaScm["bool"].Optional, "optional should be overriden to false in field: bool")
 	assert.Falsef(t, testCustomizableSchemaScm["bool"].Required, "required should be overriden to false in field: bool")
@@ -29,17 +29,17 @@ func TestCustomizableSchemaSetReadOnly(t *testing.T) {
 }
 
 func TestCustomizableSchemaSetComputed(t *testing.T) {
-	CustomizeSchemaPath(testCustomizableSchemaScm, "string").SetComputed()
+	CustomizeSchemaPath(getEmptySchemaPathContext(), testCustomizableSchemaScm, "string").SetComputed()
 	assert.Truef(t, testCustomizableSchemaScm["string"].Computed, "computed should be overriden to true in field: string")
 }
 
 func TestCustomizableSchemaSetDefault(t *testing.T) {
-	CustomizeSchemaPath(testCustomizableSchemaScm, "non_optional").SetDefault("abc")
+	CustomizeSchemaPath(getEmptySchemaPathContext(), testCustomizableSchemaScm, "non_optional").SetDefault("abc")
 	assert.Truef(t, testCustomizableSchemaScm["non_optional"].Default == "abc", "default should be overriden to abc in field: non_optional")
 }
 
 func TestCustomizableSchemaSetSuppressDiff(t *testing.T) {
-	CustomizeSchemaPath(testCustomizableSchemaScm, "non_optional").SetSuppressDiff()
+	CustomizeSchemaPath(getEmptySchemaPathContext(), testCustomizableSchemaScm, "non_optional").SetSuppressDiff()
 	assert.Truef(t, testCustomizableSchemaScm["non_optional"].DiffSuppressFunc != nil, "DiffSuppressfunc should be set in field: non_optional")
 }
 
@@ -128,7 +128,7 @@ func TestCustomizableSchemaSetCustomSuppressDiffWithDefault(t *testing.T) {
 
 	for _, tt := range tc {
 		t.Run(tt.name, func(t *testing.T) {
-			CustomizeSchemaPath(testCustomizableSchemaScm, tt.fieldName).SetSuppressDiffWithDefault(tt.dv)
+			CustomizeSchemaPath(getEmptySchemaPathContext(), testCustomizableSchemaScm, tt.fieldName).SetSuppressDiffWithDefault(tt.dv)
 			assert.Truef(t, testCustomizableSchemaScm[tt.fieldName].DiffSuppressFunc != nil, "DiffSuppressFunc should be set in field: %s", tt.fieldName)
 
 			assert.Equal(t, tt.result, testCustomizableSchemaScm[tt.fieldName].DiffSuppressFunc("", tt.old, tt.new, nil))
@@ -137,67 +137,91 @@ func TestCustomizableSchemaSetCustomSuppressDiffWithDefault(t *testing.T) {
 }
 
 func TestCustomizableSchemaSetCustomSuppressDiff(t *testing.T) {
-	CustomizeSchemaPath(testCustomizableSchemaScm, "non_optional").SetCustomSuppressDiff(diffSuppressor("test", CustomizeSchemaPath(testCustomizableSchemaScm, "non_optional").Schema))
+	CustomizeSchemaPath(getEmptySchemaPathContext(), testCustomizableSchemaScm, "non_optional").SetCustomSuppressDiff(diffSuppressor("test", CustomizeSchemaPath(getEmptySchemaPathContext(), testCustomizableSchemaScm, "non_optional").Schema))
 	assert.Truef(t, testCustomizableSchemaScm["non_optional"].DiffSuppressFunc != nil, "DiffSuppressfunc should be set in field: non_optional")
 }
 
 func TestCustomizableSchemaSetSensitive(t *testing.T) {
-	CustomizeSchemaPath(testCustomizableSchemaScm, "non_optional").SetSensitive()
+	CustomizeSchemaPath(getEmptySchemaPathContext(), testCustomizableSchemaScm, "non_optional").SetSensitive()
 	assert.Truef(t, testCustomizableSchemaScm["non_optional"].Sensitive, "sensitive should be overriden to true in field: non_optional")
 }
 
 func TestCustomizableSchemaSetForceNew(t *testing.T) {
-	CustomizeSchemaPath(testCustomizableSchemaScm, "non_optional").SetForceNew()
+	CustomizeSchemaPath(getEmptySchemaPathContext(), testCustomizableSchemaScm, "non_optional").SetForceNew()
 	assert.Truef(t, testCustomizableSchemaScm["non_optional"].ForceNew, "forcenew should be overriden to true in field: non_optional")
 }
 
 func TestCustomizableSchemaSetMaxItems(t *testing.T) {
-	CustomizeSchemaPath(testCustomizableSchemaScm, "int_slice").SetMaxItems(5)
+	CustomizeSchemaPath(getEmptySchemaPathContext(), testCustomizableSchemaScm, "int_slice").SetMaxItems(5)
 	assert.Truef(t, testCustomizableSchemaScm["int_slice"].MaxItems == 5, "maxItems should be overriden to 5 in field: int_slice")
 }
 
 func TestCustomizableSchemaSetMinItems(t *testing.T) {
-	CustomizeSchemaPath(testCustomizableSchemaScm, "int_slice").SetMinItems(3)
+	CustomizeSchemaPath(getEmptySchemaPathContext(), testCustomizableSchemaScm, "int_slice").SetMinItems(3)
 	assert.Truef(t, testCustomizableSchemaScm["int_slice"].MinItems == 3, "maxItems should be overriden to 5 in field: int_slice")
 }
 
 func TestCustomizableSchemaSetConflictsWith(t *testing.T) {
-	CustomizeSchemaPath(testCustomizableSchemaScm, "non_optional").SetConflictsWith([]string{"abc"})
+	CustomizeSchemaPath(getEmptySchemaPathContext(), testCustomizableSchemaScm, "non_optional").SetConflictsWith([]string{"abc"})
 	assert.Truef(t, len(testCustomizableSchemaScm["non_optional"].ConflictsWith) == 1, "conflictsWith should be set in field: non_optional")
 }
 
+func TestCustomizableSchemaSetConflictsWith_PathInContext(t *testing.T) {
+	fakeContextWithPath := SchemaPathContext{
+		path:       []string{"a", "0", "b"},
+		schemaPath: []*schema.Schema{},
+	}
+	CustomizeSchemaPath(fakeContextWithPath, testCustomizableSchemaScm, "float").SetConflictsWith([]string{"abc"})
+	assert.Truef(t, len(testCustomizableSchemaScm["flat"].ConflictsWith) == 1, "conflictsWith should be set in field: float")
+	assert.Truef(t, CustomizeSchemaPath(fakeContextWithPath, testCustomizableSchemaScm, "float").Schema.ConflictsWith[0] == "a.0.b.abc", "conflictsWith should be set with the correct prefix")
+}
+
+func TestCustomizableSchemaSetConflictsWith_MultiItemList(t *testing.T) {
+	fakeContextWithPath := SchemaPathContext{
+		path: []string{"a", "0", "b"},
+		schemaPath: []*schema.Schema{
+			{
+				Type:     schema.TypeList,
+				MaxItems: 10,
+			},
+		},
+	}
+	CustomizeSchemaPath(fakeContextWithPath, testCustomizableSchemaScm, "bool").SetConflictsWith([]string{"abc"})
+	assert.Truef(t, len(testCustomizableSchemaScm["bool"].ConflictsWith) == 0, "conflictsWith should not be set when there's multi item list in the path")
+}
+
 func TestCustomizableSchemaSetExactlyOneOf(t *testing.T) {
-	CustomizeSchemaPath(testCustomizableSchemaScm, "non_optional").SetExactlyOneOf([]string{"abc"})
+	CustomizeSchemaPath(getEmptySchemaPathContext(), testCustomizableSchemaScm, "non_optional").SetExactlyOneOf([]string{"abc"})
 	assert.Truef(t, len(testCustomizableSchemaScm["non_optional"].ExactlyOneOf) == 1, "ExactlyOneOf should be set in field: non_optional")
 }
 
 func TestCustomizableSchemaAtLeastOneOf(t *testing.T) {
-	CustomizeSchemaPath(testCustomizableSchemaScm, "non_optional").SetAtLeastOneOf([]string{"abc"})
+	CustomizeSchemaPath(getEmptySchemaPathContext(), testCustomizableSchemaScm, "non_optional").SetAtLeastOneOf([]string{"abc"})
 	assert.Truef(t, len(testCustomizableSchemaScm["non_optional"].AtLeastOneOf) == 1, "AtLeastOneOf should be set in field: non_optional")
 }
 
 func TestCustomizableSchemaSetRequiredWith(t *testing.T) {
-	CustomizeSchemaPath(testCustomizableSchemaScm, "non_optional").SetRequiredWith([]string{"abc"})
+	CustomizeSchemaPath(getEmptySchemaPathContext(), testCustomizableSchemaScm, "non_optional").SetRequiredWith([]string{"abc"})
 	assert.Truef(t, len(testCustomizableSchemaScm["non_optional"].RequiredWith) == 1, "RequiredWith should be set in field: non_optional")
 }
 func TestCustomizableSchemaSetDeprecated(t *testing.T) {
-	CustomizeSchemaPath(testCustomizableSchemaScm, "non_optional").SetDeprecated("test reason")
+	CustomizeSchemaPath(getEmptySchemaPathContext(), testCustomizableSchemaScm, "non_optional").SetDeprecated("test reason")
 	assert.Truef(t, testCustomizableSchemaScm["non_optional"].Deprecated == "test reason", "deprecated should be overriden in field: non_optional")
 }
 
 func TestCustomizableSchemaSetValidateFunc(t *testing.T) {
-	CustomizeSchemaPath(testCustomizableSchemaScm, "non_optional").SetValidateFunc(validation.StringInSlice([]string{"PHOTON", "STANDARD"}, false))
+	CustomizeSchemaPath(getEmptySchemaPathContext(), testCustomizableSchemaScm, "non_optional").SetValidateFunc(validation.StringInSlice([]string{"PHOTON", "STANDARD"}, false))
 	assert.Truef(t, testCustomizableSchemaScm["non_optional"].ValidateFunc != nil, "validateFunc should be set in field: non_optional")
 }
 
 func TestCustomizableSchemaSetValidateDiagFunc(t *testing.T) {
-	CustomizeSchemaPath(testCustomizableSchemaScm, "non_optional").SetValidateDiagFunc(validation.ToDiagFunc(validation.IntAtLeast(0)))
+	CustomizeSchemaPath(getEmptySchemaPathContext(), testCustomizableSchemaScm, "non_optional").SetValidateDiagFunc(validation.ToDiagFunc(validation.IntAtLeast(0)))
 	assert.Truef(t, testCustomizableSchemaScm["non_optional"].ValidateDiagFunc != nil, "validateDiagFunc should be set in field: non_optional")
 }
 
 func TestCustomizableSchemaAddNewField(t *testing.T) {
 
-	CustomizeSchemaPath(testCustomizableSchemaScm).AddNewField("test", &schema.Schema{
+	CustomizeSchemaPath(getEmptySchemaPathContext(), testCustomizableSchemaScm).AddNewField("test", &schema.Schema{
 		Type:     schema.TypeString,
 		Optional: true,
 		Computed: true,
@@ -205,7 +229,7 @@ func TestCustomizableSchemaAddNewField(t *testing.T) {
 
 	assert.Truef(t, MustSchemaPath(testCustomizableSchemaScm, "test").Type == schema.TypeString, "field test should be added to the top level")
 
-	CustomizeSchemaPath(testCustomizableSchemaScm, "ptr_item").AddNewField("test", &schema.Schema{
+	CustomizeSchemaPath(getEmptySchemaPathContext(), testCustomizableSchemaScm, "ptr_item").AddNewField("test", &schema.Schema{
 		Type:     schema.TypeString,
 		Optional: true,
 		Computed: true,

--- a/common/reflect_resource.go
+++ b/common/reflect_resource.go
@@ -65,7 +65,9 @@ func RegisterResourceProvider(v any, r ResourceProvider) {
 // Generic interface for ResourceProvider. Using CustomizeSchema function to keep track of additional information
 // on top of the generated go-sdk struct.
 type ResourceProvider interface {
-	CustomizeSchema(map[string]*schema.Schema) map[string]*schema.Schema
+	// The first input is the schema we would like to customize, the second input is a context containing the
+	// path leading to the current resource, this is used as inputs for CustomizeSchemaPath.
+	CustomizeSchema(map[string]*schema.Schema, SchemaPathContext) map[string]*schema.Schema
 }
 
 // Interface for ResourceProvider instances that need aliases for fields.
@@ -100,7 +102,7 @@ type RecursiveResourceProvider interface {
 }
 
 // Takes in a ResourceProvider and converts that into a map from string to schema.
-func resourceProviderStructToSchema(v ResourceProvider) map[string]*schema.Schema {
+func resourceProviderStructToSchema(v ResourceProvider, scp SchemaPathContext) map[string]*schema.Schema {
 	rv := reflect.ValueOf(v)
 	var scm map[string]*schema.Schema
 	aliases := map[string]map[string]string{}
@@ -108,11 +110,11 @@ func resourceProviderStructToSchema(v ResourceProvider) map[string]*schema.Schem
 		aliases = rpwa.Aliases()
 	}
 	if rrp, ok := v.(RecursiveResourceProvider); ok {
-		scm = typeToSchema(rv, aliases, getRecursionTrackingContext(rrp))
+		scm = typeToSchema(rv, aliases, getRecursionTrackingContext(rrp), scp)
 	} else {
-		scm = typeToSchema(rv, aliases, getEmptyRecursionTrackingContext())
+		scm = typeToSchema(rv, aliases, getEmptyRecursionTrackingContext(), scp)
 	}
-	scm = v.CustomizeSchema(scm)
+	scm = v.CustomizeSchema(scm, scp)
 	return scm
 }
 
@@ -210,10 +212,10 @@ func StructToSchema(v any, customize func(map[string]*schema.Schema) map[string]
 		if customize != nil {
 			panic("customize should be nil if the input implements the ResourceProvider interface; use CustomizeSchema of ResourceProvider instead")
 		}
-		return resourceProviderStructToSchema(rp)
+		return resourceProviderStructToSchema(rp, getEmptySchemaPathContext())
 	}
 	rv := reflect.ValueOf(v)
-	scm := typeToSchema(rv, map[string]map[string]string{}, getEmptyRecursionTrackingContext())
+	scm := typeToSchema(rv, map[string]map[string]string{}, getEmptyRecursionTrackingContext(), getEmptySchemaPathContext())
 	if customize != nil {
 		scm = customize(scm)
 	}
@@ -364,7 +366,7 @@ func listAllFields(v reflect.Value) []field {
 	return fields
 }
 
-func typeToSchema(v reflect.Value, aliases map[string]map[string]string, rt recursionTrackingContext) map[string]*schema.Schema {
+func typeToSchema(v reflect.Value, aliases map[string]map[string]string, rt recursionTrackingContext, scp SchemaPathContext) map[string]*schema.Schema {
 	scm := map[string]*schema.Schema{}
 	rk := v.Kind()
 	if rk == reflect.Ptr {
@@ -449,7 +451,7 @@ func typeToSchema(v reflect.Value, aliases map[string]map[string]string, rt recu
 			scm[fieldName].Type = schema.TypeList
 			elem := typeField.Type.Elem()
 			sv := reflect.New(elem).Elem()
-			nestedSchema := typeToSchema(sv, aliases, rt)
+			nestedSchema := typeToSchema(sv, aliases, rt, scp.addToPath(fieldName, scm[fieldName]))
 			if strings.Contains(tfTag, "suppress_diff") {
 				scm[fieldName].DiffSuppressFunc = diffSuppressor(fieldName, scm[fieldName])
 				for k, v := range nestedSchema {
@@ -466,7 +468,7 @@ func typeToSchema(v reflect.Value, aliases map[string]map[string]string, rt recu
 			elem := typeField.Type  // changed from ptr
 			sv := reflect.New(elem) // changed from ptr
 
-			nestedSchema := typeToSchema(sv, aliases, rt)
+			nestedSchema := typeToSchema(sv, aliases, rt, scp.addToPath(fieldName, scm[fieldName]))
 			if strings.Contains(tfTag, "suppress_diff") {
 				scm[fieldName].DiffSuppressFunc = diffSuppressor(fieldName, scm[fieldName])
 				for k, v := range nestedSchema {
@@ -495,7 +497,7 @@ func typeToSchema(v reflect.Value, aliases map[string]map[string]string, rt recu
 			case reflect.Struct:
 				sv := reflect.New(elem).Elem()
 				scm[fieldName].Elem = &schema.Resource{
-					Schema: typeToSchema(sv, aliases, rt),
+					Schema: typeToSchema(sv, aliases, rt, scp.addToPath(fieldName, scm[fieldName])),
 				}
 			}
 		default:

--- a/common/reflect_resource_test.go
+++ b/common/reflect_resource_test.go
@@ -96,7 +96,7 @@ type testForEachTask struct {
 	Extra string       `json:"extra,omitempty"`
 }
 
-func (testRecursiveStruct) CustomizeSchema(s map[string]*schema.Schema) map[string]*schema.Schema {
+func (testRecursiveStruct) CustomizeSchema(s map[string]*schema.Schema, ctx SchemaPathContext) map[string]*schema.Schema {
 	return s
 }
 
@@ -273,12 +273,12 @@ func (DummyResourceProvider) Aliases() map[string]map[string]string {
 		"common.AddressNoTfTag": {"primary": "primary_alias"}}
 }
 
-func (DummyResourceProvider) CustomizeSchema(s map[string]*schema.Schema) map[string]*schema.Schema {
-	CustomizeSchemaPath(s, "addresses").SetMinItems(1)
-	CustomizeSchemaPath(s, "addresses").SetMaxItems(10)
-	CustomizeSchemaPath(s, "tags").SetMaxItems(5)
-	CustomizeSchemaPath(s, "home").SetSuppressDiff()
-	CustomizeSchemaPath(s, "things").Schema.Type = schema.TypeSet
+func (DummyResourceProvider) CustomizeSchema(s map[string]*schema.Schema, ctx SchemaPathContext) map[string]*schema.Schema {
+	CustomizeSchemaPath(ctx, s, "addresses").SetMinItems(1)
+	CustomizeSchemaPath(ctx, s, "addresses").SetMaxItems(10)
+	CustomizeSchemaPath(ctx, s, "tags").SetMaxItems(5)
+	CustomizeSchemaPath(ctx, s, "home").SetSuppressDiff()
+	CustomizeSchemaPath(ctx, s, "things").Schema.Type = schema.TypeSet
 	return s
 }
 
@@ -650,7 +650,7 @@ func TestTypeToSchemaNoStruct(t *testing.T) {
 			fmt.Sprintf("%s", p))
 	}()
 	v := reflect.ValueOf(1)
-	typeToSchema(v, nil, getEmptyRecursionTrackingContext())
+	typeToSchema(v, nil, getEmptyRecursionTrackingContext(), getEmptySchemaPathContext())
 }
 
 func TestTypeToSchemaUnsupported(t *testing.T) {
@@ -663,7 +663,7 @@ func TestTypeToSchemaUnsupported(t *testing.T) {
 		New chan int `json:"new"`
 	}
 	v := reflect.ValueOf(nonsense{})
-	typeToSchema(v, nil, getEmptyRecursionTrackingContext())
+	typeToSchema(v, nil, getEmptyRecursionTrackingContext(), getEmptySchemaPathContext())
 }
 
 type data map[string]any

--- a/jobs/resource_job.go
+++ b/jobs/resource_job.go
@@ -771,9 +771,11 @@ var jobSchema = common.StructToSchema(JobSettings{},
 		fixWebhookNotifications(s)
 		fixWebhookNotifications(common.MustSchemaMap(s, "task"))
 
+		emptyCtx := common.SchemaPathContext{}
+
 		// Suppress diff if the platform returns ALL_SUCCESS for run_if in a task
-		common.CustomizeSchemaPath(s, "task", "run_if").SetSuppressDiffWithDefault(jobs.RunIfAllSuccess)
-		common.CustomizeSchemaPath(s, "task", "for_each_task", "task", "run_if").SetSuppressDiffWithDefault(jobs.RunIfAllSuccess)
+		common.CustomizeSchemaPath(emptyCtx, s, "task", "run_if").SetSuppressDiffWithDefault(jobs.RunIfAllSuccess)
+		common.CustomizeSchemaPath(emptyCtx, s, "task", "for_each_task", "task", "run_if").SetSuppressDiffWithDefault(jobs.RunIfAllSuccess)
 
 		return s
 	})

--- a/mws/resource_mws_private_access_settings.go
+++ b/mws/resource_mws_private_access_settings.go
@@ -13,15 +13,16 @@ import (
 
 func ResourceMwsPrivateAccessSettings() common.Resource {
 	pasSchema := common.StructToSchema(provisioning.PrivateAccessSettings{}, func(m map[string]*schema.Schema) map[string]*schema.Schema {
-		common.CustomizeSchemaPath(m, "private_access_settings_name").SetValidateFunc(validation.StringLenBetween(4, 256))
-		common.CustomizeSchemaPath(m, "private_access_settings_name").SetRequired()
+		emptyCtx := common.SchemaPathContext{}
+		common.CustomizeSchemaPath(emptyCtx, m, "private_access_settings_name").SetValidateFunc(validation.StringLenBetween(4, 256))
+		common.CustomizeSchemaPath(emptyCtx, m, "private_access_settings_name").SetRequired()
 
-		common.CustomizeSchemaPath(m, "region").SetRequired()
+		common.CustomizeSchemaPath(emptyCtx, m, "region").SetRequired()
 
-		common.CustomizeSchemaPath(m, "private_access_settings_id").SetComputed()
+		common.CustomizeSchemaPath(emptyCtx, m, "private_access_settings_id").SetComputed()
 
-		common.CustomizeSchemaPath(m, "private_access_level").SetValidateFunc(validation.StringInSlice([]string{"ACCOUNT", "ENDPOINT"}, true))
-		common.CustomizeSchemaPath(m, "private_access_level").SetDefault("ACCOUNT")
+		common.CustomizeSchemaPath(emptyCtx, m, "private_access_level").SetValidateFunc(validation.StringInSlice([]string{"ACCOUNT", "ENDPOINT"}, true))
+		common.CustomizeSchemaPath(emptyCtx, m, "private_access_level").SetDefault("ACCOUNT")
 
 		common.AddAccountIdField(m)
 		return m

--- a/secrets/resource_secret_scope.go
+++ b/secrets/resource_secret_scope.go
@@ -17,9 +17,9 @@ import (
 // SecretScope is a struct that encapsulates the secret scope
 type SecretScope workspace.CreateScope
 
-func (s SecretScope) CustomizeSchema(m map[string]*schema.Schema) map[string]*schema.Schema {
-	common.CustomizeSchemaPath(m, "name").SetValidateFunc(validScope)
-	common.CustomizeSchemaPath(m, "backend_type").SetComputed()
+func (s SecretScope) CustomizeSchema(m map[string]*schema.Schema, ctx common.SchemaPathContext) map[string]*schema.Schema {
+	common.CustomizeSchemaPath(ctx, m, "name").SetValidateFunc(validScope)
+	common.CustomizeSchemaPath(ctx, m, "backend_type").SetComputed()
 	return m
 }
 

--- a/sharing/resource_recipient.go
+++ b/sharing/resource_recipient.go
@@ -23,24 +23,25 @@ func recepientPropertiesSuppressDiff(k, old, new string, d *schema.ResourceData)
 
 func ResourceRecipient() common.Resource {
 	recipientSchema := common.StructToSchema(sharing.RecipientInfo{}, func(s map[string]*schema.Schema) map[string]*schema.Schema {
-		common.CustomizeSchemaPath(s, "authentication_type").SetForceNew().SetRequired().SetValidateFunc(
+		emptyCtx := common.SchemaPathContext{}
+		common.CustomizeSchemaPath(emptyCtx, s, "authentication_type").SetForceNew().SetRequired().SetValidateFunc(
 			validation.StringInSlice([]string{"TOKEN", "DATABRICKS"}, false))
-		common.CustomizeSchemaPath(s, "sharing_code").SetSuppressDiff().SetForceNew().SetSensitive()
-		common.CustomizeSchemaPath(s, "name").SetForceNew().SetRequired().SetCustomSuppressDiff(common.EqualFoldDiffSuppress)
-		common.CustomizeSchemaPath(s, "owner").SetSuppressDiff()
-		common.CustomizeSchemaPath(s, "properties_kvpairs").SetSuppressDiff()
-		common.CustomizeSchemaPath(s, "properties_kvpairs", "properties").SetCustomSuppressDiff(recepientPropertiesSuppressDiff)
-		common.CustomizeSchemaPath(s, "data_recipient_global_metastore_id").SetForceNew().SetConflictsWith([]string{"ip_access_list"})
-		common.CustomizeSchemaPath(s, "ip_access_list").SetConflictsWith([]string{"data_recipient_global_metastore_id"})
+		common.CustomizeSchemaPath(emptyCtx, s, "sharing_code").SetSuppressDiff().SetForceNew().SetSensitive()
+		common.CustomizeSchemaPath(emptyCtx, s, "name").SetForceNew().SetRequired().SetCustomSuppressDiff(common.EqualFoldDiffSuppress)
+		common.CustomizeSchemaPath(emptyCtx, s, "owner").SetSuppressDiff()
+		common.CustomizeSchemaPath(emptyCtx, s, "properties_kvpairs").SetSuppressDiff()
+		common.CustomizeSchemaPath(emptyCtx, s, "properties_kvpairs", "properties").SetCustomSuppressDiff(recepientPropertiesSuppressDiff)
+		common.CustomizeSchemaPath(emptyCtx, s, "data_recipient_global_metastore_id").SetForceNew().SetConflictsWith([]string{"ip_access_list"})
+		common.CustomizeSchemaPath(emptyCtx, s, "ip_access_list").SetConflictsWith([]string{"data_recipient_global_metastore_id"})
 
 		// ReadOnly fields
 		for _, path := range []string{"created_at", "created_by", "updated_at", "updated_by", "metastore_id", "region",
 			"cloud", "activated", "activation_url"} {
-			common.CustomizeSchemaPath(s, path).SetReadOnly()
+			common.CustomizeSchemaPath(emptyCtx, s, path).SetReadOnly()
 		}
-		common.CustomizeSchemaPath(s, "tokens").SetReadOnly().SetOptional()
+		common.CustomizeSchemaPath(emptyCtx, s, "tokens").SetReadOnly().SetOptional()
 		for _, path := range []string{"id", "created_at", "created_by", "activation_url", "expiration_time", "updated_at", "updated_by"} {
-			common.CustomizeSchemaPath(s, "tokens", path).SetReadOnly()
+			common.CustomizeSchemaPath(emptyCtx, s, "tokens", path).SetReadOnly()
 		}
 
 		return s

--- a/sql/resource_sql_endpoint.go
+++ b/sql/resource_sql_endpoint.go
@@ -54,9 +54,10 @@ func resolveDataSourceID(ctx context.Context, w *databricks.WorkspaceClient, war
 func ResourceSqlEndpoint() common.Resource {
 	s := common.StructToSchema(SqlWarehouse{}, func(
 		m map[string]*schema.Schema) map[string]*schema.Schema {
+		emptyCtx := common.SchemaPathContext{}
 		m["id"].Computed = true
 		common.SetDefault(m["auto_stop_mins"], 120)
-		common.CustomizeSchemaPath(m, "channel").SetSuppressDiff()
+		common.CustomizeSchemaPath(emptyCtx, m, "channel").SetSuppressDiff()
 		common.MustSchemaPath(m, "channel", "name").Default = "CHANNEL_NAME_CURRENT"
 		common.SetRequired(m["cluster_size"])
 		common.SetReadOnly(m["creator_name"])
@@ -69,17 +70,17 @@ func ResourceSqlEndpoint() common.Resource {
 		common.SetDefault(m["max_num_clusters"], 1)
 		m["max_num_clusters"].ValidateDiagFunc = validation.ToDiagFunc(
 			validation.IntBetween(1, MaxNumClusters))
-		common.CustomizeSchemaPath(m, "min_num_clusters").SetSuppressDiff()
+		common.CustomizeSchemaPath(emptyCtx, m, "min_num_clusters").SetSuppressDiff()
 		common.SetRequired(m["name"])
 		common.SetReadOnly(m["num_active_sessions"])
 		common.SetReadOnly(m["num_clusters"])
 		common.SetReadOnly(m["odbc_params"])
 		common.SetDefault(m["spot_instance_policy"], "COST_OPTIMIZED")
 		common.SetReadOnly(m["state"])
-		common.CustomizeSchemaPath(m, "tags").SetSuppressDiff()
+		common.CustomizeSchemaPath(emptyCtx, m, "tags").SetSuppressDiff()
 		common.SetRequired(common.MustSchemaPath(m, "tags", "custom_tags", "key"))
 		common.SetRequired(common.MustSchemaPath(m, "tags", "custom_tags", "value"))
-		common.CustomizeSchemaPath(m, "warehouse_type").
+		common.CustomizeSchemaPath(emptyCtx, m, "warehouse_type").
 			SetSuppressDiff().
 			SetValidateDiagFunc(validation.ToDiagFunc(validation.StringInSlice([]string{"PRO", "CLASSIC"}, false)))
 		return m

--- a/vectorsearch/resource_vector_search_endpoint.go
+++ b/vectorsearch/resource_vector_search_endpoint.go
@@ -18,16 +18,17 @@ func ResourceVectorSearchEndpoint() common.Resource {
 	s := common.StructToSchema(
 		vectorsearch.EndpointInfo{},
 		func(s map[string]*schema.Schema) map[string]*schema.Schema {
-			common.CustomizeSchemaPath(s, "name").SetRequired().SetForceNew()
-			common.CustomizeSchemaPath(s, "endpoint_type").SetRequired().SetForceNew()
+			emptyCtx := common.SchemaPathContext{}
+			common.CustomizeSchemaPath(emptyCtx, s, "name").SetRequired().SetForceNew()
+			common.CustomizeSchemaPath(emptyCtx, s, "endpoint_type").SetRequired().SetForceNew()
 			delete(s, "id")
-			common.CustomizeSchemaPath(s, "creator").SetReadOnly()
-			common.CustomizeSchemaPath(s, "creation_timestamp").SetReadOnly()
-			common.CustomizeSchemaPath(s, "last_updated_timestamp").SetReadOnly()
-			common.CustomizeSchemaPath(s, "last_updated_user").SetReadOnly()
-			common.CustomizeSchemaPath(s, "endpoint_status").SetReadOnly()
-			common.CustomizeSchemaPath(s, "num_indexes").SetReadOnly()
-			common.CustomizeSchemaPath(s).AddNewField("endpoint_id", &schema.Schema{
+			common.CustomizeSchemaPath(emptyCtx, s, "creator").SetReadOnly()
+			common.CustomizeSchemaPath(emptyCtx, s, "creation_timestamp").SetReadOnly()
+			common.CustomizeSchemaPath(emptyCtx, s, "last_updated_timestamp").SetReadOnly()
+			common.CustomizeSchemaPath(emptyCtx, s, "last_updated_user").SetReadOnly()
+			common.CustomizeSchemaPath(emptyCtx, s, "endpoint_status").SetReadOnly()
+			common.CustomizeSchemaPath(emptyCtx, s, "num_indexes").SetReadOnly()
+			common.CustomizeSchemaPath(emptyCtx, s).AddNewField("endpoint_id", &schema.Schema{
 				Type:     schema.TypeString,
 				Computed: true,
 			})

--- a/vectorsearch/resource_vector_search_index.go
+++ b/vectorsearch/resource_vector_search_index.go
@@ -48,19 +48,20 @@ func ResourceVectorSearchIndex() common.Resource {
 	s := common.StructToSchema(
 		vectorsearch.VectorIndex{},
 		func(s map[string]*schema.Schema) map[string]*schema.Schema {
+			emptyCtx := common.SchemaPathContext{}
 			common.MustSchemaPath(s, "delta_sync_index_spec", "embedding_vector_columns").MinItems = 1
 			exof := []string{"delta_sync_index_spec", "direct_access_index_spec"}
 			s["delta_sync_index_spec"].ExactlyOneOf = exof
 			s["direct_access_index_spec"].ExactlyOneOf = exof
 			s["name"].DiffSuppressFunc = common.EqualFoldDiffSuppress
-			common.CustomizeSchemaPath(s, "delta_sync_index_spec", "source_table").SetCustomSuppressDiff(common.EqualFoldDiffSuppress)
-			common.CustomizeSchemaPath(s, "endpoint_name").SetRequired()
-			common.CustomizeSchemaPath(s, "primary_key").SetRequired()
-			common.CustomizeSchemaPath(s, "status").SetReadOnly()
-			common.CustomizeSchemaPath(s, "creator").SetReadOnly()
-			common.CustomizeSchemaPath(s, "name").SetRequired()
-			common.CustomizeSchemaPath(s, "index_type").SetRequired()
-			common.CustomizeSchemaPath(s, "delta_sync_index_spec", "pipeline_id").SetReadOnly()
+			common.CustomizeSchemaPath(emptyCtx, s, "delta_sync_index_spec", "source_table").SetCustomSuppressDiff(common.EqualFoldDiffSuppress)
+			common.CustomizeSchemaPath(emptyCtx, s, "endpoint_name").SetRequired()
+			common.CustomizeSchemaPath(emptyCtx, s, "primary_key").SetRequired()
+			common.CustomizeSchemaPath(emptyCtx, s, "status").SetReadOnly()
+			common.CustomizeSchemaPath(emptyCtx, s, "creator").SetReadOnly()
+			common.CustomizeSchemaPath(emptyCtx, s, "name").SetRequired()
+			common.CustomizeSchemaPath(emptyCtx, s, "index_type").SetRequired()
+			common.CustomizeSchemaPath(emptyCtx, s, "delta_sync_index_spec", "pipeline_id").SetReadOnly()
 			return s
 		})
 


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
- As we introduce the schema registry, there are nested customizations we'd like to reuse. 
- However, customizations such as `ConflictsWith` require a `path` and when the path contains `TypeList` with `MaxItems>1`, it is unfeasible to apply such customizations any more.
- This PR adds a new concept called `SchemaPathContext` and it is being maintained as we go through `typeToSchema` calls. It is passed into `customizeSchema` function callback and is used as an input to `CustomizeSchemaPath` so that we can skip certain unfeasible customizations.


## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [x] covered with integration tests in `internal/acceptance`
- [x] relevant acceptance tests are passing
- [x] using Go SDK
