### PR TITLE
Update data_aws_crossaccount_policy to format resource string with account and region

### DIFF
--- a/aws/data_aws_crossaccount_policy.go
+++ b/aws/data_aws_crossaccount_policy.go
@@ -187,8 +187,8 @@ func DataAwsCrossaccountPolicy() common.Resource {
 					Effect:  "Allow",
 					Actions: "ec2:RunInstances",
 					Resources: []string{
-						"arn:aws:ec2:%s:%s:volume/*",
-						"arn:aws:ec2:%s:%s:instance/*",
+						fmt.Sprintf("arn:aws:ec2:%s:%s:volume/*", region, aws_account_id),
+						fmt.Sprintf("arn:aws:ec2:%s:%s:instance/*", region, aws_account_id),
 					},
 					Condition: map[string]map[string]string{
 						"StringEquals": {

--- a/aws/data_aws_crossaccount_policy_test.go
+++ b/aws/data_aws_crossaccount_policy_test.go
@@ -60,7 +60,7 @@ func TestDataAwsCrossAccountRestrictedPolicy(t *testing.T) {
 	}.Apply(t)
 	assert.NoError(t, err)
 	j := d.Get("json")
-	assert.Lenf(t, j, 5691, "Strange length for policy: %s", j)
+	assert.Lenf(t, j, 5725, "Strange length for policy: %s", j)
 }
 
 func TestDataAwsCrossAccountInvalidPolicy(t *testing.T) {


### PR DESCRIPTION
String with formatting wasn't passed to `fmt.Sprintf` resulting in the actual policy containing '%s' e.g. 'arn:aws:ec2:%s:%s:volume/*'. Passing the string to `fmt.Sprintf` results in the desired iam policy json.
