### PR TITLE
Run goreleaser action in snapshot mode from merge queue

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,8 +4,6 @@ on:
   push:
     tags:
       - '*'
-  pull_request:
-    types: [opened, synchronize]
   merge_group:
     types: [checks_requested]
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v6
         with:
           version: ~> v2
-          args: release --clean ${{ !startsWith(github.ref, 'refs/tags/v') && '--snapshot' }}
+          args: release --clean ${{ !startsWith(github.ref, 'refs/tags/v') && '--snapshot' || '' }}
         env:
           # use GITHUB_TOKEN that is already available in secrets.GITHUB_TOKEN
           # https://docs.github.com/en/free-pro-team@latest/actions/reference/authentication-in-a-workflow#permissions-for-the-github_token

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,10 @@ on:
   push:
     tags:
       - '*'
+  pull_request:
+    types: [opened, synchronize]
+  merge_group:
+    types: [checks_requested]
 
 jobs:
   goreleaser:
@@ -19,6 +23,13 @@ jobs:
         with:
           go-version: 1.21.x
 
+          # The default cache key for this action considers only the `go.sum` file.
+          # We include .goreleaser.yaml here to differentiate from the cache used by the push action
+          # that runs unit tests. This job produces and uses a different cache.
+          cache-dependency-path: |
+            go.sum
+            .goreleaser.yml
+
       - name: Import GPG key
         id: import_gpg
         uses: crazy-max/ghaction-import-gpg@v2
@@ -26,14 +37,11 @@ jobs:
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           PASSPHRASE: ${{ secrets.PASSPHRASE }}
 
-      - name: Pull external libraries
-        run: make vendor
-
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:
           version: ~> v2
-          args: release --clean
+          args: release --clean ${{ !startsWith(github.ref, 'refs/tags/v') && '--snapshot' }}
         env:
           # use GITHUB_TOKEN that is already available in secrets.GITHUB_TOKEN
           # https://docs.github.com/en/free-pro-team@latest/actions/reference/authentication-in-a-workflow#permissions-for-the-github_token

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,6 +1,9 @@
+version: 2
+
 before:
   hooks:
     - go mod download
+
 builds:
 - env:
     - CGO_ENABLED=0
@@ -15,6 +18,7 @@ builds:
   goarch:
     - amd64
     - arm64
+
 archives:
 - format: zip
   name_template: '{{ .ProjectName }}_{{ replace .Version "v" "" }}_{{ .Os }}_{{ .Arch }}'
@@ -22,11 +26,14 @@ archives:
     - LICENSE*
     - CHANGELOG*
     - NOTICE*
+
 checksum:
   name_template: '{{ .ProjectName }}_{{ replace .Version "v" "" }}_SHA256SUMS'
   algorithm: sha256
+
 snapshot:
   name_template: "{{ .Tag }}"
+
 signs:
   - artifacts: checksum
     args:
@@ -36,11 +43,13 @@ signs:
       - "${signature}"
       - "--detach-sign"
       - "${artifact}"
+
 changelog:
   sort: asc
   filters:
     exclude:
     - '^docs:'
     - '^test:'
+
 release:
   draft: true


### PR DESCRIPTION
## Changes

Running this action before doing an actual release should prevent situations like #3645 where it doesn't work on release.

## Tests

See workflows.