### PR TITLE
Added `LocalSsdCount` in `GcpAttributes` to ForceSendFields for `databricks_cluster` resource

### DIFF
--- a/clusters/resource_cluster.go
+++ b/clusters/resource_cluster.go
@@ -383,6 +383,9 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, c *commo
 	if createClusterRequest.Autoscale == nil {
 		createClusterRequest.ForceSendFields = []string{"NumWorkers"}
 	}
+	if createClusterRequest.GcpAttributes != nil {
+		createClusterRequest.GcpAttributes.ForceSendFields = []string{"LocalSsdCount"}
+	}
 	clusterWaiter, err := clusters.Create(ctx, createClusterRequest)
 	if err != nil {
 		return err
@@ -497,6 +500,9 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, c *commo
 	clusters := w.Clusters
 	var cluster compute.EditCluster
 	common.DataToStructPointer(d, clusterSchema, &cluster)
+	if cluster.GcpAttributes != nil {
+		cluster.GcpAttributes.ForceSendFields = []string{"LocalSsdCount"}
+	}
 	clusterId := d.Id()
 	cluster.ClusterId = clusterId
 	var clusterInfo *compute.ClusterDetails

--- a/clusters/resource_cluster.go
+++ b/clusters/resource_cluster.go
@@ -384,7 +384,9 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, c *commo
 		createClusterRequest.ForceSendFields = []string{"NumWorkers"}
 	}
 	if createClusterRequest.GcpAttributes != nil {
-		createClusterRequest.GcpAttributes.ForceSendFields = []string{"LocalSsdCount"}
+		if _, ok := d.GetOkExists("gcp_attributes.0.local_ssd_count"); ok {
+			createClusterRequest.GcpAttributes.ForceSendFields = []string{"LocalSsdCount"}
+		}
 	}
 	clusterWaiter, err := clusters.Create(ctx, createClusterRequest)
 	if err != nil {
@@ -500,9 +502,6 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, c *commo
 	clusters := w.Clusters
 	var cluster compute.EditCluster
 	common.DataToStructPointer(d, clusterSchema, &cluster)
-	if cluster.GcpAttributes != nil {
-		cluster.GcpAttributes.ForceSendFields = []string{"LocalSsdCount"}
-	}
 	clusterId := d.Id()
 	cluster.ClusterId = clusterId
 	var clusterInfo *compute.ClusterDetails

--- a/clusters/resource_cluster_test.go
+++ b/clusters/resource_cluster_test.go
@@ -1737,7 +1737,8 @@ func TestResourceClusterUpdate_LocalSsdCount(t *testing.T) {
 					SparkVersion:           "7.1-scala12",
 					NodeTypeId:             "i3.xlarge",
 					GcpAttributes: &compute.GcpAttributes{
-						LocalSsdCount: 0,
+						LocalSsdCount:   0,
+						ForceSendFields: []string{"LocalSsdCount"},
 					},
 				},
 			},

--- a/clusters/resource_cluster_test.go
+++ b/clusters/resource_cluster_test.go
@@ -1737,8 +1737,7 @@ func TestResourceClusterUpdate_LocalSsdCount(t *testing.T) {
 					SparkVersion:           "7.1-scala12",
 					NodeTypeId:             "i3.xlarge",
 					GcpAttributes: &compute.GcpAttributes{
-						LocalSsdCount:   0,
-						ForceSendFields: []string{"LocalSsdCount"},
+						LocalSsdCount: 0,
 					},
 				},
 			},


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
We always force send the local ssd count if gcp attribute is specified. 

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->
Updated unit test
- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
