### PR TITLE
Use latest version of goreleaser action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,7 @@ jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Checkout
+      - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -19,22 +18,22 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: 1.21.x
-      - 
-        name: Import GPG key
+
+      - name: Import GPG key
         id: import_gpg
         uses: crazy-max/ghaction-import-gpg@v2
         env:
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           PASSPHRASE: ${{ secrets.PASSPHRASE }}
-      - 
-        name: Pull external libraries
+
+      - name: Pull external libraries
         run: make vendor
-      -
-        name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v1
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
         with:
-          version: latest
-          args: release --rm-dist
+          version: ~> v2
+          args: release --clean
         env:
           # use GITHUB_TOKEN that is already available in secrets.GITHUB_TOKEN
           # https://docs.github.com/en/free-pro-team@latest/actions/reference/authentication-in-a-workflow#permissions-for-the-github_token


### PR DESCRIPTION
## Changes

GoReleaser was bumped to 2.0 recently and we didn't pin it.

The `--rm-dist` flag was removed in 2.0 so it no longer works.

## Tests

n/a