### PR TITLE
Added `gcp_workspace_sa` computed attribute to `databricks_mws_workspaces`

### DIFF
--- a/docs/resources/mws_workspaces.md
+++ b/docs/resources/mws_workspaces.md
@@ -368,6 +368,7 @@ In addition to all arguments above, the following attributes are exported:
 * `creation_time` - (Integer) time when workspace was created
 * `workspace_url` - (String) URL of the workspace
 * `custom_tags` - (Map) Custom Tags (if present) added to workspace
+* `gcp_workspace_sa` - (String, GCP only) identifier of a service account created for the workspace in form of `db-<workspace-id>@prod-gcp-<region>.iam.gserviceaccount.com`
 
 ## Timeouts
 

--- a/mws/resource_mws_workspaces.go
+++ b/mws/resource_mws_workspaces.go
@@ -504,6 +504,11 @@ func ResourceMwsWorkspaces() common.Resource {
 				func(m map[string]*schema.Schema) map[string]*schema.Schema {
 					return m
 				})["token"]
+
+			s["gcp_workspace_sa"] = &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			}
 			return s
 		})
 	p := common.NewPairSeparatedID("account_id", "workspace_id", "/").Schema(
@@ -554,6 +559,10 @@ func ResourceMwsWorkspaces() common.Resource {
 			}
 			d.Set("workspace_id", workspace.WorkspaceID)
 			d.Set("workspace_url", workspace.WorkspaceURL)
+			if workspace.Cloud == "gcp" {
+				d.Set("gcp_workspace_sa", fmt.Sprintf("db-%d@prod-gcp-%s.iam.gserviceaccount.com",
+					workspace.WorkspaceID, workspace.Location))
+			}
 			p.Pack(d)
 			return CreateTokenIfNeeded(workspacesAPI, workspaceSchema, d)
 		},

--- a/mws/resource_mws_workspaces_test.go
+++ b/mws/resource_mws_workspaces_test.go
@@ -132,6 +132,8 @@ func TestResourceWorkspaceCreateGcp(t *testing.T) {
 					WorkspaceStatus: WorkspaceStatusRunning,
 					DeploymentName:  "900150983cd24fb0",
 					WorkspaceName:   "labdata",
+					Location:        "bcd",
+					Cloud:           "gcp",
 				},
 			},
 		},
@@ -159,7 +161,10 @@ func TestResourceWorkspaceCreateGcp(t *testing.T) {
 		`,
 		Gcp:    true,
 		Create: true,
-	}.ApplyNoError(t)
+	}.ApplyAndExpectData(t, map[string]any{
+		"cloud":            "gcp",
+		"gcp_workspace_sa": "db-1234@prod-gcp-bcd.iam.gserviceaccount.com",
+	})
 }
 
 func TestResourceWorkspaceCreate_Error_Custom_tags(t *testing.T) {


### PR DESCRIPTION
This attribute simplifies references to the service account that is created together with workspace on GCP

## Changes
<!-- Summary of your changes that are easy to understand -->

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
