### PR TITLE
Introduce `common.NoClientData` helper function and use it in `databricks_aws_crossaccount_policy` data source

### DIFF
--- a/aws/data_aws_crossaccount_policy.go
+++ b/aws/data_aws_crossaccount_policy.go
@@ -7,7 +7,6 @@ import (
 	"regexp"
 	"slices"
 
-	"github.com/databricks/databricks-sdk-go"
 	"github.com/databricks/terraform-provider-databricks/common"
 )
 
@@ -22,7 +21,7 @@ func DataAwsCrossaccountPolicy() common.Resource {
 		Region          string   `json:"region,omitempty"`
 		SecurityGroupId string   `json:"security_group_id,omitempty"`
 	}
-	return common.AccountData(func(ctx context.Context, data *AwsCrossAccountPolicy, w *databricks.AccountClient) error {
+	return common.NoClientData(func(ctx context.Context, data *AwsCrossAccountPolicy) error {
 		if !slices.Contains([]string{"managed", "customer", "restricted"}, data.PolicyType) {
 			return fmt.Errorf("policy_type must be either 'managed', 'customer' or 'restricted'")
 		}

--- a/common/resource.go
+++ b/common/resource.go
@@ -312,7 +312,7 @@ func AccountData[T any](read func(context.Context, *T, *databricks.AccountClient
 	}, false)
 }
 
-// AccountDataWithParams defines a data source that can be used to read data from the workspace API.
+// AccountDataWithParams defines a data source that can be used to read data from the account API.
 // It differs from AccountData in that it allows extra attributes to be provided as a separate argument,
 // so the original type used to define the resource can also be used to define the data source.
 //
@@ -447,4 +447,13 @@ func AddAccountIdField(s map[string]*schema.Schema) map[string]*schema.Schema {
 		Deprecated: "Configuring `account_id` at the resource-level is deprecated; please specify it in the `provider {}` configuration block instead",
 	}
 	return s
+}
+
+// NoClientData is a generic way to define data resources in Terraform provider that doesn't require any client.
+// usage is similar to AccountData and WorkspaceData, but the read function doesn't take a client.
+func NoClientData[T any](read func(context.Context, *T) error) Resource {
+	return genericDatabricksData(func(*DatabricksClient) (any, error) { return nil, nil },
+		func(ctx context.Context, s struct{}, t *T, ac any) error {
+			return read(ctx, t)
+		}, false)
 }

--- a/common/resource_test.go
+++ b/common/resource_test.go
@@ -193,3 +193,25 @@ func TestNoCustomize(t *testing.T) {
 	}
 	assert.Equal(t, dummySchema, NoCustomize(dummySchema))
 }
+
+func fakeDataSource() Resource {
+	type Test struct {
+		SomeId string `json:"some_id" tf:"computed"`
+		Id     string `json:"id" tf:"computed"`
+	}
+	return NoClientData(func(ctx context.Context, data *Test) error {
+		data.SomeId = "abc"
+		data.Id = "def"
+		return nil
+	})
+}
+
+func TestFakeDataSource(t *testing.T) {
+	r := fakeDataSource().ToResource()
+	d := r.TestResourceData()
+	client := &DatabricksClient{}
+	diags := r.ReadContext(context.Background(), d, client)
+	assert.False(t, diags.HasError())
+	assert.Equal(t, "abc", d.Get("some_id"))
+	assert.Equal(t, "def", d.Id())
+}


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

The `databricks_aws_crossaccount_policy` and some other data sources really don't need any client to work, so they could be used with both account and workspace-level providers. To simplify things, the `common.NoClientData` was introduced, and the implementation `databricks_aws_crossaccount_policy` has changed to use it.

This fixes #3505


## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
