### PR TITLE
Fix resource_cluster bug with ebs volume fields

### DIFF
--- a/clusters/resource_cluster.go
+++ b/clusters/resource_cluster.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"slices"
 	"strings"
 	"time"
 
@@ -23,8 +24,8 @@ var clusterSchema = resourceClusterSchema()
 var clusterSchemaVersion = 4
 
 const (
-	numWorkerErr                     = "NumWorkers could be 0 only for SingleNode clusters. See https://docs.databricks.com/clusters/single-node.html for more details"
-	unsupportedExceptCreateOrEditErr = "unsupported type %T, must be one of %scompute.CreateCluster, %scompute.ClusterSpec or %scompute.EditCluster. Please report this issue to the GitHub repo"
+	numWorkerErr                              = "NumWorkers could be 0 only for SingleNode clusters. See https://docs.databricks.com/clusters/single-node.html for more details"
+	unsupportedExceptCreateEditClusterSpecErr = "unsupported type %T, must be one of %scompute.CreateCluster, %scompute.ClusterSpec or %scompute.EditCluster. Please report this issue to the GitHub repo"
 )
 
 func ResourceCluster() common.Resource {
@@ -135,7 +136,7 @@ func Validate(cluster any) error {
 		master = c.SparkConf["spark.master"]
 		resourceClass = c.CustomTags["ResourceClass"]
 	default:
-		return fmt.Errorf(unsupportedExceptCreateOrEditErr, cluster, "", "", "")
+		return fmt.Errorf(unsupportedExceptCreateEditClusterSpecErr, cluster, "", "", "")
 	}
 	if profile == "singleNode" && strings.HasPrefix(master, "local") && resourceClass == "SingleNode" {
 		return nil
@@ -232,7 +233,7 @@ func ModifyRequestOnInstancePool(cluster any) error {
 		c.DriverNodeTypeId = ""
 		return nil
 	default:
-		return fmt.Errorf(unsupportedExceptCreateOrEditErr, cluster, "*", "*", "*")
+		return fmt.Errorf(unsupportedExceptCreateEditClusterSpecErr, cluster, "*", "*", "*")
 	}
 }
 
@@ -260,7 +261,7 @@ func FixInstancePoolChangeIfAny(d *schema.ResourceData, cluster any) error {
 		}
 		return nil
 	default:
-		return fmt.Errorf(unsupportedExceptCreateOrEditErr, cluster, "*", "*", "*")
+		return fmt.Errorf(unsupportedExceptCreateEditClusterSpecErr, cluster, "*", "*", "*")
 	}
 }
 
@@ -439,6 +440,105 @@ func setPinnedStatus(ctx context.Context, d *schema.ResourceData, clusterAPI com
 	return d.Set("is_pinned", pinnedEvent == compute.EventTypePinned)
 }
 
