### PR TITLE
Exporter: fix generation of `run_as` blocks in `databricks_job`

### DIFF
--- a/exporter/context.go
+++ b/exporter/context.go
@@ -360,10 +360,10 @@ func (ic *importContext) Run() error {
 		if err != nil {
 			return err
 		}
+		ic.meUserName = me.UserName
 		for _, g := range me.Groups {
 			if g.Display == "admins" {
 				ic.meAdmin = true
-				ic.meUserName = me.UserName
 				break
 			}
 		}

--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -2553,7 +2553,19 @@ resource "databricks_pipeline" "def" {
 func TestImportingRunJobTask(t *testing.T) {
 	qa.HTTPFixturesApply(t,
 		[]qa.HTTPFixture{
-			meAdminFixture,
+			{
+				Method:       "GET",
+				ReuseRequest: true,
+				Resource:     "/api/2.0/preview/scim/v2/Me",
+				Response: scim.User{
+					Groups: []scim.ComplexValue{
+						{
+							Display: "admins",
+						},
+					},
+					UserName: "user@domain.com",
+				},
+			},
 			noCurrentMetastoreAttached,
 			emptyRepos,
 			emptyIpAccessLIst,
@@ -2598,6 +2610,9 @@ func TestImportingRunJobTask(t *testing.T) {
 			assert.True(t, strings.Contains(contentStr, `resource "databricks_job" "jartask_932035899730845"`))
 			assert.True(t, strings.Contains(contentStr, `run_as {
     service_principal_name = "c1b2a35b-87c4-481a-a0fb-0508be621957"
+  }`))
+			assert.False(t, strings.Contains(contentStr, `run_as {
+     user_name = "user@domain.com"
   }`))
 		})
 }

--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -2596,5 +2596,8 @@ func TestImportingRunJobTask(t *testing.T) {
 			assert.True(t, strings.Contains(contentStr, `job_id = databricks_job.jartask_932035899730845.id`))
 			assert.True(t, strings.Contains(contentStr, `resource "databricks_job" "runjobtask_1047501313827425"`))
 			assert.True(t, strings.Contains(contentStr, `resource "databricks_job" "jartask_932035899730845"`))
+			assert.True(t, strings.Contains(contentStr, `run_as {
+    service_principal_name = "c1b2a35b-87c4-481a-a0fb-0508be621957"
+  }`))
 		})
 }

--- a/exporter/importables.go
+++ b/exporter/importables.go
@@ -635,6 +635,9 @@ var resourcesMap map[string]importable = map[string]importable{
 				if js.NotificationSettings != nil {
 					return reflect.DeepEqual(*js.NotificationSettings, sdk_jobs.JobNotificationSettings{})
 				}
+			case "run_as":
+				log.Printf("[DEBUG] Skipping run_as field in job %s", d.Id())
+				return !(js.RunAs != nil && (js.RunAs.UserName != "" || js.RunAs.ServicePrincipalName != ""))
 			}
 			if strings.HasPrefix(pathString, "task.") {
 				parts := strings.Split(pathString, ".")

--- a/exporter/importables.go
+++ b/exporter/importables.go
@@ -636,8 +636,16 @@ var resourcesMap map[string]importable = map[string]importable{
 					return reflect.DeepEqual(*js.NotificationSettings, sdk_jobs.JobNotificationSettings{})
 				}
 			case "run_as":
-				log.Printf("[DEBUG] Skipping run_as field in job %s", d.Id())
-				return !(js.RunAs != nil && (js.RunAs.UserName != "" || js.RunAs.ServicePrincipalName != ""))
+				if js.RunAs != nil && (js.RunAs.UserName != "" || js.RunAs.ServicePrincipalName != "") {
+					var user string
+					if js.RunAs.UserName != "" {
+						user = js.RunAs.UserName
+					} else {
+						user = js.RunAs.ServicePrincipalName
+					}
+					return user == ic.meUserName
+				}
+				return true
 			}
 			if strings.HasPrefix(pathString, "task.") {
 				parts := strings.Split(pathString, ".")

--- a/exporter/test-data/run-job-child.json
+++ b/exporter/test-data/run-job-child.json
@@ -1,6 +1,8 @@
 {
   "created_time":1678702840675,
   "job_id":932035899730845,
+  "run_as_user_name": "c1b2a35b-87c4-481a-a0fb-0508be621957",
+  "run_as_owner": false,
   "settings": {
     "format":"MULTI_TASK",
     "max_concurrent_runs":1,

--- a/exporter/test-data/run-job-main.json
+++ b/exporter/test-data/run-job-main.json
@@ -1,6 +1,8 @@
 {
   "created_time":1700654567867,
   "job_id":1047501313827425,
+  "run_as_user_name": "user@domain.com",
+  "run_as_owner": false,
   "settings": {
     "format":"MULTI_TASK",
     "max_concurrent_runs":1,


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

Because the `run_as` was marked as `computed` it was ignored when generating the code.

Fixes #3723

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
