### PR TITLE
Stabilize integration tests

### DIFF
--- a/internal/acceptance/account_rule_set_test.go
+++ b/internal/acceptance/account_rule_set_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/databricks/databricks-sdk-go/service/iam"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/databricks/terraform-provider-databricks/common"
@@ -45,15 +46,17 @@ func TestMwsAccAccountServicePrincipalRuleSetsFullLifeCycle(t *testing.T) {
 				role = "roles/servicePrincipal.manager"
 			}
 		}`,
-		Check: resourceCheck("databricks_access_control_rule_set.sp_rule_set",
-			func(ctx context.Context, client *common.DatabricksClient, id string) error {
+		Check: resourceCheckWithState("databricks_access_control_rule_set.sp_rule_set",
+			func(ctx context.Context, client *common.DatabricksClient, state *terraform.InstanceState) error {
+				id := state.ID
+				eTag := state.Attributes["etag"]
 				a, err := client.AccountClient()
 				if err != nil {
 					return err
 				}
 				ruleSetRes, err := a.AccessControl.GetRuleSet(ctx, iam.GetRuleSetRequest{
 					Name: id,
-					Etag: "",
+					Etag: eTag,
 				})
 				if err != nil {
 					return err

--- a/test-config.yaml
+++ b/test-config.yaml
@@ -3,3 +3,9 @@ ignored_tests:
     - package: github.com/databricks/terraform-provider-databricks/internal/acceptance
       test_name: TestAccGroupsUpdateDisplayName
       comment: Failures due to read-after-write inconsistency. Tracked in https://databricks.atlassian.net/browse/ES-1100061
+    - package: github.com/databricks/terraform-provider-databricks/internal/acceptance
+      test_name: TestMwsAccGroupDataSplitMembers
+      comment: Failures due to read-after-write inconsistency. Tracked in https://databricks.atlassian.net/browse/ES-1100061
+    - package: github.com/databricks/terraform-provider-databricks/internal/acceptance
+      test_name: TestAccServicePrincipalResourceOnAws
+      comment: Failures due to read-after-write inconsistency. Tracked in https://databricks.atlassian.net/browse/ES-1100061


### PR DESCRIPTION
## Changes
Recently, I observed a couple of issues with integration tests:
* TestMwsAccGroupDataSplitMembers and TestAccServicePrincipalResourceOnAws failed due to the API not responding with the correct information after update. I've added these to flaky tests.
* TestMwsAccAccountServicePrincipalRuleSetsFullLifeCycle failed flakily because we use no ETag, which as a result returns a stale version of the setting. I changed the check to use the ETag stored in TF state, which should ensure that the latest version of the setting is always returned.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
