### PR TITLE
Use fixture cluster for `databricks_sql_permissions` integration test

### DIFF
--- a/internal/acceptance/sql_permissions_test.go
+++ b/internal/acceptance/sql_permissions_test.go
@@ -8,50 +8,44 @@ import (
 	"github.com/databricks/databricks-sdk-go"
 	"github.com/databricks/databricks-sdk-go/service/compute"
 	"github.com/databricks/terraform-provider-databricks/qa"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/stretchr/testify/require"
 )
 
 func TestAccTableACL(t *testing.T) {
-	talbeName := qa.RandomName("table_acl_")
+	loadWorkspaceEnv(t)
+	tableName := qa.RandomName("table_acl_")
+	clusterId := GetEnvOrSkipTest(t, "TEST_TABLE_ACL_CLUSTER_ID")
+	ctx := context.Background()
+	w := databricks.Must(databricks.NewWorkspaceClient())
+	err := w.Clusters.EnsureClusterIsRunning(ctx, clusterId)
+	require.NoError(t, err)
+
+	executor, err := w.CommandExecution.Start(ctx, clusterId, compute.LanguagePython)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		err = executor.Destroy(ctx)
+		require.NoError(t, err)
+	})
+
+	cr, err := executor.Execute(ctx, fmt.Sprintf("spark.range(10).write.saveAsTable('%s')", tableName))
+	require.NoError(t, err)
+	require.False(t, cr.Failed(), cr.Error())
+
+	t.Cleanup(func() {
+		cr, err = executor.Execute(ctx, fmt.Sprintf(`spark.sql("DROP TABLE %s")`, tableName))
+		require.NoError(t, err)
+		require.False(t, cr.Failed(), cr.Error())
+	})
 	workspaceLevel(t, step{
-		Template: `data "databricks_current_user" "me" {}`,
-		Check: func(s *terraform.State) error {
-			// we need to run table creation within check code of previous step,
-			// so that we know that environment variables are loaded by WorkspaceLevel
-			// in the necessary way.
-			ctx := context.Background()
-			w := databricks.Must(databricks.NewWorkspaceClient())
-			info, err := w.Clusters.GetOrCreateRunningCluster(ctx, "tf-dummy")
-			require.NoError(t, err)
-
-			executor, err := w.CommandExecution.Start(ctx, info.ClusterId, compute.LanguagePython)
-			require.NoError(t, err)
-			t.Cleanup(func() {
-				err = executor.Destroy(ctx)
-				require.NoError(t, err)
-			})
-
-			cr, err := executor.Execute(ctx, fmt.Sprintf("spark.range(10).write.saveAsTable('%s')", talbeName))
-			require.NoError(t, err)
-			require.False(t, cr.Failed(), cr.Error())
-
-			t.Cleanup(func() {
-				cr, err = executor.Execute(ctx, fmt.Sprintf(`spark.sql("DROP TABLE %s")`, talbeName))
-				require.NoError(t, err)
-				require.False(t, cr.Failed(), cr.Error())
-			})
-			return nil
-		},
-	}, step{
 		Template: `
 		resource "databricks_sql_permissions" "this" {
-			table = "` + talbeName + `"
+			table = "` + tableName + `"
 
 			privilege_assignments {
 				principal = "users"
 				privileges = ["SELECT"]
 			}
+			cluster_id = "` + clusterId + `"
 		}`,
 	})
 }


### PR DESCRIPTION
## Changes
The cluster used for `databricks_sql_permissions` needs to be configured for table ACLs. This appears to have been set up manually at one point. After moving to a new E2 account in GCP, this test started to fail, as that cluster was not automatically provisioned.

I've provisioned a cluster in each workspace that can be used for testing Table ACLs. I've changed `TestAccTableACL` to use this cluster for both the creation and tear-down of the table under test as well as the permission changes.

## Tests
Verified in the following environments:
- [x] GCP
- [ ] AWS
- [ ] Azure

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
