### PR TITLE
Fix databricks_current_metastore data source names in docs examples

### DIFF
--- a/docs/data-sources/current_metastore.md
+++ b/docs/data-sources/current_metastore.md
@@ -18,7 +18,7 @@ data "databricks_current_metastore" "this" {
 }
 
 output "some_metastore" {
-  value = data.databricks_metastore.this.metastore_info[0]
+  value = data.databricks_current_metastore.this.metastore_info[0]
 }
 ```
 

--- a/docs/guides/unity-catalog-default.md
+++ b/docs/guides/unity-catalog-default.md
@@ -23,7 +23,7 @@ data "databricks_current_metastore" "this" {
 }
 
 resource "databricks_grants" "this" {
-  metastore = data.databricks_metastore.this.id
+  metastore = data.databricks_current_metastore.this.id
   grant {
     principal  = "Data Engineers"
     privileges = ["CREATE_CATALOG", "CREATE_EXTERNAL_LOCATION"]


### PR DESCRIPTION
## Changes
I noticed that example codes provided in databricks_current_metastore docs aren't working - the data source name differs between definition and reference. Go tests use this data source correctly so it's only docs issue

## Tests
I ran script with updated example code locally

- [ ] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
