### PR TITLE
Enhance DataAwsAssumeRolePolicy to allow the role to assume itself

### DIFF
--- a/aws/data_aws_assume_role_policy_test.go
+++ b/aws/data_aws_assume_role_policy_test.go
@@ -19,3 +19,19 @@ func TestDataAwsAssumeRolePolicy(t *testing.T) {
 	j := d.Get("json")
 	assert.Lenf(t, j, 299, "Strange length for policy: %s", j)
 }
+
+func TestDataAwsAssumeRolePolicySelfAssume(t *testing.T) {
+	d, err := qa.ResourceFixture{
+		Read:        true,
+		Resource:    DataAwsAssumeRolePolicy(),
+		NonWritable: true,
+		ID:          ".",
+		HCL: `
+		external_id = "abc"
+		predicted_role_arn = "arn:aws:iam::aws-account:role/role-name"
+		`,
+	}.Apply(t)
+	assert.NoError(t, err)
+	j := d.Get("json")
+	assert.Lenf(t, j, 628, "Strange length for policy: %s", j)
+}


### PR DESCRIPTION
## Changes
AWS roles used to be implicitly able to assume itself. As of somewhen last year this is no longer the case, therefore whenever a role wants to assume itself, it has to be configured explicitly in the assume role policy. We are using the `DataAwsAssumeRolePolicy` in our terraform stacks for a lot of roles but recently learned that this might cause issues. Therefore we would like to add the capabilities to this terraform resource, that the self assumption is also possible.

When creating roles with terraform, it is a little tricky to do this self assumption. Since ARNs are predictable, you could think, that you just can predict the ARN of your -to-be-created-role and add it to the list of `Allow-sts:AssumeRole` directly. But AWS will perform a check and will fail if the ARN is not already present. Since we are just about to create the role with that ARN, this is not possible. However, going in and adding the concrete check for the role as `Condition-ArnLike`, we will postpone the check if the ARN is actually existing to the runtime. At this time the ARN is present and the check will work as expected.

We do this kind of IAM approach for role self assumptions at a lot of other places ever since AWS announced their policy change last year and we didn't had problems with it so far.


## Tests
I ran `make test` and verified that this addition is not breaking existing behaviour/existing tests. I added another test and verified the output policy of my test:
```
        	            	{
        	            	  "Version": "2012-10-17",
        	            	  "Statement": [
        	            	    {
        	            	      "Effect": "Allow",
        	            	      "Action": "sts:AssumeRole",
        	            	      "Principal": {
        	            	        "AWS": "arn:aws:iam::414351767826:root"
        	            	      },
        	            	      "Condition": {
        	            	        "StringEquals": {
        	            	          "sts:ExternalId": "abc"
        	            	        }
        	            	      }
        	            	    },
        	            	    {
        	            	      "Sid": "ExplicitSelfRoleAssumption",
        	            	      "Effect": "Allow",
        	            	      "Action": "sts:AssumeRole",
        	            	      "Principal": {
        	            	        "AWS": "arn:aws:iam::aws-account:role/root"
        	            	      },
        	            	      "Condition": {
        	            	        "ArnLike": {
        	            	          "aws:PrincipalArn": "arn:aws:iam::aws-account:role/role-name"
        	            	        }
        	            	      }
        	            	    }
        	            	  ]
        	            	}
```

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
