### PR TITLE
Add tfsdk <> gosdk structs converter functions and tests

### DIFF
--- a/common/reflect_resource_plugin_framework.go
+++ b/common/reflect_resource_plugin_framework.go
@@ -1,0 +1,291 @@
+package common
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// Converts a tfsdk struct into a go-sdk struct.
+func TfSdkToGoSdkStruct(tfsdk interface{}, gosdk interface{}, ctx context.Context) error {
+	srcVal := reflect.ValueOf(tfsdk)
+	destVal := reflect.ValueOf(gosdk)
+
+	if srcVal.Kind() == reflect.Ptr {
+		srcVal = srcVal.Elem()
+	}
+
+	if destVal.Kind() != reflect.Ptr {
+		panic("please provide a pointer for the gosdk struct")
+	}
+	destVal = destVal.Elem()
+
+	if srcVal.Kind() != reflect.Struct || destVal.Kind() != reflect.Struct {
+		panic("input should be structs")
+	}
+
+	forceSendFieldsField := destVal.FieldByName("ForceSendFields")
+
+	srcType := srcVal.Type()
+	for i := 0; i < srcVal.NumField(); i++ {
+		srcField := srcVal.Field(i)
+		srcFieldName := srcType.Field(i).Name
+
+		destField := destVal.FieldByName(srcFieldName)
+
+		srcFieldTag := srcType.Field(i).Tag.Get("tfsdk")
+		if srcFieldTag == "-" {
+			continue
+		}
+
+		tfSdkToGoSdkSingleField(srcField, destField, srcFieldName, &forceSendFieldsField, ctx)
+	}
+
+	return nil
+}
+
+func tfSdkToGoSdkSingleField(srcField reflect.Value, destField reflect.Value, srcFieldName string, forceSendFieldsField *reflect.Value, ctx context.Context) error {
+
+	if !destField.IsValid() {
+		panic(fmt.Errorf("destination field is not valid: %s", destField.Type().Name()))
+	}
+
+	if !destField.CanSet() {
+		panic(fmt.Errorf("destination field can not be set: %s", destField.Type().Name()))
+	}
+	srcFieldValue := srcField.Interface()
+
+	if srcFieldValue == nil {
+		return nil
+	} else if srcField.Kind() == reflect.Ptr {
+		// Allocate new memory for the destination field
+		destField.Set(reflect.New(destField.Type().Elem()))
+
+		// Recursively populate the nested struct.
+		if err := TfSdkToGoSdkStruct(srcFieldValue, destField.Interface(), ctx); err != nil {
+			return err
+		}
+	} else if srcField.Kind() == reflect.Struct {
+		switch v := srcFieldValue.(type) {
+		case types.Bool:
+			destField.SetBool(v.ValueBool())
+			if !v.IsNull() {
+				addToForceSendFields(srcFieldName, forceSendFieldsField)
+			}
+		case types.Int64:
+			destField.SetInt(v.ValueInt64())
+			if !v.IsNull() {
+				addToForceSendFields(srcFieldName, forceSendFieldsField)
+			}
+		case types.Float64:
+			destField.SetFloat(v.ValueFloat64())
+			if !v.IsNull() {
+				addToForceSendFields(srcFieldName, forceSendFieldsField)
+			}
+		case types.String:
+			destField.SetString(v.ValueString())
+			if !v.IsNull() {
+				addToForceSendFields(srcFieldName, forceSendFieldsField)
+			}
+		case types.List:
+			diag := v.ElementsAs(ctx, destField.Addr().Interface(), false)
+			if len(diag) != 0 {
+				panic("Error")
+			}
+		case types.Map:
+			v.ElementsAs(ctx, destField.Addr().Interface(), false)
+		default:
+			// If it is a real stuct instead of a tfsdk type, recursively resolve it.
+			if err := TfSdkToGoSdkStruct(srcFieldValue, destField.Addr().Interface(), ctx); err != nil {
+				return err
+			}
+		}
+	} else if srcField.Kind() == reflect.Slice {
+		destSlice := reflect.MakeSlice(destField.Type(), srcField.Len(), srcField.Cap())
+		for j := 0; j < srcField.Len(); j++ {
+			nestedSrcField := srcField.Index(j)
+			nestedSrcField.Kind()
+
+			srcElem := srcField.Index(j)
+
+			destElem := destSlice.Index(j)
+			if err := tfSdkToGoSdkSingleField(srcElem, destElem, "", nil, ctx); err != nil {
+				return err
+			}
+		}
+		destField.Set(destSlice)
+	} else if srcField.Kind() == reflect.Map {
+		destMap := reflect.MakeMap(destField.Type())
+		for _, key := range srcField.MapKeys() {
+			srcMapValue := srcField.MapIndex(key)
+			destMapValue := reflect.New(destField.Type().Elem()).Elem()
+			destMapKey := reflect.ValueOf(key.Interface())
+			if err := tfSdkToGoSdkSingleField(srcMapValue, destMapValue, "", nil, ctx); err != nil {
+				return err
+			}
+			destMap.SetMapIndex(destMapKey, destMapValue)
+		}
+		destField.Set(destMap)
+	} else {
+		panic(fmt.Errorf("unknown type for field: %s", srcField.Type().Name()))
+	}
+	return nil
+}
+
+// Converts a go-sdk struct into a tfsdk struct.
+func GoSdkToTfSdkStruct(gosdk interface{}, tfsdk interface{}, ctx context.Context) error {
+
+	srcVal := reflect.ValueOf(gosdk)
+	destVal := reflect.ValueOf(tfsdk)
+
+	if srcVal.Kind() == reflect.Ptr {
+		srcVal = srcVal.Elem()
+	}
+
+	if destVal.Kind() != reflect.Ptr {
+		panic("please provide a pointer for the tfsdk struct")
+	}
+	destVal = destVal.Elem()
+
+	if srcVal.Kind() != reflect.Struct || destVal.Kind() != reflect.Struct {
+		panic(fmt.Errorf("input should be structs %s, %s", srcVal.Type().Name(), destVal.Type().Name()))
+	}
+
+	forceSendField := srcVal.FieldByName("ForceSendFields")
+	if !forceSendField.IsValid() {
+		panic(fmt.Errorf("go sdk struct does not have valid ForceSendField %s", srcVal.Type().Name()))
+	}
+	switch forceSendField.Interface().(type) {
+	case []string:
+	default:
+		panic(fmt.Errorf("ForceSendField is not of type []string"))
+	}
+	forceSendFieldVal := forceSendField.Interface().([]string)
+	srcType := srcVal.Type()
+	for i := 0; i < srcVal.NumField(); i++ {
+		srcField := srcVal.Field(i)
+		srcFieldName := srcVal.Type().Field(i).Name
+
+		destField := destVal.FieldByName(srcFieldName)
+		srcFieldTag := srcType.Field(i).Tag.Get("json")
+		if srcFieldTag == "-" {
+			continue
+		}
+		goSdkToTfSdkSingleField(srcField, destField, srcFieldName, forceSendFieldVal, false, ctx)
+	}
+	return nil
+}
+
+func goSdkToTfSdkSingleField(srcField reflect.Value, destField reflect.Value, srcFieldName string, forceSendField []string, alwaysAdd bool, ctx context.Context) error {
+
+	if !destField.IsValid() {
+		panic(fmt.Errorf("destination field is not valid: %s", destField.Type().Name()))
+	}
+
+	if !destField.CanSet() {
+		panic(fmt.Errorf("destination field can not be set: %s", destField.Type().Name()))
+	}
+
+	srcFieldValue := srcField.Interface()
+
+	if srcFieldValue == nil {
+		return nil
+	}
+	switch srcField.Kind() {
+	case reflect.Ptr:
+		destField.Set(reflect.New(destField.Type().Elem()))
+
+		// Recursively populate the nested struct.
+		if err := GoSdkToTfSdkStruct(srcFieldValue, destField.Interface(), ctx); err != nil {
+			return err
+		}
+	case reflect.Bool:
+		boolVal := srcFieldValue.(bool)
+		// check if alwaysAdd is false or the value is zero or if the field is in the forceSendFields list
+		if alwaysAdd || !(!boolVal && !checkTheStringInForceSendFields(srcFieldName, forceSendField)) {
+			destField.Set(reflect.ValueOf(types.BoolValue(boolVal)))
+		} else {
+			destField.Set(reflect.ValueOf(types.BoolNull()))
+		}
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64, reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		// convert any kind of integer to int64
+		intVal := srcField.Convert(reflect.TypeOf(int64(0))).Interface().(int64)
+		// check if alwaysAdd is true or the value is zero or if the field is in the forceSendFields list
+		if alwaysAdd || !(intVal == 0 && !checkTheStringInForceSendFields(srcFieldName, forceSendField)) {
+			destField.Set(reflect.ValueOf(types.Int64Value(int64(intVal))))
+		} else {
+			destField.Set(reflect.ValueOf(types.Int64Null()))
+		}
+	case reflect.Float32, reflect.Float64:
+		// convert any kind of float to float64
+		float64Val := srcField.Convert(reflect.TypeOf(float64(0))).Interface().(float64)
+		// check if alwaysAdd is true or the value is zero or if the field is in the forceSendFields list
+		if alwaysAdd || !(float64Val == 0 && !checkTheStringInForceSendFields(srcFieldName, forceSendField)) {
+			destField.Set(reflect.ValueOf(types.Float64Value(float64Val)))
+		} else {
+			destField.Set(reflect.ValueOf(types.Float64Null()))
+		}
+	case reflect.String:
+		strVal := srcFieldValue.(string)
+		// check if alwaysAdd is false or the value is zero or if the field is in the forceSendFields list
+		if alwaysAdd || !(strVal == "" && !checkTheStringInForceSendFields(srcFieldName, forceSendField)) {
+			destField.Set(reflect.ValueOf(types.StringValue(strVal)))
+		} else {
+			destField.Set(reflect.ValueOf(types.StringNull()))
+		}
+	case reflect.Struct:
+		// resolve the nested struct by recursively calling the function
+		if err := GoSdkToTfSdkStruct(srcFieldValue, destField.Addr().Interface(), ctx); err != nil {
+			return err
+		}
+	case reflect.Slice:
+		destSlice := reflect.MakeSlice(destField.Type(), srcField.Len(), srcField.Cap())
+		for j := 0; j < srcField.Len(); j++ {
+			nestedSrcField := srcField.Index(j)
+			nestedSrcField.Kind()
+
+			srcElem := srcField.Index(j)
+
+			destElem := destSlice.Index(j)
+			if err := goSdkToTfSdkSingleField(srcElem, destElem, "", nil, true, ctx); err != nil {
+				return err
+			}
+		}
+		destField.Set(destSlice)
+	case reflect.Map:
+		destMap := reflect.MakeMap(destField.Type())
+		for _, key := range srcField.MapKeys() {
+			srcMapValue := srcField.MapIndex(key)
+			destMapValue := reflect.New(destField.Type().Elem()).Elem()
+			destMapKey := reflect.ValueOf(key.Interface())
+			if err := goSdkToTfSdkSingleField(srcMapValue, destMapValue, "", nil, true, ctx); err != nil {
+				return err
+			}
+			destMap.SetMapIndex(destMapKey, destMapValue)
+		}
+		destField.Set(destMap)
+	default:
+		panic(fmt.Errorf("unknown type for field: %s", srcField.Type().Name()))
+	}
+	return nil
+}
+
+func addToForceSendFields(fieldName string, forceSendFieldsField *reflect.Value) {
+	if forceSendFieldsField == nil {
+		return
+	}
+	forceSendFields := forceSendFieldsField.Interface().([]string)
+	forceSendFields = append(forceSendFields, fieldName)
+	forceSendFieldsField.Set(reflect.ValueOf(forceSendFields))
+}
+
+func checkTheStringInForceSendFields(fieldName string, forceSendFields []string) bool {
+	for _, field := range forceSendFields {
+		if field == fieldName {
+			return true
+		}
+	}
+	return false
+}

