### PR TITLE
Make the schedule.pause_status field read-only

### DIFF
--- a/catalog/resource_quality_monitor.go
+++ b/catalog/resource_quality_monitor.go
@@ -53,6 +53,7 @@ func ResourceQualityMonitor() common.Resource {
 			common.CustomizeSchemaPath(m, "profile_metrics_table_name").SetReadOnly()
 			common.CustomizeSchemaPath(m, "status").SetReadOnly()
 			common.CustomizeSchemaPath(m, "dashboard_id").SetReadOnly()
+			common.CustomizeSchemaPath(m, "schedule", "pause_status").SetReadOnly()
 			return m
 		},
 	)

--- a/docs/resources/quality_monitor.md
+++ b/docs/resources/quality_monitor.md
@@ -112,7 +112,6 @@ table.
 * `schedule` - The schedule for automatically updating and refreshing metric tables.  This block consists of following fields:
     * `quartz_cron_expression` - string expression that determines when to run the monitor. See [Quartz documentation](https://www.quartz-scheduler.org/documentation/quartz-2.3.0/tutorials/crontrigger.html) for examples.
     * `timezone_id` - string with timezone id (e.g., `PST`) in which to evaluate the Quartz expression.
-    * `pause_status` - optional string field that indicates whether a schedule is paused (`PAUSED`) or not (`UNPAUSED`).
 * `skip_builtin_dashboard` - Whether to skip creating a default dashboard summarizing data quality metrics.
 * `slicing_exprs` - List of column expressions to slice data with for targeted analysis. The data is grouped by each expression independently, resulting in a separate slice for each predicate and its complements. For high-cardinality columns, only the top 100 unique values by frequency will generate slices.
 * `warehouse_id` - Optional argument to specify the warehouse for dashboard creation. If not specified, the first running warehouse will be used.


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
This PR will resolve https://github.com/databricks/terraform-provider-databricks/issues/3691.
- Make the `schedule.pause_status` field read-only.
- Remove the description of the field from the documentation.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [x] using Go SDK

I locally confirmed that the `terraform plan` command no longer showed any change for the `schedule.pause_status` field.