### PR TITLE
Fix bug with job create zero values

### DIFF
--- a/clusters/clusters_api.go
+++ b/clusters/clusters_api.go
@@ -173,6 +173,7 @@ type GcpAttributes struct {
 	BootDiskSize            int32        `json:"boot_disk_size,omitempty"`
 	ZoneId                  string       `json:"zone_id,omitempty"`
 	LocalSsdCount           int32        `json:"local_ssd_count,omitempty"`
+	ForceSendFields         []string     `json:"-"`
 }
 
 // DbfsStorageInfo contains the destination string for DBFS
@@ -431,6 +432,7 @@ type Cluster struct {
 	WorkloadType     *WorkloadType `json:"workload_type,omitempty"`
 	RuntimeEngine    string        `json:"runtime_engine,omitempty"`
 	ClusterMounts    []MountInfo   `json:"cluster_mount_infos,omitempty" tf:"alias:cluster_mount_info"`
+	ForceSendFields  []string      `json:"-"`
 }
 
 // TODO: Remove this once all the resources using clusters are migrated to Go SDK.
@@ -491,6 +493,18 @@ func (cluster *Cluster) FixInstancePoolChangeIfAny(d *schema.ResourceData) {
 		oldDriverPool == oldInstancePool &&
 		oldDriverPool == newDriverPool {
 		cluster.DriverInstancePoolID = cluster.InstancePoolID
+	}
+}
+
+// TODO: Remove this once we fully migrate away from jobs api 2.0
+func (cluster *Cluster) SetForceSendFieldsForClusterCreate(d *schema.ResourceData, getPrefix string) {
+	if cluster.Autoscale == nil {
+		cluster.ForceSendFields = []string{"NumWorkers"}
+	}
+	if cluster.GcpAttributes != nil {
+		if _, ok := d.GetOkExists(fmt.Sprintf("%s.gcp_attributes.0.local_ssd_count", getPrefix)); ok {
+			cluster.GcpAttributes.ForceSendFields = []string{"LocalSsdCount"}
+		}
 	}
 }
 

--- a/clusters/clusters_api.go
+++ b/clusters/clusters_api.go
@@ -173,7 +173,6 @@ type GcpAttributes struct {
 	BootDiskSize            int32        `json:"boot_disk_size,omitempty"`
 	ZoneId                  string       `json:"zone_id,omitempty"`
 	LocalSsdCount           int32        `json:"local_ssd_count,omitempty"`
-	ForceSendFields         []string     `json:"-"`
 }
 
 // DbfsStorageInfo contains the destination string for DBFS

--- a/clusters/clusters_api.go
+++ b/clusters/clusters_api.go
@@ -431,7 +431,6 @@ type Cluster struct {
 	WorkloadType     *WorkloadType `json:"workload_type,omitempty"`
 	RuntimeEngine    string        `json:"runtime_engine,omitempty"`
 	ClusterMounts    []MountInfo   `json:"cluster_mount_infos,omitempty" tf:"alias:cluster_mount_info"`
-	ForceSendFields  []string      `json:"-"`
 }
 
 // TODO: Remove this once all the resources using clusters are migrated to Go SDK.
@@ -492,13 +491,6 @@ func (cluster *Cluster) FixInstancePoolChangeIfAny(d *schema.ResourceData) {
 		oldDriverPool == oldInstancePool &&
 		oldDriverPool == newDriverPool {
 		cluster.DriverInstancePoolID = cluster.InstancePoolID
-	}
-}
-
-// TODO: Remove this once we fully migrate away from jobs api 2.0
-func (cluster *Cluster) SetForceSendFieldsForClusterCreate(d *schema.ResourceData) {
-	if cluster.Autoscale == nil {
-		cluster.ForceSendFields = []string{"NumWorkers"}
 	}
 }
 