--- a/common/reflect_resource_plugin_framework_test.go
+++ b/common/reflect_resource_plugin_framework_test.go
@@ -1,0 +1,256 @@
+package common
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+)
+
+type DummyTfSdk struct {
+	Enabled           types.Bool                  `tfsdk:"enabled"`
+	Workers           types.Int64                 `tfsdk:"workers"`
+	Floats            types.Float64               `tfsdk:"floats"`
+	Description       types.String                `tfsdk:"description"`
+	Tasks             types.String                `tfsdk:"task"`
+	Nested            *DummyNestedTfSdk           `tfsdk:"nested"`
+	NoPointerNested   DummyNestedTfSdk            `tfsdk:"no_pointer_nested"`
+	NestedList        []DummyNestedTfSdk          `tfsdk:"nested_list"`
+	NestedPointerList []*DummyNestedTfSdk         `tfsdk:"nested_pointer_list"`
+	Map               map[string]types.String     `tfsdk:"map"`
+	NestedMap         map[string]DummyNestedTfSdk `tfsdk:"nested_map"`
+	Repeated          []types.Int64               `tfsdk:"repeated"`
+	Attributes        map[string]types.String     `tfsdk:"attributes"`
+	Irrelevant        types.String                `tfsdk:"-"`
+}
+
+type DummyNestedTfSdk struct {
+	Name    types.String `tfsdk:"name"`
+	Enabled types.Bool   `tfsdk:"enabled"`
+}
+
+type DummyGoSdk struct {
+	Enabled           bool                        `json:"enabled"`
+	Workers           int64                       `json:"workers"`
+	Floats            float64                     `json:"floats"`
+	Description       string                      `json:"description"`
+	Tasks             string                      `json:"tasks"`
+	Nested            *DummyNestedGoSdk           `json:"nested"`
+	NoPointerNested   DummyNestedGoSdk            `json:"no_pointer_nested"`
+	NestedList        []DummyNestedGoSdk          `json:"nested_list"`
+	NestedPointerList []*DummyNestedGoSdk         `json:"nested_pointer_list"`
+	Map               map[string]string           `json:"map"`
+	NestedMap         map[string]DummyNestedGoSdk `json:"nested_map"`
+	Repeated          []int64                     `json:"repeated"`
+	Attributes        map[string]string           `json:"attributes"`
+	ForceSendFields   []string                    `json:"-"`
+}
+
+type DummyNestedGoSdk struct {
+	Name            string   `json:"name"`
+	Enabled         bool     `json:"enabled"`
+	ForceSendFields []string `json:"-"`
+}
+
+type emptyCtx struct{}
+
+func (emptyCtx) Deadline() (deadline time.Time, ok bool) {
+	return
+}
+
+func (emptyCtx) Done() <-chan struct{} {
+	return nil
+}
+
+func (emptyCtx) Err() error {
+	return nil
+}
+
+func (emptyCtx) Value(key any) any {
+	return nil
+}
+
+var ctx = emptyCtx{}
+
+// Constructing a dummy tfsdk struct.
+var tfSdkStruct = DummyTfSdk{
+	Enabled:     types.BoolValue(false),
+	Workers:     types.Int64Value(12),
+	Description: types.StringValue("abc"),
+	Tasks:       types.StringNull(),
+	Nested: &DummyNestedTfSdk{
+		Name:    types.StringValue("def"),
+		Enabled: types.BoolValue(true),
+	},
+	NoPointerNested: DummyNestedTfSdk{
+		Name:    types.StringValue("def"),
+		Enabled: types.BoolValue(true),
+	},
+	NestedList: []DummyNestedTfSdk{
+		{
+			Name:    types.StringValue("def"),
+			Enabled: types.BoolValue(true),
+		},
+		{
+			Name:    types.StringValue("def"),
+			Enabled: types.BoolValue(true),
+		},
+	},
+	Map: map[string]types.String{
+		"key1": types.StringValue("value1"),
+		"key2": types.StringValue("value2"),
+	},
+	NestedMap: map[string]DummyNestedTfSdk{
+		"key1": {
+			Name:    types.StringValue("abc"),
+			Enabled: types.BoolValue(false),
+		},
+		"key2": {
+			Name:    types.StringValue("def"),
+			Enabled: types.BoolValue(true),
+		},
+	},
+	NestedPointerList: []*DummyNestedTfSdk{
+		{
+			Name:    types.StringValue("def"),
+			Enabled: types.BoolValue(true),
+		},
+		{
+			Name:    types.StringValue("def"),
+			Enabled: types.BoolValue(true),
+		},
+	},
+	Attributes: map[string]types.String{"key": types.StringValue("value")},
+	Repeated:   []types.Int64{types.Int64Value(12), types.Int64Value(34)},
+}
+
+func TestGetAndSetPluginFramework(t *testing.T) {
+	// Creating schema.
+	scm := schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"enabled": schema.BoolAttribute{
+				Required: true,
+			},
+			"workers": schema.Int64Attribute{
+				Optional: true,
+			},
+			"description": schema.StringAttribute{
+				Optional: true,
+			},
+			"task": schema.StringAttribute{
+				Optional: true,
+			},
+			"repeated": schema.ListAttribute{
+				ElementType: types.Int64Type,
+				Optional:    true,
+			},
+			"floats": schema.Float64Attribute{
+				Optional: true,
+			},
+			"nested": schema.SingleNestedAttribute{
+				Optional: true,
+				Attributes: map[string]schema.Attribute{
+					"name": schema.StringAttribute{
+						Optional: true,
+					},
+					"enabled": schema.BoolAttribute{
+						Optional: true,
+					},
+				},
+			},
+			"no_pointer_nested": schema.SingleNestedAttribute{
+				Optional: true,
+				Attributes: map[string]schema.Attribute{
+					"name": schema.StringAttribute{
+						Optional: true,
+					},
+					"enabled": schema.BoolAttribute{
+						Optional: true,
+					},
+				},
+			},
+			"nested_list": schema.ListNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"name": schema.StringAttribute{
+							Optional: true,
+						},
+						"enabled": schema.BoolAttribute{
+							Optional: true,
+						},
+					},
+				},
+				Optional: true,
+			},
+			"map": schema.MapAttribute{
+				ElementType: types.StringType,
+				Optional:    true,
+			},
+			"nested_pointer_list": schema.ListNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"name": schema.StringAttribute{
+							Optional: true,
+						},
+						"enabled": schema.BoolAttribute{
+							Optional: true,
+						},
+					},
+				},
+				Optional: true,
+			},
+			"attributes": schema.MapAttribute{
+				ElementType: types.StringType,
+				Optional:    true,
+			},
+			"nested_map": schema.MapNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"name": schema.StringAttribute{
+							Optional: true,
+						},
+						"enabled": schema.BoolAttribute{
+							Optional: true,
+						},
+					},
+				},
+				Optional: true,
+			},
+		},
+	}
+	state := tfsdk.State{
+		Schema: scm,
+	}
+
+	// Assert that we can set state from the tfsdk struct.
+	diags := state.Set(ctx, tfSdkStruct)
+	assert.Len(t, diags, 0)
+
+	// Assert that we can get a struct from the state.
+	getterStruct := DummyTfSdk{}
+	diags = state.Get(ctx, &getterStruct)
+	assert.Len(t, diags, 0)
+
+	// Assert the struct populated from .Get is exactly the same as the original tfsdk struct.
+	assert.True(t, reflect.DeepEqual(getterStruct, tfSdkStruct))
+
+}
+
+func TestStructConversion(t *testing.T) {
+	// Convert from tfsdk to gosdk struct using the converter function
+	convertedGoSdkStruct := DummyGoSdk{}
+	e := TfSdkToGoSdkStruct(tfSdkStruct, &convertedGoSdkStruct, ctx)
+	assert.NoError(t, e)
+
+	// Convert the gosdk struct back to tfsdk struct
+	convertedTfSdkStruct := DummyTfSdk{}
+	e = GoSdkToTfSdkStruct(convertedGoSdkStruct, &convertedTfSdkStruct, ctx)
+	assert.NoError(t, e)
+
+	// Assert that the struct is exactly the same after tfsdk --> gosdk --> tfsdk
+	assert.True(t, reflect.DeepEqual(tfSdkStruct, convertedTfSdkStruct))
+}

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/hcl v1.0.0
 	github.com/hashicorp/hcl/v2 v2.20.1
+	github.com/hashicorp/terraform-plugin-framework v1.9.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.34.0
 	github.com/stretchr/testify v1.9.0
@@ -48,7 +49,6 @@ require (
 	github.com/hashicorp/logutils v1.0.0 // indirect
 	github.com/hashicorp/terraform-exec v0.21.0 // indirect
 	github.com/hashicorp/terraform-json v0.22.1 // indirect
-	github.com/hashicorp/terraform-plugin-framework v1.9.0 // indirect
 	github.com/hashicorp/terraform-plugin-go v0.23.0 // indirect
 	github.com/hashicorp/terraform-registry-address v0.2.3 // indirect
 	github.com/hashicorp/terraform-svchost v0.1.1 // indirect


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
<img width="1372" alt="image" src="https://github.com/databricks/terraform-provider-databricks/assets/67326663/637a9b72-7316-4c02-bb6f-ed6991c39226">
As illustrated in the diagram, we need converter function between tfsdk and gosdk structs to support the plugin framework migration


 This PR adds converter functions as well as related unit tests

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [x] covered with integration tests in `internal/acceptance`
- [x] relevant acceptance tests are passing
- [x] using Go SDK
