### PR TITLE
Fixed Issue: The field `node_type_id` cannot be supplied when an instance pool ID is provided

### DIFF
--- a/clusters/resource_cluster.go
+++ b/clusters/resource_cluster.go
@@ -148,7 +148,7 @@ func ModifyRequestOnInstancePool(cluster *compute.CreateCluster) {
 // This method is a duplicate of FixInstancePoolChangeIfAny(d *schema.ResourceData) in clusters/clusters_api.go that uses Go SDK.
 // Long term, FixInstancePoolChangeIfAny(d *schema.ResourceData) in clusters_api.go will be removed once all the resources using clusters are migrated to Go SDK.
 // https://github.com/databricks/terraform-provider-databricks/issues/824
-func FixInstancePoolChangeIfAny(d *schema.ResourceData, cluster compute.CreateCluster) {
+func FixInstancePoolChangeIfAny(d *schema.ResourceData, cluster *compute.CreateCluster) {
 	oldInstancePool, newInstancePool := d.GetChange("instance_pool_id")
 	oldDriverPool, newDriverPool := d.GetChange("driver_instance_pool_id")
 	if oldInstancePool != newInstancePool &&
@@ -393,7 +393,7 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, c *commo
 			return err
 		}
 		ModifyRequestOnInstancePool(&cluster)
-		FixInstancePoolChangeIfAny(d, cluster)
+		FixInstancePoolChangeIfAny(d, &cluster)
 
 		// We can only call the resize api if the cluster is in the running state
 		// and only the cluster size (ie num_workers OR autoscale) is being changed

--- a/clusters/resource_cluster.go
+++ b/clusters/resource_cluster.go
@@ -24,7 +24,7 @@ var clusterSchemaVersion = 3
 
 const (
 	numWorkerErr                     = "NumWorkers could be 0 only for SingleNode clusters. See https://docs.databricks.com/clusters/single-node.html for more details"
-	unsupportedExceptCreateOrEditErr = "unsupported type %T, must be either *compute.CreateCluster or *compute.EditCluster. Please report this issue to the GitHub repo"
+	unsupportedExceptCreateOrEditErr = "unsupported type %T, must be either %scompute.CreateCluster or %scompute.EditCluster. Please report this issue to the GitHub repo"
 )
 
 func ResourceCluster() common.Resource {
@@ -124,7 +124,7 @@ func Validate(cluster any) error {
 		master = c.SparkConf["spark.master"]
 		resourceClass = c.CustomTags["ResourceClass"]
 	default:
-		return fmt.Errorf(unsupportedExceptCreateOrEditErr, cluster)
+		return fmt.Errorf(unsupportedExceptCreateOrEditErr, cluster, "", "")
 	}
 	if profile == "singleNode" && strings.HasPrefix(master, "local") && resourceClass == "SingleNode" {
 		return nil
@@ -193,7 +193,7 @@ func ModifyRequestOnInstancePool(cluster any) error {
 		c.DriverNodeTypeId = ""
 		return nil
 	default:
-		return fmt.Errorf(unsupportedExceptCreateOrEditErr, cluster)
+		return fmt.Errorf(unsupportedExceptCreateOrEditErr, cluster, "*", "*")
 	}
 }
 

--- a/clusters/resource_cluster_test.go
+++ b/clusters/resource_cluster_test.go
@@ -1554,7 +1554,8 @@ func TestModifyClusterRequestAws(t *testing.T) {
 		NodeTypeId:        "d",
 		DriverNodeTypeId:  "e",
 	}
-	ModifyRequestOnInstancePool(&c)
+	err := ModifyRequestOnInstancePool(&c)
+	assert.NoError(t, err)
 	assert.Equal(t, "", c.AwsAttributes.ZoneId)
 	assert.Equal(t, "", c.NodeTypeId)
 	assert.Equal(t, "", c.DriverNodeTypeId)
@@ -1571,7 +1572,8 @@ func TestModifyClusterRequestAzure(t *testing.T) {
 		NodeTypeId:        "d",
 		DriverNodeTypeId:  "e",
 	}
-	ModifyRequestOnInstancePool(&c)
+	err := ModifyRequestOnInstancePool(&c)
+	assert.NoError(t, err)
 	assert.Equal(t, &compute.AzureAttributes{}, c.AzureAttributes)
 	assert.Equal(t, "", c.NodeTypeId)
 	assert.Equal(t, "", c.DriverNodeTypeId)
@@ -1588,7 +1590,8 @@ func TestModifyClusterRequestGcp(t *testing.T) {
 		NodeTypeId:        "d",
 		DriverNodeTypeId:  "e",
 	}
-	ModifyRequestOnInstancePool(&c)
+	err := ModifyRequestOnInstancePool(&c)
+	assert.NoError(t, err)
 	assert.Equal(t, false, c.GcpAttributes.UsePreemptibleExecutors)
 	assert.Equal(t, "", c.NodeTypeId)
 	assert.Equal(t, "", c.DriverNodeTypeId)

--- a/clusters/resource_cluster_test.go
+++ b/clusters/resource_cluster_test.go
@@ -1544,17 +1544,15 @@ func TestResourceClusterUpdate_FailNumWorkersZero(t *testing.T) {
 }
 
 func TestModifyClusterRequestAws(t *testing.T) {
-	c := ClusterSpec{
-		ClusterSpec: compute.ClusterSpec{
-			InstancePoolId: "a",
-			AwsAttributes: &compute.AwsAttributes{
-				InstanceProfileArn: "b",
-				ZoneId:             "c",
-			},
-			EnableElasticDisk: true,
-			NodeTypeId:        "d",
-			DriverNodeTypeId:  "e",
+	c := compute.CreateCluster{
+		InstancePoolId: "a",
+		AwsAttributes: &compute.AwsAttributes{
+			InstanceProfileArn: "b",
+			ZoneId:             "c",
 		},
+		EnableElasticDisk: true,
+		NodeTypeId:        "d",
+		DriverNodeTypeId:  "e",
 	}
 	ModifyRequestOnInstancePool(&c)
 	assert.Equal(t, "", c.AwsAttributes.ZoneId)
@@ -1564,16 +1562,14 @@ func TestModifyClusterRequestAws(t *testing.T) {
 }
 
 func TestModifyClusterRequestAzure(t *testing.T) {
-	c := ClusterSpec{
-		ClusterSpec: compute.ClusterSpec{
-			InstancePoolId: "a",
-			AzureAttributes: &compute.AzureAttributes{
-				FirstOnDemand: 1,
-			},
-			EnableElasticDisk: true,
-			NodeTypeId:        "d",
-			DriverNodeTypeId:  "e",
+	c := compute.CreateCluster{
+		InstancePoolId: "a",
+		AzureAttributes: &compute.AzureAttributes{
+			FirstOnDemand: 1,
 		},
+		EnableElasticDisk: true,
+		NodeTypeId:        "d",
+		DriverNodeTypeId:  "e",
 	}
 	ModifyRequestOnInstancePool(&c)
 	assert.Equal(t, &compute.AzureAttributes{}, c.AzureAttributes)
@@ -1583,16 +1579,14 @@ func TestModifyClusterRequestAzure(t *testing.T) {
 }
 
 func TestModifyClusterRequestGcp(t *testing.T) {
-	c := ClusterSpec{
-		ClusterSpec: compute.ClusterSpec{
-			InstancePoolId: "a",
-			GcpAttributes: &compute.GcpAttributes{
-				UsePreemptibleExecutors: true,
-			},
-			EnableElasticDisk: true,
-			NodeTypeId:        "d",
-			DriverNodeTypeId:  "e",
+	c := compute.CreateCluster{
+		InstancePoolId: "a",
+		GcpAttributes: &compute.GcpAttributes{
+			UsePreemptibleExecutors: true,
 		},
+		EnableElasticDisk: true,
+		NodeTypeId:        "d",
+		DriverNodeTypeId:  "e",
 	}
 	ModifyRequestOnInstancePool(&c)
 	assert.Equal(t, false, c.GcpAttributes.UsePreemptibleExecutors)

--- a/internal/acceptance/cluster_test.go
+++ b/internal/acceptance/cluster_test.go
@@ -49,7 +49,7 @@ func TestAccClusterResource_CreateClusterWithLibraries(t *testing.T) {
 	})
 }
 
-func singleNodeClusterTemplate(autoTerminatinoMinutes string) string {
+func singleNodeClusterTemplate(autoTerminationMinutes string) string {
 	return fmt.Sprintf(`
 		data "databricks_spark_version" "latest" {
 		}
@@ -67,7 +67,7 @@ func singleNodeClusterTemplate(autoTerminatinoMinutes string) string {
 				"ResourceClass" = "SingleNode"
 			}
 		}
-	`, autoTerminatinoMinutes)
+	`, autoTerminationMinutes)
 }
 
 func TestAccClusterResource_CreateSingleNodeCluster(t *testing.T) {

--- a/internal/acceptance/cluster_test.go
+++ b/internal/acceptance/cluster_test.go
@@ -1,6 +1,7 @@
 package acceptance
 
 import (
+	"fmt"
 	"testing"
 )
 
@@ -48,42 +49,31 @@ func TestAccClusterResource_CreateClusterWithLibraries(t *testing.T) {
 	})
 }
 
+func singleNodeClusterTemplate(autoTerminatinoMinutes string) string {
+	return fmt.Sprintf(`
+		data "databricks_spark_version" "latest" {
+		}
+		resource "databricks_cluster" "this" {
+			cluster_name = "singlenode-{var.RANDOM}"
+			spark_version = data.databricks_spark_version.latest.id
+			instance_pool_id = "{env.TEST_INSTANCE_POOL_ID}"
+			num_workers = 0
+			autotermination_minutes = %s
+			spark_conf = {
+				"spark.databricks.cluster.profile" = "singleNode"
+				"spark.master" = "local[*]"
+			}
+			custom_tags = {
+				"ResourceClass" = "SingleNode"
+			}
+		}
+	`, autoTerminatinoMinutes)
+}
+
 func TestAccClusterResource_CreateSingleNodeCluster(t *testing.T) {
 	workspaceLevel(t, step{
-		Template: `
-		data "databricks_spark_version" "latest" {
-		}
-		resource "databricks_cluster" "this" {
-			cluster_name = "singlenode-{var.RANDOM}"
-			spark_version = data.databricks_spark_version.latest.id
-			instance_pool_id = "{env.TEST_INSTANCE_POOL_ID}"
-			num_workers = 0
-			autotermination_minutes = 10
-			spark_conf = {
-				"spark.databricks.cluster.profile" = "singleNode"
-				"spark.master" = "local[*]"
-			}
-			custom_tags = {
-				"ResourceClass" = "SingleNode"
-			}
-		}`,
+		Template: singleNodeClusterTemplate("10"),
 	}, step{
-		Template: `
-		data "databricks_spark_version" "latest" {
-		}
-		resource "databricks_cluster" "this" {
-			cluster_name = "singlenode-{var.RANDOM}"
-			spark_version = data.databricks_spark_version.latest.id
-			instance_pool_id = "{env.TEST_INSTANCE_POOL_ID}"
-			num_workers = 0
-			autotermination_minutes = 20
-			spark_conf = {
-				"spark.databricks.cluster.profile" = "singleNode"
-				"spark.master" = "local[*]"
-			}
-			custom_tags = {
-				"ResourceClass" = "SingleNode"
-			}
-		}`,
+		Template: singleNodeClusterTemplate("20"),
 	})
 }

--- a/internal/acceptance/cluster_test.go
+++ b/internal/acceptance/cluster_test.go
@@ -67,5 +67,23 @@ func TestAccClusterResource_CreateSingleNodeCluster(t *testing.T) {
 				"ResourceClass" = "SingleNode"
 			}
 		}`,
+	}, step{
+		Template: `
+		data "databricks_spark_version" "latest" {
+		}
+		resource "databricks_cluster" "this" {
+			cluster_name = "singlenode-{var.RANDOM}"
+			spark_version = data.databricks_spark_version.latest.id
+			instance_pool_id = "{env.TEST_INSTANCE_POOL_ID}"
+			num_workers = 0
+			autotermination_minutes = 20
+			spark_conf = {
+				"spark.databricks.cluster.profile" = "singleNode"
+				"spark.master" = "local[*]"
+			}
+			custom_tags = {
+				"ResourceClass" = "SingleNode"
+			}
+		}`,
 	})
 }


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
We earlier used to have only one spec that we used to pass for all the requests, after migration since we use different requests, we need to modify the fields for them as well. 

Fixes: https://github.com/databricks/terraform-provider-databricks/issues/3533 

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->
Updated unit tests and integration test to check for this. Also, manually used this change (local binary) to run tf apply over test infra.

This wasn't caught in unit or integration test so there is a gap in our tests. The above step in integration test updates `autotermination_minutes` and this should repro this issue and changes should fix it. 

Integration test passes on PR and fail on main. 

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [x] covered with integration tests in `internal/acceptance`
- [x] relevant acceptance tests are passing
- [x] using Go SDK
