### PR TITLE
Exporter: Don't list directories in the incremental mode

### DIFF
--- a/docs/guides/experimental-exporter.md
+++ b/docs/guides/experimental-exporter.md
@@ -64,7 +64,7 @@ Services are just logical groups of resources used for filtering and organizatio
 
 * `access` - [databricks_permissions](../resources/permissions.md), [databricks_instance_profile](../resources/instance_profile.md) and [databricks_ip_access_list](../resources/ip_access_list.md).
 * `compute` - **listing** [databricks_cluster](../resources/cluster.md).
-* `directories` - **listing** [databricks_directory](../resources/directory.md).
+* `directories` - **listing** [databricks_directory](../resources/directory.md).  *Please note that directories aren't listed when running in the incremental mode! Only directories with updated notebooks will be emitted.*
 * `dlt` - **listing** [databricks_pipeline](../resources/pipeline.md).
 * `groups` - **listing** [databricks_group](../data-sources/group.md) with [membership](../resources/group_member.md) and [data access](../resources/group_instance_profile.md).
 * `jobs` - **listing** [databricks_job](../resources/job.md). Usually, there are more automated workflows than interactive clusters, so they get their own file in this tool's output.  *Please note that workflows deployed and maintained via [Databricks Asset Bundles](https://docs.databricks.com/en/dev-tools/bundles/index.html) aren't exported!*

--- a/exporter/importables.go
+++ b/exporter/importables.go
@@ -2052,6 +2052,9 @@ var resourcesMap map[string]importable = map[string]importable{
 		// TODO: think if we really need this, we need directories only for permissions,
 		// and only when they are different from parents & notebooks
 		List: func(ic *importContext) error {
+			if ic.incremental {
+				return nil
+			}
 			directoryList := ic.getAllDirectories()
 			for offset, directory := range directoryList {
 				if strings.HasPrefix(directory.Path, "/Repos") {

--- a/exporter/util.go
+++ b/exporter/util.go
@@ -1159,7 +1159,7 @@ func listNotebooksAndWorkspaceFiles(ic *importContext) error {
 	allObjects := ic.getAllWorkspaceObjects(func(objects []workspace.ObjectStatus) {
 		for _, object := range objects {
 			if object.ObjectType == workspace.Directory {
-				if !ic.incremental && object.Path != "/" {
+				if !ic.incremental && object.Path != "/" && ic.isServiceEnabled("directories") {
 					objectsChannel <- object
 				}
 			} else {
@@ -1184,7 +1184,11 @@ func listNotebooksAndWorkspaceFiles(ic *importContext) error {
 			if ic.shouldSkipWorkspaceObject(object, updatedSinceMs) {
 				continue
 			}
-			emitWorkpaceObject(ic, object)
+			if object.ObjectType == workspace.Directory && !ic.incremental && ic.isServiceEnabled("directories") && object.Path != "/" {
+				emitWorkpaceObject(ic, object)
+			} else if (object.ObjectType == workspace.Notebook || object.ObjectType == workspace.File) && ic.isServiceEnabled("notebooks") {
+				emitWorkpaceObject(ic, object)
+			}
 		}
 	}
 	return nil

--- a/exporter/util_test.go
+++ b/exporter/util_test.go
@@ -429,3 +429,13 @@ func TestEmitWorkspaceObjectParentDirectory(t *testing.T) {
 	assert.True(t, exists)
 	assert.Equal(t, dirPath, dir)
 }
+
+func TestDirectoryIncrementalMode(t *testing.T) {
+	ic := importContextForTest()
+	ic.incremental = true
+
+	// test direct listing
+	assert.Nil(t, resourcesMap["databricks_directory"].List(ic))
+	// test emit during workspace listing
+	assert.True(t, ic.shouldSkipWorkspaceObject(workspace.ObjectStatus{ObjectType: workspace.Directory}, 111111))
+}


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

Because directories don't have timestamps, we're ending up emitting all of them anyway...
Instead, rely on the behavior of them emitted as dependencies for notebooks

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
