### PR TITLE
Docs: remove confusing mention of cloud types for `databricks_clusters` and `databricks_sql_warehouses` data sources

### DIFF
--- a/docs/data-sources/clusters.md
+++ b/docs/data-sources/clusters.md
@@ -9,19 +9,17 @@ Retrieves a list of [databricks_cluster](../resources/cluster.md#cluster_id) ids
 
 ## Example Usage
 
-Retrieve all clusters on this workspace on AWS or GCP:
+Retrieve cluster IDs for all clusters:
 
 ```hcl
 data "databricks_clusters" "all" {
-  depends_on = [databricks_mws_workspaces.this]
 }
 ```
 
-Retrieve all clusters with "Shared" in their cluster name on this Azure Databricks workspace:
+Retrieve cluster IDs for all clusters having "Shared" in the cluster name:
 
 ```hcl
 data "databricks_clusters" "all_shared" {
-  depends_on            = [azurerm_databricks_workspace.this]
   cluster_name_contains = "shared"
 }
 ```

--- a/docs/data-sources/sql_warehouses.md
+++ b/docs/data-sources/sql_warehouses.md
@@ -9,19 +9,17 @@ Retrieves a list of [databricks_sql_endpoint](../resources/sql_endpoint.md#id) i
 
 ## Example Usage
 
-Retrieve all SQL warehouses on this workspace on AWS or GCP:
+Retrieve IDs for all SQL warehouses:
 
 ```hcl
 data "databricks_sql_warehouses" "all" {
-  depends_on = [databricks_mws_workspaces.this]
 }
 ```
 
-Retrieve all clusters with "Shared" in their cluster name on this Azure Databricks workspace:
+Retrieve IDs for all clusters having "Shared" in the warehouse name:
 
 ```hcl
 data "databricks_sql_warehouses" "all_shared" {
-  depends_on              = [azurerm_databricks_workspace.this]
   warehouse_name_contains = "shared"
 }
 ```


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->


Fixes #3513

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
