### PR TITLE
Add customize diff for `databricks_grant` and `databricks_grants` for case insensitivity & spaces in grants

### DIFF
--- a/catalog/permissions/permissions.go
+++ b/catalog/permissions/permissions.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/databricks/databricks-sdk-go"
@@ -119,18 +120,22 @@ var Mappings = SecurableMapping{
 	"volume":             catalog.SecurableType("volume"),
 }
 
+func normalizePrivilege(privilege string) string {
+	return strings.Replace(privilege, " ", "_", -1)
+}
+
 // Utils for Slice and Set
 func SliceToSet(in []catalog.Privilege) *schema.Set {
 	var out []any
 	for _, v := range in {
-		out = append(out, v.String())
+		out = append(out, normalizePrivilege(v.String()))
 	}
 	return schema.NewSet(schema.HashString, out)
 }
 
 func SetToSlice(set *schema.Set) (ss []catalog.Privilege) {
 	for _, v := range set.List() {
-		ss = append(ss, catalog.Privilege(v.(string)))
+		ss = append(ss, catalog.Privilege(normalizePrivilege(v.(string))))
 	}
 	return
 }

--- a/catalog/permissions/permissions.go
+++ b/catalog/permissions/permissions.go
@@ -121,7 +121,7 @@ var Mappings = SecurableMapping{
 }
 
 func normalizePrivilege(privilege string) string {
-	return strings.Replace(privilege, " ", "_", -1)
+	return strings.ToUpper(strings.Replace(privilege, " ", "_", -1))
 }
 
 // Utils for Slice and Set

--- a/catalog/permissions/permissions.go
+++ b/catalog/permissions/permissions.go
@@ -120,7 +120,7 @@ var Mappings = SecurableMapping{
 	"volume":             catalog.SecurableType("volume"),
 }
 
