### PR TITLE
Add DATABRICKS_USER_AGENT_EXTRA

### DIFF
--- a/provider/provider.go
+++ b/provider/provider.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"os"
 	"reflect"
+	"regexp"
 	"sort"
 	"strings"
+	"unicode"
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -47,6 +50,17 @@ func init() {
 	// IMPORTANT: this line cannot be changed, because it's used for
 	// internal purposes at Databricks.
 	useragent.WithProduct("databricks-tf-provider", common.Version())
+
+	userAgentExtraEnv := os.Getenv("DATABRICKS_USER_AGENT_EXTRA")
+	out, err := parseUserAgentExtra(userAgentExtraEnv)
+
+	if err != nil {
+		panic(fmt.Errorf("failed to parse DATABRICKS_USER_AGENT_EXTRA: %s", err))
+	}
+
+	for _, extra := range out {
+		useragent.WithUserAgentExtra(extra.Key, extra.Value)
+	}
 }
 
 // DatabricksProvider returns the entire terraform provider object
@@ -267,4 +281,44 @@ func configureDatabricksClient(ctx context.Context, d *schema.ResourceData) (any
 		return commands.NewCommandsAPI(ctx, client)
 	})
 	return pc, nil
+}
+
+type userAgentExtra struct {
+	Key   string
+	Value string
+}
+
+// Regex for product strings. See RFC 9110.
+//
+// product = token ["/" product-version]
+// product-version = token
+// token = 1*tchar
+// tchar = "!" / "#" / "$" / "%" / "&" / "'" / "*" / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~" / DIGIT / ALPHA
+var productRegexRfc9110 = regexp.MustCompile("^([!#$%&'*+\\-.^_`|~0-9A-Za-z]+)(/([!#$%&'*+\\-.^_`|~0-9A-Za-z]+))?$")
+
+func parseUserAgentExtra(env string) ([]userAgentExtra, error) {
+	out := []userAgentExtra{}
+
+	products := strings.FieldsFunc(env, func(r rune) bool {
+		return unicode.IsSpace(r)
+	})
+
+	for _, product := range products {
+		match := productRegexRfc9110.FindStringSubmatch(product)
+
+		if len(match) != 4 {
+			return nil, fmt.Errorf("product string must follow RFC 9110: %s", product)
+		}
+
+		if match[3] == "" {
+			return nil, fmt.Errorf("product string must include version: %s", product)
+		}
+
+		out = append(out, userAgentExtra{
+			Key:   match[1],
+			Value: match[3],
+		})
+	}
+
+	return out, nil
 }

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -477,3 +477,75 @@ func configureProviderAndReturnClient(t *testing.T, tt providerFixture) (*common
 	}
 	return client, nil
 }
+
+type parseUserAgentTestCase struct {
+	name string
+	env  string
+	err  error
+	out  []userAgentExtra
+}
+
+func Test_ParseUserAgentExtra(t *testing.T) {
+	testCases := []parseUserAgentTestCase{
+		{
+			name: "single product",
+			env:  "databricks-cli/0.1.2",
+			err:  nil,
+			out: []userAgentExtra{
+				{"databricks-cli", "0.1.2"},
+			},
+		},
+		{
+			name: "multiple products",
+			env:  "databricks-cli/0.1.2 custom-thing/0.0.1",
+			err:  nil,
+			out: []userAgentExtra{
+				{"databricks-cli", "0.1.2"},
+				{"custom-thing", "0.0.1"},
+			},
+		},
+		{
+			name: "multiple products with many separators",
+			env:  "\ta/0.0.1\tb/0.0.2 \t c/0.0.3",
+			err:  nil,
+			out: []userAgentExtra{
+				{"a", "0.0.1"},
+				{"b", "0.0.2"},
+				{"c", "0.0.3"},
+			},
+		},
+		{
+			name: "empty string",
+			env:  "",
+			err:  nil,
+			out:  []userAgentExtra{},
+		},
+		{
+			name: "product with comment",
+			env:  "a/0.0.1 (my comment)",
+			err:  fmt.Errorf("product string must follow RFC 9110: (my"),
+			out:  nil,
+		},
+		{
+			name: "no version",
+			env:  "cli",
+			err:  fmt.Errorf("product string must include version: cli"),
+			out:  nil,
+		},
+		{
+			name: "invalid format",
+			env:  "no/no/no",
+			err:  fmt.Errorf("product string must follow RFC 9110: no/no/no"),
+			out:  nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := parseUserAgentExtra(tc.env)
+
+			assert.Equal(t, tc.err, err)
+			assert.Equal(t, tc.out, out)
+		})
+	}
+}


### PR DESCRIPTION
## Changes
Support DATABRICKS_USER_AGENT_EXTRA environment variable.

It contains a list of products to add as extras to the user agent header. Product strings must follow RFC 9110, contain version numbers, and can't contain comments. E.g:

```
DATABRICKS_USER_AGENT_EXTRA="databricks-cli/0.1.2 my-project/0.0.1"
```

## Tests
I added unit tests

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
