### PR TITLE
Modify state upgrader to remove `ebs_volume_iops` set to zero

### DIFF
--- a/clusters/resource_cluster.go
+++ b/clusters/resource_cluster.go
@@ -20,7 +20,7 @@ const DefaultProvisionTimeout = 30 * time.Minute
 const DbfsDeprecationWarning = "For init scripts use 'volumes', 'workspace' or cloud storage location instead of 'dbfs'."
 
 var clusterSchema = resourceClusterSchema()
-var clusterSchemaVersion = 3
+var clusterSchemaVersion = 4
 
 const (
 	numWorkerErr                     = "NumWorkers could be 0 only for SingleNode clusters. See https://docs.databricks.com/clusters/single-node.html for more details"
@@ -39,7 +39,7 @@ func ResourceCluster() common.Resource {
 		StateUpgraders: []schema.StateUpgrader{
 			{
 				Type:    clusterSchemaV0(),
-				Version: 2,
+				Version: 3,
 				Upgrade: removeZeroAwsEbsVolumeAttributes,
 			},
 		},
@@ -64,6 +64,10 @@ func removeZeroAwsEbsVolumeAttributes(ctx context.Context, rawState map[string]i
 			if awsAttributes["ebs_volume_count"] == 0 {
 				log.Printf("[INFO] remove zero ebs_volume_count")
 				delete(awsAttributes, "ebs_volume_count")
+			}
+			if awsAttributes["ebs_volume_iops"] == 0 {
+				log.Printf("[INFO] remove zero ebs_volume_iops")
+				delete(awsAttributes, "ebs_volume_iops")
 			}
 			if awsAttributes["ebs_volume_size"] == 0 {
 				log.Printf("[INFO] remove zero ebs_volume_size")


### PR DESCRIPTION
## Changes
Modify state upgrader to remove aws_attributes.ebs_volume_iops

## Tests
Tested manually, I was able to modify the cluster after using the repro

```
resource "databricks_cluster" "shared_autoscaling" {
  cluster_name            = "Shared Autoscaling"
  spark_version           = data.databricks_spark_version.latest_lts.id
  node_type_id            = data.databricks_node_type.smallest.id
  autotermination_minutes = 20

  aws_attributes {
    availability     = "SPOT" # Change to SPOT_WITH_FALLBACK
    ebs_volume_count = null
    ebs_volume_size  = null
    ebs_volume_type  = null
  }

  autoscale {
    min_workers = 1
    max_workers = 3
  }
}
```

And changing "SPOT" to "SPOT_WITH_FALLBACK"

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

Resolves issue #3599 
