### PR TITLE
Exporter: Emit directories during the listing only if they are explicitly configured in `-listing`

### DIFF
--- a/exporter/util.go
+++ b/exporter/util.go
@@ -62,6 +62,7 @@ func (ic *importContext) emitInitScripts(initScripts []compute.InitScriptInfo) {
 			ic.emitWorkspaceFileOrRepo(is.Workspace.Destination)
 		}
 		if is.Volumes != nil {
+			// TODO: we should emit allow list for init scripts as well
 			ic.emitIfVolumeFile(is.Volumes.Destination)
 		}
 	}
@@ -412,6 +413,7 @@ func (ic *importContext) emitLibraries(libs []compute.Library) {
 		ic.emitIfWsfsFile(lib.Egg)
 		// Files on UC Volumes
 		ic.emitIfVolumeFile(lib.Whl)
+		// TODO: we should emit UC allow list as well
 		ic.emitIfVolumeFile(lib.Jar)
 	}
 
@@ -1159,7 +1161,7 @@ func listNotebooksAndWorkspaceFiles(ic *importContext) error {
 	allObjects := ic.getAllWorkspaceObjects(func(objects []workspace.ObjectStatus) {
 		for _, object := range objects {
 			if object.ObjectType == workspace.Directory {
-				if !ic.incremental && object.Path != "/" && ic.isServiceEnabled("directories") {
+				if !ic.incremental && object.Path != "/" && ic.isServiceInListing("directories") {
 					objectsChannel <- object
 				}
 			} else {
@@ -1184,9 +1186,9 @@ func listNotebooksAndWorkspaceFiles(ic *importContext) error {
 			if ic.shouldSkipWorkspaceObject(object, updatedSinceMs) {
 				continue
 			}
-			if object.ObjectType == workspace.Directory && !ic.incremental && ic.isServiceEnabled("directories") && object.Path != "/" {
+			if object.ObjectType == workspace.Directory && !ic.incremental && ic.isServiceInListing("directories") && object.Path != "/" {
 				emitWorkpaceObject(ic, object)
-			} else if (object.ObjectType == workspace.Notebook || object.ObjectType == workspace.File) && ic.isServiceEnabled("notebooks") {
+			} else if (object.ObjectType == workspace.Notebook || object.ObjectType == workspace.File) && ic.isServiceInListing("notebooks") {
 				emitWorkpaceObject(ic, object)
 			}
 		}


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->


The exporter emitted directories even if they were specified only in `-services`, leading to the exporting of unnecessary objects.  To return to the behavior between 1.38 and 1.45, add `directories` to the `-listing`

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
