### PR TITLE
data source `databricks_current_metastore` should not error out for non-UC workspaces

### DIFF
--- a/catalog/data_current_metastore.go
+++ b/catalog/data_current_metastore.go
@@ -2,6 +2,7 @@ package catalog
 
 import (
 	"context"
+	"strings"
 
 	"github.com/databricks/databricks-sdk-go"
 	"github.com/databricks/databricks-sdk-go/service/catalog"
@@ -16,11 +17,16 @@ func DataSourceCurrentMetastore() common.Resource {
 	return common.WorkspaceData(func(ctx context.Context, data *CurrentMetastore, wc *databricks.WorkspaceClient) error {
 		summary, err := wc.Metastores.Summary(ctx)
 		if err != nil {
+			if strings.Contains(err.Error(), "No metastore assigned for the current workspace") {
+				data.Metastore = nil
+				data.Id = "no_metastore"
+				return nil
+			}
 			return err
+		} else {
+			data.Metastore = summary
+			data.Id = summary.MetastoreId
 		}
-		data.Metastore = summary
-		data.Id = summary.MetastoreId
-
 		return nil
 	})
 }

--- a/docs/data-sources/current_metastore.md
+++ b/docs/data-sources/current_metastore.md
@@ -26,7 +26,7 @@ output "some_metastore" {
 
 This data source exports the following attributes:
 
-* `id` - metastore ID.
+* `id` - metastore ID. Will be `no_metastore` if there is no metastore assigned for the current workspace
 * `metastore_info` - summary about a metastore attached to the current workspace returned by [Get a metastore summary API](https://docs.databricks.com/api/workspace/metastores/summary). This contains the following attributes (check the API page for up-to-date details):
   * `name` - Name of metastore.
   * `metastore_id` - Metastore ID.


### PR DESCRIPTION
## Changes
Closes #3484

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] relevant acceptance tests are passing
- [x] using Go SDK
