### PR TITLE
Added `ConflictsWith` to legacy tasks in `databricks_job` to avoid erors when job parameters are used

### DIFF
--- a/docs/resources/job.md
+++ b/docs/resources/job.md
@@ -285,6 +285,8 @@ This block defines a job-level parameter for the job. You can define several job
 * `name` - (Required) The name of the defined parameter. May only contain alphanumeric characters, `_`, `-`, and `.`.
 * `default` - (Required) Default value of the parameter.
 
+*You can use this block only together with `task` blocks, not with the legacy tasks specification!*
+
 ### notification_settings Configuration Block (Task Level)
 
 This block controls notification settings for both email & webhook notifications on a task level:

--- a/jobs/resource_job.go
+++ b/jobs/resource_job.go
@@ -760,6 +760,9 @@ var jobSchema = common.StructToSchema(JobSettings{},
 
 		for _, attr := range topLevelDeprecatedAttr {
 			s[attr].Deprecated = "should be used inside a task block and not inside a job block"
+			if strings.HasSuffix(attr, "_task") {
+				s[attr].ConflictsWith = []string{"parameter"}
+			}
 		}
 
 		// we need to have only one of user name vs service principal in the run_as block

--- a/jobs/resource_job_test.go
+++ b/jobs/resource_job_test.go
@@ -776,6 +776,24 @@ func TestResourceJobCreate_JobParameters_DefaultIsRequired(t *testing.T) {
 	}.ExpectError(t, "invalid config supplied. [parameter.#.default] Missing required argument")
 }
 
+func TestResourceJobCreate_JobParameters_SingleTasksConflict(t *testing.T) {
+	qa.ResourceFixture{
+		Create:   true,
+		Resource: ResourceJob(),
+		HCL: `
+		name = "JobParameterTesting"
+
+		parameter {
+				name = "key"
+				default = ""
+		}
+
+		notebook_task {
+			notebook_path = "/Shared/test"
+		}`,
+	}.ExpectError(t, "invalid config supplied. [notebook_task] Conflicting configuration arguments")
+}
+
 func TestResourceJobCreate_JobClusters(t *testing.T) {
 	d, err := qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

When legacy tasks are used the `databricks_job` resource uses REST API 2.0 that doesn't support `parameters`.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [x] relevant acceptance tests are passing
- [ ] using Go SDK
