### PR TITLE
Document support of `requirements.txt` specification in cluster libraries

### DIFF
--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -199,6 +199,15 @@ library {
 }
 ```
 
+Installing Python libraries listed in the `requirements.txt` file.  Only Workspace paths and Unity Catalog Volumes paths are supported.  Requires a cluster with DBR 15.0+.
+
+
+```hcl
+library {
+  requirements = "/Workspace/path/to/requirements.txt"
+}
+```
+
 Installing artifacts from Maven repository. You can also optionally specify a `repo` parameter for a custom Maven-style repository, that should be accessible without any authentication. Maven libraries are resolved in Databricks Control Plane, so repo should be accessible from it. It can even be properly configured [maven s3 wagon](https://github.com/seahen/maven-s3-wagon), [AWS CodeArtifact](https://aws.amazon.com/codeartifact/) or [Azure Artifacts](https://azure.microsoft.com/en-us/services/devops/artifacts/).
 
 ```hcl

--- a/docs/resources/library.md
+++ b/docs/resources/library.md
@@ -83,6 +83,19 @@ resource "databricks_library" "fbprophet" {
 }
 ```
 
+## Python requirements files
+
+Installing Python libraries listed in the `requirements.txt` file.  Only Workspace paths and Unity Catalog Volumes paths are supported.  Requires a cluster with DBR 15.0+.
+
+
+```hcl
+resource "databricks_library" "libraries" {
+  cluster_id   = databricks_cluster.this.id
+  requirements = "/Workspace/path/to/requirements.txt"
+}
+```
+
+
 ## Python EGG
 
 ```hcl
@@ -109,6 +122,7 @@ resource "databricks_library" "rkeops" {
   }
 }
 ```
+
 
 ## Import
 


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

Support for `requirements` parameter came via SDK, but documentation was missing.

Fixes #3471

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
