### PR TITLE
add `databricks_table` data source

### DIFF
--- a/catalog/data_table.go
+++ b/catalog/data_table.go
@@ -1,0 +1,25 @@
+package catalog
+
+import (
+	"context"
+
+	"github.com/databricks/databricks-sdk-go"
+	"github.com/databricks/databricks-sdk-go/service/catalog"
+	"github.com/databricks/terraform-provider-databricks/common"
+)
+
+func DataSourceTable() common.Resource {
+	return common.WorkspaceData(func(ctx context.Context, data *struct {
+		Id    string             `json:"id,omitempty" tf:"computed"`
+		Name  string             `json:"name"`
+		Table *catalog.TableInfo `json:"table_info,omitempty" tf:"computed"`
+	}, w *databricks.WorkspaceClient) error {
+		table, err := w.Tables.GetByFullName(ctx, data.Name)
+		if err != nil {
+			return err
+		}
+		data.Table = table
+		data.Id = table.TableId
+		return nil
+	})
+}

--- a/catalog/data_table_test.go
+++ b/catalog/data_table_test.go
@@ -1,0 +1,44 @@
+package catalog
+
+import (
+	"testing"
+
+	"github.com/databricks/databricks-sdk-go/experimental/mocks"
+	"github.com/databricks/databricks-sdk-go/service/catalog"
+	"github.com/databricks/terraform-provider-databricks/qa"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestTableData(t *testing.T) {
+	qa.ResourceFixture{
+		MockWorkspaceClientFunc: func(m *mocks.MockWorkspaceClient) {
+			e := m.GetMockTablesAPI().EXPECT()
+			e.GetByFullName(mock.Anything, "a.b.c").Return(&catalog.TableInfo{
+				FullName: "a.b.c",
+				Name:     "c",
+			}, nil)
+		},
+		Resource: DataSourceTable(),
+		HCL: `
+		name="a.b.c"`,
+		Read:        true,
+		NonWritable: true,
+		ID:          "_",
+	}.ApplyAndExpectData(t, map[string]any{
+		"name": "a.b.c",
+		"table": map[string]any{
+			"full_name": "a.b.c",
+			"name":      "c",
+		},
+	})
+}
+
+func TestTableData_Error(t *testing.T) {
+	qa.ResourceFixture{
+		Fixtures:    qa.HTTPFailures,
+		Resource:    DataSourceTable(),
+		Read:        true,
+		NonWritable: true,
+		ID:          "_",
+	}.ExpectError(t, "i'm a teapot")
+}

--- a/catalog/data_table_test.go
+++ b/catalog/data_table_test.go
@@ -14,8 +14,10 @@ func TestTableData(t *testing.T) {
 		MockWorkspaceClientFunc: func(m *mocks.MockWorkspaceClient) {
 			e := m.GetMockTablesAPI().EXPECT()
 			e.GetByFullName(mock.Anything, "a.b.c").Return(&catalog.TableInfo{
-				FullName: "a.b.c",
-				Name:     "c",
+				FullName:  "a.b.c",
+				Name:      "c",
+				Owner:     "account users",
+				TableType: catalog.TableTypeExternal,
 			}, nil)
 		},
 		Resource: DataSourceTable(),
@@ -25,11 +27,11 @@ func TestTableData(t *testing.T) {
 		NonWritable: true,
 		ID:          "_",
 	}.ApplyAndExpectData(t, map[string]any{
-		"name": "a.b.c",
-		"table": map[string]any{
-			"full_name": "a.b.c",
-			"name":      "c",
-		},
+		"name":                    "a.b.c",
+		"table_info.0.full_name":  "a.b.c",
+		"table_info.0.name":       "c",
+		"table_info.0.owner":      "account users",
+		"table_info.0.table_type": "EXTERNAL",
 	})
 }
 

--- a/docs/data-sources/table.md
+++ b/docs/data-sources/table.md
@@ -19,9 +19,7 @@ data "databricks_table" "fct_transactions" {
 }
 
 resource "databricks_grants" "things" {
-  for_each = data.databricks_tables.things.ids
-
-  table = each.value
+  table = data.databricks_table.fct_transactions.name
 
   grant {
     principal  = "sensitive"

--- a/docs/data-sources/table.md
+++ b/docs/data-sources/table.md
@@ -1,0 +1,58 @@
+---
+subcategory: "Unity Catalog"
+---
+# databricks_table Data Source
+
+-> **Note** This data source could be only used with workspace-level provider!
+
+-> **Note** If you have a fully automated setup with workspaces created by [databricks_mws_workspaces](../resources/mws_workspaces.md) or [azurerm_databricks_workspace](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/databricks_workspace), please make sure to add [depends_on attribute](../guides/troubleshooting.md#data-resources-and-authentication-is-not-configured-errors) in order to prevent _default auth: cannot configure default credentials_ errors.
+
+Retrieves details of a specific table in Unity Catalog, that were created by Terraform or manually. Use [databricks_tables](tables.md) to retrieve multiple tables in Unity Catalog
+
+## Example Usage
+
+Read  on a specific table `main.certified.fct_transactions`:
+
+```hcl
+data "databricks_table" "fct_transactions" {
+  name = "main.certified.fct_transactions"
+}
+
+resource "databricks_grants" "things" {
+  for_each = data.databricks_tables.things.ids
+
+  table = each.value
+
+  grant {
+    principal  = "sensitive"
+    privileges = ["SELECT", "MODIFY"]
+  }
+}
+```
+
+## Argument Reference
+
+* `name` - (Required) Full name of the databricks_table: _`catalog`.`schema`.`table`_
+
+## Attribute Reference
+
+This data source exports the following attributes:
+
+* `table_info` - TableInfo object for a Unity Catalog table. This contains the following attributes:
+  * `name` - Name of table, relative to parent schema.
+  * `catalog_name` - Name of parent catalog.
+  * `schema_name` - Name of parent schema relative to its parent catalog.
+  * `table_type` - Table type, e.g. MANAGED, EXTERNAL, VIEW
+  * `data_source_format` - Table format, e.g. DELTA, CSV, JSON
+  * `view_definition` - View definition SQL (when `table_type` is VIEW, MATERIALIZED_VIEW, or STREAMING_TABLE)
+  * `view_dependencies` - View dependencies (when `table_type` is VIEW or MATERIALIZED_VIEW, STREAMING_TABLE)
+  * `columns` - Array of ColumnInfo objects of the table's columns
+  * `owner` - Current owner of the table
+  * `comment` - Free-form text description
+
+## Related Resources
+
+The following resources are used in the same context:
+
+* [databricks_grant](../resources/grant.md) to manage grants within Unity Catalog.
+* [databricks_tables](tables.md) to list all tables within a schema in Unity Catalog.

--- a/internal/acceptance/data_table_test.go
+++ b/internal/acceptance/data_table_test.go
@@ -1,0 +1,62 @@
+package acceptance
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/stretchr/testify/require"
+)
+
+func checkTableDataSourcePopulated(t *testing.T) func(s *terraform.State) error {
+	return func(s *terraform.State) error {
+		_, ok := s.Modules[0].Resources["data.databricks_table.this"]
+		require.True(t, ok, "data.databricks_table.this has to be there")
+		return nil
+	}
+}
+func TestUcAccDataSourceTable(t *testing.T) {
+	unityWorkspaceLevel(t, step{
+		Template: `
+		resource "databricks_catalog" "sandbox" {
+			name         = "sandbox{var.RANDOM}"
+			comment      = "this catalog is managed by terraform"
+			properties = {
+				purpose = "testing"
+			}
+		}
+		
+		resource "databricks_schema" "things" {
+			catalog_name = databricks_catalog.sandbox.id
+			name         = "things{var.RANDOM}"
+			comment      = "this database is managed by terraform"
+			properties = {
+				kind = "various"
+			}
+		}
+		
+		resource "databricks_table" "mytable" {
+			catalog_name = databricks_catalog.sandbox.id
+			schema_name = databricks_schema.things.name
+			name = "bar"
+			table_type = "MANAGED"
+			data_source_format = "DELTA"
+			
+			column {
+				name      = "id"
+				position  = 0
+				type_name = "INT"
+				type_text = "int"
+				type_json = "{\"name\":\"id\",\"type\":\"integer\",\"nullable\":true,\"metadata\":{}}"
+			}
+		}		
+
+		data "databricks_table" "this" {
+			name = databricks_table.mytable.full_name
+			depends_on = [
+				databricks_table.mytable,
+			]
+		}
+		`,
+		Check: checkTableDataSourcePopulated(t),
+	})
+}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -107,6 +107,7 @@ func DatabricksProvider() *schema.Provider {
 			"databricks_sql_warehouses":           sql.DataSourceWarehouses().ToResource(),
 			"databricks_storage_credential":       catalog.DataSourceStorageCredential().ToResource(),
 			"databricks_storage_credentials":      catalog.DataSourceStorageCredentials().ToResource(),
+			"databricks_table":                    catalog.DataSourceTable().ToResource(),
 			"databricks_tables":                   catalog.DataSourceTables().ToResource(),
 			"databricks_views":                    catalog.DataSourceViews().ToResource(),
 			"databricks_volumes":                  catalog.DataSourceVolumes().ToResource(),


### PR DESCRIPTION
## Changes
- Add `databricks_table` data source. This should simplify use cases where customers need to retrieve a specific table for permissions granting & other purposes

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [x] covered with integration tests in `internal/acceptance`
- [x] relevant acceptance tests are passing
- [x] using Go SDK
