### PR TITLE
Exporter: ignore instance pools with the empty name

### DIFF
--- a/exporter/importables.go
+++ b/exporter/importables.go
@@ -234,6 +234,11 @@ var resourcesMap map[string]importable = map[string]importable{
 				"inst_pool_"+ic.Importables["databricks_instance_pool"].Name(ic, r.Data))
 			return nil
 		},
+		Ignore: func(ic *importContext, r *resource) bool {
+			isIgnored := r.Data.Get("instance_pool_name") == ""
+			ic.addIgnoredResource(fmt.Sprintf("databricks_instance_pool. id=%s", r.ID))
+			return isIgnored
+		},
 	},
 	"databricks_instance_profile": {
 		Service: "access",

--- a/exporter/importables_test.go
+++ b/exporter/importables_test.go
@@ -93,12 +93,22 @@ func TestInstancePool(t *testing.T) {
 	assert.Equal(t, "def", name)
 
 	ic.meAdmin = true
-	err := resourcesMap["databricks_instance_pool"].Import(ic, &resource{
+	r := &resource{
 		ID:   "abc",
 		Data: d,
-	})
+	}
+	err := resourcesMap["databricks_instance_pool"].Import(ic, r)
 	assert.NoError(t, err)
 	assert.True(t, ic.testEmits["databricks_permissions[inst_pool_def] (id: /instance-pools/abc)"])
+
+	// Check ignore function
+	assert.True(t, resourcesMap["databricks_instance_pool"].Ignore(ic, r))
+	assert.Equal(t, 1, len(ic.ignoredResources))
+	assert.Contains(t, ic.ignoredResources, "databricks_instance_pool. id=abc")
+	//
+	d.Set("instance_pool_name", "test")
+	assert.False(t, resourcesMap["databricks_instance_pool"].Ignore(ic, r))
+	assert.Equal(t, 1, len(ic.ignoredResources))
 }
 
 func TestClusterPolicy(t *testing.T) {


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

Instance pools must have a name, but sometimes the resource don't have it because an instance pool was used in the `databricks_job` but was deleted, keeping the reference in the job definition.

Fixes #3521

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
