### PR TITLE
Revert `RemoveUnnecessaryFieldsFromForceSendFields `

### DIFF
--- a/clusters/resource_cluster.go
+++ b/clusters/resource_cluster.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"slices"
 	"strings"
 	"time"
 
@@ -440,105 +439,6 @@ func setPinnedStatus(ctx context.Context, d *schema.ResourceData, clusterAPI com
 	return d.Set("is_pinned", pinnedEvent == compute.EventTypePinned)
 }
 
-func RemoveUnnecessaryFieldsFromForceSendFields(cluster any) error {
-	switch clusterSpec := cluster.(type) {
-	case *compute.ClusterSpec:
-		if clusterSpec.AwsAttributes != nil {
-			newAwsAttributesForceSendFields := []string{}
-			// These fields should never be 0.
-			unnecessaryFieldNamesForAwsAttributes := []string{
-				"SpotBidPricePercent",
-				"EbsVolumeCount",
-				"EbsVolumeIops",
-				"EbsVolumeSize",
-				"EbsVolumeThroughput",
-			}
-			for _, field := range clusterSpec.AwsAttributes.ForceSendFields {
-				if !slices.Contains(unnecessaryFieldNamesForAwsAttributes, field) {
-					newAwsAttributesForceSendFields = append(newAwsAttributesForceSendFields, field)
-				}
-			}
-			clusterSpec.AwsAttributes.ForceSendFields = newAwsAttributesForceSendFields
-		}
-		if clusterSpec.GcpAttributes != nil {
-			newGcpAttributesForceSendFields := []string{}
-			// Should never be 0.
-			unnecessaryFieldNamesForGcpAttributes := []string{
-				"BootDiskSize",
-			}
-			for _, field := range clusterSpec.GcpAttributes.ForceSendFields {
-				if !slices.Contains(unnecessaryFieldNamesForGcpAttributes, field) {
-					newGcpAttributesForceSendFields = append(newGcpAttributesForceSendFields, field)
-				}
-			}
-			clusterSpec.GcpAttributes.ForceSendFields = newGcpAttributesForceSendFields
-		}
-		if clusterSpec.AzureAttributes != nil {
-			newAzureAttributesForceSendFields := []string{}
-			// Should never be 0.
-			unnecessaryFieldNamesForAzureAttributes := []string{
-				"FirstOnDemand",
-				"SpotBidMaxPrice",
-			}
-			for _, field := range clusterSpec.AzureAttributes.ForceSendFields {
-				if !slices.Contains(unnecessaryFieldNamesForAzureAttributes, field) {
-					newAzureAttributesForceSendFields = append(newAzureAttributesForceSendFields, field)
-				}
-			}
-			clusterSpec.AzureAttributes.ForceSendFields = newAzureAttributesForceSendFields
-		}
-		return nil
-	case *compute.EditCluster:
-		if clusterSpec.AwsAttributes != nil {
-			newAwsAttributesForceSendFields := []string{}
-			// These fields should never be 0.
-			unnecessaryFieldNamesForAwsAttributes := []string{
-				"SpotBidPricePercent",
-				"EbsVolumeCount",
-				"EbsVolumeIops",
-				"EbsVolumeSize",
-				"EbsVolumeThroughput",
-			}
-			for _, field := range clusterSpec.AwsAttributes.ForceSendFields {
-				if !slices.Contains(unnecessaryFieldNamesForAwsAttributes, field) {
-					newAwsAttributesForceSendFields = append(newAwsAttributesForceSendFields, field)
-				}
-			}
-			clusterSpec.AwsAttributes.ForceSendFields = newAwsAttributesForceSendFields
-		}
-		if clusterSpec.GcpAttributes != nil {
-			newGcpAttributesForceSendFields := []string{}
-			// Should never be 0.
-			unnecessaryFieldNamesForGcpAttributes := []string{
-				"BootDiskSize",
-			}
-			for _, field := range clusterSpec.GcpAttributes.ForceSendFields {
-				if !slices.Contains(unnecessaryFieldNamesForGcpAttributes, field) {
-					newGcpAttributesForceSendFields = append(newGcpAttributesForceSendFields, field)
-				}
-			}
-			clusterSpec.GcpAttributes.ForceSendFields = newGcpAttributesForceSendFields
-		}
-		if clusterSpec.AzureAttributes != nil {
-			newAzureAttributesForceSendFields := []string{}
-			// Should never be 0.
-			unnecessaryFieldNamesForAzureAttributes := []string{
-				"FirstOnDemand",
-				"SpotBidMaxPrice",
-			}
-			for _, field := range clusterSpec.AzureAttributes.ForceSendFields {
-				if !slices.Contains(unnecessaryFieldNamesForAzureAttributes, field) {
-					newAzureAttributesForceSendFields = append(newAzureAttributesForceSendFields, field)
-				}
-			}
-			clusterSpec.AzureAttributes.ForceSendFields = newAzureAttributesForceSendFields
-		}
-		return nil
-	default:
-		return fmt.Errorf(unsupportedExceptCreateEditClusterSpecErr, cluster, "*", "*", "*")
-	}
-}
-
 func resourceClusterRead(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
 	w, err := c.WorkspaceClient()
 	if err != nil {
@@ -674,7 +574,6 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, c *commo
 				Autoscale: cluster.Autoscale,
 			})
 		} else {
-			err = RemoveUnnecessaryFieldsFromForceSendFields(&cluster)
 			if err != nil {
 				return err
 			}

--- a/jobs/jobs_api_go_sdk.go
+++ b/jobs/jobs_api_go_sdk.go
@@ -165,10 +165,6 @@ func updateJobClusterSpec(clusterSpec *compute.ClusterSpec, d *schema.ResourceDa
 	if err != nil {
 		return err
 	}
-	err = clusters.RemoveUnnecessaryFieldsFromForceSendFields(clusterSpec)
-	if err != nil {
-		return err
-	}
 	return nil
 }
 


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
- Revert `RemoveUnnecessaryFieldsFromForceSendFields` from jobs and clusters resources, as we decided to revert https://github.com/databricks/terraform-provider-databricks/pull/3385

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [x] covered with integration tests in `internal/acceptance`
- [x] relevant acceptance tests are passing
- [x] using Go SDK
