### PR TITLE
Update jobs library fields from set to list

### DIFF
--- a/jobs/resource_job.go
+++ b/jobs/resource_job.go
@@ -219,7 +219,7 @@ type JobTaskSettings struct {
 	ExistingClusterID string            `json:"existing_cluster_id,omitempty" tf:"group:cluster_type"`
 	NewCluster        *clusters.Cluster `json:"new_cluster,omitempty" tf:"group:cluster_type"`
 	JobClusterKey     string            `json:"job_cluster_key,omitempty" tf:"group:cluster_type"`
-	Libraries         []compute.Library `json:"libraries,omitempty" tf:"slice_set,alias:library"`
+	Libraries         []compute.Library `json:"libraries,omitempty" tf:"alias:library"`
 
 	NotebookTask    *NotebookTask       `json:"notebook_task,omitempty" tf:"group:task_type"`
 	SparkJarTask    *SparkJarTask       `json:"spark_jar_task,omitempty" tf:"group:task_type"`
@@ -294,7 +294,7 @@ type JobSettings struct {
 	PythonWheelTask        *PythonWheelTask  `json:"python_wheel_task,omitempty" tf:"group:task_type"`
 	DbtTask                *DbtTask          `json:"dbt_task,omitempty" tf:"group:task_type"`
 	RunJobTask             *RunJobTask       `json:"run_job_task,omitempty" tf:"group:task_type"`
-	Libraries              []compute.Library `json:"libraries,omitempty" tf:"slice_set,alias:library"`
+	Libraries              []compute.Library `json:"libraries,omitempty" tf:"alias:library"`
 	TimeoutSeconds         int32             `json:"timeout_seconds,omitempty"`
 	MaxRetries             int32             `json:"max_retries,omitempty"`
 	MinRetryIntervalMillis int32             `json:"min_retry_interval_millis,omitempty"`
@@ -630,9 +630,6 @@ func (JobSettingsResource) CustomizeSchema(s *common.CustomizableSchema) *common
 
 	s.SchemaPath("job_cluster", "new_cluster", "cluster_id").SetOptional()
 	s.SchemaPath("new_cluster", "cluster_id").SetOptional()
-
-	s.SchemaPath("library").Schema.Type = schema.TypeSet
-	s.SchemaPath("task", "library").Schema.Type = schema.TypeSet
 
 	// Technically this is required by the API, but marking it optional since we can infer it from the hostname.
 	s.SchemaPath("git_source", "provider").SetOptional()

--- a/jobs/resource_job_test.go
+++ b/jobs/resource_job_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/databricks/terraform-provider-databricks/clusters"
 	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/databricks/terraform-provider-databricks/qa"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -32,10 +31,10 @@ func TestResourceJobCreate(t *testing.T) {
 					},
 					Libraries: []compute.Library{
 						{
-							Jar: "dbfs://ff/gg/hh.jar",
+							Jar: "dbfs://aa/bb/cc.jar",
 						},
 						{
-							Jar: "dbfs://aa/bb/cc.jar",
+							Jar: "dbfs://ff/gg/hh.jar",
 						},
 					},
 					Schedule: &CronSchedule{
@@ -77,10 +76,10 @@ func TestResourceJobCreate(t *testing.T) {
 						},
 						Libraries: []compute.Library{
 							{
-								Jar: "dbfs://ff/gg/hh.jar",
+								Jar: "dbfs://aa/bb/cc.jar",
 							},
 							{
-								Jar: "dbfs://aa/bb/cc.jar",
+								Jar: "dbfs://ff/gg/hh.jar",
 							},
 						},
 						Name:                   "Featurizer",
@@ -2021,10 +2020,10 @@ func TestResourceJobRead(t *testing.T) {
 						},
 						Libraries: []compute.Library{
 							{
-								Jar: "dbfs://ff/gg/hh.jar",
+								Jar: "dbfs://aa/bb/cc.jar",
 							},
 							{
-								Jar: "dbfs://aa/bb/cc.jar",
+								Jar: "dbfs://ff/gg/hh.jar",
 							},
 						},
 						Name:                   "Featurizer",
@@ -2044,7 +2043,7 @@ func TestResourceJobRead(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, "Featurizer", d.Get("name"))
-	libraries := d.Get("library").(*schema.Set).List()
+	libraries := d.Get("library").([]interface{})
 	assert.Len(t, libraries, 2)
 	allDbfsLibs := []string{}
 	for _, lib := range libraries {
@@ -2125,10 +2124,10 @@ func TestResourceJobUpdate(t *testing.T) {
 						},
 						Libraries: []compute.Library{
 							{
-								Jar: "dbfs://ff/gg/hh.jar",
+								Jar: "dbfs://aa/bb/cc.jar",
 							},
 							{
-								Jar: "dbfs://aa/bb/cc.jar",
+								Jar: "dbfs://ff/gg/hh.jar",
 							},
 						},
 						Name:                   "Featurizer New",
@@ -2152,10 +2151,10 @@ func TestResourceJobUpdate(t *testing.T) {
 						},
 						Libraries: []compute.Library{
 							{
-								Jar: "dbfs://ff/gg/hh.jar",
+								Jar: "dbfs://aa/bb/cc.jar",
 							},
 							{
-								Jar: "dbfs://aa/bb/cc.jar",
+								Jar: "dbfs://ff/gg/hh.jar",
 							},
 						},
 						Name:                   "Featurizer New",


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
- Ordering is important, updating the library fields in jobs schema from set to list
- Previously it wasn't updated because during the go-sdk schema migration we wanted to minimize breaking schema changes

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [x] covered with integration tests in `internal/acceptance`
- [x] relevant acceptance tests are passing
- [x] using Go SDK
