### PR TITLE
[DOC] (RADICAL) Improve Job documentation structure

### DIFF
--- a/docs/resources/job.md
+++ b/docs/resources/job.md
@@ -80,8 +80,11 @@ The resource supports the following arguments:
 
 * `name` - (Optional) An optional name for the job. The default value is Untitled.
 * `description` - (Optional) An optional description for the job. The maximum length is 1024 characters in UTF-8 encoding.
+* `task` - (Optional) A list of task specification that the job will execute. See [task Configuration Block](#task-configuration-block) below.
 * `job_cluster` - (Optional) A list of job [databricks_cluster](cluster.md) specifications that can be shared and reused by tasks of this job. Libraries cannot be declared in a shared job cluster. You must declare dependent libraries in task settings. *Multi-task syntax*
+* `trigger` - (Optional) The conditions that triggers the job to start. See [trigger Configuration Block](#trigger-configuration-block) below.
 * `always_running` - (Optional, Deprecated) (Bool) Whenever the job is always running, like a Spark Streaming application, on every update restart the current active run or start it again, if nothing it is not running. False by default. Any job runs are started with `parameters` specified in `spark_jar_task` or `spark_submit_task` or `spark_python_task` or `notebook_task` blocks.
+* `run_as` - (Optional) The user or the service prinicipal the job runs as. See [run_as Configuration Block](#run_as-configuration-block) below.
 * `control_run_state` - (Optional) (Bool) If true, the Databricks provider will stop and start the job as needed to ensure that the active run for the job reflects the deployed configuration. For continuous jobs, the provider respects the `pause_status` by stopping the current active run. This flag cannot be set for non-continuous jobs.
 
   When migrating from `always_running` to `control_run_state`, set `continuous` as follows:
@@ -91,6 +94,7 @@ The resource supports the following arguments:
   ```
 
 * `library` - (Optional) (List) An optional list of libraries to be installed on the cluster that will execute the job. Please consult [libraries section of the databricks_cluster](cluster.md#library-configuration-block) resource for more information.
+* `git_source` - (Optional) Specifices the a Git repository for task source code. See [git_source Configuration Block](#git_source-configuration-block) below.
 * `timeout_seconds` - (Optional) (Integer) An optional timeout applied to each run of this job. The default behavior is to have no timeout.
 * `min_retry_interval_millis` - (Optional) (Integer) An optional minimal interval in milliseconds between the start of the failed run and the subsequent retry run. The default behavior is that unsuccessful runs are immediately retried.
 * `max_concurrent_runs` - (Optional) (Integer) An optional maximum allowed number of concurrent runs of the job. Defaults to *1*.
@@ -99,6 +103,7 @@ The resource supports the following arguments:
 * `notification_settings` - (Optional) An optional block controlling the notification settings on the job level (described below).
 * `schedule` - (Optional) (List) An optional periodic schedule for this job. The default behavior is that the job runs when triggered by clicking Run Now in the Jobs UI or sending an API request to runNow. This field is a block and is documented below.
 * `health` - (Optional) An optional block that specifies the health conditions for the job (described below).
+* `tags` - (Optional) An optional map of the tags associated with the job. See [tags Configuration Map](#tags-configuration-map)
 
 ### task Configuration Block
 
@@ -133,7 +138,141 @@ This block describes individual tasks:
 
 -> **Note** If no `job_cluster_key`, `existing_cluster_id`, or `new_cluster` were specified in task definition, then task will executed using serverless compute.
 
-### library Configuration Block
+#### spark_jar_task Configuration Block
+
+* `parameters` - (Optional) (List) Parameters passed to the main method.
+* `main_class_name` - (Optional) The full name of the class containing the main method to be executed. This class must be contained in a JAR provided as a library. The code should use `SparkContext.getOrCreate` to obtain a Spark context; otherwise, runs of the job will fail.
+
+#### spark_submit_task Configuration Block
+
+You can invoke Spark submit tasks only on new clusters. **In the `new_cluster` specification, `libraries` and `spark_conf` are not supported**. Instead, use --jars and --py-files to add Java and Python libraries and `--conf` to set the Spark configuration. By default, the Spark submit job uses all available memory (excluding reserved memory for Databricks services). You can set `--driver-memory`, and `--executor-memory` to a smaller value to leave some room for off-heap usage. **Please use `spark_jar_task`, `spark_python_task` or `notebook_task` wherever possible**.
+
+* `parameters` - (Optional) (List) Command-line parameters passed to spark submit.
+
+#### spark_python_task Configuration Block
+
+* `python_file` - (Required) The URI of the Python file to be executed. [databricks_dbfs_file](dbfs_file.md#path), cloud file URIs (e.g. `s3:/`, `abfss:/`, `gs:/`), workspace paths and remote repository are supported. For Python files stored in the Databricks workspace, the path must be absolute and begin with `/Repos`. For files stored in a remote repository, the path must be relative. This field is required.
+* `source` - (Optional) Location type of the Python file, can only be `GIT`. When set to `GIT`, the Python file will be retrieved from a Git repository defined in `git_source`.
+* `parameters` - (Optional) (List) Command line parameters passed to the Python file.
+
+#### notebook_task Configuration Block
+
+* `notebook_path` - (Required) The path of the [databricks_notebook](notebook.md#path) to be run in the Databricks workspace or remote repository. For notebooks stored in the Databricks workspace, the path must be absolute and begin with a slash. For notebooks stored in a remote repository, the path must be relative. This field is required.
+* `source` - (Optional) Location type of the notebook, can only be `WORKSPACE` or `GIT`. When set to `WORKSPACE`, the notebook will be retrieved from the local Databricks workspace. When set to `GIT`, the notebook will be retrieved from a Git repository defined in `git_source`. If the value is empty, the task will use `GIT` if `git_source` is defined and `WORKSPACE` otherwise.
+* `base_parameters` - (Optional) (Map) Base parameters to be used for each run of this job. If the run is initiated by a call to run-now with parameters specified, the two parameters maps will be merged. If the same key is specified in base_parameters and in run-now, the value from run-now will be used. If the notebook takes a parameter that is not specified in the job’s base_parameters or the run-now override parameters, the default value from the notebook will be used. Retrieve these parameters in a notebook using `dbutils.widgets.get`.
+* `warehouse_id` - (Optional) ID of the (the [databricks_sql_endpoint](sql_endpoint.md)) that will be used to execute the task with SQL notebook.
+
+#### pipeline_task Configuration Block
+
+* `pipeline_id` - (Required) The pipeline's unique ID.
+* `full_refresh` - (Optional) (Bool) Specifies if there should be full refresh of the pipeline.
+
+-> **Note** The following configuration blocks are only supported inside a `task` block
+
+#### python_wheel_task Configuration Block
+
+* `entry_point` - (Optional) Python function as entry point for the task
+* `package_name` - (Optional) Name of Python package
+* `parameters` - (Optional) Parameters for the task
+* `named_parameters` - (Optional) Named parameters for the task
+
+#### dbt_task Configuration Block
+
+* `commands` - (Required) (Array) Series of dbt commands to execute in sequence. Every command must start with "dbt".
+* `source` - (Optional) The source of the project. Possible values are `WORKSPACE` and `GIT`.  Defaults to `GIT` if a `git_source` block is present in the job definition.
+* `project_directory` - (Required when `source` is `WORKSPACE`) The path where dbt should look for `dbt_project.yml`. Equivalent to passing `--project-dir` to the dbt CLI.
+  * If `source` is `GIT`: Relative path to the directory in the repository specified in the `git_source` block. Defaults to the repository's root directory when not specified.
+  * If `source` is `WORKSPACE`: Absolute path to the folder in the workspace.
+* `profiles_directory` - (Optional) The relative path to the directory in the repository specified by `git_source` where dbt should look in for the `profiles.yml` file. If not specified, defaults to the repository's root directory. Equivalent to passing `--profile-dir` to a dbt command.
+* `catalog` - (Optional) The name of the catalog to use inside Unity Catalog.
+* `schema` - (Optional) The name of the schema dbt should run in. Defaults to `default`.
+* `warehouse_id` - (Optional) The ID of the SQL warehouse that dbt should execute against.
+
+You also need to include a `git_source` block to configure the repository that contains the dbt project.
+
+#### run_job_task Configuration Block
+
+* `job_id` - (Required)(String) ID of the job
+* `job_parameters` - (Optional)(Map) Job parameters for the task
+
+#### condition_task Configuration Block
+
+The `condition_task` specifies a condition with an outcome that can be used to control the execution of dependent tasks.
+
+* `left` - The left operand of the condition task. It could be a string value, job state, or a parameter reference.
+* `right` - The right operand of the condition task. It could be a string value, job state, or parameter reference.
+* `op` - The string specifying the operation used to compare operands.  Currently, following operators are supported: `EQUAL_TO`, `GREATER_THAN`, `GREATER_THAN_OR_EQUAL`, `LESS_THAN`, `LESS_THAN_OR_EQUAL`, `NOT_EQUAL`. (Check the [API docs](https://docs.databricks.com/api/workspace/jobs/create) for the latest information).
+
+This task does not require a cluster to execute and does not support retries or notifications.
+
+#### for_each_task Configuration Block
+
+* `concurrency` - (Optional) Controls the number of active iteration task runs. Default is 20, maximum allowed is 100.
+* `inputs` - (Required) (String) Array for task to iterate on. This can be a JSON string or a reference to an array parameter.
+* `task` - (Required) Task to run against the `inputs` list.
+
+#### sql_task Configuration Block
+
+One of the `query`, `dashboard` or `alert` needs to be provided.
+
+* `warehouse_id` - (Required) ID of the (the [databricks_sql_endpoint](sql_endpoint.md)) that will be used to execute the task.  Only Serverless & Pro warehouses are supported right now.
+* `parameters` - (Optional) (Map) parameters to be used for each run of this task. The SQL alert task does not support custom parameters.
+* `query` - (Optional) block consisting of single string field: `query_id` - identifier of the Databricks SQL Query ([databricks_sql_query](sql_query.md)).
+* `dashboard` - (Optional) block consisting of following fields:
+  * `dashboard_id` - (Required) (String) identifier of the Databricks SQL Dashboard [databricks_sql_dashboard](sql_dashboard.md).
+  * `subscriptions` - (Optional) a list of subscription blocks consisting out of one of the required fields: `user_name` for user emails or `destination_id` - for Alert destination's identifier.
+  * `custom_subject` - (Optional) string specifying a custom subject of email sent.
+  * `pause_subscriptions` - (Optional) flag that specifies if subscriptions are paused or not.
+* `alert` - (Optional) block consisting of following fields:
+  * `alert_id` - (Required) (String) identifier of the Databricks SQL Alert.
+  * `subscriptions` - (Required) a list of subscription blocks consisting out of one of the required fields: `user_name` for user emails or `destination_id` - for Alert destination's identifier.
+  * `pause_subscriptions` - (Optional) flag that specifies if subscriptions are paused or not.
+* `file` - (Optional) block consisting of single string fields:
+  * `source` - (Optional) The source of the project. Possible values are `WORKSPACE` and `GIT`.
+  * `path` - If `source` is `GIT`: Relative path to the file in the repository specified in the `git_source` block with SQL commands to execute. If `source` is `WORKSPACE`: Absolute path to the file in the workspace with SQL commands to execute.
+
+Example
+
+```hcl
+resource "databricks_job" "sql_aggregation_job" {
+  name = "Example SQL Job"
+  task {
+    task_key = "run_agg_query"
+    sql_task {
+      warehouse_id = databricks_sql_endpoint.sql_job_warehouse.id
+      query {
+        query_id = databricks_sql_query.agg_query.id
+      }
+    }
+  }
+  task {
+    task_key = "run_dashboard"
+    sql_task {
+      warehouse_id = databricks_sql_endpoint.sql_job_warehouse.id
+      dashboard {
+        dashboard_id = databricks_sql_dashboard.dash.id
+        subscriptions {
+          user_name = "user@domain.com"
+        }
+      }
+    }
+  }
+  task {
+    task_key = "run_alert"
+    sql_task {
+      warehouse_id = databricks_sql_endpoint.sql_job_warehouse.id
+      alert {
+        alert_id = databricks_sql_alert.alert.id
+        subscriptions {
+          user_name = "user@domain.com"
+        }
+      }
+    }
+  }
+}
+```
+
+#### library Configuration Block
 This block descripes an optional library to be installed on the cluster that will execute the job. For multiple libraries, use multiple blocks. If the job specifies more than one task, these blocks needs to be placed within the task block. Please consult [libraries section of the databricks_cluster](cluster.md#library-configuration-block) resource for more information.
 
 ```hcl
@@ -146,14 +285,14 @@ resource "databricks_job" "this" {
 }
 ```
 
-### depends_on Configuration Block
+#### depends_on Configuration Block
 
 This block describes upstream dependencies of a given task. For multiple upstream dependencies, use multiple blocks.
 
 * `task_key` - (Required) The name of the task this task depends on.
 * `outcome` - (Optional, string) Can only be specified on condition task dependencies. The outcome of the dependent task that must be met for this task to run. Possible values are `"true"` or `"false"`.
 
--> **Note** Similar to the tasks themselves, each dependency inside the task need to be declared in alphabetical order with respect to task_key in order to get consistent Terraform diffs. 
+-> **Note** Similar to the tasks themselves, each dependency inside the task need to be declared in alphabetical order with respect to task_key in order to get consistent Terraform diffs.
 
 ### tags Configuration Map
 
@@ -311,139 +450,6 @@ This block describes health conditions for a given job or an individual task. It
   * `op` - (Optional) string specifying the operation used to evaluate the given metric. The only supported operation is `GREATER_THAN`.
   * `value` - (Optional) integer value used to compare to the given metric.
 
-### spark_jar_task Configuration Block
-
-* `parameters` - (Optional) (List) Parameters passed to the main method.
-* `main_class_name` - (Optional) The full name of the class containing the main method to be executed. This class must be contained in a JAR provided as a library. The code should use `SparkContext.getOrCreate` to obtain a Spark context; otherwise, runs of the job will fail.
-
-### spark_submit_task Configuration Block
-
-You can invoke Spark submit tasks only on new clusters. **In the `new_cluster` specification, `libraries` and `spark_conf` are not supported**. Instead, use --jars and --py-files to add Java and Python libraries and `--conf` to set the Spark configuration. By default, the Spark submit job uses all available memory (excluding reserved memory for Databricks services). You can set `--driver-memory`, and `--executor-memory` to a smaller value to leave some room for off-heap usage. **Please use `spark_jar_task`, `spark_python_task` or `notebook_task` wherever possible**.
-
-* `parameters` - (Optional) (List) Command-line parameters passed to spark submit.
-
-### spark_python_task Configuration Block
-
-* `python_file` - (Required) The URI of the Python file to be executed. [databricks_dbfs_file](dbfs_file.md#path), cloud file URIs (e.g. `s3:/`, `abfss:/`, `gs:/`), workspace paths and remote repository are supported. For Python files stored in the Databricks workspace, the path must be absolute and begin with `/Repos`. For files stored in a remote repository, the path must be relative. This field is required.
-* `source` - (Optional) Location type of the Python file, can only be `GIT`. When set to `GIT`, the Python file will be retrieved from a Git repository defined in `git_source`.
-* `parameters` - (Optional) (List) Command line parameters passed to the Python file.
-
-### notebook_task Configuration Block
-
-* `notebook_path` - (Required) The path of the [databricks_notebook](notebook.md#path) to be run in the Databricks workspace or remote repository. For notebooks stored in the Databricks workspace, the path must be absolute and begin with a slash. For notebooks stored in a remote repository, the path must be relative. This field is required.
-* `source` - (Optional) Location type of the notebook, can only be `WORKSPACE` or `GIT`. When set to `WORKSPACE`, the notebook will be retrieved from the local Databricks workspace. When set to `GIT`, the notebook will be retrieved from a Git repository defined in `git_source`. If the value is empty, the task will use `GIT` if `git_source` is defined and `WORKSPACE` otherwise.
-* `base_parameters` - (Optional) (Map) Base parameters to be used for each run of this job. If the run is initiated by a call to run-now with parameters specified, the two parameters maps will be merged. If the same key is specified in base_parameters and in run-now, the value from run-now will be used. If the notebook takes a parameter that is not specified in the job’s base_parameters or the run-now override parameters, the default value from the notebook will be used. Retrieve these parameters in a notebook using `dbutils.widgets.get`.
-* `warehouse_id` - (Optional) ID of the (the [databricks_sql_endpoint](sql_endpoint.md)) that will be used to execute the task with SQL notebook.
-
-### pipeline_task Configuration Block
-
-* `pipeline_id` - (Required) The pipeline's unique ID.
-* `full_refresh` - (Optional) (Bool) Specifies if there should be full refresh of the pipeline.
-
--> **Note** The following configuration blocks are only supported inside a `task` block
-
-### python_wheel_task Configuration Block
-
-* `entry_point` - (Optional) Python function as entry point for the task
-* `package_name` - (Optional) Name of Python package
-* `parameters` - (Optional) Parameters for the task
-* `named_parameters` - (Optional) Named parameters for the task
-
-### dbt_task Configuration Block
-
-* `commands` - (Required) (Array) Series of dbt commands to execute in sequence. Every command must start with "dbt".
-* `source` - (Optional) The source of the project. Possible values are `WORKSPACE` and `GIT`.  Defaults to `GIT` if a `git_source` block is present in the job definition.
-* `project_directory` - (Required when `source` is `WORKSPACE`) The path where dbt should look for `dbt_project.yml`. Equivalent to passing `--project-dir` to the dbt CLI.
-  * If `source` is `GIT`: Relative path to the directory in the repository specified in the `git_source` block. Defaults to the repository's root directory when not specified.
-  * If `source` is `WORKSPACE`: Absolute path to the folder in the workspace.
-* `profiles_directory` - (Optional) The relative path to the directory in the repository specified by `git_source` where dbt should look in for the `profiles.yml` file. If not specified, defaults to the repository's root directory. Equivalent to passing `--profile-dir` to a dbt command.
-* `catalog` - (Optional) The name of the catalog to use inside Unity Catalog.
-* `schema` - (Optional) The name of the schema dbt should run in. Defaults to `default`.
-* `warehouse_id` - (Optional) The ID of the SQL warehouse that dbt should execute against.
-
-You also need to include a `git_source` block to configure the repository that contains the dbt project.
-
-### run_job_task Configuration Block
-
-* `job_id` - (Required)(String) ID of the job
-* `job_parameters` - (Optional)(Map) Job parameters for the task
-
-### condition_task Configuration Block
-
-The `condition_task` specifies a condition with an outcome that can be used to control the execution of dependent tasks.
-
-* `left` - The left operand of the condition task. It could be a string value, job state, or a parameter reference.
-* `right` - The right operand of the condition task. It could be a string value, job state, or parameter reference.
-* `op` - The string specifying the operation used to compare operands.  Currently, following operators are supported: `EQUAL_TO`, `GREATER_THAN`, `GREATER_THAN_OR_EQUAL`, `LESS_THAN`, `LESS_THAN_OR_EQUAL`, `NOT_EQUAL`. (Check the [API docs](https://docs.databricks.com/api/workspace/jobs/create) for the latest information).
-
-This task does not require a cluster to execute and does not support retries or notifications.
-
-### for_each_task Configuration Block
-
-* `concurrency` - (Optional) Controls the number of active iteration task runs. Default is 20, maximum allowed is 100.
-* `inputs` - (Required) (String) Array for task to iterate on. This can be a JSON string or a reference to an array parameter.
-* `task` - (Required) Task to run against the `inputs` list.
-
-### sql_task Configuration Block
-
-One of the `query`, `dashboard` or `alert` needs to be provided.
-
-* `warehouse_id` - (Required) ID of the (the [databricks_sql_endpoint](sql_endpoint.md)) that will be used to execute the task.  Only Serverless & Pro warehouses are supported right now.
-* `parameters` - (Optional) (Map) parameters to be used for each run of this task. The SQL alert task does not support custom parameters.
-* `query` - (Optional) block consisting of single string field: `query_id` - identifier of the Databricks SQL Query ([databricks_sql_query](sql_query.md)).
-* `dashboard` - (Optional) block consisting of following fields:
-  * `dashboard_id` - (Required) (String) identifier of the Databricks SQL Dashboard [databricks_sql_dashboard](sql_dashboard.md).
-  * `subscriptions` - (Optional) a list of subscription blocks consisting out of one of the required fields: `user_name` for user emails or `destination_id` - for Alert destination's identifier.
-  * `custom_subject` - (Optional) string specifying a custom subject of email sent.
-  * `pause_subscriptions` - (Optional) flag that specifies if subscriptions are paused or not.
-* `alert` - (Optional) block consisting of following fields:
-  * `alert_id` - (Required) (String) identifier of the Databricks SQL Alert.
-  * `subscriptions` - (Required) a list of subscription blocks consisting out of one of the required fields: `user_name` for user emails or `destination_id` - for Alert destination's identifier.
-  * `pause_subscriptions` - (Optional) flag that specifies if subscriptions are paused or not.
-* `file` - (Optional) block consisting of single string fields:
-  * `source` - (Optional) The source of the project. Possible values are `WORKSPACE` and `GIT`.
-  * `path` - If `source` is `GIT`: Relative path to the file in the repository specified in the `git_source` block with SQL commands to execute. If `source` is `WORKSPACE`: Absolute path to the file in the workspace with SQL commands to execute.
-
-Example
-
-```hcl
-resource "databricks_job" "sql_aggregation_job" {
-  name = "Example SQL Job"
-  task {
-    task_key = "run_agg_query"
-    sql_task {
-      warehouse_id = databricks_sql_endpoint.sql_job_warehouse.id
-      query {
-        query_id = databricks_sql_query.agg_query.id
-      }
-    }
-  }
-  task {
-    task_key = "run_dashboard"
-    sql_task {
-      warehouse_id = databricks_sql_endpoint.sql_job_warehouse.id
-      dashboard {
-        dashboard_id = databricks_sql_dashboard.dash.id
-        subscriptions {
-          user_name = "user@domain.com"
-        }
-      }
-    }
-  }
-  task {
-    task_key = "run_alert"
-    sql_task {
-      warehouse_id = databricks_sql_endpoint.sql_job_warehouse.id
-      alert {
-        alert_id = databricks_sql_alert.alert.id
-        subscriptions {
-          user_name = "user@domain.com"
-        }
-      }
-    }
-  }
-}
-```
 
 ## Attribute Reference
 


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
It seems the number of parameters has outgrown the current structure of the job documentation. This PR ensures that
* all documented fields are listed in the first section
* the parameter hierarchy of the task parameters is reflected and the task parameters are grouped

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
