### PR TITLE
Make customizable error logs more readable

### DIFF
--- a/common/customizable_schema.go
+++ b/common/customizable_schema.go
@@ -194,7 +194,7 @@ func (s *CustomizableSchema) SetConflictsWith(value []string) *CustomizableSchem
 		panic("SetConflictsWith cannot take in an empty list")
 	}
 	if s.pathContainsMultipleItemsList() {
-		log.Printf("[DEBUG] ConflictsWith skipped for %v, path contains TypeList block with MaxItems not equal to 1", strings.Join(s.path, "."))
+		log.Printf("[DEBUG] ConflictsWith skipped for %v, path contains TypeList block with MaxItems not equal to 1", getPrefixedValue(s.context.path, value))
 		return s
 	}
 	s.Schema.ConflictsWith = getPrefixedValue(s.context.path, value)
@@ -206,7 +206,7 @@ func (s *CustomizableSchema) SetExactlyOneOf(value []string) *CustomizableSchema
 		panic("SetExactlyOneOf cannot take in an empty list")
 	}
 	if s.pathContainsMultipleItemsList() {
-		log.Printf("[DEBUG] ExactlyOneOf skipped for %v, path contains TypeList block with MaxItems not equal to 1", strings.Join(s.path, "."))
+		log.Printf("[DEBUG] ExactlyOneOf skipped for %v, path contains TypeList block with MaxItems not equal to 1", getPrefixedValue(s.context.path, value))
 		return s
 	}
 	s.Schema.ExactlyOneOf = getPrefixedValue(s.context.path, value)
@@ -218,7 +218,7 @@ func (s *CustomizableSchema) SetAtLeastOneOf(value []string) *CustomizableSchema
 		panic("SetAtLeastOneOf cannot take in an empty list")
 	}
 	if s.pathContainsMultipleItemsList() {
-		log.Printf("[DEBUG] AtLeastOneOf skipped for %v, path contains TypeList block with MaxItems not equal to 1", strings.Join(s.path, "."))
+		log.Printf("[DEBUG] AtLeastOneOf skipped for %v, path contains TypeList block with MaxItems not equal to 1", getPrefixedValue(s.context.path, value))
 		return s
 	}
 	s.Schema.AtLeastOneOf = getPrefixedValue(s.context.path, value)
@@ -230,7 +230,7 @@ func (s *CustomizableSchema) SetRequiredWith(value []string) *CustomizableSchema
 		panic("SetRequiredWith cannot take in an empty list")
 	}
 	if s.pathContainsMultipleItemsList() {
-		log.Printf("[DEBUG] SetRequiredWith skipped for %v, path contains TypeList block with MaxItems not equal to 1", strings.Join(s.path, "."))
+		log.Printf("[DEBUG] SetRequiredWith skipped for %v, path contains TypeList block with MaxItems not equal to 1", getPrefixedValue(s.context.path, value))
 		return s
 	}
 	s.Schema.RequiredWith = getPrefixedValue(s.context.path, value)


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
- Make customizable schema error messages more readable by providing the entire path with prefix
- This made debugging much easier, as I encountered such cases myself during the jobs go-sdk migration
- Before: `[DEBUG] ConflictsWith skipped for driver_instance_pool_id, path contains TypeList block with MaxItems not equal to 1`
- After `[DEBUG] ConflictsWith skipped for jobs.job_settings.new_cluster.driver_instance_pool_id, path contains TypeList block with MaxItems not equal to 1`

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [x] covered with integration tests in `internal/acceptance`
- [x] relevant acceptance tests are passing
- [x] using Go SDK
