### PR TITLE
Remove empty lines to avoid triggering unchanged diff detection

### DIFF
--- a/common/util.go
+++ b/common/util.go
@@ -31,9 +31,20 @@ func IsExporter(ctx context.Context) bool {
 	return GetTerraformVersionFromContext(ctx) == "exporter"
 }
 
+func removeEmptyLines(text string) string {
+	lines := strings.Split(text, "\n")
+	var nonEmptyLines []string
+	for _, line := range lines {
+		if line != "" {
+			nonEmptyLines = append(nonEmptyLines, line)
+		}
+	}
+	return strings.Join(nonEmptyLines, "\n")
+}
+
 func SuppressDiffWhitespaceChange(k, old, new string, d *schema.ResourceData) bool {
 	log.Printf("[DEBUG] Suppressing diff for %v: old=%#v new=%#v", k, old, new)
-	return strings.TrimSpace(old) == strings.TrimSpace(new)
+	return removeEmptyLines(strings.TrimSpace(old)) == removeEmptyLines(strings.TrimSpace(new))
 }
 
 func MustInt64(s string) int64 {


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
Remove empty lines to avoid triggering unchanged diff detection. Related to this issue.
https://github.com/databricks/terraform-provider-databricks/issues/3019

TrimSpace solve the issue but if there are empty new lines inside the SQL each time terraform detect the change. So remove empty lines when checking terraform state diff detection. 

Sample
```
SELECT
  column_a,
  
  column_b
FROM table
```

Evidence
![img](https://github.com/databricks/terraform-provider-databricks/assets/40357957/88aa49ae-0385-4f4c-b94d-c345135019f5)

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [x] relevant acceptance tests are passing
- [x] using Go SDK
