### PR TITLE
[Internal] Refactored `databricks_zones` and `databricks_spark_versions` data sources to Go SDK

### DIFF
--- a/access/resource_sql_permissions.go
+++ b/access/resource_sql_permissions.go
@@ -272,7 +272,7 @@ func (ta *SqlPermissions) initCluster(ctx context.Context, d *schema.ResourceDat
 }
 
 func (ta *SqlPermissions) getOrCreateCluster(clustersAPI clusters.ClustersAPI) (string, error) {
-	sparkVersion := clustersAPI.LatestSparkVersionOrDefault(clusters.SparkVersionRequest{
+	sparkVersion := clusters.LatestSparkVersionOrDefault(clustersAPI.Context(), clustersAPI.WorkspaceClient(), compute.SparkVersionRequest{
 		Latest: true,
 	})
 	nodeType := clustersAPI.GetSmallestNodeType(compute.NodeTypeRequest{LocalDisk: true})

--- a/access/resource_sql_permissions_test.go
+++ b/access/resource_sql_permissions_test.go
@@ -185,11 +185,11 @@ var createHighConcurrencyCluster = []qa.HTTPFixture{
 		Method:       "GET",
 		ReuseRequest: true,
 		Resource:     "/api/2.0/clusters/spark-versions",
-		Response: clusters.SparkVersionsList{
-			SparkVersions: []clusters.SparkVersion{
+		Response: compute.GetSparkVersionsResponse{
+			Versions: []compute.SparkVersion{
 				{
-					Version:     "7.1.x-cpu-ml-scala2.12",
-					Description: "7.1 ML (includes Apache Spark 3.0.0, Scala 2.12)",
+					Key:  "7.1.x-cpu-ml-scala2.12",
+					Name: "7.1 ML (includes Apache Spark 3.0.0, Scala 2.12)",
 				},
 			},
 		},
@@ -262,11 +262,11 @@ var createSharedCluster = []qa.HTTPFixture{
 		Method:       "GET",
 		ReuseRequest: true,
 		Resource:     "/api/2.0/clusters/spark-versions",
-		Response: clusters.SparkVersionsList{
-			SparkVersions: []clusters.SparkVersion{
+		Response: compute.GetSparkVersionsResponse{
+			Versions: []compute.SparkVersion{
 				{
-					Version:     "7.1.x-cpu-ml-scala2.12",
-					Description: "7.1 ML (includes Apache Spark 3.0.0, Scala 2.12)",
+					Key:  "7.1.x-cpu-ml-scala2.12",
+					Name: "7.1 ML (includes Apache Spark 3.0.0, Scala 2.12)",
 				},
 			},
 		},

--- a/access/resource_sql_permissions_test.go
+++ b/access/resource_sql_permissions_test.go
@@ -222,7 +222,7 @@ var createHighConcurrencyCluster = []qa.HTTPFixture{
 			AutoterminationMinutes: 10,
 			ClusterName:            "terraform-table-acl",
 			NodeTypeID:             "Standard_F4s",
-			SparkVersion:           "7.3.x-scala2.12",
+			SparkVersion:           "11.3.x-scala2.12",
 			CustomTags: map[string]string{
 				"ResourceClass": "SingleNode",
 			},
@@ -299,7 +299,7 @@ var createSharedCluster = []qa.HTTPFixture{
 			AutoterminationMinutes: 10,
 			ClusterName:            "terraform-table-acl",
 			NodeTypeID:             "Standard_F4s",
-			SparkVersion:           "7.3.x-scala2.12",
+			SparkVersion:           "11.3.x-scala2.12",
 			CustomTags: map[string]string{
 				"ResourceClass": "SingleNode",
 			},

--- a/catalog/resource_sql_table.go
+++ b/catalog/resource_sql_table.go
@@ -159,7 +159,7 @@ func (ti *SqlTableInfo) initCluster(ctx context.Context, d *schema.ResourceData,
 }
 
 func (ti *SqlTableInfo) getOrCreateCluster(clusterName string, clustersAPI clusters.ClustersAPI) (string, error) {
-	sparkVersion := clustersAPI.LatestSparkVersionOrDefault(clusters.SparkVersionRequest{
+	sparkVersion := clusters.LatestSparkVersionOrDefault(clustersAPI.Context(), clustersAPI.WorkspaceClient(), compute.SparkVersionRequest{
 		Latest: true,
 	})
 	nodeType := clustersAPI.GetSmallestNodeType(compute.NodeTypeRequest{LocalDisk: true})

--- a/catalog/resource_sql_table_test.go
+++ b/catalog/resource_sql_table_test.go
@@ -1248,15 +1248,11 @@ var baseClusterFixture = []qa.HTTPFixture{
 		Method:       "GET",
 		ReuseRequest: true,
 		Resource:     "/api/2.0/clusters/spark-versions",
-		Response: clusters.SparkVersionsList{
-			SparkVersions: []clusters.SparkVersion{
+		Response: compute.GetSparkVersionsResponse{
+			Versions: []compute.SparkVersion{
 				{
-					Version:     "7.1.x-cpu-ml-scala2.12",
-					Description: "7.1 ML (includes Apache Spark 3.0.0, Scala 2.12)",
-				},
-				{
-					Version:     "7.3.x-scala2.12",
-					Description: "7.3 LTS (includes Apache Spark 3.0.1, Scala 2.12)",
+					Key:  "7.1.x-cpu-ml-scala2.12",
+					Name: "7.1 ML (includes Apache Spark 3.0.0, Scala 2.12)",
 				},
 			},
 		},

--- a/catalog/resource_sql_table_test.go
+++ b/catalog/resource_sql_table_test.go
@@ -1254,6 +1254,10 @@ var baseClusterFixture = []qa.HTTPFixture{
 					Key:  "7.1.x-cpu-ml-scala2.12",
 					Name: "7.1 ML (includes Apache Spark 3.0.0, Scala 2.12)",
 				},
+				{
+					Key:  "7.3.x-scala2.12",
+					Name: "7.3 LTS (includes Apache Spark 3.0.1, Scala 2.12)",
+				},
 			},
 		},
 	},

--- a/clusters/clusters_api.go
+++ b/clusters/clusters_api.go
@@ -881,7 +881,6 @@ var getOrCreateClusterMutex sync.Mutex
 
 // GetOrCreateRunningCluster creates an autoterminating cluster if it doesn't exist
 func (a ClustersAPI) GetOrCreateRunningCluster(name string, custom ...Cluster) (c ClusterInfo, err error) {
-	w, err := a.client.WorkspaceClient()
 	getOrCreateClusterMutex.Lock()
 	defer getOrCreateClusterMutex.Unlock()
 
@@ -915,14 +914,13 @@ func (a ClustersAPI) GetOrCreateRunningCluster(name string, custom ...Cluster) (
 		LocalDisk: true,
 	})
 	log.Printf("[INFO] Creating an autoterminating cluster with node type %s", smallestNodeType)
-	latestVersion, _ := w.Clusters.SelectSparkVersion(a.context, compute.SparkVersionRequest{
-		Latest:          true,
-		LongTermSupport: true,
-	})
 	r := Cluster{
-		NumWorkers:             1,
-		ClusterName:            name,
-		SparkVersion:           latestVersion,
+		NumWorkers:  1,
+		ClusterName: name,
+		SparkVersion: LatestSparkVersionOrDefault(a.Context(), a.WorkspaceClient(), compute.SparkVersionRequest{
+			Latest:          true,
+			LongTermSupport: true,
+		}),
 		NodeTypeID:             smallestNodeType,
 		AutoterminationMinutes: 10,
 	}

--- a/clusters/clusters_api_sdk.go
+++ b/clusters/clusters_api_sdk.go
@@ -35,3 +35,12 @@ func StartClusterAndGetInfo(ctx context.Context, w *databricks.WorkspaceClient, 
 	}
 	return w.Clusters.StartByClusterIdAndWait(ctx, clusterID)
 }
+
+// LatestSparkVersionOrDefault returns Spark version matching the definition, or default in case of error
+func LatestSparkVersionOrDefault(ctx context.Context, w *databricks.WorkspaceClient, svr compute.SparkVersionRequest) string {
+	version, err := w.Clusters.SelectSparkVersion(ctx, svr)
+	if err != nil {
+		return "7.3.x-scala2.12"
+	}
+	return version
+}

--- a/clusters/clusters_api_sdk.go
+++ b/clusters/clusters_api_sdk.go
@@ -40,7 +40,7 @@ func StartClusterAndGetInfo(ctx context.Context, w *databricks.WorkspaceClient, 
 func LatestSparkVersionOrDefault(ctx context.Context, w *databricks.WorkspaceClient, svr compute.SparkVersionRequest) string {
 	version, err := w.Clusters.SelectSparkVersion(ctx, svr)
 	if err != nil {
-		return "7.3.x-scala2.12"
+		return "11.3.x-scala2.12"
 	}
 	return version
 }

--- a/clusters/clusters_api_test.go
+++ b/clusters/clusters_api_test.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 
 	// "reflect"
-	"strings"
+
 	"testing"
 
 	"github.com/databricks/databricks-sdk-go/apierr"
@@ -28,23 +28,23 @@ func TestGetOrCreateRunningCluster_AzureAuth(t *testing.T) {
 			Method:       "GET",
 			ReuseRequest: true,
 			Resource:     "/api/2.0/clusters/spark-versions",
-			Response: SparkVersionsList{
-				SparkVersions: []SparkVersion{
+			Response: compute.GetSparkVersionsResponse{
+				Versions: []compute.SparkVersion{
 					{
-						Version:     "7.1.x-cpu-ml-scala2.12",
-						Description: "7.1 ML (includes Apache Spark 3.0.0, Scala 2.12)",
+						Key:  "7.1.x-cpu-ml-scala2.12",
+						Name: "7.1 ML (includes Apache Spark 3.0.0, Scala 2.12)",
 					},
 					{
-						Version:     "apache-spark-2.4.x-scala2.11",
-						Description: "Light 2.4 (includes Apache Spark 2.4, Scala 2.11)",
+						Key:  "apache-spark-2.4.x-scala2.11",
+						Name: "Light 2.4 (includes Apache Spark 2.4, Scala 2.11)",
 					},
 					{
-						Version:     "7.3.x-scala2.12",
-						Description: "7.3 LTS (includes Apache Spark 3.0.1, Scala 2.12)",
+						Key:  "7.3.x-scala2.12",
+						Name: "7.3 LTS (includes Apache Spark 3.0.1, Scala 2.12)",
 					},
 					{
-						Version:     "6.4.x-scala2.11",
-						Description: "6.4 (includes Apache Spark 2.4.5, Scala 2.11)",
+						Key:  "6.4.x-scala2.11",
+						Name: "6.4 (includes Apache Spark 2.4.5, Scala 2.11)",
 					},
 				},
 			},
@@ -1014,119 +1014,6 @@ func TestEventsEmptyResult(t *testing.T) {
 	clusterEvents, err := NewClustersAPI(ctx, client).Events(EventsRequest{ClusterID: "abc", MaxItems: 3, Limit: 2})
 	require.NoError(t, err)
 	assert.Equal(t, len(clusterEvents), 0)
-}
-
-func TestListSparkVersions(t *testing.T) {
-	client, server, err := qa.HttpFixtureClient(t, []qa.HTTPFixture{
-		{
-			Method:   "GET",
-			Resource: "/api/2.0/clusters/spark-versions",
-			Response: SparkVersionsList{
-				SparkVersions: []SparkVersion{
-					{
-						Version:     "7.1.x-cpu-ml-scala2.12",
-						Description: "7.1 ML (includes Apache Spark 3.0.0, Scala 2.12)",
-					},
-					{
-						Version:     "apache-spark-2.4.x-scala2.11",
-						Description: "Light 2.4 (includes Apache Spark 2.4, Scala 2.11)",
-					},
-					{
-						Version:     "7.3.x-hls-scala2.12",
-						Description: "7.3 LTS Genomics (includes Apache Spark 3.0.1, Scala 2.12)",
-					},
-					{
-						Version:     "6.4.x-scala2.11",
-						Description: "6.4 (includes Apache Spark 2.4.5, Scala 2.11)",
-					},
-				},
-			},
-		},
-	})
-	defer server.Close()
-	require.NoError(t, err)
-
-	ctx := context.Background()
-	sparkVersions, err := NewClustersAPI(ctx, client).ListSparkVersions()
-	require.NoError(t, err)
-	require.Equal(t, 4, len(sparkVersions.SparkVersions))
-	require.Equal(t, "6.4.x-scala2.11", sparkVersions.SparkVersions[3].Version)
-}
-
-func TestListSparkVersionsWithError(t *testing.T) {
-	client, server, err := qa.HttpFixtureClient(t, []qa.HTTPFixture{
-		{
-			Method:   "GET",
-			Resource: "/api/2.0/clusters/spark-versions",
-			Response: "{garbage....",
-		},
-	})
-	defer server.Close()
-	require.NoError(t, err)
-
-	ctx := context.Background()
-	_, err = NewClustersAPI(ctx, client).ListSparkVersions()
-	require.Error(t, err)
-	require.Equal(t, true, strings.Contains(err.Error(), "invalid character 'g' looking"))
-}
-
-func TestGetLatestSparkVersion(t *testing.T) {
-	versions := SparkVersionsList{
-		SparkVersions: []SparkVersion{
-			{
-				Version:     "7.1.x-cpu-ml-scala2.12",
-				Description: "7.1 ML (includes Apache Spark 3.0.0, Scala 2.12)",
-			},
-			{
-				Version:     "apache-spark-2.4.x-scala2.11",
-				Description: "Light 2.4 (includes Apache Spark 2.4, Scala 2.11)",
-			},
-			{
-				Version:     "7.3.x-hls-scala2.12",
-				Description: "7.3 LTS Genomics (includes Apache Spark 3.0.1, Scala 2.12)",
-			},
-			{
-				Version:     "6.4.x-scala2.11",
-				Description: "6.4 (includes Apache Spark 2.4.5, Scala 2.11)",
-			},
-			{
-				Version:     "7.3.x-scala2.12",
-				Description: "7.3 LTS (includes Apache Spark 3.0.1, Scala 2.12)",
-			},
-			{
-				Version:     "7.4.x-scala2.12",
-				Description: "7.4 (includes Apache Spark 3.0.1, Scala 2.12)",
-			},
-			{
-				Version:     "7.1.x-scala2.12",
-				Description: "7.1 (includes Apache Spark 3.0.0, Scala 2.12)",
-			},
-		},
-	}
-
-	version, err := versions.LatestSparkVersion(SparkVersionRequest{Scala: "2.12", Latest: true})
-	require.NoError(t, err)
-	require.Equal(t, "7.4.x-scala2.12", version)
-
-	version, err = versions.LatestSparkVersion(SparkVersionRequest{Scala: "2.12", LongTermSupport: true, Latest: true})
-	require.NoError(t, err)
-	require.Equal(t, "7.3.x-scala2.12", version)
-
-	version, err = versions.LatestSparkVersion(SparkVersionRequest{Scala: "2.12", Latest: true, SparkVersion: "3.0.0"})
-	require.NoError(t, err)
-	require.Equal(t, "7.1.x-scala2.12", version)
-
-	_, err = versions.LatestSparkVersion(SparkVersionRequest{Scala: "2.12"})
-	require.Error(t, err)
-	require.Equal(t, true, strings.Contains(err.Error(), "query returned multiple results"))
-
-	_, err = versions.LatestSparkVersion(SparkVersionRequest{Scala: "2.12", ML: true, Genomics: true})
-	require.Error(t, err)
-	require.Equal(t, true, strings.Contains(err.Error(), "query returned no results"))
-
-	_, err = versions.LatestSparkVersion(SparkVersionRequest{Scala: "2.12", SparkVersion: "3.10"})
-	require.Error(t, err)
-	require.Equal(t, true, strings.Contains(err.Error(), "query returned no results"))
 }
 
 func TestClusterState_CanReach(t *testing.T) {

--- a/clusters/data_spark_version.go
+++ b/clusters/data_spark_version.go
@@ -2,128 +2,12 @@ package clusters
 
 import (
 	"context"
-	"fmt"
-	"regexp"
-	"sort"
-	"strings"
 
 	"github.com/databricks/databricks-sdk-go"
 	"github.com/databricks/databricks-sdk-go/service/compute"
 	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"golang.org/x/mod/semver"
 )
-
-// SparkVersion - contains information about specific version
-type SparkVersion struct {
-	Version     string `json:"key"`
-	Description string `json:"name"`
-}
-
-// SparkVersionsList - returns a list of all currently supported Spark Versions
-// https://docs.databricks.com/dev-tools/api/latest/clusters.html#runtime-versions
-type SparkVersionsList struct {
-	SparkVersions []SparkVersion `json:"versions"`
-}
-
-// SparkVersionRequest - filtering request
-type SparkVersionRequest struct {
-	LongTermSupport bool   `json:"long_term_support,omitempty"`
-	Beta            bool   `json:"beta,omitempty" tf:"conflicts:long_term_support"`
-	Latest          bool   `json:"latest,omitempty" tf:"default:true"`
-	ML              bool   `json:"ml,omitempty"`
-	Genomics        bool   `json:"genomics,omitempty"`
-	GPU             bool   `json:"gpu,omitempty"`
-	Scala           string `json:"scala,omitempty" tf:"default:2.12"`
-	SparkVersion    string `json:"spark_version,omitempty"`
-	Photon          bool   `json:"photon,omitempty"`
-	Graviton        bool   `json:"graviton,omitempty"`
-}
-
-// ListSparkVersions returns smallest (or default) node type id given the criteria
-func (a ClustersAPI) ListSparkVersions() (SparkVersionsList, error) {
-	var sparkVersions SparkVersionsList
-	err := a.client.Get(a.context, "/clusters/spark-versions", nil, &sparkVersions)
-	return sparkVersions, err
-}
-
-type sparkVersionsType []string
-
-func (s sparkVersionsType) Len() int {
-	return len(s)
-}
-func (s sparkVersionsType) Swap(i, j int) {
-	s[i], s[j] = s[j], s[i]
-}
-
-var dbrVersionRegex = regexp.MustCompile(`^(\d+\.\d+)\.x-.*`)
-
-func extractDbrVersions(s string) string {
-	m := dbrVersionRegex.FindStringSubmatch(s)
-	if len(m) > 1 {
-		return m[1]
-	}
-	return s
-}
-
-func (s sparkVersionsType) Less(i, j int) bool {
-	return semver.Compare("v"+extractDbrVersions(s[i]), "v"+extractDbrVersions(s[j])) > 0
-}
-
-// LatestSparkVersion returns latest version matching the request parameters
-func (sparkVersions SparkVersionsList) LatestSparkVersion(req SparkVersionRequest) (string, error) {
-	var versions []string
-
-	for _, version := range sparkVersions.SparkVersions {
-		if strings.Contains(version.Version, "-scala"+req.Scala) {
-			matches := ((!strings.Contains(version.Version, "apache-spark-")) &&
-				(strings.Contains(version.Version, "-ml-") == req.ML) &&
-				(strings.Contains(version.Version, "-hls-") == req.Genomics) &&
-				(strings.Contains(version.Version, "-gpu-") == req.GPU) &&
-				(strings.Contains(version.Version, "-photon-") == req.Photon) &&
-				(strings.Contains(version.Version, "-aarch64-") == req.Graviton) &&
-				(strings.Contains(version.Description, "Beta") == req.Beta))
-			if matches && req.LongTermSupport {
-				matches = (matches && (strings.Contains(version.Description, "LTS") || strings.Contains(version.Version, "-esr-")))
-			}
-			if matches && len(req.SparkVersion) > 0 {
-				matches = (matches && strings.Contains(version.Description, "Apache Spark "+req.SparkVersion))
-			}
-			if matches {
-				versions = append(versions, version.Version)
-			}
-		}
-	}
-	if len(versions) < 1 {
-		return "", fmt.Errorf("spark versions query returned no results. Please change your search criteria and try again")
-	} else if len(versions) > 1 {
-		if req.Latest {
-			sort.Sort(sparkVersionsType(versions))
-		} else {
-			return "", fmt.Errorf("spark versions query returned multiple results. Please change your search criteria and try again")
-		}
-	}
-
-	return versions[0], nil
-}
-
-// LatestSparkVersion returns latest version matching the request parameters
-func (a ClustersAPI) LatestSparkVersion(svr SparkVersionRequest) (string, error) {
-	sparkVersions, err := a.ListSparkVersions()
-	if err != nil {
-		return "", err
-	}
-	return sparkVersions.LatestSparkVersion(svr)
-}
-
-// LatestSparkVersionOrDefault returns Spark version matching the definition, or default in case of error
-func (a ClustersAPI) LatestSparkVersionOrDefault(svr SparkVersionRequest) string {
-	version, err := a.LatestSparkVersion(svr)
-	if err != nil {
-		return "7.3.x-scala2.12"
-	}
-	return version
-}
 
 // DataSourceSparkVersion returns DBR version matching to the specification
 func DataSourceSparkVersion() common.Resource {

--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -180,10 +180,10 @@ func TestImportingMounts(t *testing.T) {
 				Method:       "GET",
 				ReuseRequest: true,
 				Resource:     "/api/2.0/clusters/spark-versions",
-				Response: clusters.SparkVersionsList{
-					SparkVersions: []clusters.SparkVersion{
+				Response: compute.GetSparkVersionsResponse{
+					Versions: []compute.SparkVersion{
 						{
-							Version: "Foo LTS",
+							Key: "Foo LTS",
 						},
 					},
 				},

--- a/storage/gs_test.go
+++ b/storage/gs_test.go
@@ -65,7 +65,7 @@ func TestCreateOrValidateClusterForGoogleStorage_WorksOnDeletedCluster(t *testin
 				GcpAttributes: &clusters.GcpAttributes{
 					GoogleServiceAccount: "service-account",
 				},
-				SparkVersion:           "7.3.x-scala2.12",
+				SparkVersion:           "11.3.x-scala2.12",
 				NumWorkers:             0,
 				NodeTypeID:             "i3.xlarge",
 				AutoterminationMinutes: 10,

--- a/storage/mounts.go
+++ b/storage/mounts.go
@@ -137,11 +137,10 @@ func getCommonClusterObject(clustersAPI clusters.ClustersAPI, clusterName string
 	return clusters.Cluster{
 		NumWorkers:  0,
 		ClusterName: clusterName,
-		SparkVersion: clustersAPI.LatestSparkVersionOrDefault(
-			clusters.SparkVersionRequest{
-				Latest:          true,
-				LongTermSupport: true,
-			}),
+		SparkVersion: clusters.LatestSparkVersionOrDefault(clustersAPI.Context(), clustersAPI.WorkspaceClient(), compute.SparkVersionRequest{
+			Latest:          true,
+			LongTermSupport: true,
+		}),
 		NodeTypeID: clustersAPI.GetSmallestNodeType(
 			compute.NodeTypeRequest{
 				LocalDisk: true,

--- a/storage/mounts_test.go
+++ b/storage/mounts_test.go
@@ -212,7 +212,7 @@ func TestDeletedMountClusterRecreates(t *testing.T) {
 				AutoterminationMinutes: 10,
 				ClusterName:            "terraform-mount",
 				NodeTypeID:             "Standard_F4s",
-				SparkVersion:           "7.3.x-scala2.12",
+				SparkVersion:           "11.3.x-scala2.12",
 				CustomTags: map[string]string{
 					"ResourceClass": "SingleNode",
 				},

--- a/storage/mounts_test.go
+++ b/storage/mounts_test.go
@@ -174,11 +174,11 @@ func TestDeletedMountClusterRecreates(t *testing.T) {
 			Method:       "GET",
 			ReuseRequest: true,
 			Resource:     "/api/2.0/clusters/spark-versions",
-			Response: clusters.SparkVersionsList{
-				SparkVersions: []clusters.SparkVersion{
+			Response: compute.GetSparkVersionsResponse{
+				Versions: []compute.SparkVersion{
 					{
-						Version:     "7.1.x-cpu-ml-scala2.12",
-						Description: "7.1 ML (includes Apache Spark 3.0.0, Scala 2.12)",
+						Key:  "7.1.x-cpu-ml-scala2.12",
+						Name: "7.1 ML (includes Apache Spark 3.0.0, Scala 2.12)",
 					},
 				},
 			},

--- a/storage/resource_mount_test.go
+++ b/storage/resource_mount_test.go
@@ -21,11 +21,11 @@ import (
 // Test interface compliance via compile time error
 var _ Mount = (*S3IamMount)(nil)
 
-var sparkVersionsResponse = clusters.SparkVersionsList{
-	SparkVersions: []clusters.SparkVersion{
+var sparkVersionsResponse = compute.GetSparkVersionsResponse{
+	Versions: []compute.SparkVersion{
 		{
-			Version:     "7.3.x-scala2.12",
-			Description: "7.3 LTS (includes Apache Spark 3.0.1, Scala 2.12)",
+			Key:  "7.3.x-scala2.12",
+			Name: "7.3 LTS (includes Apache Spark 3.0.1, Scala 2.12)",
 		},
 	},
 }

--- a/storage/s3_test.go
+++ b/storage/s3_test.go
@@ -62,7 +62,7 @@ func TestPreprocessS3MountOnDeletedClusterWorks(t *testing.T) {
 					"ResourceClass": "SingleNode",
 				},
 				ClusterName:  "terraform-mount-s3-access",
-				SparkVersion: "7.3.x-scala2.12",
+				SparkVersion: "11.3.x-scala2.12",
 				NumWorkers:   0,
 				NodeTypeID:   "i3.xlarge",
 				AwsAttributes: &clusters.AwsAttributes{


### PR DESCRIPTION
## Changes
- `LatestSparkVersionOrDefault` now returns 11.3 LTS, as 7.3 LTS is deprecated
- Refactored `databricks_zones` to Go SDK
- Refactored `databricks_spark_versions` to Go SDK. This refactoring require one additional change to `resource.go`:
  - Add new method `WorkspaceDataWithCustomizeFunc` to allow customization of the data source schema
- Removed Spark versions related methods, as these have now moved to Go SDK. This requires migrating the function `LatestSparkVersionOrDefault` to a Go SDK method, which requires changing existing structs in Terraform provider to equivalent in Go SDK (`clusters.SparkVersionsList` to `compute.GetSparkVersionsResponse`, etc.)

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] covered with integration tests in `internal/acceptance`
- [x] relevant acceptance tests are passing
- [x] using Go SDK
