### PR TITLE
Exporter: optimize generation of `databricks_group_member` resource

### DIFF
--- a/exporter/importables.go
+++ b/exporter/importables.go
@@ -903,10 +903,12 @@ var resourcesMap map[string]importable = map[string]importable{
 						ID:       parent.Value,
 					})
 					if parent.Type == "direct" {
+						id := fmt.Sprintf("%s|%s", parent.Value, g.ID)
 						ic.Emit(&resource{
 							Resource: "databricks_group_member",
-							ID:       fmt.Sprintf("%s|%s", parent.Value, g.ID),
+							ID:       id,
 							Name:     fmt.Sprintf("%s_%s_%s", parent.Display, parent.Value, g.DisplayName),
+							Data:     ic.makeGroupMemberData(id, parent.Value, g.ID),
 						})
 					}
 				}
@@ -917,10 +919,12 @@ var resourcesMap map[string]importable = map[string]importable{
 							ID:       x.Value,
 						})
 						if !builtInUserGroup {
+							id := fmt.Sprintf("%s|%s", g.ID, x.Value)
 							ic.Emit(&resource{
 								Resource: "databricks_group_member",
-								ID:       fmt.Sprintf("%s|%s", g.ID, x.Value),
+								ID:       id,
 								Name:     fmt.Sprintf("%s_%s_%s_%s", g.DisplayName, g.ID, x.Display, x.Value),
+								Data:     ic.makeGroupMemberData(id, g.ID, x.Value),
 							})
 						}
 					}
@@ -930,10 +934,12 @@ var resourcesMap map[string]importable = map[string]importable{
 							ID:       x.Value,
 						})
 						if !builtInUserGroup {
+							id := fmt.Sprintf("%s|%s", g.ID, x.Value)
 							ic.Emit(&resource{
 								Resource: "databricks_group_member",
-								ID:       fmt.Sprintf("%s|%s", g.ID, x.Value),
+								ID:       id,
 								Name:     fmt.Sprintf("%s_%s_%s_%s", g.DisplayName, g.ID, x.Display, x.Value),
+								Data:     ic.makeGroupMemberData(id, g.ID, x.Value),
 							})
 						}
 					}
@@ -943,10 +949,12 @@ var resourcesMap map[string]importable = map[string]importable{
 							ID:       x.Value,
 						})
 						if !builtInUserGroup {
+							id := fmt.Sprintf("%s|%s", g.ID, x.Value)
 							ic.Emit(&resource{
 								Resource: "databricks_group_member",
-								ID:       fmt.Sprintf("%s|%s", g.ID, x.Value),
+								ID:       id,
 								Name:     fmt.Sprintf("%s_%s_%s_%s", g.DisplayName, g.ID, x.Display, x.Value),
+								Data:     ic.makeGroupMemberData(id, g.ID, x.Value),
 							})
 						}
 					}

--- a/exporter/util.go
+++ b/exporter/util.go
@@ -371,10 +371,12 @@ func (ic *importContext) emitGroups(u scim.User) {
 			Resource: "databricks_group",
 			ID:       g.Value,
 		})
+		id := fmt.Sprintf("%s|%s", g.Value, u.ID)
 		ic.Emit(&resource{
 			Resource: "databricks_group_member",
-			ID:       fmt.Sprintf("%s|%s", g.Value, u.ID),
+			ID:       id,
 			Name:     fmt.Sprintf("%s_%s_%s_%s", g.Display, g.Value, u.DisplayName, u.ID),
+			Data:     ic.makeGroupMemberData(id, g.Value, u.ID),
 		})
 	}
 }
@@ -1494,4 +1496,13 @@ func dltIsMatchingCatalogAndSchema(ic *importContext, res *resource, ra *resourc
 
 	result := ra_catalog_name.(string) == res_catalog_name && ra_schema_name.(string) == res_schema_name
 	return result
+}
+
+func (ic *importContext) makeGroupMemberData(id, groupId, memberId string) *schema.ResourceData {
+	data := scim.ResourceGroupMember().ToResource().TestResourceData()
+	data.MarkNewResource()
+	data.SetId(id)
+	data.Set("group_id", groupId)
+	data.Set("member_id", memberId)
+	return data
 }


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

With this change we're generating resource data directly because we have all necessary information - this should decrease the number of REST API calls to SCIM API because the Read operation of `databricks_group_member` reads a group for each group member.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
