### PR TITLE
Retry API calls until context timeout

### DIFF
--- a/provider/provider.go
+++ b/provider/provider.go
@@ -279,6 +279,12 @@ func configureDatabricksClient(ctx context.Context, d *schema.ResourceData) (any
 			cfg.AuthType = newer
 		}
 	}
+	cfg.EnsureResolved()
+	// Unless set explicitly, the provider will retry indefinitely until context is cancelled
+	// by either a timeout or interrupt.
+	if cfg.RetryTimeoutSeconds == 0 {
+		cfg.RetryTimeoutSeconds = -1
+	}
 	client, err := client.New(cfg)
 	if err != nil {
 		return nil, diag.FromErr(err)


### PR DESCRIPTION
## Changes
The SDK currently sets a default retry timeout of 5 minutes for all API requests. This is convenient for users who call APIs with contexts with no timeout or that can't be cancelled, like context.Background(). However, in Terraform, the context timeout is determined by a combination of instance-level timeouts, resource-level timeouts, and a default timeout of 20m.

This PR changes the provider to use an indefinite retry timeout for all API requests. This allows API calls to be retried for the entire length of the resource creation operation, e.g. in case there is a low rate limit for an API and the resources in question cannot all be created within 5 minutes.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
