### PR TITLE
Add `databricks_catalog` data source

### DIFF
--- a/catalog/data_catalog.go
+++ b/catalog/data_catalog.go
@@ -1,0 +1,25 @@
+package catalog
+
+import (
+	"context"
+
+	"github.com/databricks/databricks-sdk-go"
+	"github.com/databricks/databricks-sdk-go/service/catalog"
+	"github.com/databricks/terraform-provider-databricks/common"
+)
+
+func DataSourceCatalog() common.Resource {
+	return common.WorkspaceData(func(ctx context.Context, data *struct {
+		Id    string               `json:"id,omitempty" tf:"computed"`
+		Name  string               `json:"name"`
+		Catalog *catalog.CatalogInfo `json:"catalog_info,omitempty" tf:"computed"`
+	}, w *databricks.WorkspaceClient) error {
+		catalog, err := w.Catalogs.GetByName(ctx, data.Name)
+		if err != nil {
+			return err
+		}
+		data.Catalog = catalog
+		data.Id = catalog.Name
+		return nil
+	})
+}

--- a/catalog/data_catalog.go
+++ b/catalog/data_catalog.go
@@ -10,8 +10,8 @@ import (
 
 func DataSourceCatalog() common.Resource {
 	return common.WorkspaceData(func(ctx context.Context, data *struct {
-		Id    string               `json:"id,omitempty" tf:"computed"`
-		Name  string               `json:"name"`
+		Id      string               `json:"id,omitempty" tf:"computed"`
+		Name    string               `json:"name"`
 		Catalog *catalog.CatalogInfo `json:"catalog_info,omitempty" tf:"computed"`
 	}, w *databricks.WorkspaceClient) error {
 		catalog, err := w.Catalogs.GetByName(ctx, data.Name)

--- a/catalog/data_catalog_test.go
+++ b/catalog/data_catalog_test.go
@@ -1,0 +1,45 @@
+package catalog
+
+import (
+	"testing"
+
+	"github.com/databricks/databricks-sdk-go/experimental/mocks"
+	"github.com/databricks/databricks-sdk-go/service/catalog"
+	"github.com/databricks/terraform-provider-databricks/qa"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestCatalogData(t *testing.T) {
+	qa.ResourceFixture{
+		MockWorkspaceClientFunc: func(m *mocks.MockWorkspaceClient) {
+			e := m.GetMockCatalogsAPI().EXPECT()
+			e.GetByName(mock.Anything, "a").Return(&catalog.CatalogInfo{
+				Name:        "a",
+				Owner:       "account users",
+				CatalogType: "MANAGED_CATALOG",
+			}, nil)
+		},
+		Resource: DataSourceCatalog(),
+		HCL: `
+		name="a"`,
+		Read:        true,
+		NonWritable: true,
+		ID:          "_",
+	}.ApplyAndExpectData(t, map[string]any{
+		"name":                        "a",
+		"id":                          "a",
+		"catalog_info.0.name":         "a",
+		"catalog_info.0.owner":        "account users",
+		"catalog_info.0.catalog_type": "MANAGED_CATALOG",
+	})
+}
+
+func TestCatalogData_Error(t *testing.T) {
+	qa.ResourceFixture{
+		Fixtures:    qa.HTTPFailures,
+		Resource:    DataSourceCatalog(),
+		Read:        true,
+		NonWritable: true,
+		ID:          "_",
+	}.ExpectError(t, "i'm a teapot")
+}

--- a/docs/data-sources/catalog.md
+++ b/docs/data-sources/catalog.md
@@ -1,0 +1,67 @@
+---
+subcategory: "Unity Catalog"
+---
+# databricks_catalog Data Source
+
+-> **Note** This data source could be only used with workspace-level provider!
+
+-> **Note** If you have a fully automated setup with workspaces created by [databricks_mws_workspaces](../resources/mws_workspaces.md) or [azurerm_databricks_workspace](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/databricks_workspace), please make sure to add [depends_on attribute](../guides/troubleshooting.md#data-resources-and-authentication-is-not-configured-errors) in order to prevent _default auth: cannot configure default credentials_ errors.
+
+Retrieves details of a specific catalog in Unity Catalog, that were created by Terraform or manually. Use [databricks_catalogs](catalogs.md) to retrieve IDs of multiple catalogs from Unity Catalog
+
+## Example Usage
+
+Read  on a specific catalog `test`:
+
+```hcl
+data "databricks_catalog" "test" {
+  name = "test"
+}
+resource "databricks_grants" "things" {
+  catalog = data.databricks_catalog.test.name
+  grant {
+    principal  = "sensitive"
+    privileges = ["USE_CATALOG"]
+  }
+}
+```
+
+## Argument Reference
+
+* `name` - (Required) name of the catalog
+
+## Attribute Reference
+
+This data source exports the following attributes:
+
+* `id` - same as the `name`
+* `catalog_info` - the [CatalogInfo](https://pkg.go.dev/github.com/databricks/databricks-sdk-go/service/catalog#CatalogInfo) object for a Unity Catalog catalog. This contains the following attributes (see ):
+  * `name` - Name of the catalog
+  * `full_name` The full name of the catalog. Corresponds with the name field.
+  * `catalog_type` - Type of the catalog, e.g. `MANAGED_CATALOG`, `DELTASHARING_CATALOG`, `SYSTEM_CATALOG`, 
+  * `owner` - Current owner of the catalog
+  * `comment` - Free-form text description
+  * `storage_location` -  Storage Location URL (full path) for managed tables within catalog.
+  * `storage_root` - Storage root URL for managed tables within catalog.
+  * `connection_name` - The name of the connection to an external data source.
+  * `provider_name` - The name of delta sharing provider.
+  * `share_name` -  The name of the share under the share provider.
+  * `created_at` - Time at which this catalog was created, in epoch milliseconds.
+  * `created_by` - Username of catalog creator.
+  * `updated_at` - Time at which this catalog was last modified, in epoch milliseconds.
+  * `updated_by` - Username of user who last modified catalog.
+  * `effective_predictive_optimization_flag` - object describing applied predictive optimization flag.
+  * `enable_predictive_optimization` - Whether predictive optimization should be enabled for this object and objects under it.
+  * `isolation_mode` - Whether the current securable is accessible from all workspaces or a  specific set of workspaces.
+  * `metastore_id` - Unique identifier of parent metastore.
+  * `options` - A map of key-value properties attached to the securable.
+  * `properties` - A map of key-value properties attached to the securable.
+  * `securable_kind` - Kind of catalog securable.
+  * `securable_type` - Securable type.
+
+## Related Resources
+
+The following resources are used in the same context:
+
+* [databricks_grant](../resources/grant.md) to manage grants within Unity Catalog.
+* [databricks_catalogs](catalogs.md) to list all catalogs within Unity Catalog metastore.

--- a/internal/acceptance/data_catalog_test.go
+++ b/internal/acceptance/data_catalog_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestUcAccDataSourceTable(t *testing.T) {
+func TestUcAccDataSourceCatalog(t *testing.T) {
 	unityWorkspaceLevel(t, step{
 		Template: `
 		resource "databricks_catalog" "sandbox" {

--- a/internal/acceptance/data_catalog_test.go
+++ b/internal/acceptance/data_catalog_test.go
@@ -1,0 +1,34 @@
+package acceptance
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUcAccDataSourceTable(t *testing.T) {
+	unityWorkspaceLevel(t, step{
+		Template: `
+		resource "databricks_catalog" "sandbox" {
+			name         = "sandbox{var.RANDOM}"
+			comment      = "this catalog is managed by terraform"
+			properties = {
+				purpose = "testing"
+			}
+		}
+		
+		data "databricks_catalog" "this" {
+			name = databricks_catalog.name
+			depends_on = [
+				databricks_catalog.sandbox,
+			]
+		}
+		`,
+		Check: func(s *terraform.State) error {
+			_, ok := s.Modules[0].Resources["data.databricks_catalog.this"]
+			require.True(t, ok, "data.databricks_catalog.this has to be there")
+			return nil
+		},
+	})
+}

--- a/internal/acceptance/data_catalog_test.go
+++ b/internal/acceptance/data_catalog_test.go
@@ -19,7 +19,7 @@ func TestUcAccDataSourceTable(t *testing.T) {
 		}
 		
 		data "databricks_catalog" "this" {
-			name = databricks_catalog.name
+			name = databricks_catalog.sandbox.name
 			depends_on = [
 				databricks_catalog.sandbox,
 			]

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -74,6 +74,7 @@ func DatabricksProvider() *schema.Provider {
 			"databricks_cluster":                  clusters.DataSourceCluster().ToResource(),
 			"databricks_clusters":                 clusters.DataSourceClusters().ToResource(),
 			"databricks_cluster_policy":           policies.DataSourceClusterPolicy().ToResource(),
+			"databricks_catalog":                  catalog.DataSourceCatalog().ToResource(),
 			"databricks_catalogs":                 catalog.DataSourceCatalogs().ToResource(),
 			"databricks_current_config":           mws.DataSourceCurrentConfiguration().ToResource(),
 			"databricks_current_metastore":        catalog.DataSourceCurrentMetastore().ToResource(),


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

It could be used to retrieve information about specific catalogs inside UC metastore.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [x] covered with integration tests in `internal/acceptance`
- [x] relevant acceptance tests are passing
- [x] using Go SDK
