### PR TITLE
Jobs GoSDK schema migration

### DIFF
--- a/clusters/resource_cluster.go
+++ b/clusters/resource_cluster.go
@@ -123,6 +123,34 @@ type ClusterSpec struct {
 	Libraries []compute.Library `json:"libraries,omitempty" tf:"slice_set,alias:library"`
 }
 
+func (ClusterSpec) CustomizeSchemaResourceSpecific(s *common.CustomizableSchema) *common.CustomizableSchema {
+	s.SchemaPath("autotermination_minutes").SetDefault(60)
+	s.AddNewField("default_tags", &schema.Schema{
+		Type:     schema.TypeMap,
+		Computed: true,
+	})
+	s.AddNewField("is_pinned", &schema.Schema{
+		Type:     schema.TypeBool,
+		Optional: true,
+		Default:  false,
+		DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+			if old == "" && new == "false" {
+				return true
+			}
+			return old == new
+		},
+	})
+	s.AddNewField("state", &schema.Schema{
+		Type:     schema.TypeString,
+		Computed: true,
+	})
+	s.AddNewField("url", &schema.Schema{
+		Type:     schema.TypeString,
+		Computed: true,
+	})
+	return s
+}
+
 func (ClusterSpec) CustomizeSchema(s *common.CustomizableSchema) *common.CustomizableSchema {
 	s.SchemaPath("cluster_source").SetReadOnly()
 	s.SchemaPath("enable_elastic_disk").SetComputed()
@@ -158,7 +186,6 @@ func (ClusterSpec) CustomizeSchema(s *common.CustomizableSchema) *common.Customi
 	s.SchemaPath("aws_attributes", "zone_id").SetCustomSuppressDiff(ZoneDiffSuppress)
 	s.SchemaPath("azure_attributes").SetSuppressDiff().SetConflictsWith([]string{"aws_attributes", "gcp_attributes"})
 	s.SchemaPath("gcp_attributes").SetSuppressDiff().SetConflictsWith([]string{"aws_attributes", "azure_attributes"})
-	s.SchemaPath("autotermination_minutes").SetDefault(60)
 	s.SchemaPath("autoscale", "max_workers").SetOptional()
 	s.SchemaPath("autoscale", "min_workers").SetOptional()
 	s.SchemaPath("cluster_log_conf", "dbfs", "destination").SetRequired()
@@ -168,31 +195,8 @@ func (ClusterSpec) CustomizeSchema(s *common.CustomizableSchema) *common.Customi
 		Type:     schema.TypeString,
 		Computed: true,
 	})
-	s.AddNewField("default_tags", &schema.Schema{
-		Type:     schema.TypeMap,
-		Computed: true,
-	})
-	s.AddNewField("state", &schema.Schema{
-		Type:     schema.TypeString,
-		Computed: true,
-	})
 	s.SchemaPath("instance_pool_id").SetConflictsWith([]string{"driver_node_type_id", "node_type_id"})
 	s.SchemaPath("runtime_engine").SetValidateFunc(validation.StringInSlice([]string{"PHOTON", "STANDARD"}, false))
