### PR TITLE
Jobs Methods GoSDK Migration 

### DIFF
--- a/common/reflect_resource.go
+++ b/common/reflect_resource.go
@@ -617,7 +617,7 @@ func iterFields(rv reflect.Value, path []string, s map[string]*schema.Schema, al
 			return fmt.Errorf("inconsistency: %s has omitempty, but is not optional", fieldName)
 		}
 		defaultEmpty := reflect.ValueOf(fieldSchema.Default).Kind() == reflect.Invalid
-		if fieldSchema.Optional && defaultEmpty && !omitEmpty {
+		if !isGoSDK && fieldSchema.Optional && defaultEmpty && !omitEmpty {
 			return fmt.Errorf("inconsistency: %s is optional, default is empty, but has no omitempty", fieldName)
 		}
 		err := cb(fieldSchema, append(path, fieldName), field)

--- a/docs/resources/job.md
+++ b/docs/resources/job.md
@@ -426,9 +426,9 @@ The following parameter is only available on task level.
 This block describes health conditions for a given job or an individual task. It consists of the following attributes:
 
 * `rules` - (List) list of rules that are represented as objects with the following attributes:
-  * `metric` - (Optional) string specifying the metric to check.  The only supported metric is `RUN_DURATION_SECONDS` (check [Jobs REST API documentation](https://docs.databricks.com/api/workspace/jobs/create) for the latest information).
-  * `op` - (Optional) string specifying the operation used to evaluate the given metric. The only supported operation is `GREATER_THAN`.
-  * `value` - (Optional) integer value used to compare to the given metric.
+  * `metric` - (Required) string specifying the metric to check.  The only supported metric is `RUN_DURATION_SECONDS` (check [Jobs REST API documentation](https://docs.databricks.com/api/workspace/jobs/create) for the latest information).
+  * `op` - (Required) string specifying the operation used to evaluate the given metric. The only supported operation is `GREATER_THAN`.
+  * `value` - (Required) integer value used to compare to the given metric.
 
 ### tags Configuration Map
 

--- a/jobs/jobs_api_go_sdk.go
+++ b/jobs/jobs_api_go_sdk.go
@@ -1,0 +1,297 @@
+package jobs
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"sort"
+	"time"
+
+	"github.com/databricks/databricks-sdk-go"
+	"github.com/databricks/databricks-sdk-go/apierr"
+	"github.com/databricks/databricks-sdk-go/service/compute"
+	"github.com/databricks/databricks-sdk-go/service/jobs"
+	"github.com/databricks/terraform-provider-databricks/clusters"
+	"github.com/databricks/terraform-provider-databricks/common"
+	"github.com/databricks/terraform-provider-databricks/repos"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func (js *JobSettingsResource) adjustTasks() {
+	js.sortTasksByKey()
+	for _, task := range js.Tasks {
+		sort.Slice(task.DependsOn, func(i, j int) bool {
+			return task.DependsOn[i].TaskKey < task.DependsOn[j].TaskKey
+		})
+		sortWebhookNotifications(task.WebhookNotifications)
+	}
+}
+
+func (js *JobSettingsResource) sortTasksByKey() {
+	sort.Slice(js.Tasks, func(i, j int) bool {
+		return js.Tasks[i].TaskKey < js.Tasks[j].TaskKey
+	})
+}
+
+func adjustTasks(cj *jobs.CreateJob) {
+	sortTasksByKey(cj)
+	for _, task := range cj.Tasks {
+		sort.Slice(task.DependsOn, func(i, j int) bool {
+			return task.DependsOn[i].TaskKey < task.DependsOn[j].TaskKey
+		})
+		sortWebhookNotifications(task.WebhookNotifications)
+	}
+}
+
+func sortTasksByKey(cj *jobs.CreateJob) {
+	sort.Slice(cj.Tasks, func(i, j int) bool {
+		return cj.Tasks[i].TaskKey < cj.Tasks[j].TaskKey
+	})
+}
+
+func (js *JobSettingsResource) sortWebhooksByID() {
+	sortWebhookNotifications(js.WebhookNotifications)
+}
+
+func sortWebhooksByID(cj *jobs.CreateJob) {
+	sortWebhookNotifications(cj.WebhookNotifications)
+}
+
+func (js *JobSettingsResource) isMultiTask() bool {
+	return js.Format == "MULTI_TASK" || len(js.Tasks) > 0
+}
+
+func getJobLifecycleManagerGoSdk(d *schema.ResourceData, m *common.DatabricksClient) jobLifecycleManager {
+	if d.Get("always_running").(bool) {
+		return alwaysRunningLifecycleManagerGoSdk{d: d, m: m}
+	}
+	if d.Get("control_run_state").(bool) {
+		return controlRunStateLifecycleManagerGoSdk{d: d, m: m}
+	}
+	return noopLifecycleManager{}
+}
+
+type alwaysRunningLifecycleManagerGoSdk struct {
+	d *schema.ResourceData
+	m *common.DatabricksClient
+}
+
+func (a alwaysRunningLifecycleManagerGoSdk) OnCreate(ctx context.Context) error {
+	w, err := a.m.WorkspaceClient()
+	if err != nil {
+		return err
+	}
+	jobID, err := parseJobId(a.d.Id())
+	if err != nil {
+		return err
+	}
+
+	return Start(jobID, a.d.Timeout(schema.TimeoutCreate), w, ctx)
+}
+
+func (a alwaysRunningLifecycleManagerGoSdk) OnUpdate(ctx context.Context) error {
+	w, err := a.m.WorkspaceClient()
+	if err != nil {
+		return err
+	}
+	jobID, err := parseJobId(a.d.Id())
+	if err != nil {
+		return err
+	}
+
+	err = StopActiveRun(jobID, a.d.Timeout(schema.TimeoutUpdate), w, ctx)
+
+	if err != nil {
+		return err
+	}
+	return Start(jobID, a.d.Timeout(schema.TimeoutUpdate), w, ctx)
+}
+
+type controlRunStateLifecycleManagerGoSdk struct {
+	d *schema.ResourceData
+	m *common.DatabricksClient
+}
+
+func (c controlRunStateLifecycleManagerGoSdk) OnCreate(ctx context.Context) error {
+	return nil
+}
+
+func (c controlRunStateLifecycleManagerGoSdk) OnUpdate(ctx context.Context) error {
+	if c.d.Get("continuous") == nil {
+		return nil
+	}
+
+	jobID, err := parseJobId(c.d.Id())
+	if err != nil {
+		return err
+	}
+
+	w, err := c.m.WorkspaceClient()
+	if err != nil {
+		return err
+	}
+
+	// Only use RunNow to stop the active run if the job is unpaused.
+	pauseStatus := c.d.Get("continuous.0.pause_status").(string)
+	if pauseStatus == "UNPAUSED" {
+		// Previously, RunNow() was not supported for continuous jobs. Now, calling RunNow()
+		// on a continuous job works, cancelling the active run if there is one, and resetting
+		// the exponential backoff timer. So, we try to call RunNow() first, and if it fails,
+		// we call StopActiveRun() instead.
+		_, err := w.Jobs.RunNow(ctx, jobs.RunNow{
+			JobId: jobID,
+		})
+
+		if err == nil {
+			return nil
+		}
+
+		// RunNow() returns 404 when the feature is disabled.
+		var apiErr *apierr.APIError
+		if errors.As(err, &apiErr) && apiErr.StatusCode != 404 {
+			return err
+		}
+	}
+
+	return StopActiveRun(jobID, c.d.Timeout(schema.TimeoutUpdate), w, ctx)
+}
+
+// Removing unnecesary fields out of ClusterSpec's ForceSendFields because the current terraform plugin sdk
+// has a limitation that it will always set unspecified values to the zero value.
+func removeUnnecessaryFieldsFromForceSendFields(clusterSpec *compute.ClusterSpec) error {
+	if clusterSpec.AwsAttributes != nil {
+		newAwsAttributesForceSendFields := []string{}
+		// These fields should never be 0.
+		unnecessaryFieldNamesForAwsAttributes := []string{
+			"SpotBidPricePercent",
+			"EbsVolumeCount",
+			"EbsVolumeIops",
+			"EbsVolumeSize",
+			"EbsVolumeThroughput",
+		}
+		for _, field := range clusterSpec.AwsAttributes.ForceSendFields {
+			if !slices.Contains(unnecessaryFieldNamesForAwsAttributes, field) {
+				newAwsAttributesForceSendFields = append(newAwsAttributesForceSendFields, field)
+			}
+		}
+		clusterSpec.AwsAttributes.ForceSendFields = newAwsAttributesForceSendFields
+	}
+	return nil
+}
+
+func updateJobClusterSpec(clusterSpec *compute.ClusterSpec, d *schema.ResourceData) {
+	clusters.ModifyRequestOnInstancePool(clusterSpec)
+	clusters.FixInstancePoolChangeIfAny(d, clusterSpec)
+	removeUnnecessaryFieldsFromForceSendFields(clusterSpec)
+}
+
+func prepareJobSettingsForUpdateGoSdk(d *schema.ResourceData, js *JobSettingsResource) {
+	if js.NewCluster != nil {
+		updateJobClusterSpec(js.NewCluster, d)
+	}
+	for _, task := range js.Tasks {
+		if task.NewCluster != nil {
+			updateJobClusterSpec(task.NewCluster, d)
+		}
+	}
+	for i := range js.JobClusters {
+		updateJobClusterSpec(&js.JobClusters[i].NewCluster, d)
+	}
+}
+
+func Create(createJob jobs.CreateJob, w *databricks.WorkspaceClient, ctx context.Context) (int64, error) {
+	adjustTasks(&createJob)
+	sortWebhooksByID(&createJob)
+	var gitSource *jobs.GitSource = createJob.GitSource
+	if gitSource != nil && gitSource.GitProvider == "" {
+		var provider jobs.GitProvider = jobs.GitProvider(repos.GetGitProviderFromUrl(gitSource.GitUrl))
+		gitSource.GitProvider = provider
+		if gitSource.GitProvider == "" {
+			return 0, fmt.Errorf("git source is not empty but Git Provider is not specified and cannot be guessed by url %+v", gitSource)
+		}
+		if gitSource.GitBranch == "" && gitSource.GitTag == "" && gitSource.GitCommit == "" {
+			return 0, fmt.Errorf("git source is not empty but none of branch, commit and tag is specified")
+		}
+	}
+	res, err := w.Jobs.Create(ctx, createJob)
+	return res.JobId, err
+}
+
+func Update(jobID int64, js JobSettingsResource, w *databricks.WorkspaceClient, ctx context.Context) error {
+	err := w.Jobs.Reset(ctx, jobs.ResetJob{
+		JobId:       jobID,
+		NewSettings: js.JobSettings,
+	})
+	return wrapMissingJobError(err, fmt.Sprintf("%d", jobID))
+}
+
+func Read(jobID int64, w *databricks.WorkspaceClient, ctx context.Context) (job *jobs.Job, err error) {
+	job, err = w.Jobs.GetByJobId(ctx, jobID)
+	err = wrapMissingJobError(err, fmt.Sprintf("%d", jobID))
+	if job.Settings != nil {
+		js := JobSettingsResource{JobSettings: *job.Settings}
+		js.adjustTasks()
+		js.sortWebhooksByID()
+	}
+
+	// Populate the `run_as` field. In the settings struct it can only be set on write and is not
+	// returned on read. Therefore, we populate it from the top-level `run_as_user_name` field so
+	// that Terraform can still diff it with the intended state.
+	if job.Settings != nil && job.RunAsUserName != "" {
+		if common.StringIsUUID(job.RunAsUserName) {
+			job.Settings.RunAs = &jobs.JobRunAs{
+				ServicePrincipalName: job.RunAsUserName,
+			}
+		} else {
+			job.Settings.RunAs = &jobs.JobRunAs{
+				UserName: job.RunAsUserName,
+			}
+		}
+	}
+
+	return
+}
+
+func Start(jobID int64, timeout time.Duration, w *databricks.WorkspaceClient, ctx context.Context) error {
+	res, err := w.Jobs.RunNow(ctx, jobs.RunNow{
+		JobId: jobID,
+	})
+	if err != nil {
+		return err
+	}
+
+	_, err = res.GetWithTimeout(timeout)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func StopActiveRun(jobID int64, timeout time.Duration, w *databricks.WorkspaceClient, ctx context.Context) error {
+	runs, err := w.Jobs.ListRunsAll(ctx, jobs.ListRunsRequest{
+		JobId:      jobID,
+		ActiveOnly: true,
+	})
+	if err != nil {
+		return err
+	}
+	if len(runs) > 1 {
+		return fmt.Errorf("`always_running` must be specified only with "+
+			"`max_concurrent_runs = 1`. There are %d active runs", len(runs))
+	}
+	if len(runs) == 1 {
+		activeRun := runs[0]
+		res, err := w.Jobs.CancelRun(ctx, jobs.CancelRun{
+			RunId: activeRun.RunId,
+		})
+		if err != nil {
+			return fmt.Errorf("cannot cancel run %d: %v", activeRun.RunId, err)
+		}
+		_, err = res.GetWithTimeout(timeout)
+		if err != nil {
+			return fmt.Errorf("cannot cancel run, error waiting for run to be terminated %d: %v", activeRun.RunId, err)
+		}
+	}
+	return nil
+}

--- a/jobs/resource_job.go
+++ b/jobs/resource_job.go
@@ -99,7 +99,7 @@ type SqlTask struct {
 	Dashboard   *SqlDashboardTask `json:"dashboard,omitempty"`
 	Alert       *SqlAlertTask     `json:"alert,omitempty"`
 	File        *SqlFileTask      `json:"file,omitempty"`
-	WarehouseID string            `json:"warehouse_id,omitempty"`
+	WarehouseID string            `json:"warehouse_id"`
 	Parameters  map[string]string `json:"parameters,omitempty"`
 }
 
@@ -130,7 +130,7 @@ type ForEachTask struct {
 }
 
 type ForEachNestedTask struct {
-	TaskKey     string                `json:"task_key,omitempty"`
+	TaskKey     string                `json:"task_key"`
 	Description string                `json:"description,omitempty"`
 	DependsOn   []jobs.TaskDependency `json:"depends_on,omitempty"`
 	RunIf       string                `json:"run_if,omitempty"`
@@ -201,9 +201,9 @@ type GitSource struct {
 // End Jobs + Repo integration preview
 
 type JobHealthRule struct {
-	Metric    string `json:"metric,omitempty"`
-	Operation string `json:"op,omitempty"`
-	Value     int64  `json:"value,omitempty"`
+	Metric    string `json:"metric"`
+	Operation string `json:"op"`
+	Value     int64  `json:"value"`
 }
 
 type JobHealth struct {
@@ -211,7 +211,7 @@ type JobHealth struct {
 }
 
 type JobTaskSettings struct {
-	TaskKey     string                `json:"task_key,omitempty"`
+	TaskKey     string                `json:"task_key"`
 	Description string                `json:"description,omitempty"`
 	DependsOn   []jobs.TaskDependency `json:"depends_on,omitempty"`
 	RunIf       string                `json:"run_if,omitempty"`
@@ -246,8 +246,8 @@ type JobTaskSettings struct {
 }
 
 type JobCluster struct {
-	JobClusterKey string            `json:"job_cluster_key,omitempty" tf:"group:cluster_type"`
-	NewCluster    *clusters.Cluster `json:"new_cluster,omitempty" tf:"group:cluster_type"`
+	JobClusterKey string            `json:"job_cluster_key" tf:"group:cluster_type"`
+	NewCluster    *clusters.Cluster `json:"new_cluster" tf:"group:cluster_type"`
 }
 
 type ContinuousConf struct {
@@ -446,6 +446,42 @@ type JobsAPI struct {
 	context context.Context
 }
 
+var jobSpecAliases = map[string]string{
+	"tasks":        "task",
+	"parameters":   "parameter",
+	"job_clusters": "job_cluster",
+	"environments": "environment",
+}
+
+// JobCreate + JobSettingResource related aliases.
+var jobsAliases = map[string]map[string]string{
+	"jobs.JobSettingsResource": jobSpecAliases,
+	"jobs.JobCreateStruct":     jobSpecAliases,
+	"jobs.GitSource": {
+		"git_url":      "url",
+		"git_provider": "provider",
+		"git_branch":   "branch",
+		"git_tag":      "tag",
+		"git_commit":   "commit",
+	},
+	"jobs.Task": {
+		"libraries": "library",
+	},
+}
+
+// Need a struct for JobCreate because there are aliases we need and it'll be needed in the create method.
+type JobCreateStruct struct {
+	jobs.CreateJob
+}
+
+func (JobCreateStruct) Aliases() map[string]map[string]string {
+	return jobsAliases
+}
+
+func (JobCreateStruct) CustomizeSchema(s *common.CustomizableSchema) *common.CustomizableSchema {
+	return s
+}
+
 type JobSettingsResource struct {
 	jobs.JobSettings
 
@@ -469,25 +505,7 @@ type JobSettingsResource struct {
 }
 
 func (JobSettingsResource) Aliases() map[string]map[string]string {
-	aliases := map[string]map[string]string{
-		"jobs.JobSettingsResource": {
-			"tasks":        "task",
-			"parameters":   "parameter",
-			"job_clusters": "job_cluster",
-			"environments": "environment",
-		},
-		"jobs.GitSource": {
-			"git_url":      "url",
-			"git_provider": "provider",
-			"git_branch":   "branch",
-			"git_tag":      "tag",
-			"git_commit":   "commit",
-		},
-		"jobs.Task": {
-			"libraries": "library",
-		},
-	}
-	return aliases
+	return jobsAliases
 }
 
 func (JobSettingsResource) CustomizeSchema(s *common.CustomizableSchema) *common.CustomizableSchema {
@@ -591,13 +609,8 @@ func (JobSettingsResource) CustomizeSchema(s *common.CustomizableSchema) *common
 	s.SchemaPath("task", "for_each_task", "task", "new_cluster", "cluster_id").Schema.Computed = false
 
 	// ======= To keep consistency with the manually maintained schema, should be reverted once full migration is done. ======
-	s.SchemaPath("task", "task_key").SetOptional()
-	s.SchemaPath("task", "for_each_task", "task", "task_key").SetOptional()
 
 	s.SchemaPath("trigger", "table_update", "table_names").SetRequired()
-
-	s.SchemaPath("task", "sql_task", "warehouse_id").SetOptional()
-	s.SchemaPath("task", "for_each_task", "task", "sql_task", "warehouse_id").SetOptional()
 
 	s.SchemaPath("task", "python_wheel_task", "entry_point").SetOptional()
 	s.SchemaPath("task", "for_each_task", "task", "python_wheel_task", "entry_point").SetOptional()
@@ -608,10 +621,6 @@ func (JobSettingsResource) CustomizeSchema(s *common.CustomizableSchema) *common
 	s.SchemaPath("task", "sql_task", "alert", "subscriptions").SetRequired()
 	s.SchemaPath("task", "for_each_task", "task", "sql_task", "alert", "subscriptions").SetRequired()
 
-	s.SchemaPath("health", "rules", "metric").SetOptional()
-	s.SchemaPath("health", "rules", "op").SetOptional()
-	s.SchemaPath("health", "rules", "value").SetOptional()
-
 	s.SchemaPath("task", "new_cluster", "cluster_id").SetOptional()
 	s.SchemaPath("task", "for_each_task", "task", "new_cluster", "cluster_id").SetOptional()
 
@@ -619,25 +628,14 @@ func (JobSettingsResource) CustomizeSchema(s *common.CustomizableSchema) *common
 	s.SchemaPath("task", "health", "rules").SetRequired()
 	s.SchemaPath("task", "for_each_task", "task", "health", "rules").SetRequired()
 
-	s.SchemaPath("task", "health", "rules", "op").SetOptional()
-	s.SchemaPath("task", "for_each_task", "task", "health", "rules", "op").SetOptional()
-
-	s.SchemaPath("task", "health", "rules", "metric").SetOptional()
-	s.SchemaPath("task", "for_each_task", "task", "health", "rules", "metric").SetOptional()
-
-	s.SchemaPath("task", "health", "rules", "value").SetOptional()
-	s.SchemaPath("task", "for_each_task", "task", "health", "rules", "value").SetOptional()
-
-	s.SchemaPath("job_cluster", "job_cluster_key").SetOptional()
-	s.SchemaPath("job_cluster", "new_cluster").SetOptional()
 	s.SchemaPath("job_cluster", "new_cluster", "cluster_id").SetOptional()
-
 	s.SchemaPath("new_cluster", "cluster_id").SetOptional()
-
-	s.SchemaPath("git_source", "provider").SetOptional()
 
 	s.SchemaPath("library").Schema.Type = schema.TypeSet
 	s.SchemaPath("task", "library").Schema.Type = schema.TypeSet
+
+	// Technically this is required by the API, but marking it optional since we can infer it from the hostname.
+	s.SchemaPath("git_source", "provider").SetOptional()
 
 	return s
 }
@@ -959,6 +957,7 @@ func (a alwaysRunningLifecycleManager) OnCreate(ctx context.Context) error {
 	}
 	return NewJobsAPI(ctx, a.m).Start(jobID, a.d.Timeout(schema.TimeoutCreate))
 }
+
 func (a alwaysRunningLifecycleManager) OnUpdate(ctx context.Context) error {
 	api := NewJobsAPI(ctx, a.m)
 	jobID, err := parseJobId(a.d.Id())
@@ -1039,7 +1038,7 @@ var jobsGoSdkSchema = common.StructToSchema(JobSettingsResource{}, nil)
 
 func ResourceJob() common.Resource {
 	getReadCtx := func(ctx context.Context, d *schema.ResourceData) context.Context {
-		var js JobSettings
+		var js JobSettingsResource
 		common.DataToStructPointer(d, jobsGoSdkSchema, &js)
 		if js.isMultiTask() {
 			return context.WithValue(ctx, common.Api, common.API_2_1)
@@ -1054,7 +1053,7 @@ func ResourceJob() common.Resource {
 			Update: schema.DefaultTimeout(clusters.DefaultProvisionTimeout),
 		},
 		CustomizeDiff: func(ctx context.Context, d *schema.ResourceDiff) error {
-			var js JobSettings
+			var js JobSettingsResource
 			common.DiffToStructPointer(d, jobsGoSdkSchema, &js)
 			alwaysRunning := d.Get("always_running").(bool)
 			if alwaysRunning && js.MaxConcurrentRuns > 1 {
@@ -1073,12 +1072,12 @@ func ResourceJob() common.Resource {
 				if task.NewCluster == nil {
 					continue
 				}
-				if err := task.NewCluster.Validate(); err != nil {
+				if err := clusters.Validate(*task.NewCluster); err != nil {
 					return fmt.Errorf("task %s invalid: %w", task.TaskKey, err)
 				}
 			}
 			if js.NewCluster != nil {
-				if err := js.NewCluster.Validate(); err != nil {
+				if err := clusters.Validate(*js.NewCluster); err != nil {
 					return fmt.Errorf("invalid job cluster: %w", err)
 				}
 			}
@@ -1088,40 +1087,99 @@ func ResourceJob() common.Resource {
 			var js JobSettings
 			common.DataToStructPointer(d, jobsGoSdkSchema, &js)
 			if js.isMultiTask() {
-				ctx = context.WithValue(ctx, common.Api, common.API_2_1)
+				// Api 2.1
+				w, err := c.WorkspaceClient()
+				if err != nil {
+					return err
+				}
+				var cj JobCreateStruct
+				common.DataToStructPointer(d, jobsGoSdkSchema, &cj)
+				jobId, err := Create(cj.CreateJob, w, ctx)
+				if err != nil {
+					return err
+				}
+				d.SetId(fmt.Sprintf("%d", jobId))
+				return getJobLifecycleManagerGoSdk(d, c).OnCreate(ctx)
+			} else {
+				// Api 2.0
+				// TODO: Deprecate and remove this code path
+				jobsAPI := NewJobsAPI(ctx, c)
+				job, err := jobsAPI.Create(js)
+				if err != nil {
+					return err
+				}
+				d.SetId(job.ID())
+				return getJobLifecycleManager(d, c).OnCreate(ctx)
 			}
-			jobsAPI := NewJobsAPI(ctx, c)
-			job, err := jobsAPI.Create(js)
-			if err != nil {
-				return err
-			}
-			d.SetId(job.ID())
-			return getJobLifecycleManager(d, c).OnCreate(ctx)
 		},
 		Read: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
-			ctx = getReadCtx(ctx, d)
-			job, err := NewJobsAPI(ctx, c).Read(d.Id())
-			if err != nil {
-				return err
-			}
-			d.Set("url", c.FormatURL("#job/", d.Id()))
-			return common.StructToData(*job.Settings, jobsGoSdkSchema, d)
-		},
-		Update: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
-			var js JobSettings
+			var js JobSettingsResource
 			common.DataToStructPointer(d, jobsGoSdkSchema, &js)
 			if js.isMultiTask() {
-				ctx = context.WithValue(ctx, common.Api, common.API_2_1)
-			}
+				// Api 2.1
+				w, err := c.WorkspaceClient()
+				if err != nil {
+					return err
+				}
+				jobID, err := parseJobId(d.Id())
+				if err != nil {
+					return err
+				}
+				job, err := Read(jobID, w, ctx)
+				if err != nil {
+					return err
+				}
+				d.Set("url", c.FormatURL("#job/", d.Id()))
 
-			prepareJobSettingsForUpdate(d, js)
-
-			jobsAPI := NewJobsAPI(ctx, c)
-			err := jobsAPI.Update(d.Id(), js)
-			if err != nil {
-				return err
+				res := JobSettingsResource{
+					JobSettings: *job.Settings,
+				}
+				return common.StructToData(res, jobsGoSdkSchema, d)
+			} else {
+				// Api 2.0
+				// TODO: Deprecate and remove this code path
+				job, err := NewJobsAPI(ctx, c).Read(d.Id())
+				if err != nil {
+					return err
+				}
+				d.Set("url", c.FormatURL("#job/", d.Id()))
+				return common.StructToData(*job.Settings, jobsGoSdkSchema, d)
 			}
-			return getJobLifecycleManager(d, c).OnUpdate(ctx)
+		},
+		Update: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
+			var jsr JobSettingsResource
+			common.DataToStructPointer(d, jobsGoSdkSchema, &jsr)
+			if jsr.isMultiTask() {
+				// Api 2.1
+				prepareJobSettingsForUpdateGoSdk(d, &jsr)
+				jobID, err := parseJobId(d.Id())
+				if err != nil {
+					return err
+				}
+				w, err := c.WorkspaceClient()
+				if err != nil {
+					return err
+				}
+				err = Update(jobID, jsr, w, ctx)
+				if err != nil {
+					return err
+				}
+				return getJobLifecycleManagerGoSdk(d, c).OnUpdate(ctx)
+			} else {
+				// Api 2.0
+				// TODO: Deprecate and remove this code path
+				var js JobSettings
+				common.DataToStructPointer(d, jobsGoSdkSchema, &js)
+
+				prepareJobSettingsForUpdate(d, js)
+
+				jobsAPI := NewJobsAPI(ctx, c)
+				err := jobsAPI.Update(d.Id(), js)
+				if err != nil {
+					return err
+				}
+				return getJobLifecycleManager(d, c).OnUpdate(ctx)
+			}
 		},
 		Delete: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
 			ctx = getReadCtx(ctx, d)

--- a/jobs/resource_job_test.go
+++ b/jobs/resource_job_test.go
@@ -1885,7 +1885,6 @@ func TestResourceJobCreateFromGitSource(t *testing.T) {
 				import_from_git_branch = "main"
 				dirty_state = "NOT_SYNCED"
 			}
-			provider = "gitHub"
 		}
 
 		task {

--- a/jobs/resource_job_test.go
+++ b/jobs/resource_job_test.go
@@ -996,19 +996,19 @@ func TestResourceJobCreate_SqlSubscriptions(t *testing.T) {
 			{
 				Method:   "POST",
 				Resource: "/api/2.1/jobs/create",
-				ExpectedRequest: JobSettings{
+				ExpectedRequest: jobs.CreateJob{
 					Name:              "TF SQL task subscriptions",
 					MaxConcurrentRuns: 1,
-					Tasks: []JobTaskSettings{
+					Tasks: []jobs.Task{
 						{
 							TaskKey: "a",
-							SqlTask: &SqlTask{
-								WarehouseID: "dca3a0ba199040eb",
-								Alert: &SqlAlertTask{
-									AlertID: "3cf91a42-6217-4f3c-a6f0-345d489051b9",
-									Subscriptions: []SqlSubscription{
+							SqlTask: &jobs.SqlTask{
+								WarehouseId: "dca3a0ba199040eb",
+								Alert: &jobs.SqlTaskAlert{
+									AlertId: "3cf91a42-6217-4f3c-a6f0-345d489051b9",
+									Subscriptions: []jobs.SqlTaskSubscription{
 										{UserName: "user@domain.com"},
-										{DestinationID: "Test"},
+										{DestinationId: "Test"},
 									},
 									PauseSubscriptions: true,
 								},
@@ -1016,15 +1016,17 @@ func TestResourceJobCreate_SqlSubscriptions(t *testing.T) {
 						},
 						{
 							TaskKey: "d",
-							SqlTask: &SqlTask{
-								WarehouseID: "dca3a0ba199040eb",
-								Dashboard: &SqlDashboardTask{
-									DashboardID: "d81a7760-7fd2-443e-bf41-95a60c2f4c7c",
-									Subscriptions: []SqlSubscription{
+							SqlTask: &jobs.SqlTask{
+								WarehouseId: "dca3a0ba199040eb",
+								Dashboard: &jobs.SqlTaskDashboard{
+									DashboardId:        "d81a7760-7fd2-443e-bf41-95a60c2f4c7c",
+									PauseSubscriptions: false,
+									Subscriptions: []jobs.SqlTaskSubscription{
 										{UserName: "user@domain.com"},
-										{DestinationID: "Test"},
+										{DestinationId: "Test"},
 									},
-									CustomSubject: "test",
+									CustomSubject:   "test",
+									ForceSendFields: []string{"PauseSubscriptions"},
 								},
 							},
 						},
@@ -1037,20 +1039,20 @@ func TestResourceJobCreate_SqlSubscriptions(t *testing.T) {
 			{
 				Method:   "GET",
 				Resource: "/api/2.1/jobs/get?job_id=789",
-				Response: Job{
-					JobID: 789,
-					Settings: &JobSettings{
+				Response: jobs.Job{
+					JobId: 789,
+					Settings: &jobs.JobSettings{
 						Name: "TF SQL task subscriptions",
-						Tasks: []JobTaskSettings{
+						Tasks: []jobs.Task{
 							{
 								TaskKey: "a",
-								SqlTask: &SqlTask{
-									WarehouseID: "dca3a0ba199040eb",
-									Alert: &SqlAlertTask{
-										AlertID: "3cf91a42-6217-4f3c-a6f0-345d489051b9",
-										Subscriptions: []SqlSubscription{
+								SqlTask: &jobs.SqlTask{
+									WarehouseId: "dca3a0ba199040eb",
+									Alert: &jobs.SqlTaskAlert{
+										AlertId: "3cf91a42-6217-4f3c-a6f0-345d489051b9",
+										Subscriptions: []jobs.SqlTaskSubscription{
 											{UserName: "user@domain.com"},
-											{DestinationID: "Test"},
+											{DestinationId: "Test"},
 										},
 										PauseSubscriptions: true,
 									},
@@ -1058,13 +1060,13 @@ func TestResourceJobCreate_SqlSubscriptions(t *testing.T) {
 							},
 							{
 								TaskKey: "d",
-								SqlTask: &SqlTask{
-									WarehouseID: "dca3a0ba199040eb",
-									Dashboard: &SqlDashboardTask{
-										DashboardID: "d81a7760-7fd2-443e-bf41-95a60c2f4c7c",
-										Subscriptions: []SqlSubscription{
+								SqlTask: &jobs.SqlTask{
+									WarehouseId: "dca3a0ba199040eb",
+									Dashboard: &jobs.SqlTaskDashboard{
+										DashboardId: "d81a7760-7fd2-443e-bf41-95a60c2f4c7c",
+										Subscriptions: []jobs.SqlTaskSubscription{
 											{UserName: "user@domain.com"},
-											{DestinationID: "Test"},
+											{DestinationId: "Test"},
 										},
 										CustomSubject: "test",
 									},
@@ -1825,7 +1827,6 @@ func TestResourceJobCreateFromGitSource(t *testing.T) {
 				Method:   "POST",
 				Resource: "/api/2.1/jobs/create",
 				ExpectedRequest: JobSettings{
-					ExistingClusterID: "abc",
 					Tasks: []JobTaskSettings{
 						{
 							TaskKey: "b",
@@ -1872,7 +1873,7 @@ func TestResourceJobCreateFromGitSource(t *testing.T) {
 		},
 		Create:   true,
 		Resource: ResourceJob(),
-		HCL: `existing_cluster_id = "abc"
+		HCL: `
 		max_concurrent_runs = 1
 		name = "GitSourceJob"
 
@@ -1884,6 +1885,7 @@ func TestResourceJobCreateFromGitSource(t *testing.T) {
 				import_from_git_branch = "main"
 				dirty_state = "NOT_SYNCED"
 			}
+			provider = "gitHub"
 		}
 
 		task {
@@ -1973,7 +1975,7 @@ func TestResourceJobCreateFromGitSourceWithoutProviderFail(t *testing.T) {
 			}
 		}
 	`,
-	}.ExpectError(t, "git source is not empty but Git Provider is not specified and cannot be guessed by url &{Url:https://custom.git.hosting.com/databricks/terraform-provider-databricks Provider: Branch: Tag:0.4.8 Commit: JobSource:<nil>}")
+	}.ExpectError(t, "git source is not empty but Git Provider is not specified and cannot be guessed by url &{GitBranch: GitCommit: GitProvider: GitSnapshot:<nil> GitTag:0.4.8 GitUrl:https://custom.git.hosting.com/databricks/terraform-provider-databricks JobSource:<nil> ForceSendFields:[]}")
 }
 
 func TestResourceJobCreateSingleNode_Fail(t *testing.T) {
@@ -2205,6 +2207,7 @@ func TestResourceJobUpdate_RunIfSuppressesDiffIfAllSuccess(t *testing.T) {
 						MaxConcurrentRuns: 1,
 						Tasks: []JobTaskSettings{
 							{
+								TaskKey: "task1",
 								NotebookTask: &NotebookTask{
 									NotebookPath: "/foo/bar",
 								},
@@ -2214,9 +2217,11 @@ func TestResourceJobUpdate_RunIfSuppressesDiffIfAllSuccess(t *testing.T) {
 								RunIf: "ALL_SUCCESS",
 							},
 							{
+								TaskKey: "task2",
 								ForEachTask: &ForEachTask{
 									Inputs: "abc",
 									Task: ForEachNestedTask{
+										TaskKey:      "task3",
 										NotebookTask: &NotebookTask{NotebookPath: "/bar/foo"},
 										// The diff is suppressed here. Value is from
 										// the terraform state.
@@ -2238,13 +2243,16 @@ func TestResourceJobUpdate_RunIfSuppressesDiffIfAllSuccess(t *testing.T) {
 						Name: "My job",
 						Tasks: []JobTaskSettings{
 							{
+								TaskKey:      "task1",
 								NotebookTask: &NotebookTask{NotebookPath: "/foo/bar"},
 								RunIf:        "ALL_SUCCESS",
 							},
 							{
+								TaskKey: "task2",
 								ForEachTask: &ForEachTask{
 									Inputs: "abc",
 									Task: ForEachNestedTask{
+										TaskKey:      "task3",
 										NotebookTask: &NotebookTask{NotebookPath: "/bar/foo"},
 										RunIf:        "ALL_SUCCESS",
 									},
@@ -2265,14 +2273,17 @@ func TestResourceJobUpdate_RunIfSuppressesDiffIfAllSuccess(t *testing.T) {
 		HCL: `
 		name = "My job"
 		task {
+			task_key = "task1"
 			notebook_task {
 				notebook_path = "/foo/bar"
 			}
 		}
 		task {
+			task_key = "task2"
 			for_each_task {
 				inputs = "abc"
 				task {
+					task_key = "task3"
 					notebook_task {
 						notebook_path = "/bar/foo"
 					}
@@ -2295,6 +2306,7 @@ func TestResourceJobUpdate_RunIfDoesNotSuppressIfNotAllSuccess(t *testing.T) {
 						MaxConcurrentRuns: 1,
 						Tasks: []JobTaskSettings{
 							{
+								TaskKey: "task1",
 								NotebookTask: &NotebookTask{
 									NotebookPath: "/foo/bar",
 								},
@@ -2304,9 +2316,11 @@ func TestResourceJobUpdate_RunIfDoesNotSuppressIfNotAllSuccess(t *testing.T) {
 								// RunIf is not set, as implied from the HCL config.
 							},
 							{
+								TaskKey: "task2",
 								ForEachTask: &ForEachTask{
 									Inputs: "abc",
 									Task: ForEachNestedTask{
+										TaskKey:      "task3",
 										NotebookTask: &NotebookTask{NotebookPath: "/bar/foo"},
 										// The diff is not suppressed. RunIf is
 										// not set, as implied from the HCL config.
@@ -2327,13 +2341,16 @@ func TestResourceJobUpdate_RunIfDoesNotSuppressIfNotAllSuccess(t *testing.T) {
 						Name: "My job",
 						Tasks: []JobTaskSettings{
 							{
+								TaskKey:      "task1",
 								NotebookTask: &NotebookTask{NotebookPath: "/foo/bar"},
 								RunIf:        "AT_LEAST_ONE_FAILED",
 							},
 							{
+								TaskKey: "task2",
 								ForEachTask: &ForEachTask{
 									Task: ForEachNestedTask{
-										RunIf: "AT_LEAST_ONE_FAILED",
+										TaskKey: "task3",
+										RunIf:   "AT_LEAST_ONE_FAILED",
 									},
 								},
 							},
@@ -2352,14 +2369,17 @@ func TestResourceJobUpdate_RunIfDoesNotSuppressIfNotAllSuccess(t *testing.T) {
 		HCL: `
 		name = "My job"
 		task {
+			task_key = "task1"
 			notebook_task {
 				notebook_path = "/foo/bar"
 			}
 		}
 		task {
+			task_key = "task2"
 			for_each_task {
 				inputs = "abc"
 				task {
+					task_key = "task3"
 					notebook_task {
 						notebook_path = "/bar/foo"
 					}
@@ -2376,58 +2396,44 @@ func TestResourceJobUpdate_NodeTypeToInstancePool(t *testing.T) {
 			{
 				Method:   "POST",
 				Resource: "/api/2.1/jobs/reset",
-				ExpectedRequest: UpdateJobRequest{
-					JobID: 789,
-					NewSettings: &JobSettings{
-						NewCluster: &clusters.Cluster{
-							InstancePoolID:       "instance-pool-worker",
-							DriverInstancePoolID: "instance-pool-driver",
-							SparkVersion:         "spark-1",
-							NumWorkers:           1,
-						},
-						Tasks: []JobTaskSettings{
+				ExpectedRequest: jobs.ResetJob{
+					JobId: 789,
+					NewSettings: jobs.JobSettings{
+						JobClusters: []jobs.JobCluster{
 							{
-								NewCluster: &clusters.Cluster{
-									InstancePoolID:       "instance-pool-worker-task",
-									DriverInstancePoolID: "instance-pool-driver-task",
-									SparkVersion:         "spark-2",
-									NumWorkers:           2,
-								},
-							},
-						},
-						JobClusters: []JobCluster{
-							{
-								NewCluster: &clusters.Cluster{
-									InstancePoolID:       "instance-pool-worker-job",
-									DriverInstancePoolID: "instance-pool-driver-job",
+								JobClusterKey: "job_cluster_1",
+								NewCluster: compute.ClusterSpec{
+									InstancePoolId:       "instance-pool-worker-job",
+									DriverInstancePoolId: "instance-pool-driver-job",
 									SparkVersion:         "spark-3",
 									NumWorkers:           3,
 								},
 							},
 						},
-						Name:                   "Featurizer New",
-						MaxRetries:             3,
-						MinRetryIntervalMillis: 5000,
-						RetryOnTimeout:         true,
-						MaxConcurrentRuns:      1,
+						Tasks: []jobs.Task{
+							{
+								TaskKey: "task1",
+								NewCluster: &compute.ClusterSpec{
+									InstancePoolId:       "instance-pool-worker-task",
+									DriverInstancePoolId: "instance-pool-driver-task",
+									SparkVersion:         "spark-2",
+									NumWorkers:           2,
+								},
+							},
+						},
+						Name:              "Featurizer New",
+						MaxConcurrentRuns: 1,
 					},
 				},
 			},
 			{
 				Method:   "GET",
 				Resource: "/api/2.1/jobs/get?job_id=789",
-				Response: Job{
-					JobID: 789,
-					Settings: &JobSettings{
-						NewCluster: &clusters.Cluster{
-							NodeTypeID:       "node-type-id",
-							DriverNodeTypeID: "driver-node-type-id",
-						},
-						Name:                   "Featurizer New",
-						MaxRetries:             3,
-						MinRetryIntervalMillis: 5000,
-						RetryOnTimeout:         true,
-						MaxConcurrentRuns:      1,
+				Response: jobs.Job{
+					JobId: 789,
+					Settings: &jobs.JobSettings{
+						Name:              "Featurizer New",
+						MaxConcurrentRuns: 1,
 					},
 				},
 			},
@@ -2436,21 +2442,14 @@ func TestResourceJobUpdate_NodeTypeToInstancePool(t *testing.T) {
 		Update:   true,
 		Resource: ResourceJob(),
 		InstanceState: map[string]string{
-			"new_cluster.0.node_type_id":                      "node-type-id-worker",
-			"new_cluster.0.driver_node_type_id":               "node-type-id-driver",
 			"task.0.new_cluster.0.node_type_id":               "node-type-id-worker-task",
 			"task.0.new_cluster.0.driver_node_type_id":        "node-type-id-driver-task",
 			"job_cluster.0.new_cluster.0.node_type_id":        "node-type-id-worker-job",
 			"job_cluster.0.new_cluster.0.driver_node_type_id": "node-type-id-driver-job",
 		},
 		HCL: `
-		new_cluster = {
-			instance_pool_id = "instance-pool-worker"
-			driver_instance_pool_id = "instance-pool-driver"
-			spark_version = "spark-1"
-			num_workers = 1
-		}
 		task = {
+			task_key = "task1"
 			new_cluster = {
 				instance_pool_id = "instance-pool-worker-task"
 				driver_instance_pool_id = "instance-pool-driver-task"
@@ -2459,6 +2458,7 @@ func TestResourceJobUpdate_NodeTypeToInstancePool(t *testing.T) {
 			}
 		}
 		job_cluster = {
+			job_cluster_key = "job_cluster_1"
 			new_cluster = {
 				instance_pool_id = "instance-pool-worker-job"
 				driver_instance_pool_id = "instance-pool-driver-job"
@@ -2467,10 +2467,7 @@ func TestResourceJobUpdate_NodeTypeToInstancePool(t *testing.T) {
 			}
 		}
 		max_concurrent_runs = 1
-		max_retries = 3
-		min_retry_interval_millis = 5000
-		name = "Featurizer New"
-		retry_on_timeout = true`,
+		name = "Featurizer New"`,
 	}.Apply(t)
 	assert.NoError(t, err)
 	assert.Equal(t, "789", d.Id(), "Id should be the same as in reading")
@@ -2483,57 +2480,42 @@ func TestResourceJobUpdate_InstancePoolToNodeType(t *testing.T) {
 			{
 				Method:   "POST",
 				Resource: "/api/2.1/jobs/reset",
-				ExpectedRequest: UpdateJobRequest{
-					JobID: 789,
-					NewSettings: &JobSettings{
-						NewCluster: &clusters.Cluster{
-							NodeTypeID:   "node-type-id-1",
-							SparkVersion: "spark-1",
-							NumWorkers:   1,
-						},
-						Tasks: []JobTaskSettings{
+				ExpectedRequest: jobs.UpdateJob{
+					JobId: 789,
+					NewSettings: &jobs.JobSettings{
+						Tasks: []jobs.Task{
 							{
-								NewCluster: &clusters.Cluster{
-									NodeTypeID:   "node-type-id-2",
+								TaskKey: "task1",
+								NewCluster: &compute.ClusterSpec{
+									NodeTypeId:   "node-type-id-2",
 									SparkVersion: "spark-2",
 									NumWorkers:   2,
 								},
 							},
 						},
-						JobClusters: []JobCluster{
+						JobClusters: []jobs.JobCluster{
 							{
-								NewCluster: &clusters.Cluster{
-									NodeTypeID:   "node-type-id-3",
+								JobClusterKey: "job_cluster_1",
+								NewCluster: compute.ClusterSpec{
+									NodeTypeId:   "node-type-id-3",
 									SparkVersion: "spark-3",
 									NumWorkers:   3,
 								},
 							},
 						},
-						Name:                   "Featurizer New",
-						MaxRetries:             3,
-						MinRetryIntervalMillis: 5000,
-						RetryOnTimeout:         true,
-						MaxConcurrentRuns:      1,
+						Name:              "Featurizer New",
+						MaxConcurrentRuns: 1,
 					},
 				},
 			},
 			{
 				Method:   "GET",
 				Resource: "/api/2.1/jobs/get?job_id=789",
-				Response: Job{
-					JobID: 789,
-					Settings: &JobSettings{
-						NewCluster: &clusters.Cluster{
-							NodeTypeID:           "node-type-id",
-							DriverNodeTypeID:     "driver-node-type-id",
-							InstancePoolID:       "instance-pool-id-worker",
-							DriverInstancePoolID: "instance-pool-id-driver",
-						},
-						Name:                   "Featurizer New",
-						MaxRetries:             3,
-						MinRetryIntervalMillis: 5000,
-						RetryOnTimeout:         true,
-						MaxConcurrentRuns:      1,
+				Response: jobs.Job{
+					JobId: 789,
+					Settings: &jobs.JobSettings{
+						Name:              "Featurizer New",
+						MaxConcurrentRuns: 1,
 					},
 				},
 			},
@@ -2542,9 +2524,6 @@ func TestResourceJobUpdate_InstancePoolToNodeType(t *testing.T) {
 		Update:   true,
 		Resource: ResourceJob(),
 		InstanceState: map[string]string{
-			"new_cluster.0.instance_pool_id":           "instance-pool-id-worker",
-			"new_cluster.0.driver_instance_pool_id":    "instance-pool-id-driver",
-			"new_cluster.0.node_type_id":               "node-type-id-worker",
 			"task.0.new_cluster.0.node_type_id":        "node-type-id-worker-task",
 			"task.0.instance_pool_id":                  "instance-pool-id-worker",
 			"task.0.driver_instance_pool_id":           "instance-pool-id-driver",
@@ -2553,12 +2532,8 @@ func TestResourceJobUpdate_InstancePoolToNodeType(t *testing.T) {
 			"job_cluster.0.driver_instance_pool_id":    "instance-pool-id-driver",
 		},
 		HCL: `
-		new_cluster = {
-			node_type_id = "node-type-id-1"
-			spark_version = "spark-1"
-			num_workers = 1
-		}
 		task = {
+			task_key = "task1"
 			new_cluster = {
 				node_type_id = "node-type-id-2"
 				spark_version = "spark-2"
@@ -2566,6 +2541,7 @@ func TestResourceJobUpdate_InstancePoolToNodeType(t *testing.T) {
 			}
 		}
 		job_cluster = {
+			job_cluster_key = "job_cluster_1"
 			new_cluster = {
 				node_type_id = "node-type-id-3"
 				spark_version = "spark-3"
@@ -2573,10 +2549,7 @@ func TestResourceJobUpdate_InstancePoolToNodeType(t *testing.T) {
 			}
 		}
 		max_concurrent_runs = 1
-		max_retries = 3
-		min_retry_interval_millis = 5000
-		name = "Featurizer New"
-		retry_on_timeout = true`,
+		name = "Featurizer New"`,
 	}.Apply(t)
 	assert.NoError(t, err)
 	assert.Equal(t, "789", d.Id(), "Id should be the same as in reading")
@@ -2595,6 +2568,7 @@ func TestResourceJobUpdate_Tasks(t *testing.T) {
 						Name: "Featurizer New",
 						Tasks: []JobTaskSettings{
 							{
+								TaskKey:           "task1",
 								ExistingClusterID: "abc",
 								SparkJarTask: &SparkJarTask{
 									MainClassName: "com.labs.BarMain",
@@ -2615,6 +2589,7 @@ func TestResourceJobUpdate_Tasks(t *testing.T) {
 					Settings: &JobSettings{
 						Tasks: []JobTaskSettings{
 							{
+								TaskKey:           "task1",
 								ExistingClusterID: "abc",
 								SparkJarTask: &SparkJarTask{
 									MainClassName: "com.labs.BarMain",
@@ -2631,6 +2606,7 @@ func TestResourceJobUpdate_Tasks(t *testing.T) {
 		HCL: `
 		name = "Featurizer New"
 		task {
+			task_key = "task1"
 			existing_cluster_id = "abc"
 			spark_jar_task {
 				main_class_name = "com.labs.BarMain"

--- a/jobs/resource_job_webhook_test.go
+++ b/jobs/resource_job_webhook_test.go
@@ -19,6 +19,7 @@ func TestResourceJobUpdate_WebhookNotifications(t *testing.T) {
 						Name: "Webhook test",
 						Tasks: []JobTaskSettings{
 							{
+								TaskKey:           "task1",
 								ExistingClusterID: "abc",
 							},
 						},
@@ -42,6 +43,7 @@ func TestResourceJobUpdate_WebhookNotifications(t *testing.T) {
 						Name: "Webhook test",
 						Tasks: []JobTaskSettings{
 							{
+								TaskKey:           "task1",
 								ExistingClusterID: "abc",
 							},
 						},
@@ -72,6 +74,7 @@ func TestResourceJobUpdate_WebhookNotifications(t *testing.T) {
 		HCL: `
 		name = "Webhook test"
 		task {
+			task_key = "task1"
 			existing_cluster_id = "abc"
 		}
 		webhook_notifications {


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
- Migrated `Read, Update, Create` methods to the go-sdk migration for the jobs resource
  - Updated cluster related methods to accept `compute.ClusterSpec` as a valid input in `resource_cluster.go`
  - Created `jobs_api_go_sdk.go` to replicate go-sdk versions of necessary methods that were part of `JobsApi`
  - Updated jobs manually written schema to be consistent with the go-sdk schema, mostly taking out some `omitempty`
  - Updated the `Read, Update, Create` methods to have two branches, if it's api2.0, make it run the exact same code as before, otherwise, use the go-sdk to perform the same actions
  - Updated unit tests to include some missing fields that are newly marked as required, such as `task_key`
  - Updated doc about schema changes
  - Removed `autotermination_minutes` from the cluster spec used by jobs because it is confirmed to be never useful for jobs


## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [x] covered with integration tests in `internal/acceptance`
- [x] relevant acceptance tests are passing
- [x] using Go SDK
