### PR TITLE
Fixed: Issue with `databricks_cluster` resource using `exporter` does not include cluster libraries

### DIFF
--- a/clusters/resource_cluster.go
+++ b/clusters/resource_cluster.go
@@ -645,7 +645,7 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, c *commo
 		return err
 	}
 
-	var clusterLibraries ClusterSpec
+	var clusterLibraries LibraryWithAlias
 	common.DataToStructPointer(d, clusterSchema, &clusterLibraries)
 	libsToInstall, libsToUninstall := libraries.GetLibrariesToInstallAndUninstall(clusterLibraries.Libraries, libsClusterStatus)
 

--- a/clusters/resource_cluster.go
+++ b/clusters/resource_cluster.go
@@ -285,11 +285,6 @@ type LibraryWithAlias struct {
 	Libraries []compute.Library `json:"libraries,omitempty" tf:"slice_set,alias:library"`
 }
 
-type InstallLibraryWithAlias struct {
-	ClusterId string `json:"cluster_id"`
-	LibraryWithAlias
-}
-
 type ClusterSpec struct {
 	compute.ClusterSpec
 	LibraryWithAlias

--- a/clusters/resource_cluster.go
+++ b/clusters/resource_cluster.go
@@ -502,11 +502,8 @@ func resourceClusterRead(ctx context.Context, d *schema.ResourceData, c *common.
 		return err
 	}
 	libList := libsClusterStatus.ToLibraryList()
-	return common.StructToData(InstallLibraryWithAlias{
-		ClusterId: libList.ClusterId,
-		LibraryWithAlias: LibraryWithAlias{
-			Libraries: libList.Libraries,
-		},
+	return common.StructToData(LibraryWithAlias{
+		Libraries: libList.Libraries,
 	}, clusterSchema, d)
 }
 

--- a/clusters/resource_cluster.go
+++ b/clusters/resource_cluster.go
@@ -286,6 +286,16 @@ type ClusterSpec struct {
 	Libraries []compute.Library `json:"libraries,omitempty" tf:"slice_set,alias:library"`
 }
 
+var clusterAliases = map[string]map[string]string{
+	"clusters.ClusterSpec": {
+		"libraries": "library",
+	},
+}
+
+func (ClusterSpec) Aliases() map[string]map[string]string {
+	return clusterAliases
+}
+
 func (ClusterSpec) CustomizeSchemaResourceSpecific(s *common.CustomizableSchema) *common.CustomizableSchema {
 	s.AddNewField("default_tags", &schema.Schema{
 		Type:     schema.TypeMap,


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
compute.InstallLibraries doesn't have Aliases and since it isn't local we can't add alias using Aliases(), to solve this we abstract out the compute.Library with alias and use it to while write to resource data

Fixes: https://github.com/databricks/terraform-provider-databricks/issues/3558

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->
Created a cluster with library and used exporter on main branch which shows no library block reproducing the issue. After changes, libraries are shown. 

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
