### PR TITLE
Fix invalid priviledges in grants.md

### DIFF
--- a/docs/resources/grants.md
+++ b/docs/resources/grants.md
@@ -274,15 +274,15 @@ resource "databricks_grants" "some" {
   }
   grant {
     principal  = databricks_service_principal.my_sp.application_id
-    privileges = ["USE_SCHEMA", "MODIFY"]
+    privileges = ["CREATE_EXTERNAL_TABLE", "READ_FILES"]
   }
   grant {
     principal  = databricks_group.my_group.display_name
-    privileges = ["USE_SCHEMA", "MODIFY"]
+    privileges = ["CREATE_EXTERNAL_TABLE", "READ_FILES"]
   }
   grant {
     principal  = databricks_group.my_user.user_name
-    privileges = ["USE_SCHEMA", "MODIFY"]
+    privileges = ["CREATE_EXTERNAL_TABLE", "READ_FILES"]
   }
 }
 ```


### PR DESCRIPTION
## Changes
Fixes the example docs so correct privileges are used when granting permissions on External Locations.
See https://docs.databricks.com/en/data-governance/unity-catalog/manage-privileges/privileges.html#privilege-types-by-securable-object-in-unity-catalog

## Tests
N/A

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
