### PR TITLE
Add test config for ignoring failed integration tests

### DIFF
--- a/test-config.yaml
+++ b/test-config.yaml
@@ -1,0 +1,5 @@
+ignored_tests:
+  go:
+    - package: github.com/databricks/terraform-provider-databricks/internal/acceptance
+      test_name: TestAccGroupsUpdateDisplayName
+      comment: Failures due to read-after-write inconsistency. Tracked in https://databricks.atlassian.net/browse/ES-1100061


### PR DESCRIPTION
## Changes
This PR adds a test config to ignore test failures in `TestAccGroupsUpdateDisplayName`, which is currently flaky due to transient read-after-write inconsistencies.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
