### PR TITLE
Added support for CustomizeDiff for resource_share

### DIFF
--- a/internal/acceptance/share_test.go
+++ b/internal/acceptance/share_test.go
@@ -26,7 +26,7 @@ const preTestTemplate = `
 	resource "databricks_table" "mytable" {
 		catalog_name = databricks_catalog.sandbox.id
 		schema_name = databricks_schema.things.name
-		name = "bar"
+		name = "abc"
 		table_type = "MANAGED"
 		data_source_format = "DELTA"
 		
@@ -42,7 +42,39 @@ const preTestTemplate = `
 	resource "databricks_table" "mytable_2" {
 		catalog_name = databricks_catalog.sandbox.id
 		schema_name = databricks_schema.things.name
-		name = "bar_2"
+		name = "def"
+		table_type = "MANAGED"
+		data_source_format = "DELTA"
+		
+		column {
+			name      = "id"
+			position  = 0
+			type_name = "INT"
+			type_text = "int"
+			type_json = "{\"name\":\"id\",\"type\":\"integer\",\"nullable\":true,\"metadata\":{}}"
+		}
+	}
+
+	resource "databricks_table" "mytable_3" {
+		catalog_name = databricks_catalog.sandbox.id
+		schema_name = databricks_schema.things.name
+		name = "xyz"
+		table_type = "MANAGED"
+		data_source_format = "DELTA"
+		
+		column {
+			name      = "id"
+			position  = 0
+			type_name = "INT"
+			type_text = "int"
+			type_json = "{\"name\":\"id\",\"type\":\"integer\",\"nullable\":true,\"metadata\":{}}"
+		}
+	}
+
+	resource "databricks_table" "mytable_4" {
+		catalog_name = databricks_catalog.sandbox.id
+		schema_name = databricks_schema.things.name
+		name = "pqr"
 		table_type = "MANAGED"
 		data_source_format = "DELTA"
 		
@@ -122,6 +154,59 @@ func shareTemplateWithOwner(comment string, owner string) string {
 				data_object_type = "TABLE"
 			}								
 		}`, owner, comment)
+}
+
+func TestUcAccShare_MultipleObjects(t *testing.T) {
+	unityWorkspaceLevel(t, step{
+		Template: preTestTemplate + preTestTemplateUpdate + `		
+		resource "databricks_share" "myshare" {
+			name  = "{var.STICKY_RANDOM}-terraform-delta-share"
+			owner = "account users"
+			object {
+				name = databricks_table.mytable_2.id
+				comment = "def"
+				data_object_type = "TABLE"
+			}					
+		}		
+		`,
+	}, step{
+		Template: preTestTemplate + preTestTemplateUpdate + `
+		resource "databricks_share" "myshare" {
+			name  = "{var.STICKY_RANDOM}-terraform-delta-share"
+			owner = "account users"
+			object {
+				name = databricks_table.mytable.id
+				comment = "abc"
+				data_object_type = "TABLE"
+			}
+			object {
+				name = databricks_table.mytable_2.id
+				comment = "def - updated"
+				data_object_type = "TABLE"
+			}
+			object {
+				name = databricks_table.mytable_3.id
+				comment = "xyz"
+				data_object_type = "TABLE"
+			}
+		}`,
+	}, step{
+		Template: preTestTemplate + preTestTemplateUpdate + `
+		resource "databricks_share" "myshare" {
+			name  = "{var.STICKY_RANDOM}-terraform-delta-share"
+			owner = "account users"
+			object {
+				name = databricks_table.mytable_2.id
+				comment = "def - updated 2"
+				data_object_type = "TABLE"
+			}
+			object {
+				name = databricks_table.mytable_4.id
+				comment = "xyz - updated"
+				data_object_type = "TABLE"
+			}
+		}`,
+	})
 }
 
 func TestUcAccUpdateShare(t *testing.T) {


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
We are trying to see whether using CustomizeDiff works since using force_new isn't for any object update isn't feasible. This is a followup to the PR: https://github.com/databricks/terraform-provider-databricks/pull/3529

Please see the highlighted comment below. 

This is a great use case for prioritising moving towards using terraform plugin framework (https://github.com/databricks/terraform-provider-databricks/pull/3510) as we can access config, state and plan easily: https://developer.hashicorp.com/terraform/plugin/framework/handling-data/accessing-values whereas here we would have to use more hacks and it would lead to piling up of technical debt even if we get to have it working somehow. 

This situation could occur for other similar resources with lists. 

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->
Integration test
- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
