### PR TITLE
Add terraform support for periodic triggers

### DIFF
--- a/docs/resources/job.md
+++ b/docs/resources/job.md
@@ -345,6 +345,10 @@ This block describes the queue settings of the job:
 ### trigger Configuration Block
 
 * `pause_status` - (Optional) Indicate whether this trigger is paused or not. Either `PAUSED` or `UNPAUSED`. When the `pause_status` field is omitted in the block, the server will default to using `UNPAUSED` as a value for `pause_status`.
+* `periodic` - (Optional) configuration block to define a trigger for Periodic Triggers consisting of the following attributes:
+  * `interval` - (Required) Specifies the interval at which the job should run. This value is required.
+  * `unit` - (Required) Options are {"DAYS", "HOURS", "WEEKS"}.
+
 * `file_arrival` - (Optional) configuration block to define a trigger for [File Arrival events](https://learn.microsoft.com/en-us/azure/databricks/workflows/jobs/file-arrival-triggers) consisting of following attributes:
   * `url` - (Required) URL to be monitored for file arrivals. The path must point to the root or a subpath of the external location. Please note that the URL must have a trailing slash character (`/`).
   * `min_time_between_triggers_seconds` - (Optional) If set, the trigger starts a run only after the specified amount of time passed since the last time the trigger fired. The minimum allowed value is 60 seconds.

--- a/jobs/resource_job.go
+++ b/jobs/resource_job.go
@@ -272,9 +272,15 @@ type TableUpdate struct {
 	WaitAfterLastChangeSeconds    int32    `json:"wait_after_last_change_seconds,omitempty"`
 }
 
+type Periodic struct {
+	Interval int32  `json:"interval"`
+	Unit     string `json:"unit"`
+}
+
 type Trigger struct {
 	FileArrival *FileArrival `json:"file_arrival,omitempty"`
 	TableUpdate *TableUpdate `json:"table_update,omitempty"`
+	Periodic    *Periodic    `json:"periodic,omitempty"`
 	PauseStatus string       `json:"pause_status,omitempty" tf:"default:UNPAUSED"`
 }
 
@@ -566,9 +572,10 @@ func (JobSettingsResource) CustomizeSchema(s *common.CustomizableSchema) *common
 	s.SchemaPath("continuous").SetConflictsWith([]string{"schedule", "trigger"})
 	s.SchemaPath("trigger").SetConflictsWith([]string{"continuous", "schedule"})
 
-	trigger_eoo := []string{"trigger.0.file_arrival", "trigger.0.table_update"}
+	trigger_eoo := []string{"trigger.0.file_arrival", "trigger.0.table_update", "trigger.0.periodic"}
 	s.SchemaPath("trigger", "file_arrival").SetExactlyOneOf(trigger_eoo)
 	s.SchemaPath("trigger", "table_update").SetExactlyOneOf(trigger_eoo)
+	s.SchemaPath("trigger", "periodic").SetExactlyOneOf(trigger_eoo)
 
 	// Deprecated Job API 2.0 attributes
 	var topLevelDeprecatedAttr = []string{

--- a/jobs/resource_job_test.go
+++ b/jobs/resource_job_test.go
@@ -1415,7 +1415,7 @@ func TestResourceJobCreate_Trigger_PeriodicCreate(t *testing.T) {
 						Trigger: &Trigger{
 							PauseStatus: "UNPAUSED",
 							Periodic: &Periodic{
-								Interval: 42,
+								Interval: 4,
 								Unit:     "HOURS",
 							},
 						},

--- a/jobs/resource_job_test.go
+++ b/jobs/resource_job_test.go
@@ -1381,6 +1381,62 @@ func TestResourceJobCreate_Trigger_TableUpdateCreate(t *testing.T) {
 	}.ApplyNoError(t)
 }
 
+func TestResourceJobCreate_Trigger_PeriodicCreate(t *testing.T) {
+	qa.ResourceFixture{
+		Create:   true,
+		Resource: ResourceJob(),
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "POST",
+				Resource: "/api/2.0/jobs/create",
+				ExpectedRequest: JobSettings{
+					MaxConcurrentRuns: 1,
+					Name:              "Test",
+					Trigger: &Trigger{
+						PauseStatus: "UNPAUSED",
+						Periodic: &Periodic{
+							Interval: 4,
+							Unit:     "HOURS",
+						},
+					},
+				},
+				Response: Job{
+					JobID: 1042,
+				},
+			},
+			{
+				Method:   "GET",
+				Resource: "/api/2.0/jobs/get?job_id=1042",
+				Response: Job{
+					JobID: 1042,
+					Settings: &JobSettings{
+						MaxConcurrentRuns: 1,
+						Name:              "Test",
+						Trigger: &Trigger{
+							PauseStatus: "UNPAUSED",
+							Periodic: &Periodic{
+								Interval: 42,
+								Unit:     "HOURS",
+							},
+						},
+					},
+				},
+			},
+		},
+		HCL: `
+		trigger {
+			pause_status = "UNPAUSED"
+			periodic {
+				interval = 4
+				unit = "HOURS"
+			}
+		}
+		max_concurrent_runs = 1
+		name = "Test"
+		`,
+	}.ApplyNoError(t)
+}
+
 func TestResourceJobUpdate_ControlRunState_ContinuousUpdateRunNow(t *testing.T) {
 	qa.ResourceFixture{
 		Update:   true,


### PR DESCRIPTION
## Changes
- Add terraform support for periodic trigger for workflows. 

## Tests
- New test added to validate periodic triggers.


- [X] `make test` run locally
- [X] relevant change in `docs/` folder
- [X] covered with integration tests in `internal/acceptance`
- [X] relevant acceptance tests are passing
```
➜  terraform-provider-databricks git:(periodic_triggers) ✗ CLOUD_ENV=aws go test -timeout 4800s -run ^TestAccPeriodicTrigger$ github.com/databricks/terraform-provider-databricks/internal/acceptance
ok  	github.com/databricks/terraform-provider-databricks/internal/acceptance	5.003s
```
- [X] using Go SDK
