### PR TITLE
[Feature] Add `active` attribute to `databricks_user` data source

### DIFF
--- a/docs/data-sources/user.md
+++ b/docs/data-sources/user.md
@@ -45,6 +45,7 @@ Data source exposes the following attributes:
 - `home` - Home folder of the [user](../resources/user.md), e.g. `/Users/mr.foo@example.com`.
 - `repos` - Personal Repos location of the [user](../resources/user.md), e.g. `/Repos/mr.foo@example.com`.
 - `alphanumeric` - Alphanumeric representation of user local name. e.g. `mr_foo`.
+- `active` - Whether the [user](../resources/user.md) is active.
 
 * `acl_principal_id` - identifier for use in [databricks_access_control_rule_set](../resources/access_control_rule_set.md), e.g. `users/mr.foo@example.com`.
 

--- a/scim/data_user.go
+++ b/scim/data_user.go
@@ -67,6 +67,10 @@ func DataSourceUser() common.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"active": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
 		},
 		Read: func(ctx context.Context, d *schema.ResourceData, m *common.DatabricksClient) error {
 			usersAPI := NewUsersAPI(ctx, m)
@@ -81,6 +85,7 @@ func DataSourceUser() common.Resource {
 			d.Set("acl_principal_id", fmt.Sprintf("users/%s", user.UserName))
 			d.Set("external_id", user.ExternalID)
 			d.Set("application_id", user.ApplicationID)
+			d.Set("active", user.Active)
 			splits := strings.Split(user.UserName, "@")
 			norm := nonAlphanumeric.ReplaceAllLiteralString(splits[0], "_")
 			norm = strings.ToLower(norm)

--- a/scim/data_user_test.go
+++ b/scim/data_user_test.go
@@ -22,6 +22,7 @@ func TestDataSourceUser(t *testing.T) {
 						{
 							ID:       "123",
 							UserName: "mr.test@example.com",
+							Active:   true,
 						},
 					},
 				},
@@ -41,6 +42,7 @@ func TestDataSourceUser(t *testing.T) {
 	assert.Equal(t, d.Get("home"), "/Users/mr.test@example.com")
 	assert.Equal(t, d.Get("acl_principal_id"), "users/mr.test@example.com")
 	assert.Equal(t, d.Get("alphanumeric"), "mr_test")
+	assert.Equal(t, d.Get("active"), true)
 }
 
 func TestDataSourceUserGerUser(t *testing.T) {


### PR DESCRIPTION
## Changes
Add `active` attribute to `databricks_user` data source.

Resolves #3731 

## Tests
Acceptance test and verified using the following code:
```
terraform {
  required_providers {
    databricks = {
      source = "databricks/databricks"
    }
  }
}

provider "databricks" {
  profile = "<REDACTED>"
}

data "databricks_user" "this" {
  user_name = "<REDACTED>"
}

output "user" {
  value = data.databricks_user.this.active
}
```

Output:
```
❯ terraform apply
data.databricks_user.this: Reading...
data.databricks_user.this: Read complete after 1s [id=<REDACTED>]

Changes to Outputs:
  + user = true
```

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [x] relevant acceptance tests are passing
- [ ] using Go SDK
