### PR TITLE
Fixed case sensitivity for principals in `databricks_grants` and `databricks_grant`

### DIFF
--- a/catalog/resource_grant.go
+++ b/catalog/resource_grant.go
@@ -20,15 +20,15 @@ func diffPermissionsForPrincipal(principal string, desired catalog.PermissionsLi
 	// diffs change sets for principal
 	configured := map[string]*schema.Set{}
 	for _, v := range desired.PrivilegeAssignments {
-		if strings.EqualFold(v.Principal, principal) {
-			configured[strings.ToLower(v.Principal)] = permissions.SliceToSet(v.Privileges)
+		if v.Principal == principal {
+			configured[v.Principal] = permissions.SliceToSet(v.Privileges)
 		}
 	}
 	// existing permissions that needs removal for principal
 	remote := map[string]*schema.Set{}
 	for _, v := range existing.PrivilegeAssignments {
-		if strings.EqualFold(v.Principal, principal) {
-			remote[strings.ToLower(v.Principal)] = permissions.SliceToSet(v.Privileges)
+		if v.Principal == principal {
+			remote[v.Principal] = permissions.SliceToSet(v.Privileges)
 		}
 	}
 	// STEP 1: detect overlaps
@@ -87,7 +87,7 @@ func filterPermissionsForPrincipal(in catalog.PermissionsList, principal string)
 	grantsForPrincipal := []permissions.UnityCatalogPrivilegeAssignment{}
 	for _, v := range in.PrivilegeAssignments {
 		privileges := []string{}
-		if strings.EqualFold(v.Principal, principal) {
+		if v.Principal == principal {
 			for _, p := range v.Privileges {
 				privileges = append(privileges, p.String())
 			}
@@ -122,7 +122,7 @@ func parseSecurableId(d *schema.ResourceData) (string, string, string, error) {
 func ResourceGrant() common.Resource {
 	s := common.StructToSchema(permissions.UnityCatalogPrivilegeAssignment{},
 		func(m map[string]*schema.Schema) map[string]*schema.Schema {
-			common.CustomizeSchemaPath(m, "principal").SetForceNew().SetCustomSuppressDiff(common.EqualFoldDiffSuppress)
+			common.CustomizeSchemaPath(m, "principal").SetForceNew()
 
 			// set custom hash function for privileges
 			common.MustSchemaPath(m, "privileges").Set = func(i any) int {

--- a/catalog/resource_grant_test.go
+++ b/catalog/resource_grant_test.go
@@ -538,7 +538,7 @@ func TestResourceGrantPermissionsList_Diff_CaseSensitive(t *testing.T) {
 		catalog.PermissionsList{ // config
 			PrivilegeAssignments: []catalog.PrivilegeAssignment{
 				{
-					Principal:  "a",
+					Principal:  "A",
 					Privileges: []catalog.Privilege{"a"},
 				},
 				{
@@ -550,7 +550,7 @@ func TestResourceGrantPermissionsList_Diff_CaseSensitive(t *testing.T) {
 		catalog.PermissionsList{
 			PrivilegeAssignments: []catalog.PrivilegeAssignment{ // platform
 				{
-					Principal:  "A",
+					Principal:  "a",
 					Privileges: []catalog.Privilege{"a"},
 				},
 				{
@@ -560,7 +560,7 @@ func TestResourceGrantPermissionsList_Diff_CaseSensitive(t *testing.T) {
 			},
 		},
 	)
-	assert.Len(t, diff, 0)
+	assert.Len(t, diff, 1)
 }
 
 func TestResourceGrantPermissionsList_Diff_ExternallyAddedPriv(t *testing.T) {

--- a/catalog/resource_grants.go
+++ b/catalog/resource_grants.go
@@ -31,12 +31,12 @@ func diffPermissions(pl catalog.PermissionsList, existing catalog.PermissionsLis
 	// diffs change sets
 	configured := map[string]*schema.Set{}
 	for _, v := range pl.PrivilegeAssignments {
-		configured[strings.ToLower(v.Principal)] = permissions.SliceToSet(v.Privileges)
+		configured[v.Principal] = permissions.SliceToSet(v.Privileges)
 	}
 	// existing permissions that needs removal
 	remote := map[string]*schema.Set{}
 	for _, v := range existing.PrivilegeAssignments {
-		remote[strings.ToLower(v.Principal)] = permissions.SliceToSet(v.Privileges)
+		remote[v.Principal] = permissions.SliceToSet(v.Privileges)
 	}
 	// STEP 1: detect overlaps
 	for principal, confPrivs := range configured {

--- a/catalog/resource_grants_test.go
+++ b/catalog/resource_grants_test.go
@@ -437,7 +437,7 @@ func TestPermissionsList_Diff_CaseSensitivePrincipal(t *testing.T) {
 			},
 		},
 	)
-	assert.Len(t, diff, 0)
+	assert.Len(t, diff, 2)
 }
 
 func TestPermissionsList_Diff_LocalRemoteDiff(t *testing.T) {

--- a/internal/acceptance/grant_test.go
+++ b/internal/acceptance/grant_test.go
@@ -104,7 +104,7 @@ func TestUcAccGrant(t *testing.T) {
 	}, step{
 		Template: strings.ReplaceAll(grantTemplate, "%s", "{env.TEST_DATA_SCI_GROUP}"),
 	}, step{
-		Template: strings.ReplaceAll(strings.ReplaceAll(grantTemplate, "ALL_PRIVILEGES", "ALL PRIVILEGES"), `"%s"`, `upper("{env.TEST_DATA_SCI_GROUP}")`),
+		Template: strings.ReplaceAll(strings.ReplaceAll(grantTemplate, "ALL_PRIVILEGES", "ALL PRIVILEGES"), "%s", "{env.TEST_DATA_ENG_GROUP}"),
 	})
 }
 

--- a/internal/acceptance/grants_test.go
+++ b/internal/acceptance/grants_test.go
@@ -110,7 +110,7 @@ func TestUcAccGrants(t *testing.T) {
 	}, step{
 		Template: strings.ReplaceAll(grantsTemplate, "%s", "{env.TEST_DATA_SCI_GROUP}"),
 	}, step{
-		Template: strings.ReplaceAll(strings.ReplaceAll(grantsTemplate, "ALL_PRIVILEGES", "ALL PRIVILEGES"), `"%s"`, `upper("{env.TEST_DATA_SCI_GROUP}")`),
+		Template: strings.ReplaceAll(strings.ReplaceAll(grantsTemplate, "ALL_PRIVILEGES", "ALL PRIVILEGES"), "%s", "{env.TEST_DATA_ENG_GROUP}"),
 	})
 }
 


### PR DESCRIPTION
## Changes
- Don't normalize principals to lower case, as group names are case sensitive
- Closes #3705

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] covered with integration tests in `internal/acceptance`
- [x] relevant acceptance tests are passing
- [x] using Go SDK
