### PR TITLE
[Fix] Fix issue with case sensitive group names in `databricks_group` resource

### DIFF
--- a/scim/groups.go
+++ b/scim/groups.go
@@ -59,7 +59,18 @@ func (a GroupsAPI) ReadByDisplayName(displayName, attributes string) (group Grou
 		err = fmt.Errorf("cannot find group: %s", displayName)
 		return
 	}
-	group = groupList.Resources[0]
+	if len(groupList.Resources) == 1 {
+		group = groupList.Resources[0]
+		return
+	}
+	for _, g := range groupList.Resources {
+		if g.DisplayName == displayName {
+			group = g
+			return
+		}
+	}
+
+	err = fmt.Errorf("cannot find group: %s", displayName)
 	return
 }
 

--- a/scim/groups_test.go
+++ b/scim/groups_test.go
@@ -1,0 +1,62 @@
+package scim
+
+import (
+	"context"
+	"testing"
+
+	"github.com/databricks/terraform-provider-databricks/common"
+
+	"github.com/databricks/terraform-provider-databricks/qa"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReadByDisplayName_CaseSensitive(t *testing.T) {
+	qa.HTTPFixturesApply(t, []qa.HTTPFixture{
+		{
+			Method:   "GET",
+			Resource: "/api/2.0/preview/scim/v2/Groups?filter=displayName%20eq%20%22Name%22",
+			Response: GroupList{
+				Resources: []Group{
+					{
+						DisplayName: "name",
+						ID:          "1",
+					},
+					{
+						DisplayName: "Name",
+						ID:          "2",
+					},
+				},
+			},
+		},
+		{
+			Method:   "GET",
+			Resource: "/api/2.0/preview/scim/v2/Groups?filter=displayName%20eq%20%22name%22",
+			Response: GroupList{
+				Resources: []Group{
+					{
+						DisplayName: "name",
+						ID:          "1",
+					},
+					{
+						DisplayName: "Name",
+						ID:          "2",
+					},
+				},
+			},
+		},
+	}, func(ctx context.Context, client *common.DatabricksClient) {
+		api := NewGroupsAPI(ctx, client)
+
+		// Test case-sensitive fetch for upper-case "Name"
+		group, err := api.ReadByDisplayName("Name", "")
+		assert.NoError(t, err)
+		assert.Equal(t, "Name", group.DisplayName)
+		assert.Equal(t, "2", group.ID)
+
+		// Test case-sensitive fetch for lower-case "name"
+		group, err = api.ReadByDisplayName("name", "")
+		assert.NoError(t, err)
+		assert.Equal(t, "name", group.DisplayName)
+		assert.Equal(t, "1", group.ID)
+	})
+}


### PR DESCRIPTION
- Fixes Issue #3596, issue with case sensitive group names in databricks_group resource
- Updated ReadByDisplayName function to ensure exact case-sensitive matching of group display names.
- This addresses the issue where groups with similar names but different cases were not correctly distinguished.

## Changes
<!-- Summary of your changes that are easy to understand -->
Databricks enforces uniqueness of group names with case sensitivity, so groups like "Admins" and "admins" can exist in the same workspace. When you filter for Databricks groups matching a name with the SCIM API, the name match is not case-sensitive, and it might return multiple groups. The current code just grabs the first group from the results when multiple groups are returned. With this code change, if the length of the returned group list is greater than 1, it loops through the returned groups and searches for a match on DisplayName. 

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->
Added a test in `groups_test.go` to check that when there's a lower-case "name" group and an upper-case "Name" group,  `ReadByDisplayName` will return the right one. 

- [X] `make test` run locally
- [X] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