-func normalizePrivilege(privilege string) string {
+func NormalizePrivilege(privilege string) string {
 	return strings.ToUpper(strings.Replace(privilege, " ", "_", -1))
 }
 
@@ -128,14 +128,14 @@ func normalizePrivilege(privilege string) string {
 func SliceToSet(in []catalog.Privilege) *schema.Set {
 	var out []any
 	for _, v := range in {
-		out = append(out, normalizePrivilege(v.String()))
+		out = append(out, NormalizePrivilege(v.String()))
 	}
 	return schema.NewSet(schema.HashString, out)
 }
 
 func SetToSlice(set *schema.Set) (ss []catalog.Privilege) {
 	for _, v := range set.List() {
-		ss = append(ss, catalog.Privilege(normalizePrivilege(v.(string))))
+		ss = append(ss, catalog.Privilege(NormalizePrivilege(v.(string))))
 	}
 	return
 }

--- a/catalog/permissions/permissions.go
+++ b/catalog/permissions/permissions.go
@@ -120,6 +120,7 @@ var Mappings = SecurableMapping{
 	"volume":             catalog.SecurableType("volume"),
 }
 
+// Unity Catalog accepts privileges with spaces, but will automatically convert them to underscores
 func NormalizePrivilege(privilege string) string {
 	return strings.ToUpper(strings.Replace(privilege, " ", "_", -1))
 }

--- a/catalog/resource_grant.go
+++ b/catalog/resource_grant.go
@@ -124,6 +124,7 @@ func ResourceGrant() common.Resource {
 		func(m map[string]*schema.Schema) map[string]*schema.Schema {
 
 			m["principal"].ForceNew = true
+			m["principal"].DiffSuppressFunc = common.EqualFoldDiffSuppress
 
 			allFields := []string{}
 			for field := range permissions.Mappings {

--- a/catalog/resource_grant.go
+++ b/catalog/resource_grant.go
@@ -123,8 +123,8 @@ func ResourceGrant() common.Resource {
 	s := common.StructToSchema(permissions.UnityCatalogPrivilegeAssignment{},
 		func(m map[string]*schema.Schema) map[string]*schema.Schema {
 			common.CustomizeSchemaPath(m, "principal").SetForceNew().SetCustomSuppressDiff(common.EqualFoldDiffSuppress)
-			common.MustSchemaPath(m, "principal").DiffSuppressFunc = common.EqualFoldDiffSuppress
 
+			// set custom hash function for privileges
 			common.MustSchemaPath(m, "privileges").Set = func(i any) int {
 				privilege := i.(string)
 				return schema.HashString(permissions.NormalizePrivilege(privilege))

--- a/catalog/resource_grant.go
+++ b/catalog/resource_grant.go
@@ -20,15 +20,15 @@ func diffPermissionsForPrincipal(principal string, desired catalog.PermissionsLi
 	// diffs change sets for principal
 	configured := map[string]*schema.Set{}
 	for _, v := range desired.PrivilegeAssignments {
-		if v.Principal == principal {
-			configured[v.Principal] = permissions.SliceToSet(v.Privileges)
+		if strings.EqualFold(v.Principal, principal) {
+			configured[strings.ToLower(v.Principal)] = permissions.SliceToSet(v.Privileges)
 		}
 	}
 	// existing permissions that needs removal for principal
 	remote := map[string]*schema.Set{}
 	for _, v := range existing.PrivilegeAssignments {
-		if v.Principal == principal {
-			remote[v.Principal] = permissions.SliceToSet(v.Privileges)
+		if strings.EqualFold(v.Principal, principal) {
+			remote[strings.ToLower(v.Principal)] = permissions.SliceToSet(v.Privileges)
 		}
 	}
 	// STEP 1: detect overlaps

--- a/catalog/resource_grant.go
+++ b/catalog/resource_grant.go
@@ -122,9 +122,13 @@ func parseSecurableId(d *schema.ResourceData) (string, string, string, error) {
 func ResourceGrant() common.Resource {
 	s := common.StructToSchema(permissions.UnityCatalogPrivilegeAssignment{},
 		func(m map[string]*schema.Schema) map[string]*schema.Schema {
+			common.CustomizeSchemaPath(m, "principal").SetForceNew().SetCustomSuppressDiff(common.EqualFoldDiffSuppress)
+			common.MustSchemaPath(m, "principal").DiffSuppressFunc = common.EqualFoldDiffSuppress
 
-			m["principal"].ForceNew = true
-			m["principal"].DiffSuppressFunc = common.EqualFoldDiffSuppress
+			common.MustSchemaPath(m, "privileges").Set = func(i any) int {
+				privilege := i.(string)
+				return schema.HashString(permissions.NormalizePrivilege(privilege))
+			}
 
 			allFields := []string{}
 			for field := range permissions.Mappings {

--- a/catalog/resource_grant.go
+++ b/catalog/resource_grant.go
@@ -87,7 +87,7 @@ func filterPermissionsForPrincipal(in catalog.PermissionsList, principal string)
 	grantsForPrincipal := []permissions.UnityCatalogPrivilegeAssignment{}
 	for _, v := range in.PrivilegeAssignments {
 		privileges := []string{}
-		if v.Principal == principal {
+		if strings.EqualFold(v.Principal, principal) {
 			for _, p := range v.Privileges {
 				privileges = append(privileges, p.String())
 			}

--- a/catalog/resource_grant_test.go
+++ b/catalog/resource_grant_test.go
@@ -532,6 +532,37 @@ func TestResourceGrantPermissionsList_Diff_ExternallyAddedPrincipal(t *testing.T
 	assert.Len(t, diff, 0)
 }
 
+func TestResourceGrantPermissionsList_Diff_CaseSensitive(t *testing.T) {
+	diff := diffPermissionsForPrincipal(
+		"a",
+		catalog.PermissionsList{ // config
+			PrivilegeAssignments: []catalog.PrivilegeAssignment{
+				{
+					Principal:  "a",
+					Privileges: []catalog.Privilege{"a"},
+				},
+				{
+					Principal:  "c",
+					Privileges: []catalog.Privilege{"a"},
+				},
+			},
+		},
+		catalog.PermissionsList{
+			PrivilegeAssignments: []catalog.PrivilegeAssignment{ // platform
+				{
+					Principal:  "A",
+					Privileges: []catalog.Privilege{"a"},
+				},
+				{
+					Principal:  "b",
+					Privileges: []catalog.Privilege{"a"},
+				},
+			},
+		},
+	)
+	assert.Len(t, diff, 0)
+}
+
 func TestResourceGrantPermissionsList_Diff_ExternallyAddedPriv(t *testing.T) {
 	diff := diffPermissionsForPrincipal(
 		"a",

--- a/catalog/resource_grant_test.go
+++ b/catalog/resource_grant_test.go
@@ -586,7 +586,7 @@ func TestResourceGrantPermissionsList_Diff_ExternallyAddedPriv(t *testing.T) {
 	assert.Len(t, diff, 1)
 	assert.Len(t, diff[0].Add, 0)
 	assert.Len(t, diff[0].Remove, 1)
-	assert.Equal(t, catalog.Privilege("b"), diff[0].Remove[0])
+	assert.Equal(t, catalog.Privilege("B"), diff[0].Remove[0])
 }
 
 func TestResourceGrantPermissionsList_Diff_LocalRemoteDiff(t *testing.T) {
@@ -612,8 +612,8 @@ func TestResourceGrantPermissionsList_Diff_LocalRemoteDiff(t *testing.T) {
 	assert.Len(t, diff, 1)
 	assert.Len(t, diff[0].Add, 1)
 	assert.Len(t, diff[0].Remove, 1)
-	assert.Equal(t, catalog.Privilege("a"), diff[0].Add[0])
-	assert.Equal(t, catalog.Privilege("c"), diff[0].Remove[0])
+	assert.Equal(t, catalog.Privilege("A"), diff[0].Add[0])
+	assert.Equal(t, catalog.Privilege("C"), diff[0].Remove[0])
 }
 
 func TestResourceGrantShareGrantCreate(t *testing.T) {

--- a/catalog/resource_grants.go
+++ b/catalog/resource_grants.go
@@ -128,6 +128,7 @@ func parseId(d *schema.ResourceData) (string, string, error) {
 func ResourceGrants() common.Resource {
 	s := common.StructToSchema(PermissionsList{},
 		func(s map[string]*schema.Schema) map[string]*schema.Schema {
+			// set custom hash function for principal and privileges
 			common.MustSchemaPath(s, "grant", "privileges").Set = func(i any) int {
 				privilege := i.(string)
 				return schema.HashString(permissions.NormalizePrivilege(privilege))

--- a/catalog/resource_grants.go
+++ b/catalog/resource_grants.go
@@ -31,12 +31,12 @@ func diffPermissions(pl catalog.PermissionsList, existing catalog.PermissionsLis
 	// diffs change sets
 	configured := map[string]*schema.Set{}
 	for _, v := range pl.PrivilegeAssignments {
-		configured[v.Principal] = permissions.SliceToSet(v.Privileges)
+		configured[strings.ToLower(v.Principal)] = permissions.SliceToSet(v.Privileges)
 	}
 	// existing permissions that needs removal
 	remote := map[string]*schema.Set{}
 	for _, v := range existing.PrivilegeAssignments {
-		remote[v.Principal] = permissions.SliceToSet(v.Privileges)
+		remote[strings.ToLower(v.Principal)] = permissions.SliceToSet(v.Privileges)
 	}
 	// STEP 1: detect overlaps
 	for principal, confPrivs := range configured {

--- a/catalog/resource_grants_test.go
+++ b/catalog/resource_grants_test.go
@@ -389,7 +389,7 @@ func TestPermissionsList_Diff_ExternallyAddedPrincipal(t *testing.T) {
 	assert.Len(t, diff[0].Add, 0)
 	assert.Len(t, diff[0].Remove, 1)
 	assert.Equal(t, "b", diff[0].Principal)
-	assert.Equal(t, catalog.Privilege("a"), diff[0].Remove[0])
+	assert.Equal(t, catalog.Privilege("A"), diff[0].Remove[0])
 	assert.Equal(t, "c", diff[1].Principal)
 }
 
@@ -415,7 +415,7 @@ func TestPermissionsList_Diff_ExternallyAddedPriv(t *testing.T) {
 	assert.Len(t, diff, 1)
 	assert.Len(t, diff[0].Add, 0)
 	assert.Len(t, diff[0].Remove, 1)
-	assert.Equal(t, catalog.Privilege("b"), diff[0].Remove[0])
+	assert.Equal(t, catalog.Privilege("B"), diff[0].Remove[0])
 }
 
 func TestPermissionsList_Diff_CaseSensitivePrincipal(t *testing.T) {
@@ -462,8 +462,8 @@ func TestPermissionsList_Diff_LocalRemoteDiff(t *testing.T) {
 	assert.Len(t, diff, 1)
 	assert.Len(t, diff[0].Add, 1)
 	assert.Len(t, diff[0].Remove, 1)
-	assert.Equal(t, catalog.Privilege("a"), diff[0].Add[0])
-	assert.Equal(t, catalog.Privilege("c"), diff[0].Remove[0])
+	assert.Equal(t, catalog.Privilege("A"), diff[0].Add[0])
+	assert.Equal(t, catalog.Privilege("C"), diff[0].Remove[0])
 }
 
 func TestShareGrantCreate(t *testing.T) {

--- a/catalog/resource_grants_test.go
+++ b/catalog/resource_grants_test.go
@@ -418,6 +418,28 @@ func TestPermissionsList_Diff_ExternallyAddedPriv(t *testing.T) {
 	assert.Equal(t, catalog.Privilege("b"), diff[0].Remove[0])
 }
 
+func TestPermissionsList_Diff_CaseSensitivePrincipal(t *testing.T) {
+	diff := diffPermissions(
+		catalog.PermissionsList{ // config
+			PrivilegeAssignments: []catalog.PrivilegeAssignment{
+				{
+					Principal:  "A",
+					Privileges: []catalog.Privilege{"a"},
+				},
+			},
+		},
+		catalog.PermissionsList{
+			PrivilegeAssignments: []catalog.PrivilegeAssignment{ // platform
+				{
+					Principal:  "a",
+					Privileges: []catalog.Privilege{"a"},
+				},
+			},
+		},
+	)
+	assert.Len(t, diff, 0)
+}
+
 func TestPermissionsList_Diff_LocalRemoteDiff(t *testing.T) {
 	diff := diffPermissions(
 		catalog.PermissionsList{ // config

--- a/internal/acceptance/grant_test.go
+++ b/internal/acceptance/grant_test.go
@@ -104,9 +104,7 @@ func TestUcAccGrant(t *testing.T) {
 	}, step{
 		Template: strings.ReplaceAll(grantTemplate, "%s", "{env.TEST_DATA_SCI_GROUP}"),
 	}, step{
-		Template: strings.ReplaceAll(grantTemplate, `"%s"`, `upper("{env.TEST_DATA_SCI_GROUP}")`),
-	}, step{
-		Template: strings.ReplaceAll(grantTemplate, "ALL_PRIVILEGES", "ALL PRIVILEGES"),
+		Template: strings.ReplaceAll(strings.ReplaceAll(grantTemplate, "ALL_PRIVILEGES", "ALL PRIVILEGES"), `"%s"`, `upper("{env.TEST_DATA_SCI_GROUP}")`),
 	})
 }
 

--- a/internal/acceptance/grant_test.go
+++ b/internal/acceptance/grant_test.go
@@ -104,7 +104,9 @@ func TestUcAccGrant(t *testing.T) {
 	}, step{
 		Template: strings.ReplaceAll(grantTemplate, "%s", "{env.TEST_DATA_SCI_GROUP}"),
 	}, step{
-		Template: strings.ReplaceAll(grantTemplate, `"%s"`, (`upper("{env.TEST_DATA_SCI_GROUP}")`)),
+		Template: strings.ReplaceAll(grantTemplate, `"%s"`, `upper("{env.TEST_DATA_SCI_GROUP}")`),
+	}, step{
+		Template: strings.ReplaceAll(grantTemplate, "ALL_PRIVILEGES", "ALL PRIVILEGES"),
 	})
 }
 
@@ -133,6 +135,6 @@ func TestUcAccGrantForIdChange(t *testing.T) {
 		Template: grantTemplateForNamePermissionChange("-new", "ALL_PRIVILEGES"),
 	}, step{
 		Template:    grantTemplateForNamePermissionChange("-fail", "abc"),
-		ExpectError: regexp.MustCompile(`cannot create grant: Privilege abc is not applicable to this entity`),
+		ExpectError: regexp.MustCompile(`cannot create grant: Privilege ABC is not applicable to this entity`),
 	})
 }

--- a/internal/acceptance/grant_test.go
+++ b/internal/acceptance/grant_test.go
@@ -103,6 +103,8 @@ func TestUcAccGrant(t *testing.T) {
 		Template: strings.ReplaceAll(grantTemplate, "%s", "{env.TEST_DATA_ENG_GROUP}"),
 	}, step{
 		Template: strings.ReplaceAll(grantTemplate, "%s", "{env.TEST_DATA_SCI_GROUP}"),
+	}, step{
+		Template: strings.ReplaceAll(grantTemplate, "%s", strings.ToUpper("{env.TEST_DATA_SCI_GROUP}")),
 	})
 }
 

--- a/internal/acceptance/grant_test.go
+++ b/internal/acceptance/grant_test.go
@@ -104,7 +104,7 @@ func TestUcAccGrant(t *testing.T) {
 	}, step{
 		Template: strings.ReplaceAll(grantTemplate, "%s", "{env.TEST_DATA_SCI_GROUP}"),
 	}, step{
-		Template: strings.ReplaceAll(grantsTemplate, `"%s"`, (`upper("{env.TEST_DATA_SCI_GROUP}")`)),
+		Template: strings.ReplaceAll(grantTemplate, `"%s"`, (`upper("{env.TEST_DATA_SCI_GROUP}")`)),
 	})
 }
 

--- a/internal/acceptance/grant_test.go
+++ b/internal/acceptance/grant_test.go
@@ -104,7 +104,7 @@ func TestUcAccGrant(t *testing.T) {
 	}, step{
 		Template: strings.ReplaceAll(grantTemplate, "%s", "{env.TEST_DATA_SCI_GROUP}"),
 	}, step{
-		Template: strings.ReplaceAll(grantTemplate, "%s", strings.ToUpper("{env.TEST_DATA_SCI_GROUP}")),
+		Template: strings.ReplaceAll(grantsTemplate, `"%s"`, (`upper("{env.TEST_DATA_SCI_GROUP}")`)),
 	})
 }
 

--- a/internal/acceptance/grant_test.go
+++ b/internal/acceptance/grant_test.go
@@ -103,6 +103,8 @@ func TestUcAccGrant(t *testing.T) {
 		Template: strings.ReplaceAll(grantTemplate, "%s", "{env.TEST_DATA_ENG_GROUP}"),
 	}, step{
 		Template: strings.ReplaceAll(grantTemplate, "%s", "{env.TEST_DATA_SCI_GROUP}"),
+	}, step{
+		Template: strings.ReplaceAll(grantsTemplate, `"%s"`, (`upper("{env.TEST_DATA_SCI_GROUP}")`)),
 	})
 }
 

--- a/internal/acceptance/grant_test.go
+++ b/internal/acceptance/grant_test.go
@@ -103,8 +103,6 @@ func TestUcAccGrant(t *testing.T) {
 		Template: strings.ReplaceAll(grantTemplate, "%s", "{env.TEST_DATA_ENG_GROUP}"),
 	}, step{
 		Template: strings.ReplaceAll(grantTemplate, "%s", "{env.TEST_DATA_SCI_GROUP}"),
-	}, step{
-		Template: strings.ReplaceAll(grantsTemplate, `"%s"`, (`upper("{env.TEST_DATA_SCI_GROUP}")`)),
 	})
 }
 

--- a/internal/acceptance/grants_test.go
+++ b/internal/acceptance/grants_test.go
@@ -110,7 +110,7 @@ func TestUcAccGrants(t *testing.T) {
 	}, step{
 		Template: strings.ReplaceAll(grantsTemplate, "%s", "{env.TEST_DATA_SCI_GROUP}"),
 	}, step{
-		Template: strings.ReplaceAll(grantsTemplate, "%s", strings.ToUpper("{env.TEST_DATA_SCI_GROUP}")),
+		Template: strings.ReplaceAll(grantsTemplate, `"%s"`, (`upper("{env.TEST_DATA_SCI_GROUP}")`)),
 	})
 }
 

--- a/internal/acceptance/grants_test.go
+++ b/internal/acceptance/grants_test.go
@@ -109,6 +109,8 @@ func TestUcAccGrants(t *testing.T) {
 		Template: strings.ReplaceAll(grantsTemplate, "%s", "{env.TEST_DATA_ENG_GROUP}"),
 	}, step{
 		Template: strings.ReplaceAll(grantsTemplate, "%s", "{env.TEST_DATA_SCI_GROUP}"),
+	}, step{
+		Template: strings.ReplaceAll(grantsTemplate, "%s", strings.ToUpper("{env.TEST_DATA_SCI_GROUP}")),
 	})
 }
 

--- a/internal/acceptance/grants_test.go
+++ b/internal/acceptance/grants_test.go
@@ -109,6 +109,10 @@ func TestUcAccGrants(t *testing.T) {
 		Template: strings.ReplaceAll(grantsTemplate, "%s", "{env.TEST_DATA_ENG_GROUP}"),
 	}, step{
 		Template: strings.ReplaceAll(grantsTemplate, "%s", "{env.TEST_DATA_SCI_GROUP}"),
+	}, step{
+		Template: strings.ReplaceAll(grantsTemplate, `"%s"`, `upper("{env.TEST_DATA_SCI_GROUP}")`),
+	}, step{
+		Template: strings.ReplaceAll(grantsTemplate, "ALL_PRIVILEGES", "ALL PRIVILEGES"),
 	})
 }
 
@@ -139,6 +143,6 @@ func TestUcAccGrantsForIdChange(t *testing.T) {
 		Template: grantsTemplateForNamePermissionChange("-new", "ALL_PRIVILEGES"),
 	}, step{
 		Template:    grantsTemplateForNamePermissionChange("-fail", "abc"),
-		ExpectError: regexp.MustCompile(`Error: cannot create grants: Privilege abc is not applicable to this entity`),
+		ExpectError: regexp.MustCompile(`Error: cannot create grants: Privilege ABC is not applicable to this entity`),
 	})
 }

--- a/internal/acceptance/grants_test.go
+++ b/internal/acceptance/grants_test.go
@@ -110,9 +110,7 @@ func TestUcAccGrants(t *testing.T) {
 	}, step{
 		Template: strings.ReplaceAll(grantsTemplate, "%s", "{env.TEST_DATA_SCI_GROUP}"),
 	}, step{
-		Template: strings.ReplaceAll(grantsTemplate, `"%s"`, `upper("{env.TEST_DATA_SCI_GROUP}")`),
-	}, step{
-		Template: strings.ReplaceAll(grantsTemplate, "ALL_PRIVILEGES", "ALL PRIVILEGES"),
+		Template: strings.ReplaceAll(strings.ReplaceAll(grantsTemplate, "ALL_PRIVILEGES", "ALL PRIVILEGES"), `"%s"`, `upper("{env.TEST_DATA_SCI_GROUP}")`),
 	})
 }
 

--- a/internal/acceptance/grants_test.go
+++ b/internal/acceptance/grants_test.go
@@ -109,8 +109,6 @@ func TestUcAccGrants(t *testing.T) {
 		Template: strings.ReplaceAll(grantsTemplate, "%s", "{env.TEST_DATA_ENG_GROUP}"),
 	}, step{
 		Template: strings.ReplaceAll(grantsTemplate, "%s", "{env.TEST_DATA_SCI_GROUP}"),
-	}, step{
-		Template: strings.ReplaceAll(grantsTemplate, `"%s"`, (`upper("{env.TEST_DATA_SCI_GROUP}")`)),
 	})
 }
 


### PR DESCRIPTION
## Changes
- Normalized privileges (make upper, replacing spaces with underscores), switched principal comparison to `EqualFold` to allow validation to complete.
- Added `DiffSuppressFunc` for `principal` attribute in `databricks_grant`
- Added customized hash function for Sets to avoid drifts
- Fixed #3654, #3566, #3261, #3313
- Superseded #3292

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] covered with integration tests in `internal/acceptance`
- [x] relevant acceptance tests are passing
- [x] using Go SDK
