### PR TITLE
Exporter: track removed objects during the `Emit` phase

### DIFF
--- a/exporter/importables_test.go
+++ b/exporter/importables_test.go
@@ -100,15 +100,6 @@ func TestInstancePool(t *testing.T) {
 	err := resourcesMap["databricks_instance_pool"].Import(ic, r)
 	assert.NoError(t, err)
 	assert.True(t, ic.testEmits["databricks_permissions[inst_pool_def] (id: /instance-pools/abc)"])
-
-	// Check ignore function
-	assert.True(t, resourcesMap["databricks_instance_pool"].Ignore(ic, r))
-	assert.Equal(t, 1, len(ic.ignoredResources))
-	assert.Contains(t, ic.ignoredResources, "databricks_instance_pool. id=abc")
-	//
-	d.Set("instance_pool_name", "test")
-	assert.False(t, resourcesMap["databricks_instance_pool"].Ignore(ic, r))
-	assert.Equal(t, 1, len(ic.ignoredResources))
 }
 
 func TestClusterPolicy(t *testing.T) {
@@ -2175,9 +2166,6 @@ func TestImportGrants(t *testing.T) {
 	r := &resource{ID: id, Data: d}
 	err := resourcesMap["databricks_grants"].Import(ic, r)
 	assert.NoError(t, err)
-
-	// Test ignore function
-	assert.True(t, resourcesMap["databricks_grants"].Ignore(ic, r))
 
 	var pList tfcatalog.PermissionsList
 	common.DataToStructPointer(r.Data, s, &pList)

--- a/exporter/importables_test.go
+++ b/exporter/importables_test.go
@@ -978,6 +978,30 @@ func TestRepoListFails(t *testing.T) {
 	})
 }
 
+func TestNotebookWorkspaceFileImportNotFound(t *testing.T) {
+	qa.HTTPFixturesApply(t, []qa.HTTPFixture{
+		{
+			ReuseRequest: true,
+			MatchAny:     true,
+			Status:       404,
+			Response:     apierr.NotFound("nope"),
+		},
+	}, func(ctx context.Context, client *common.DatabricksClient) {
+		ic := importContextForTestWithClient(ctx, client)
+		err := resourcesMap["databricks_notebook"].Import(ic, &resource{
+			ID: "/abc",
+		})
+		assert.EqualError(t, err, "nope")
+		assert.Contains(t, ic.ignoredResources, "databricks_notebook. path=/abc")
+
+		err = resourcesMap["databricks_workspace_file"].Import(ic, &resource{
+			ID: "/def",
+		})
+		assert.EqualError(t, err, "nope")
+		assert.Contains(t, ic.ignoredResources, "databricks_workspace_file. path=/def")
+	})
+}
+
 func testGenerate(t *testing.T, fixtures []qa.HTTPFixture, services string, asAdmin bool, cb func(*importContext)) {
 	qa.HTTPFixturesApply(t, fixtures, func(ctx context.Context, client *common.DatabricksClient) {
 		ic := importContextForTestWithClient(ctx, client)

--- a/exporter/model.go
+++ b/exporter/model.go
@@ -343,12 +343,16 @@ func (r *resource) ImportResource(ic *importContext) {
 			return pr.ReadContext(ctx, r.Data, ic.Client)
 		},
 			fmt.Sprintf("reading %s#%s", r.Resource, r.ID))
-		if dia != nil {
+		if dia.HasError() {
 			log.Printf("[ERROR] Error reading %s#%s: %v", r.Resource, r.ID, dia)
 			return
 		}
 		if r.Data.Id() == "" {
-			r.Data.SetId(r.ID)
+			if r.Resource != "databricks_permissions" && r.Resource != "databricks_grants" {
+				log.Printf("[WARN] %s %s has empty ID because it's deleted or empty", r.Resource, r.ID)
+				ic.addIgnoredResource(fmt.Sprintf("%s. id=%s", r.Resource, r.ID))
+			}
+			return
 		}
 	}
 	r.Name = ic.ResourceName(r)

--- a/exporter/util.go
+++ b/exporter/util.go
@@ -1418,7 +1418,7 @@ func generateIgnoreObjectWithoutName(resourceType string) func(ic *importContext
 	return func(ic *importContext, r *resource) bool {
 		res := (r.Data != nil && r.Data.Get("name").(string) == "")
 		if res {
-			ic.addIgnoredResource(fmt.Sprintf("%s. ID=%s", resourceType, r.ID))
+			ic.addIgnoredResource(fmt.Sprintf("%s. id=%s", resourceType, r.ID))
 		}
 		return res
 	}

--- a/exporter/util_test.go
+++ b/exporter/util_test.go
@@ -406,7 +406,7 @@ func TestIgnoreObjectWithEmptyName(t *testing.T) {
 	require.NotNil(t, ignoreFunc)
 	assert.True(t, ignoreFunc(ic, r))
 	require.Equal(t, 1, len(ic.ignoredResources))
-	assert.Contains(t, ic.ignoredResources, "databricks_volume. ID=vtest")
+	assert.Contains(t, ic.ignoredResources, "databricks_volume. id=vtest")
 
 	d.Set("name", "test")
 	assert.False(t, ignoreFunc(ic, r))


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

In the current implementation when TF resource data has `.id` set to an empty string this means the following:

* object doesn't exist on the backend - a common situation for jobs and DLT pipelines when dependencies are deleted.
* Grants or Permissions are empty, so we don't need to generate a code for that.

Right now, all such objects are tracked and reported individually via the `Ignore` function, but not all objects have it. Also, for big exports, unnecessary objects pollute the internal state without any useful effect.

The current PR checks if `.id` is empty during the `Emit` phase, adds them to the list of ignored objects (except permissions & grants), and doesn't propagate them to the internal state.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