+func RemoveUnnecessaryFieldsFromForceSendFields(cluster any) error {
+	switch clusterSpec := cluster.(type) {
+	case *compute.ClusterSpec:
+		if clusterSpec.AwsAttributes != nil {
+			newAwsAttributesForceSendFields := []string{}
+			// These fields should never be 0.
+			unnecessaryFieldNamesForAwsAttributes := []string{
+				"SpotBidPricePercent",
+				"EbsVolumeCount",
+				"EbsVolumeIops",
+				"EbsVolumeSize",
+				"EbsVolumeThroughput",
+			}
+			for _, field := range clusterSpec.AwsAttributes.ForceSendFields {
+				if !slices.Contains(unnecessaryFieldNamesForAwsAttributes, field) {
+					newAwsAttributesForceSendFields = append(newAwsAttributesForceSendFields, field)
+				}
+			}
+			clusterSpec.AwsAttributes.ForceSendFields = newAwsAttributesForceSendFields
+		}
+		if clusterSpec.GcpAttributes != nil {
+			newGcpAttributesForceSendFields := []string{}
+			// Should never be 0.
+			unnecessaryFieldNamesForGcpAttributes := []string{
+				"BootDiskSize",
+			}
+			for _, field := range clusterSpec.GcpAttributes.ForceSendFields {
+				if !slices.Contains(unnecessaryFieldNamesForGcpAttributes, field) {
+					newGcpAttributesForceSendFields = append(newGcpAttributesForceSendFields, field)
+				}
+			}
+			clusterSpec.GcpAttributes.ForceSendFields = newGcpAttributesForceSendFields
+		}
+		if clusterSpec.AzureAttributes != nil {
+			newAzureAttributesForceSendFields := []string{}
+			// Should never be 0.
+			unnecessaryFieldNamesForAzureAttributes := []string{
+				"FirstOnDemand",
+				"SpotBidMaxPrice",
+			}
+			for _, field := range clusterSpec.AzureAttributes.ForceSendFields {
+				if !slices.Contains(unnecessaryFieldNamesForAzureAttributes, field) {
+					newAzureAttributesForceSendFields = append(newAzureAttributesForceSendFields, field)
+				}
+			}
+			clusterSpec.AzureAttributes.ForceSendFields = newAzureAttributesForceSendFields
+		}
+		return nil
+	case *compute.EditCluster:
+		if clusterSpec.AwsAttributes != nil {
+			newAwsAttributesForceSendFields := []string{}
+			// These fields should never be 0.
+			unnecessaryFieldNamesForAwsAttributes := []string{
+				"SpotBidPricePercent",
+				"EbsVolumeCount",
+				"EbsVolumeIops",
+				"EbsVolumeSize",
+				"EbsVolumeThroughput",
+			}
+			for _, field := range clusterSpec.AwsAttributes.ForceSendFields {
+				if !slices.Contains(unnecessaryFieldNamesForAwsAttributes, field) {
+					newAwsAttributesForceSendFields = append(newAwsAttributesForceSendFields, field)
+				}
+			}
+			clusterSpec.AwsAttributes.ForceSendFields = newAwsAttributesForceSendFields
+		}
+		if clusterSpec.GcpAttributes != nil {
+			newGcpAttributesForceSendFields := []string{}
+			// Should never be 0.
+			unnecessaryFieldNamesForGcpAttributes := []string{
+				"BootDiskSize",
+			}
+			for _, field := range clusterSpec.GcpAttributes.ForceSendFields {
+				if !slices.Contains(unnecessaryFieldNamesForGcpAttributes, field) {
+					newGcpAttributesForceSendFields = append(newGcpAttributesForceSendFields, field)
+				}
+			}
+			clusterSpec.GcpAttributes.ForceSendFields = newGcpAttributesForceSendFields
+		}
+		if clusterSpec.AzureAttributes != nil {
+			newAzureAttributesForceSendFields := []string{}
+			// Should never be 0.
+			unnecessaryFieldNamesForAzureAttributes := []string{
+				"FirstOnDemand",
+				"SpotBidMaxPrice",
+			}
+			for _, field := range clusterSpec.AzureAttributes.ForceSendFields {
+				if !slices.Contains(unnecessaryFieldNamesForAzureAttributes, field) {
+					newAzureAttributesForceSendFields = append(newAzureAttributesForceSendFields, field)
+				}
+			}
+			clusterSpec.AzureAttributes.ForceSendFields = newAzureAttributesForceSendFields
+		}
+		return nil
+	default:
+		return fmt.Errorf(unsupportedExceptCreateEditClusterSpecErr, cluster, "*", "*", "*")
+	}
+}
+
 func resourceClusterRead(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
 	w, err := c.WorkspaceClient()
 	if err != nil {
@@ -572,6 +672,7 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, c *commo
 				Autoscale: cluster.Autoscale,
 			})
 		} else {
+			RemoveUnnecessaryFieldsFromForceSendFields(&cluster)
 			_, err = clusters.Edit(ctx, cluster)
 		}
 		if err != nil {

--- a/clusters/resource_cluster.go
+++ b/clusters/resource_cluster.go
@@ -672,7 +672,10 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, c *commo
 				Autoscale: cluster.Autoscale,
 			})
 		} else {
-			RemoveUnnecessaryFieldsFromForceSendFields(&cluster)
+			err = RemoveUnnecessaryFieldsFromForceSendFields(&cluster)
+			if err != nil {
+				return err
+			}
 			_, err = clusters.Edit(ctx, cluster)
 		}
 		if err != nil {

--- a/internal/acceptance/cluster_test.go
+++ b/internal/acceptance/cluster_test.go
@@ -77,3 +77,30 @@ func TestAccClusterResource_CreateSingleNodeCluster(t *testing.T) {
 		Template: singleNodeClusterTemplate("20"),
 	})
 }