--- a/clusters/clusters_api.go
+++ b/clusters/clusters_api.go
@@ -497,14 +497,9 @@ func (cluster *Cluster) FixInstancePoolChangeIfAny(d *schema.ResourceData) {
 }
 
 // TODO: Remove this once we fully migrate away from jobs api 2.0
-func (cluster *Cluster) SetForceSendFieldsForClusterCreate(d *schema.ResourceData, getPrefix string) {
+func (cluster *Cluster) SetForceSendFieldsForClusterCreate(d *schema.ResourceData) {
 	if cluster.Autoscale == nil {
 		cluster.ForceSendFields = []string{"NumWorkers"}
-	}
-	if cluster.GcpAttributes != nil {
-		if _, ok := d.GetOkExists(fmt.Sprintf("%s.gcp_attributes.0.local_ssd_count", getPrefix)); ok {
-			cluster.GcpAttributes.ForceSendFields = []string{"LocalSsdCount"}
-		}
 	}
 }
 

--- a/clusters/resource_cluster.go
+++ b/clusters/resource_cluster.go
@@ -264,26 +264,16 @@ func FixInstancePoolChangeIfAny(d *schema.ResourceData, cluster any) error {
 	}
 }
 
-func SetForceSendFieldsForClusterCreate(cluster any, d *schema.ResourceData, getPrefix string) error {
+func SetForceSendFieldsForClusterCreate(cluster any, d *schema.ResourceData) error {
 	switch c := cluster.(type) {
 	case *compute.ClusterSpec:
 		if c.Autoscale == nil {
 			c.ForceSendFields = []string{"NumWorkers"}
 		}
-		if c.GcpAttributes != nil {
-			if _, ok := d.GetOkExists(fmt.Sprintf("%s.gcp_attributes.0.local_ssd_count", getPrefix)); ok {
-				c.GcpAttributes.ForceSendFields = []string{"LocalSsdCount"}
-			}
-		}
 		return nil
 	case *compute.CreateCluster:
 		if c.Autoscale == nil {
 			c.ForceSendFields = []string{"NumWorkers"}
-		}
-		if c.GcpAttributes != nil {
-			if _, ok := d.GetOkExists(getPrefix + fmt.Sprintf("%s.gcp_attributes.0.local_ssd_count", getPrefix)); ok {
-				c.GcpAttributes.ForceSendFields = []string{"LocalSsdCount"}
-			}
 		}
 		return nil
 	default:
@@ -407,7 +397,7 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, c *commo
 	if err = ModifyRequestOnInstancePool(&createClusterRequest); err != nil {
 		return err
 	}
-	SetForceSendFieldsForClusterCreate(&createClusterRequest, d, "")
+	SetForceSendFieldsForClusterCreate(&createClusterRequest, d)
 	clusterWaiter, err := clusters.Create(ctx, createClusterRequest)
 	if err != nil {
 		return err

--- a/clusters/resource_cluster.go
+++ b/clusters/resource_cluster.go
@@ -268,12 +268,12 @@ func SetForceSendFieldsForCluster(cluster any, d *schema.ResourceData) error {
 	switch c := cluster.(type) {
 	case *compute.ClusterSpec:
 		if c.Autoscale == nil {
-			c.ForceSendFields = []string{"NumWorkers"}
+			c.ForceSendFields = append(c.ForceSendFields, "NumWorkers")
 		}
 		return nil
 	case *compute.CreateCluster:
 		if c.Autoscale == nil {
-			c.ForceSendFields = []string{"NumWorkers"}
+			c.ForceSendFields = append(c.ForceSendFields, "NumWorkers")
 		}
 		return nil
 	default:

--- a/clusters/resource_cluster.go
+++ b/clusters/resource_cluster.go
@@ -397,9 +397,7 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, c *commo
 	if err = ModifyRequestOnInstancePool(&createClusterRequest); err != nil {
 		return err
 	}
-	if createClusterRequest.Autoscale == nil {
-		createClusterRequest.ForceSendFields = []string{"NumWorkers"}
-	}
+	SetForceSendFieldsForCluster(&createClusterRequest, d)
 	if createClusterRequest.GcpAttributes != nil {
 		if _, ok := d.GetOkExists("gcp_attributes.0.local_ssd_count"); ok {
 			createClusterRequest.GcpAttributes.ForceSendFields = []string{"LocalSsdCount"}

--- a/internal/acceptance/job_test.go
+++ b/internal/acceptance/job_test.go
@@ -40,7 +40,7 @@ func TestAccJobTasks(t *testing.T) {
 			job_cluster {
 				job_cluster_key = "j"
 				new_cluster {
-					num_workers   = 20
+					num_workers   = 0  // Setting it to zero intentionally to cover edge case.
 					spark_version = data.databricks_spark_version.latest.id
 					node_type_id  = data.databricks_node_type.smallest.id
 				}

--- a/jobs/jobs_api_go_sdk.go
+++ b/jobs/jobs_api_go_sdk.go
@@ -193,18 +193,16 @@ func prepareJobSettingsForUpdateGoSdk(d *schema.ResourceData, js *JobSettingsRes
 }
 
 func prepareJobSettingsForCreateGoSdk(d *schema.ResourceData, jc *JobCreateStruct) error {
-	for i, task := range jc.Tasks {
+	for _, task := range jc.Tasks {
 		if task.NewCluster != nil {
-			getPrefix := fmt.Sprintf("task.%d.new_cluster", i)
-			err := clusters.SetForceSendFieldsForClusterCreate(task.NewCluster, d, getPrefix)
+			err := clusters.SetForceSendFieldsForClusterCreate(task.NewCluster, d)
 			if err != nil {
 				return err
 			}
 		}
 	}
 	for i := range jc.JobClusters {
-		getPrefix := fmt.Sprintf("job_cluster.%d.new_cluster", i)
-		err := clusters.SetForceSendFieldsForClusterCreate(&jc.JobClusters[i].NewCluster, d, getPrefix)
+		err := clusters.SetForceSendFieldsForClusterCreate(&jc.JobClusters[i].NewCluster, d)
 		if err != nil {
 			return err
 		}

--- a/jobs/jobs_api_go_sdk.go
+++ b/jobs/jobs_api_go_sdk.go
@@ -192,6 +192,26 @@ func prepareJobSettingsForUpdateGoSdk(d *schema.ResourceData, js *JobSettingsRes
 	return nil
 }
 
+func prepareJobSettingsForCreateGoSdk(d *schema.ResourceData, jc *JobCreateStruct) error {
+	for i, task := range jc.Tasks {
+		if task.NewCluster != nil {
+			getPrefix := fmt.Sprintf("task.%d.new_cluster", i)
+			err := clusters.SetForceSendFieldsForClusterCreate(task.NewCluster, d, getPrefix)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	for i := range jc.JobClusters {
+		getPrefix := fmt.Sprintf("job_cluster.%d.new_cluster", i)
+		err := clusters.SetForceSendFieldsForClusterCreate(&jc.JobClusters[i].NewCluster, d, getPrefix)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func Create(createJob jobs.CreateJob, w *databricks.WorkspaceClient, ctx context.Context) (int64, error) {
 	adjustTasks(&createJob)
 	sortWebhooksByID(&createJob)

--- a/jobs/jobs_api_go_sdk.go
+++ b/jobs/jobs_api_go_sdk.go
@@ -165,6 +165,10 @@ func updateJobClusterSpec(clusterSpec *compute.ClusterSpec, d *schema.ResourceDa
 	if err != nil {
 		return err
 	}
+	err = clusters.SetForceSendFieldsForCluster(clusterSpec, d)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -193,16 +197,18 @@ func prepareJobSettingsForUpdateGoSdk(d *schema.ResourceData, js *JobSettingsRes
 }
 
 func prepareJobSettingsForCreateGoSdk(d *schema.ResourceData, jc *JobCreateStruct) error {
+	// We always need to add NumWorkers into ForceSendField for the go-sdk client.
+	// Before the go-sdk migration, the field `num_workers` was required, so we always sent it.
 	for _, task := range jc.Tasks {
 		if task.NewCluster != nil {
-			err := clusters.SetForceSendFieldsForClusterCreate(task.NewCluster, d)
+			err := clusters.SetForceSendFieldsForCluster(task.NewCluster, d)
 			if err != nil {
 				return err
 			}
 		}
 	}
 	for i := range jc.JobClusters {
-		err := clusters.SetForceSendFieldsForClusterCreate(&jc.JobClusters[i].NewCluster, d)
+		err := clusters.SetForceSendFieldsForCluster(&jc.JobClusters[i].NewCluster, d)
 		if err != nil {
 			return err
 		}

--- a/jobs/resource_job.go
+++ b/jobs/resource_job.go
@@ -1034,22 +1034,6 @@ func prepareJobSettingsForUpdate(d *schema.ResourceData, js JobSettings) {
 	}
 }
 
-func prepareJobSettingsForCreate(d *schema.ResourceData, js JobSettings) {
-	if js.NewCluster != nil {
-		js.NewCluster.SetForceSendFieldsForClusterCreate(d)
-	}
-	for _, task := range js.Tasks {
-		if task.NewCluster != nil {
-			task.NewCluster.SetForceSendFieldsForClusterCreate(d)
-		}
-	}
-	for _, jc := range js.JobClusters {
-		if jc.NewCluster != nil {
-			jc.NewCluster.SetForceSendFieldsForClusterCreate(d)
-		}
-	}
-}
-
 var jobsGoSdkSchema = common.StructToSchema(JobSettingsResource{}, nil)
 
 func ResourceJob() common.Resource {
@@ -1124,7 +1108,6 @@ func ResourceJob() common.Resource {
 				// Api 2.0
 				// TODO: Deprecate and remove this code path
 				jobsAPI := NewJobsAPI(ctx, c)
-				prepareJobSettingsForCreate(d, js)
 				job, err := jobsAPI.Create(js)
 				if err != nil {
 					return err

--- a/jobs/resource_job.go
+++ b/jobs/resource_job.go
@@ -1036,19 +1036,16 @@ func prepareJobSettingsForUpdate(d *schema.ResourceData, js JobSettings) {
 
 func prepareJobSettingsForCreate(d *schema.ResourceData, js JobSettings) {
 	if js.NewCluster != nil {
-		getPrefix := "new_cluster"
-		js.NewCluster.SetForceSendFieldsForClusterCreate(d, getPrefix)
+		js.NewCluster.SetForceSendFieldsForClusterCreate(d)
 	}
-	for i, task := range js.Tasks {
+	for _, task := range js.Tasks {
 		if task.NewCluster != nil {
-			getPrefix := fmt.Sprintf("task.%d.new_cluster", i)
-			task.NewCluster.SetForceSendFieldsForClusterCreate(d, getPrefix)
+			task.NewCluster.SetForceSendFieldsForClusterCreate(d)
 		}
 	}
-	for i, jc := range js.JobClusters {
+	for _, jc := range js.JobClusters {
 		if jc.NewCluster != nil {
-			getPrefix := fmt.Sprintf("job_cluster.%d.new_cluster", i)
-			jc.NewCluster.SetForceSendFieldsForClusterCreate(d, getPrefix)
+			jc.NewCluster.SetForceSendFieldsForClusterCreate(d)
 		}
 	}
 }


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
- Addressing https://github.com/databricks/terraform-provider-databricks/issues/3632
- Always add `NumWorkers` into `ForceSendFields` if a cluster is non-autoscaling. Before the go-sdk migraiton, it wasn't an issue because `num_workers` was a required field


## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [x] covered with integration tests in `internal/acceptance`
- [x] relevant acceptance tests are passing
- [x] using Go SDK
