### PR TITLE
Added `storage_credential_id` attribute to `databricks_storage_credential` resource

### DIFF
--- a/catalog/resource_storage_credential.go
+++ b/catalog/resource_storage_credential.go
@@ -35,6 +35,10 @@ func removeGcpSaField(originalSchema map[string]*schema.Schema) map[string]*sche
 
 var storageCredentialSchema = common.StructToSchema(StorageCredentialInfo{},
 	func(m map[string]*schema.Schema) map[string]*schema.Schema {
+		m["storage_credential_id"] = &schema.Schema{
+			Type:     schema.TypeString,
+			Computed: true,
+		}
 		return adjustDataAccessSchema(m)
 	})
 
@@ -122,7 +126,12 @@ func ResourceStorageCredential() common.Resource {
 						storageCredential.CredentialInfo.AzureServicePrincipal.ClientSecret = scOrig.AzureServicePrincipal.ClientSecret
 					}
 				}
-				return common.StructToData(storageCredential.CredentialInfo, storageCredentialSchema, d)
+				err = common.StructToData(storageCredential.CredentialInfo, storageCredentialSchema, d)
+				if err != nil {
+					return err
+				}
+				d.Set("storage_credential_id", storageCredential.CredentialInfo.Id)
+				return nil
 			}, func(w *databricks.WorkspaceClient) error {
 				storageCredential, err := w.StorageCredentials.GetByName(ctx, d.Id())
 				if err != nil {
@@ -136,7 +145,12 @@ func ResourceStorageCredential() common.Resource {
 						storageCredential.AzureServicePrincipal.ClientSecret = scOrig.AzureServicePrincipal.ClientSecret
 					}
 				}
-				return common.StructToData(storageCredential, storageCredentialSchema, d)
+				err = common.StructToData(storageCredential, storageCredentialSchema, d)
+				if err != nil {
+					return err
+				}
+				d.Set("storage_credential_id", storageCredential.Id)
+				return nil
 			})
 		},
 		Update: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {

--- a/catalog/resource_storage_credential_test.go
+++ b/catalog/resource_storage_credential_test.go
@@ -39,6 +39,7 @@ func TestCreateStorageCredentials(t *testing.T) {
 						ExternalId: "123",
 					},
 					MetastoreId: "d",
+					Id:          "1234-5678",
 				},
 			},
 		},
@@ -55,6 +56,7 @@ func TestCreateStorageCredentials(t *testing.T) {
 		"aws_iam_role.0.external_id": "123",
 		"aws_iam_role.0.role_arn":    "def",
 		"name":                       "a",
+		"storage_credential_id":      "1234-5678",
 	})
 }
 
@@ -163,6 +165,7 @@ func TestCreateAccountStorageCredentialWithOwner(t *testing.T) {
 						AwsIamRole: &catalog.AwsIamRoleResponse{
 							RoleArn: "arn:aws:iam::1234567890:role/MyRole-AJJHDSKSDF",
 						},
+						Id: "1234-5678",
 					},
 				},
 			},
@@ -178,7 +181,9 @@ func TestCreateAccountStorageCredentialWithOwner(t *testing.T) {
 		}
 		owner = "administrators"
 		`,
-	}.ApplyNoError(t)
+	}.ApplyAndExpectData(t, map[string]any{
+		"storage_credential_id": "1234-5678",
+	})
 }
 
 func TestCreateStorageCredentialsReadOnly(t *testing.T) {

--- a/docs/resources/storage_credential.md
+++ b/docs/resources/storage_credential.md
@@ -106,6 +106,7 @@ The following arguments are required:
 In addition to all arguments above, the following attributes are exported:
 
 - `id` - ID of this storage credential - same as the `name`.
+- `storage_credential_id` - Unique ID of storage credential.
 
 ## Import
 


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

This attribute exposes UUID of the storage credential.

Fixes #3538

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
