### PR TITLE
Relaxed cluster check for `databricks_sql_permissions`

### DIFF
--- a/access/resource_sql_permissions.go
+++ b/access/resource_sql_permissions.go
@@ -262,7 +262,7 @@ func (ta *SqlPermissions) initCluster(ctx context.Context, d *schema.ResourceDat
 	if err != nil {
 		return
 	}
-	if v, ok := clusterInfo.SparkConf["spark.databricks.acl.dfAclsEnabled"]; !ok || v != "true" {
+	if v, ok := clusterInfo.SparkConf["spark.databricks.acl.dfAclsEnabled"]; (!ok || v != "true") && clusterInfo.DataSecurityMode != "USER_ISOLATION" && clusterInfo.DataSecurityMode != "LEGACY_TABLE_ACL" {
 		err = fmt.Errorf("cluster_id: not a High-Concurrency cluster: %s (%s)",
 			clusterInfo.ClusterName, clusterInfo.ClusterID)
 		return

--- a/access/resource_sql_permissions.go
+++ b/access/resource_sql_permissions.go
@@ -263,7 +263,7 @@ func (ta *SqlPermissions) initCluster(ctx context.Context, d *schema.ResourceDat
 		return
 	}
 	if v, ok := clusterInfo.SparkConf["spark.databricks.acl.dfAclsEnabled"]; (!ok || v != "true") && clusterInfo.DataSecurityMode != "USER_ISOLATION" && clusterInfo.DataSecurityMode != "LEGACY_TABLE_ACL" {
-		err = fmt.Errorf("Specified cluster does not support setting Table ACL: %s (%s)",
+		err = fmt.Errorf("cluster_id: pecified cluster does not support setting Table ACL: %s (%s)",
 			clusterInfo.ClusterName, clusterInfo.ClusterID)
 		return
 	}

--- a/access/resource_sql_permissions_test.go
+++ b/access/resource_sql_permissions_test.go
@@ -227,11 +227,10 @@ var createHighConcurrencyCluster = []qa.HTTPFixture{
 				"ResourceClass": "SingleNode",
 			},
 			SparkConf: map[string]string{
-				"spark.databricks.acl.dfAclsEnabled":     "true",
-				"spark.databricks.repl.allowedLanguages": "python,sql",
-				"spark.databricks.cluster.profile":       "singleNode",
-				"spark.master":                           "local[*]",
+				"spark.databricks.cluster.profile": "singleNode",
+				"spark.master":                     "local[*]",
 			},
+			DataSecurityMode: "LEGACY_TABLE_ACL",
 		},
 		Response: clusters.ClusterID{
 			ClusterID: "bcd",
@@ -242,11 +241,11 @@ var createHighConcurrencyCluster = []qa.HTTPFixture{
 		ReuseRequest: true,
 		Resource:     "/api/2.0/clusters/get?cluster_id=bcd",
 		Response: clusters.ClusterInfo{
-			ClusterID: "bcd",
-			State:     "RUNNING",
+			ClusterID:        "bcd",
+			State:            "RUNNING",
+			DataSecurityMode: "LEGACY_TABLE_ACL",
 			SparkConf: map[string]string{
-				"spark.databricks.acl.dfAclsEnabled": "true",
-				"spark.databricks.cluster.profile":   "singleNode",
+				"spark.databricks.cluster.profile": "singleNode",
 			},
 		},
 	},
@@ -304,11 +303,10 @@ var createSharedCluster = []qa.HTTPFixture{
 			CustomTags: map[string]string{
 				"ResourceClass": "SingleNode",
 			},
+			DataSecurityMode: "LEGACY_TABLE_ACL",
 			SparkConf: map[string]string{
-				"spark.databricks.acl.dfAclsEnabled":     "true",
-				"spark.databricks.repl.allowedLanguages": "python,sql",
-				"spark.databricks.cluster.profile":       "singleNode",
-				"spark.master":                           "local[*]",
+				"spark.databricks.cluster.profile": "singleNode",
+				"spark.master":                     "local[*]",
 			},
 		},
 		Response: clusters.ClusterID{

--- a/docs/resources/sql_permissions.md
+++ b/docs/resources/sql_permissions.md
@@ -19,18 +19,6 @@ resource "databricks_cluster" "cluster_with_table_access_control" {
 }
 ```
 
-It could be combined with creation of High-Concurrency and Single-Node clusters - in this case it should have corresponding `custom_tags` and `spark.databricks.cluster.profile` in Spark configuration as described in [documentation for `databricks_cluster` resource](cluster.md).
-
-The created cluster could be referred to by providing its ID as `cluster_id` property.
-
-
-```hcl
-resource "databricks_sql_permissions" "foo_table" {
-  cluster_id = databricks_cluster.cluster_name.id
-  #...
-}
-```
-
 It is required to define all permissions for a securable in a single resource, otherwise Terraform cannot guarantee config drift prevention.
 
 ## Example Usage
@@ -60,11 +48,20 @@ resource "databricks_sql_permissions" "foo_table" {
 
 ## Argument Reference
 
+* `cluster_id` - (Optional) Id of an existing [databricks_cluster](cluster.md), where the appropriate `GRANT`/`REVOKE` commands are executed. This cluster must have the appropriate data security mode (`USER_ISOLATION` or `LEGACY_TABLE_ACL` specified). If no `cluster_id` is specified, a single-node TACL cluster named `terraform-table-acl` is automatically created.
+
+```hcl
+resource "databricks_sql_permissions" "foo_table" {
+  cluster_id = databricks_cluster.cluster_name.id
+  #...
+}
+```
+
 The following arguments are available to specify the data object you need to enforce access controls on. You must specify only one of those arguments (except for `table` and `view`), otherwise resource creation will fail.
 
 * `database` - Name of the database. Has default value of `default`.
-* `table` - Name of the table. Can be combined with `database`. 
-* `view` - Name of the view. Can be combined with `database`. 
+* `table` - Name of the table. Can be combined with `database`.
+* `view` - Name of the view. Can be combined with `database`.
 * `catalog` - (Boolean) If this access control for the entire catalog. Defaults to `false`.
 * `any_file` - (Boolean) If this access control for reading/writing any file. Defaults to `false`.
 * `anonymous_function` - (Boolean) If this access control for using anonymous function. Defaults to `false`.
@@ -100,7 +97,7 @@ The resource can be imported using a synthetic identifier. Examples of valid syn
 * `anonymous function/` - anonymous function. `/` suffix is mandatory.
 
 ```bash
-$ terraform import databricks_sql_permissions.foo /<object-type>/<object-name>
+terraform import databricks_sql_permissions.foo /<object-type>/<object-name>
 ```
 
 ## Related Resources


### PR DESCRIPTION
## Changes
- Allowed shared clusters to be specified for `databricks_sql_permissions`
- Updated cluster creation to use `data_security_mode` instead of `spark_conf`
- Updated documentation

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [x] covered with integration tests in `internal/acceptance`
- [x] relevant acceptance tests are passing
