### PR TITLE
Fix permanent drift for `azure_service_principal` in resource `databricks_storage_credential`

### DIFF
--- a/catalog/resource_storage_credential_test.go
+++ b/catalog/resource_storage_credential_test.go
@@ -654,3 +654,54 @@ func TestUpdateAzStorageCredentialMI(t *testing.T) {
 		`,
 	}.ApplyNoError(t)
 }
+
+func TestUpdateAzStorageCredentialSpn(t *testing.T) {
+	qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "PATCH",
+				Resource: "/api/2.1/unity-catalog/storage-credentials/a",
+				ExpectedRequest: catalog.UpdateStorageCredential{
+					Comment: "c",
+					AzureServicePrincipal: &catalog.AzureServicePrincipal{
+						ApplicationId: "SAME",
+						DirectoryId:   "SAME",
+						ClientSecret:  "CHANGED",
+					},
+				},
+			},
+			{
+				Method:   "GET",
+				Resource: "/api/2.1/unity-catalog/storage-credentials/a?",
+				Response: catalog.StorageCredentialInfo{
+					Name: "a",
+					AzureServicePrincipal: &catalog.AzureServicePrincipal{
+						ApplicationId: "SAME",
+						DirectoryId:   "SAME",
+					},
+					MetastoreId: "d",
+				},
+			},
+		},
+		Resource: ResourceStorageCredential(),
+		Update:   true,
+		ID:       "a",
+		InstanceState: map[string]string{
+			"name":    "a",
+			"comment": "c",
+		},
+		HCL: `
+		name = "a"
+		azure_service_principal {
+			application_id = "SAME"
+			directory_id = "SAME"
+			client_secret = "CHANGED"
+		}
+		comment = "c"
+		`,
+	}.ApplyAndExpectData(t, map[string]any{
+		"azure_service_principal.0.application_id": "SAME",
+		"azure_service_principal.0.directory_id":   "SAME",
+		"azure_service_principal.0.client_secret":  "CHANGED",
+	})
+}


### PR DESCRIPTION
## Changes
- The API marked `client_secret` field as sensitive and does not return it. We need to persist in the state manually

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant acceptance tests are passing
- [x] using Go SDK