+
+func awsClusterTemplate(availability string) string {
+	return fmt.Sprintf(`
+		data "databricks_spark_version" "latest" {
+		}
+		resource "databricks_cluster" "this" {
+			cluster_name = "aws-cluster-{var.RANDOM}"
+			spark_version = data.databricks_spark_version.latest.id
+			num_workers = 1
+			autotermination_minutes = 10
+			aws_attributes {
+				availability     = "%s"
+			}
+			node_type_id = "i3.xlarge"
+		}
+	`, availability)
+}
+
+func TestAwsClusterResource_CreateAndUpdateAwsAttributes(t *testing.T) {
+	if isAws(t) {
+		workspaceLevel(t, step{
+			Template: awsClusterTemplate("SPOT"),
+		}, step{
+			Template: awsClusterTemplate("SPOT_WITH_FALLBACK"),
+		})
+	}
+}

--- a/jobs/jobs_api_go_sdk.go
+++ b/jobs/jobs_api_go_sdk.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"slices"
 	"sort"
 	"time"
 
@@ -157,33 +156,10 @@ func (c controlRunStateLifecycleManagerGoSdk) OnUpdate(ctx context.Context) erro
 	return StopActiveRun(jobID, c.d.Timeout(schema.TimeoutUpdate), w, ctx)
 }
 
-// Removing unnecesary fields out of ClusterSpec's ForceSendFields because the current terraform plugin sdk
-// has a limitation that it will always set unspecified values to the zero value.
-func removeUnnecessaryFieldsFromForceSendFields(clusterSpec *compute.ClusterSpec) error {
-	if clusterSpec.AwsAttributes != nil {
-		newAwsAttributesForceSendFields := []string{}
-		// These fields should never be 0.
-		unnecessaryFieldNamesForAwsAttributes := []string{
-			"SpotBidPricePercent",
-			"EbsVolumeCount",
-			"EbsVolumeIops",
-			"EbsVolumeSize",
-			"EbsVolumeThroughput",
-		}
-		for _, field := range clusterSpec.AwsAttributes.ForceSendFields {
-			if !slices.Contains(unnecessaryFieldNamesForAwsAttributes, field) {
-				newAwsAttributesForceSendFields = append(newAwsAttributesForceSendFields, field)
-			}
-		}
-		clusterSpec.AwsAttributes.ForceSendFields = newAwsAttributesForceSendFields
-	}
-	return nil
-}
-
 func updateJobClusterSpec(clusterSpec *compute.ClusterSpec, d *schema.ResourceData) {
 	clusters.ModifyRequestOnInstancePool(clusterSpec)
 	clusters.FixInstancePoolChangeIfAny(d, clusterSpec)
-	removeUnnecessaryFieldsFromForceSendFields(clusterSpec)
+	clusters.RemoveUnnecessaryFieldsFromForceSendFields(clusterSpec)
 }
 
 func prepareJobSettingsForUpdateGoSdk(d *schema.ResourceData, js *JobSettingsResource) {

--- a/jobs/resource_job.go
+++ b/jobs/resource_job.go
@@ -1151,7 +1151,10 @@ func ResourceJob() common.Resource {
 			common.DataToStructPointer(d, jobsGoSdkSchema, &jsr)
 			if jsr.isMultiTask() {
 				// Api 2.1
-				prepareJobSettingsForUpdateGoSdk(d, &jsr)
+				err := prepareJobSettingsForUpdateGoSdk(d, &jsr)
+				if err != nil {
+					return err
+				}
 				jobID, err := parseJobId(d.Id())
 				if err != nil {
 					return err


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
- Fixing issues mentioned: https://github.com/databricks/terraform-provider-databricks/issues/3599
  - Removing unnecessary fields from force_send_fields when sending the update_cluster request
  - Have to maintain these hacks for now, until we move to the new plugin framework, which will systematically address issue like this
  - Updating jobs to also reference this function, remove the duplicated one
  - Updating jobs error handling
  - Added new integration test case in `cluster_test.go`

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [x] covered with integration tests in `internal/acceptance`
- [x] relevant acceptance tests are passing
- [x] using Go SDK
