### PR TITLE
Added state upgrader to remove `max_clusters_per_user` set to zero

### DIFF
--- a/policies/data_cluster_policy_test.go
+++ b/policies/data_cluster_policy_test.go
@@ -1,11 +1,13 @@
 package policies
 
 import (
+	"context"
 	"testing"
 
 	"github.com/databricks/databricks-sdk-go/apierr"
 	"github.com/databricks/databricks-sdk-go/service/compute"
 	"github.com/databricks/terraform-provider-databricks/qa"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestDataSourceClusterPolicy(t *testing.T) {
@@ -81,4 +83,22 @@ func TestDataSourceClusterPolicyNotFound(t *testing.T) {
 		ID:          ".",
 		HCL:         `name = "policy"`,
 	}.ExpectError(t, "Policy named 'policy' does not exist")
+}
+
+func TestDataSourceClusterPolicyStateUpgrader(t *testing.T) {
+	state, err := removeZeroMaxClustersPerUser(context.Background(),
+		map[string]any{
+			"max_clusters_per_user": 0,
+		}, nil)
+	assert.NoError(t, err)
+	_, ok := state["max_clusters_per_user"]
+	assert.False(t, ok)
+
+	state, err = removeZeroMaxClustersPerUser(context.Background(),
+		map[string]any{
+			"max_clusters_per_user": 1,
+		}, nil)
+	assert.NoError(t, err)
+	_, ok = state["max_clusters_per_user"]
+	assert.True(t, ok)
 }

--- a/policies/resource_cluster_policy.go
+++ b/policies/resource_cluster_policy.go
@@ -6,6 +6,7 @@ import (
 	"github.com/databricks/databricks-sdk-go"
 	"github.com/databricks/databricks-sdk-go/service/compute"
 	"github.com/databricks/terraform-provider-databricks/common"
+	"github.com/hashicorp/go-cty/cty"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -24,29 +25,37 @@ func isBuiltinPolicyFamily(ctx context.Context, w *databricks.WorkspaceClient, f
 	return false, nil
 }
 
+var rcpSchema = common.StructToSchema(
+	compute.CreatePolicy{},
+	func(m map[string]*schema.Schema) map[string]*schema.Schema {
+		m["policy_id"] = &schema.Schema{
+			Type:     schema.TypeString,
+			Computed: true,
+		}
+		m["definition"].ConflictsWith = []string{"policy_family_definition_overrides", "policy_family_id"}
+		m["definition"].Computed = true
+		m["definition"].DiffSuppressFunc = common.SuppressDiffWhitespaceChange
+
+		m["policy_family_definition_overrides"].ConflictsWith = []string{"definition"}
+		m["policy_family_definition_overrides"].DiffSuppressFunc = common.SuppressDiffWhitespaceChange
+		m["policy_family_id"].ConflictsWith = []string{"definition"}
+		m["policy_family_definition_overrides"].RequiredWith = []string{"policy_family_id"}
+
+		return m
+	})
+
 // ResourceClusterPolicy ...
 func ResourceClusterPolicy() common.Resource {
-	s := common.StructToSchema(
-		compute.CreatePolicy{},
-		func(m map[string]*schema.Schema) map[string]*schema.Schema {
-			m["policy_id"] = &schema.Schema{
-				Type:     schema.TypeString,
-				Computed: true,
-			}
-			m["definition"].ConflictsWith = []string{"policy_family_definition_overrides", "policy_family_id"}
-			m["definition"].Computed = true
-			m["definition"].DiffSuppressFunc = common.SuppressDiffWhitespaceChange
-
-			m["policy_family_definition_overrides"].ConflictsWith = []string{"definition"}
-			m["policy_family_definition_overrides"].DiffSuppressFunc = common.SuppressDiffWhitespaceChange
-			m["policy_family_id"].ConflictsWith = []string{"definition"}
-			m["policy_family_definition_overrides"].RequiredWith = []string{"policy_family_id"}
-
-			return m
-		})
-
 	return common.Resource{
-		Schema: s,
+		Schema:        rcpSchema,
+		SchemaVersion: 1,
+		StateUpgraders: []schema.StateUpgrader{
+			{
+				Type:    rcpSchemaV0(),
+				Version: 0,
+				Upgrade: removeZeroMaxClustersPerUser,
+			},
+		},
 		Create: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
 			w, err := c.WorkspaceClient()
 			if err != nil {
@@ -54,7 +63,7 @@ func ResourceClusterPolicy() common.Resource {
 			}
 
 			var request compute.CreatePolicy
-			common.DataToStructPointer(d, s, &request)
+			common.DataToStructPointer(d, rcpSchema, &request)
 
 			var clusterPolicy *compute.CreatePolicyResponse
 			if request.PolicyFamilyId != "" {
@@ -69,7 +78,7 @@ func ResourceClusterPolicy() common.Resource {
 					}
 					clusterPolicy = &compute.CreatePolicyResponse{PolicyId: resp.PolicyId}
 					var editRequest compute.EditPolicy
-					common.DataToStructPointer(d, s, &editRequest)
+					common.DataToStructPointer(d, rcpSchema, &editRequest)
 					editRequest.PolicyId = resp.PolicyId
 					err = w.ClusterPolicies.Edit(ctx, editRequest)
 				} else {
@@ -93,7 +102,7 @@ func ResourceClusterPolicy() common.Resource {
 			if err != nil {
 				return err
 			}
-			return common.StructToData(resp, s, d)
+			return common.StructToData(resp, rcpSchema, d)
 		},
 		Update: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
 			w, err := c.WorkspaceClient()
@@ -102,7 +111,7 @@ func ResourceClusterPolicy() common.Resource {
 			}
 
 			var request compute.EditPolicy
-			common.DataToStructPointer(d, s, &request)
+			common.DataToStructPointer(d, rcpSchema, &request)
 			request.PolicyId = d.Id()
 			if request.PolicyFamilyId != "" {
 				request.Definition = ""
@@ -116,7 +125,7 @@ func ResourceClusterPolicy() common.Resource {
 				return err
 			}
 			var request compute.EditPolicy
-			common.DataToStructPointer(d, s, &request)
+			common.DataToStructPointer(d, rcpSchema, &request)
 			if request.PolicyFamilyId != "" {
 				isBuiltin, err := isBuiltinPolicyFamily(ctx, w, request.PolicyFamilyId, request.Name)
 				if err != nil {
@@ -132,4 +141,9 @@ func ResourceClusterPolicy() common.Resource {
 			return w.ClusterPolicies.DeleteByPolicyId(ctx, d.Id())
 		},
 	}
+}
+
+func rcpSchemaV0() cty.Type {
+	return (&schema.Resource{
+		Schema: rcpSchema}).CoreConfigSchema().ImpliedType()
 }


### PR DESCRIPTION
## Changes
Added state upgrader to remove `max_clusters_per_user` set to zero

## Tests
Manually (deploying policy with 1.41 version, upgrading to the fix and applying the changes. Changes succeed and schema updated).

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [x] relevant acceptance tests are passing
- [ ] using Go SDK
