### PR TITLE
Exporter: follow up for #3556 - we need to include some UC objects into default listing

### DIFF
--- a/exporter/command.go
+++ b/exporter/command.go
@@ -41,6 +41,10 @@ func (ic *importContext) allServicesAndListing() (string, string) {
 			listing[ir.Service] = struct{}{}
 		}
 	}
+	// We need this to specify default listings of UC objects...
+	for _, ir := range []string{"uc-schemas", "uc-models", "uc-tables", "uc-volumes"} {
+		listing[ir] = struct{}{}
+	}
 	return strings.Join(maps.Keys(services), ","), strings.Join(maps.Keys(listing), ",")
 }
 


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->


The `uc-schemas`, `uc-models`, `uc-tables`, and `uc-volumes` services don't have explicit `List` operation, but we need to include them into the default listing so they will be exported in the default mode.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
