### PR TITLE
Remove table update trigger from `job.md`

### DIFF
--- a/docs/resources/job.md
+++ b/docs/resources/job.md
@@ -346,11 +346,6 @@ This block describes the queue settings of the job:
   * `url` - (Required) string with URL under the Unity Catalog external location that will be monitored for new files. Please note that have a trailing slash character (`/`).
   * `min_time_between_triggers_seconds` - (Optional) If set, the trigger starts a run only after the specified amount of time passed since the last time the trigger fired. The minimum allowed value is 60 seconds.
   * `wait_after_last_change_seconds` - (Optional) If set, the trigger starts a run only after no file activity has occurred for the specified amount of time. This makes it possible to wait for a batch of incoming files to arrive before triggering a run. The minimum allowed value is 60 seconds.
-* `table_update` - (Optional) configuration block to define a trigger for Table Update events consisting of following attributes:
-  * `table_names` - (Required) A list of Delta tables to monitor for changes. The table name must be in the format `catalog_name.schema_name.table_name`.
-  * `condition` - (Optional) The table(s) condition based on which to trigger a job run. Valid values are `ANY_UPDATED` or `ALL_UPDATED`.
-  * `min_time_between_triggers_seconds` - (Optional) If set, the trigger starts a run only after the specified amount of time passed since the last time the trigger fired. The minimum allowed value is 60 seconds.
-  * `wait_after_last_change_seconds` - (Optional) If set, the trigger starts a run only after no file activity has occurred for the specified amount of time. This makes it possible to wait for a batch of incoming files to arrive before triggering a run. The minimum allowed value is 60 seconds.
 
 ### git_source Configuration Block
 


### PR DESCRIPTION
## Changes

Remove table update trigger from `job.md` since this feature is only in private preview and we don't want customer outside of the private preview to know about it.

## Tests

No needed
