### PR TITLE
Docs: remove usage of deprecated `azurerm` options from PL guides

### DIFF
--- a/docs/guides/azure-private-link-workspace-simplified.md
+++ b/docs/guides/azure-private-link-workspace-simplified.md
@@ -180,8 +180,7 @@ resource "azurerm_subnet" "private" {
   virtual_network_name = azurerm_virtual_network.this.name
   address_prefixes     = [cidrsubnet(var.cidr, 3, 1)]
 
-  enforce_private_link_endpoint_network_policies = true
-  enforce_private_link_service_network_policies  = true
+  private_endpoint_network_policies_enabled = true
 
   delegation {
     name = "databricks"
@@ -204,11 +203,11 @@ resource "azurerm_subnet_network_security_group_association" "private" {
 
 
 resource "azurerm_subnet" "plsubnet" {
-  name                                           = "${local.prefix}-privatelink"
-  resource_group_name                            = var.rg_name
-  virtual_network_name                           = azurerm_virtual_network.this.name
-  address_prefixes                               = [cidrsubnet(var.cidr, 3, 2)]
-  enforce_private_link_endpoint_network_policies = true
+  name                                      = "${local.prefix}-privatelink"
+  resource_group_name                       = var.rg_name
+  virtual_network_name                      = azurerm_virtual_network.this.name
+  address_prefixes                          = [cidrsubnet(var.cidr, 3, 2)]
+  private_endpoint_network_policies_enabled = true
 }
 
 ```

--- a/docs/guides/azure-private-link-workspace-standard.md
+++ b/docs/guides/azure-private-link-workspace-standard.md
@@ -236,8 +236,7 @@ resource "azurerm_subnet" "transit_private" {
   virtual_network_name = azurerm_virtual_network.transit_vnet.name
   address_prefixes     = [cidrsubnet(local.cidr_transit, 6, 1)]
 
-  enforce_private_link_endpoint_network_policies = true
-  enforce_private_link_service_network_policies  = true
+  private_endpoint_network_policies_enabled = true
 
   delegation {
     name = "databricks"
@@ -260,11 +259,11 @@ resource "azurerm_subnet_network_security_group_association" "transit_private" {
 
 
 resource "azurerm_subnet" "transit_plsubnet" {
-  name                                           = "${local.prefix}-transit-privatelink"
-  resource_group_name                            = var.rg_transit
-  virtual_network_name                           = azurerm_virtual_network.transit_vnet.name
-  address_prefixes                               = [cidrsubnet(local.cidr_transit, 6, 2)]
-  enforce_private_link_endpoint_network_policies = true
+  name                                      = "${local.prefix}-transit-privatelink"
+  resource_group_name                       = var.rg_transit
+  virtual_network_name                      = azurerm_virtual_network.transit_vnet.name
+  address_prefixes                          = [cidrsubnet(local.cidr_transit, 6, 2)]
+  private_endpoint_network_policies_enabled = true
 }
 
 resource "azurerm_private_endpoint" "transit_auth" {
@@ -435,8 +434,8 @@ resource "azurerm_subnet" "app_private" {
   virtual_network_name = azurerm_virtual_network.app_vnet.name
   address_prefixes     = [cidrsubnet(local.cidr_dp, 6, 1)]
 
-  enforce_private_link_endpoint_network_policies = true
-  enforce_private_link_service_network_policies  = true
+  private_endpoint_network_policies_enabled     = true
+  private_link_service_network_policies_enabled = true
 
   delegation {
     name = "databricks"
@@ -460,12 +459,12 @@ resource "azurerm_subnet_network_security_group_association" "app_private" {
 
 
 resource "azurerm_subnet" "app_plsubnet" {
-  provider                                       = azurerm.app
-  name                                           = "${local.prefix}-app-privatelink"
-  resource_group_name                            = var.rg_dp
-  virtual_network_name                           = azurerm_virtual_network.app_vnet.name
-  address_prefixes                               = [cidrsubnet(local.cidr_dp, 6, 2)]
-  enforce_private_link_endpoint_network_policies = true
+  provider                                  = azurerm.app
+  name                                      = "${local.prefix}-app-privatelink"
+  resource_group_name                       = var.rg_dp
+  virtual_network_name                      = azurerm_virtual_network.app_vnet.name
+  address_prefixes                          = [cidrsubnet(local.cidr_dp, 6, 2)]
+  private_endpoint_network_policies_enabled = true
 }
 
 resource "azurerm_databricks_workspace" "app_workspace" {


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

fixes #3602

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