-	s.AddNewField("is_pinned", &schema.Schema{
-		Type:     schema.TypeBool,
-		Optional: true,
-		Default:  false,
-		DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-			if old == "" && new == "false" {
-				return true
-			}
-			return old == new
-		},
-	})
-	s.AddNewField("url", &schema.Schema{
-		Type:     schema.TypeString,
-		Computed: true,
-	})
 	s.SchemaPath("num_workers").SetDefault(0).SetValidateDiagFunc(validation.ToDiagFunc(validation.IntAtLeast(0)))
 	s.AddNewField("cluster_mount_info", &schema.Schema{
 		Type:     schema.TypeList,
@@ -498,5 +502,4 @@ func resourceClusterDelete(ctx context.Context, d *schema.ResourceData, c *commo
 
 func init() {
 	common.RegisterResourceProvider(compute.ClusterSpec{}, ClusterSpec{})
-	common.RegisterResourceProvider(compute.Library{}, LibraryResource{})
 }

--- a/clusters/resource_cluster.go
+++ b/clusters/resource_cluster.go
@@ -502,4 +502,5 @@ func resourceClusterDelete(ctx context.Context, d *schema.ResourceData, c *commo
 
 func init() {
 	common.RegisterResourceProvider(compute.ClusterSpec{}, ClusterSpec{})
+	common.RegisterResourceProvider(compute.Library{}, LibraryResource{})
 }

--- a/clusters/resource_library.go
+++ b/clusters/resource_library.go
@@ -16,11 +16,15 @@ type LibraryResource struct {
 	compute.Library
 }
 
-func (LibraryResource) CustomizeSchema(s *common.CustomizableSchema) *common.CustomizableSchema {
+func (LibraryResource) CustomizeSchemaResourceSpecific(s *common.CustomizableSchema) *common.CustomizableSchema {
 	s.AddNewField("cluster_id", &schema.Schema{
 		Type:     schema.TypeString,
 		Required: true,
 	})
+	return s
+}
+
+func (LibraryResource) CustomizeSchema(s *common.CustomizableSchema) *common.CustomizableSchema {
 	return s
 }
 

--- a/common/customizable_schema.go
+++ b/common/customizable_schema.go
@@ -253,17 +253,24 @@ func (s *CustomizableSchema) SetValidateDiagFunc(validate func(interface{}, cty.
 }
 
 func (s *CustomizableSchema) AddNewField(key string, newField *schema.Schema) *CustomizableSchema {
-	cv, ok := s.Schema.Elem.(*schema.Resource)
-	if !ok {
-		panic("Cannot add new field, target is not nested resource")
-	}
-	_, exists := cv.Schema[key]
+	scm := s.GetSchemaMap()
+	_, exists := scm[key]
 	if exists {
 		panic("Cannot add new field, " + key + " already exists in the schema")
 	}
-	cv.Schema[key] = newField
+	scm[key] = newField
 	if s.isSuppressDiff {
 		newField.DiffSuppressFunc = diffSuppressor(key, newField)
 	}
+	return s
+}
+
+func (s *CustomizableSchema) RemoveField(key string) *CustomizableSchema {
+	scm := s.GetSchemaMap()
+	_, exists := scm[key]
+	if !exists {
+		panic("Cannot remove new field, " + key + " does not exist in the schema")
+	}
+	delete(scm, key)
 	return s
 }

--- a/common/reflect_resource.go
+++ b/common/reflect_resource.go
@@ -42,7 +42,7 @@ var kindMap = map[reflect.Kind]string{
 // Global registry for ResoureProvider, the goal is to make StructToSchema able to find pre-registered ResourceProvider for a
 // given struct so that we don't have to specify aliases and customizations redundantly if one schema references the another
 // schema.
-var resourceProviderRegistry map[string]ResourceProvider
+var resourceProviderRegistry map[reflect.Type]ResourceProvider
 
 // Pre-registered ResourceProvider for a given struct into resourceProviderRegistry.
 // This function should be called in the init() function in packages with ResourceProvider.
@@ -53,20 +53,46 @@ var resourceProviderRegistry map[string]ResourceProvider
 //	}
 func RegisterResourceProvider(v any, r ResourceProvider) {
 	if resourceProviderRegistry == nil {
-		resourceProviderRegistry = make(map[string]ResourceProvider)
+		resourceProviderRegistry = make(map[reflect.Type]ResourceProvider)
 	}
-	typeName := getNameForType(reflect.ValueOf(v).Type())
-	if _, ok := resourceProviderRegistry[typeName]; ok {
-		errMsg := fmt.Sprintf("%s has already been registered, please avoid registering the same type repeatedly.", typeName)
+	t := getResourceProviderRegistryKey(v)
+	if _, ok := resourceProviderRegistry[t]; ok {
+		errMsg := fmt.Sprintf("%s has already been registered, please avoid registering the same type repeatedly.", getNameForType(t))
 		panic(errMsg)
 	}
-	resourceProviderRegistry[typeName] = r
+	resourceProviderRegistry[t] = r
+}
+
+func getResourceProviderRegistryKey(v any) reflect.Type {
+	t := reflect.ValueOf(v).Type()
+	return getNonPointerType(t)
+}
+
+func getNonPointerType(t reflect.Type) reflect.Type {
+	if t.Kind() == reflect.Ptr {
+		return t.Elem()
+	} else {
+		return t
+	}
 }
 
 // Generic interface for ResourceProvider. Using CustomizeSchema function to keep track of additional information
 // on top of the generated go-sdk struct.
 type ResourceProvider interface {
 	CustomizeSchema(*CustomizableSchema) *CustomizableSchema
+}
+
+// Interface for ResourcePrivider that needs certain customizaitons that shouldn't be shared.
+type ResourceProviderWithResourceSpecificCustomization interface {
+	ResourceProvider
+	// Customizations in this function will not be applied when this type is referenced from another resource by resourceProviderRegistry.
+	// Example use case:
+	//    // autotermination_minutes should only have a default value of 60 for the clusters resource, but not in the nested cluster schema in jobs
+	//    func (ClusterSpec) CustomizeSchemaResourceSpecific(s *common.CustomizableSchema) *common.CustomizableSchema {
+	// 	      s.SchemaPath("autotermination_minutes").SetDefault(60)
+	// 	      return s
+	//    }
+	CustomizeSchemaResourceSpecific(*CustomizableSchema) *CustomizableSchema
 }
 
 // Interface for ResourceProvider instances that need aliases for fields.
@@ -101,7 +127,23 @@ type RecursiveResourceProvider interface {
 }
 
 // Takes in a ResourceProvider and converts that into a map from string to schema.
+// Used by typeToSchema when encountering types registered in the resourceProviderRegistry.
+func resourceProviderStructToSchemaNestedResource(v ResourceProvider, scp schemaPathContext) map[string]*schema.Schema {
+	return resourceProviderStructToSchemaInternal(v, scp).GetSchemaMap()
+}
+
+// Used only by StructToSchema because it tries to apply resource specific customizations.
 func resourceProviderStructToSchema(v ResourceProvider, scp schemaPathContext) map[string]*schema.Schema {
+	customizedScm := resourceProviderStructToSchemaInternal(v, scp)
+	if rps, ok := v.(ResourceProviderWithResourceSpecificCustomization); ok {
+		// Apply resource specific customizations, if applicable.
+		return rps.CustomizeSchemaResourceSpecific(customizedScm).GetSchemaMap()
+	} else {
+		return customizedScm.GetSchemaMap()
+	}
+}
+
+func resourceProviderStructToSchemaInternal(v ResourceProvider, scp schemaPathContext) *CustomizableSchema {
 	rv := reflect.ValueOf(v)
 	var scm map[string]*schema.Schema
 	aliases := map[string]map[string]string{}
@@ -115,8 +157,7 @@ func resourceProviderStructToSchema(v ResourceProvider, scp schemaPathContext) m
 	}
 	cs := CustomizeSchemaPath(scm)
 	cs.context = scp
-	scm = v.CustomizeSchema(cs).GetSchemaMap()
-	return scm
+	return v.CustomizeSchema(cs)
 }
 
 func reflectKind(k reflect.Kind) string {
@@ -372,6 +413,9 @@ func listAllFields(v reflect.Value) []field {
 }
 
 func typeToSchema(v reflect.Value, aliases map[string]map[string]string, tc trackingContext) map[string]*schema.Schema {
+	if rpStruct, ok := resourceProviderRegistry[getNonPointerType(v.Type())]; ok {
+		return resourceProviderStructToSchemaNestedResource(rpStruct, tc.pathCtx)
+	}
 	scm := map[string]*schema.Schema{}
 	rk := v.Kind()
 	if rk == reflect.Ptr {

--- a/jobs/resource_job.go
+++ b/jobs/resource_job.go
@@ -587,6 +587,9 @@ func (JobSettingsResource) CustomizeSchema(s *common.CustomizableSchema) *common
 	s.SchemaPath("task", "run_if").SetSuppressDiffWithDefault(jobs.RunIfAllSuccess)
 	s.SchemaPath("task", "for_each_task", "task", "run_if").SetSuppressDiffWithDefault(jobs.RunIfAllSuccess)
 
+	s.SchemaPath("task", "for_each_task", "task", "new_cluster", "cluster_id").Schema.Computed = false
+	s.SchemaPath("task", "for_each_task", "task", "new_cluster").RemoveField("cluster_source")
+
 	// ======= To keep consistency with the manually maintained schema, should be reverted once full migration is done. ======
 	s.SchemaPath("task", "task_key").SetOptional()
 	s.SchemaPath("task", "for_each_task", "task", "task_key").SetOptional()
@@ -867,6 +870,14 @@ func jobSettingsSchema(s map[string]*schema.Schema, prefix string) {
 		p.Type = schema.TypeInt
 		p.ValidateDiagFunc = validation.ToDiagFunc(validation.IntAtLeast(0))
 		p.Required = false
+	}
+	if p, err := common.SchemaPath(s, "new_cluster", "cluster_id"); err == nil {
+		p.Computed = false
+	}
+	if p, err := common.SchemaPath(s, "new_cluster"); err == nil {
+		if r, ok := p.Elem.(*schema.Resource); ok {
+			delete(r.Schema, "cluster_source")
+		}
 	}
 	if p, err := common.SchemaPath(s, "new_cluster", "init_scripts", "dbfs"); err == nil {
 		p.Deprecated = clusters.DbfsDeprecationWarning


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
- Make `typeToSchema` check and reuse information for registered resources in the `resourceProviderRegistry`
- Taking `Library` out of the registry because the only customization is not needed in other resources
- Migrating jobs resource schema to use the GoSDK schema
  - Constructed resource provider with `CustomizeSchema` function that takes in all of the existing customizations
  - Tried making the new schema as similar as possible to the original schema
  - Updated the schema used in the resource as well as in `DataToStructPointer` and `StructToData` function calls
  - Updated `resource_job_test`
- Adding `CustomizeSchemaResourceSpecific` function so that customizations don't always have to be shared for registry references

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [x] covered with integration tests in `internal/acceptance`
- [x] relevant acceptance tests are passing
- [x] using Go SDK
