### PR TITLE
Add TestMwsAccServicePrincipalResourceOnAws to flaky tests

### DIFF
--- a/test-config.yaml
+++ b/test-config.yaml
@@ -9,3 +9,6 @@ ignored_tests:
     - package: github.com/databricks/terraform-provider-databricks/internal/acceptance
       test_name: TestAccServicePrincipalResourceOnAws
       comment: Failures due to read-after-write inconsistency. Tracked in https://databricks.atlassian.net/browse/ES-1100061
+    - package: github.com/databricks/terraform-provider-databricks/internal/acceptance
+      test_name: TestMwsAccServicePrincipalResourceOnAws
+      comment: Failures due to read-after-write inconsistency. Tracked in https://databricks.atlassian.net/browse/ES-1100061


### PR DESCRIPTION
## Changes
Adding another SCIM test that is flaky to the test-config.yaml to allow it to be ignored on failures.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
