### PR TITLE
Fix bug in collectionToMaps

### DIFF
--- a/common/reflect_resource.go
+++ b/common/reflect_resource.go
@@ -667,11 +667,16 @@ func collectionToMaps(v any, s *schema.Schema, aliases map[string]map[string]str
 			fieldPath := strings.Join(path, ".")
 			switch fieldSchema.Type {
 			case schema.TypeList, schema.TypeSet:
-				nv, err := collectionToMaps(fieldValue, fieldSchema, aliases)
-				if err != nil {
-					return fmt.Errorf("%s: %v", path, err)
+				_, ok := fieldSchema.Elem.(*schema.Schema)
+				if ok {
+					data[fieldName] = fieldValue
+				} else {
+					nv, err := collectionToMaps(fieldValue, fieldSchema, aliases)
+					if err != nil {
+						return fmt.Errorf("%s: %v", path, err)
+					}
+					data[fieldName] = nv
 				}
-				data[fieldName] = nv
 			case schema.TypeBool, schema.TypeInt:
 				if !isIntOrBoolExplicitlySet(v, valueField) {
 					return nil

--- a/common/reflect_resource.go
+++ b/common/reflect_resource.go
@@ -669,6 +669,7 @@ func collectionToMaps(v any, s *schema.Schema, aliases map[string]map[string]str
 			case schema.TypeList, schema.TypeSet:
 				_, ok := fieldSchema.Elem.(*schema.Schema)
 				if ok {
+					// If Elem is a *schema.Schema, we do not call collectionToMaps but directly populate the map with fieldValue.
 					data[fieldName] = fieldValue
 				} else {
 					nv, err := collectionToMaps(fieldValue, fieldSchema, aliases)

--- a/common/reflect_resource_test.go
+++ b/common/reflect_resource_test.go
@@ -79,7 +79,10 @@ type testStruct struct {
 	TfOptional     string            `json:"tf_optional" tf:"optional"`
 	Hidden         string            `json:"-"`
 	Hidden2        string
+	Indirect       []IndirectString `json:"indirect"`
 }
+
+type IndirectString string
 
 type testRecursiveStruct struct {
 	Task  *testJobTask `json:"task,omitempty"`
@@ -957,4 +960,13 @@ func TestStructToSchema_recursive(t *testing.T) {
 	// Should error out on the 3rd level of for_each_task.
 	_, err = SchemaPath(s, "task", "for_each_task", "task", "for_each_task", "task", "for_each_task")
 	assert.Error(t, err)
+}
+
+func TestStructToData_IndirectString(t *testing.T) {
+	d := schema.TestResourceDataRaw(t, scm, map[string]any{})
+	d.MarkNewResource()
+	err := StructToData(testStruct{
+		Indirect: []IndirectString{"a"},
+	}, scm, d)
+	assert.NoError(t, err)
 }


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
- As mentioned in this [thread](https://github.com/databricks/terraform-provider-databricks/pull/3564#issuecomment-2104175779), there is a bug with `collectionToMaps`
- The reason is that in `collectionToMap`, in the callback function we pass into `iterFields`, we are not handling the case where a list schema's Elem` is a `*schema.Schema`.
- This PR basically takes the [block](https://github.com/databricks/terraform-provider-databricks/blob/ff8f028786eb146887cace71b6781c892c42a25e/common/reflect_resource.go#L773-L778) in the callback function in `StructToData` into `collectionToMaps` 

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->
- Tested by executing the failing unit test on the mentioned PR, verified it works
- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [x] covered with integration tests in `internal/acceptance`
- [x] relevant acceptance tests are passing
- [x] using Go SDK
