### PR TITLE
Remove dependency to "internal" SDK's struct `APIErrorBody`

### DIFF
--- a/access/resource_ip_access_list_test.go
+++ b/access/resource_ip_access_list_test.go
@@ -8,8 +8,8 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/databricks/databricks-sdk-go/apierr"
 	"github.com/databricks/databricks-sdk-go/service/settings"
+	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/databricks/terraform-provider-databricks/qa"
 
 	"github.com/stretchr/testify/assert"
@@ -93,7 +93,7 @@ func TestAPIACLCreate_Error(t *testing.T) {
 			{
 				Method:   http.MethodPost,
 				Resource: "/api/2.0/ip-access-lists",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "RESOURCE_ALREADY_EXISTS",
 					Message:   "IP access list with type (" + TestingListTypeString + ") and label (" + TestingLabel + ") already exists",
 				},
@@ -185,7 +185,7 @@ func TestIPACLUpdate_Error(t *testing.T) {
 				ExpectedRequest: settings.UpdateIpAccessList{
 					Enabled: TestingEnabled,
 				},
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "SERVER_ERROR",
 					Message:   "Something unexpected happened",
 				},
@@ -240,7 +240,7 @@ func TestIPACLRead_NotFound(t *testing.T) {
 			{
 				Method:   http.MethodGet,
 				Resource: "/api/2.0/ip-access-lists/" + TestingId + "?",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "RESOURCE_DOES_NOT_EXIST",
 					Message:   "Can't find an IP access list with id: " + TestingId + ".",
 				},
@@ -260,7 +260,7 @@ func TestIPACLRead_Error(t *testing.T) {
 			{
 				Method:   http.MethodGet,
 				Resource: "/api/2.0/ip-access-lists/" + TestingId + "?",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "SERVER_ERROR",
 					Message:   "Something unexpected happened",
 				},
@@ -298,7 +298,7 @@ func TestIPACLDelete_Error(t *testing.T) {
 			{
 				Method:   http.MethodDelete,
 				Resource: fmt.Sprintf("/api/2.0/ip-access-lists/%s?", TestingId),
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_STATE",
 					Message:   "Something went wrong",
 				},

--- a/aws/resource_group_instance_profile_test.go
+++ b/aws/resource_group_instance_profile_test.go
@@ -3,7 +3,7 @@ package aws
 import (
 	"testing"
 
-	"github.com/databricks/databricks-sdk-go/apierr"
+	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/databricks/terraform-provider-databricks/scim"
 
 	"github.com/databricks/terraform-provider-databricks/qa"
@@ -56,7 +56,7 @@ func TestResourceGroupInstanceProfileCreate_Error(t *testing.T) {
 			{
 				Method:   "PATCH",
 				Resource: "/api/2.0/preview/scim/v2/Groups/abc",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},
@@ -80,7 +80,7 @@ func TestResourceGroupInstanceProfileCreate_Error_InvalidARN(t *testing.T) {
 			{
 				Method:   "PATCH",
 				Resource: "/api/2.0/preview/scim/v2/Groups/abc",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},
@@ -103,7 +103,7 @@ func TestResourceGroupInstanceProfileCreate_Error_OtherARN(t *testing.T) {
 			{
 				Method:   "PATCH",
 				Resource: "/api/2.0/preview/scim/v2/Groups/abc",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},
@@ -152,7 +152,7 @@ func TestResourceGroupInstanceProfileRead_NotFound(t *testing.T) {
 			{
 				Method:   "GET",
 				Resource: "/api/2.0/preview/scim/v2/Groups/abc?attributes=roles",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "NOT_FOUND",
 					Message:   "Item not found",
 				},
@@ -192,7 +192,7 @@ func TestResourceGroupInstanceProfileRead_Error(t *testing.T) {
 			{
 				Method:   "GET",
 				Resource: "/api/2.0/preview/scim/v2/Groups/abc?attributes=roles",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},
@@ -232,7 +232,7 @@ func TestResourceGroupInstanceProfileDelete_Error(t *testing.T) {
 			{
 				Method:   "PATCH",
 				Resource: "/api/2.0/preview/scim/v2/Groups/abc",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},

--- a/aws/resource_instance_profile_test.go
+++ b/aws/resource_instance_profile_test.go
@@ -3,7 +3,7 @@ package aws
 import (
 	"testing"
 
-	"github.com/databricks/databricks-sdk-go/apierr"
+	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/databricks/terraform-provider-databricks/qa"
 
 	"github.com/stretchr/testify/assert"
@@ -114,7 +114,7 @@ func TestResourceInstanceProfileCreate_Error(t *testing.T) {
 			{
 				Method:   "POST",
 				Resource: "/api/2.0/instance-profiles/add",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},
@@ -249,7 +249,7 @@ func TestResourceInstanceProfileRead_Error(t *testing.T) {
 			{
 				Method:   "GET",
 				Resource: "/api/2.0/instance-profiles/list",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},
@@ -289,7 +289,7 @@ func TestResourceInstanceProfileDelete_Error(t *testing.T) {
 			{
 				Method:   "POST",
 				Resource: "/api/2.0/instance-profiles/remove",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},
@@ -356,7 +356,7 @@ func TestResourceInstanceProfileUpdate_Error(t *testing.T) {
 			{
 				Method:   "POST",
 				Resource: "/api/2.0/instance-profiles/edit",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},

--- a/aws/resource_service_principal_role_test.go
+++ b/aws/resource_service_principal_role_test.go
@@ -3,7 +3,7 @@ package aws
 import (
 	"testing"
 
-	"github.com/databricks/databricks-sdk-go/apierr"
+	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/databricks/terraform-provider-databricks/scim"
 
 	"github.com/databricks/terraform-provider-databricks/qa"
@@ -53,7 +53,7 @@ func TestResourceServicePrincipalRoleCreate_Error(t *testing.T) {
 			{
 				Method:   "PATCH",
 				Resource: "/api/2.0/preview/scim/v2/ServicePrincipals/abc",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},
@@ -119,7 +119,7 @@ func TestResourceServicePrincipalRoleRead_NotFound(t *testing.T) {
 			{
 				Method:   "GET",
 				Resource: "/api/2.0/preview/scim/v2/ServicePrincipals/abc?attributes=roles",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "NOT_FOUND",
 					Message:   "Item not found",
 				},

--- a/aws/resource_user_instance_profile_test.go
+++ b/aws/resource_user_instance_profile_test.go
@@ -3,7 +3,7 @@ package aws
 import (
 	"testing"
 
-	"github.com/databricks/databricks-sdk-go/apierr"
+	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/databricks/terraform-provider-databricks/scim"
 
 	"github.com/databricks/terraform-provider-databricks/qa"
@@ -68,7 +68,7 @@ func TestResourceUserInstanceProfileCreate_Error(t *testing.T) {
 			{
 				Method:   "PATCH",
 				Resource: "/api/2.0/preview/scim/v2/Users/abc",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},
@@ -138,7 +138,7 @@ func TestResourceUserInstanceProfileRead_NotFound(t *testing.T) {
 			{
 				Method:   "GET",
 				Resource: "/api/2.0/preview/scim/v2/Users/abc?attributes=roles",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "NOT_FOUND",
 					Message:   "Item not found",
 				},
@@ -158,7 +158,7 @@ func TestResourceUserInstanceProfileRead_Error(t *testing.T) {
 			{
 				Method:   "GET",
 				Resource: "/api/2.0/preview/scim/v2/Users/abc?attributes=roles",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},
@@ -198,7 +198,7 @@ func TestResourceUserInstanceProfileDelete_Error(t *testing.T) {
 			{
 				Method:   "PATCH",
 				Resource: "/api/2.0/preview/scim/v2/Users/abc",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},

--- a/catalog/resource_artifact_allowlist_test.go
+++ b/catalog/resource_artifact_allowlist_test.go
@@ -4,8 +4,8 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/databricks/databricks-sdk-go/apierr"
 	"github.com/databricks/databricks-sdk-go/service/catalog"
+	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/databricks/terraform-provider-databricks/qa"
 	"github.com/stretchr/testify/assert"
 )
@@ -105,7 +105,7 @@ func TestArtifactAllowlistCreate_Error(t *testing.T) {
 				Method:          http.MethodPut,
 				Resource:        "/api/2.1/unity-catalog/artifact-allowlists/INIT_SCRIPT",
 				ExpectedRequest: setArtifact,
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "SERVER_ERROR",
 					Message:   "Something unexpected happened",
 				},
@@ -156,7 +156,7 @@ func TestResourceArtifactAllowlistRead_Error(t *testing.T) {
 			{
 				Method:   "GET",
 				Resource: "/api/2.1/unity-catalog/artifact-allowlists/INIT_SCRIPT?",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},
@@ -219,7 +219,7 @@ func TestArtifactAllowlistUpdate_Error(t *testing.T) {
 				Method:          http.MethodPut,
 				Resource:        "/api/2.1/unity-catalog/artifact-allowlists/INIT_SCRIPT",
 				ExpectedRequest: updateArtifact,
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "SERVER_ERROR",
 					Message:   "Something unexpected happened",
 				},
@@ -280,7 +280,7 @@ func TestArtifactAllowlistDelete_Error(t *testing.T) {
 					ArtifactType:     catalog.ArtifactTypeInitScript,
 					ArtifactMatchers: []catalog.ArtifactMatcher{},
 				},
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_STATE",
 					Message:   "Something went wrong",
 				},

--- a/catalog/resource_connection_test.go
+++ b/catalog/resource_connection_test.go
@@ -4,8 +4,8 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/databricks/databricks-sdk-go/apierr"
 	"github.com/databricks/databricks-sdk-go/service/catalog"
+	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/databricks/terraform-provider-databricks/qa"
 	"github.com/stretchr/testify/assert"
 )
@@ -145,7 +145,7 @@ func TestConnectionsCreate_Error(t *testing.T) {
 						"host": "test.com",
 					},
 				},
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "SERVER_ERROR",
 					Message:   "Something unexpected happened",
 				},
@@ -210,7 +210,7 @@ func TestConnectionRead_Error(t *testing.T) {
 			{
 				Method:   "GET",
 				Resource: "/api/2.1/unity-catalog/connections/testConnectionName?",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},
@@ -395,7 +395,7 @@ func TestConnectionUpdate_Error(t *testing.T) {
 						"host": "test.com",
 					},
 				},
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "SERVER_ERROR",
 					Message:   "Something unexpected happened",
 				},
@@ -443,7 +443,7 @@ func TestConnectionDelete_Error(t *testing.T) {
 			{
 				Method:   http.MethodDelete,
 				Resource: "/api/2.1/unity-catalog/connections/testConnectionName?",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_STATE",
 					Message:   "Something went wrong",
 				},

--- a/catalog/resource_external_location_test.go
+++ b/catalog/resource_external_location_test.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/databricks/databricks-sdk-go/apierr"
 	"github.com/databricks/databricks-sdk-go/experimental/mocks"
 	"github.com/databricks/databricks-sdk-go/service/catalog"
+	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/databricks/terraform-provider-databricks/qa"
 	"github.com/stretchr/testify/mock"
 )
@@ -450,7 +450,7 @@ func TestUpdateExternalLocationRollback(t *testing.T) {
 					Url:            "s3://foo/bar",
 					CredentialName: "xyz",
 				},
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "SERVER_ERROR",
 					Message:   "Something unexpected happened",
 				},
@@ -514,7 +514,7 @@ func TestUpdateExternalLocationRollbackError(t *testing.T) {
 					Url:            "s3://foo/bar",
 					CredentialName: "xyz",
 				},
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "SERVER_ERROR",
 					Message:   "Something unexpected happened",
 				},
@@ -526,7 +526,7 @@ func TestUpdateExternalLocationRollbackError(t *testing.T) {
 				ExpectedRequest: catalog.UpdateExternalLocation{
 					Owner: "administrators",
 				},
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},

--- a/catalog/resource_storage_credential_test.go
+++ b/catalog/resource_storage_credential_test.go
@@ -3,9 +3,9 @@ package catalog
 import (
 	"testing"
 
-	"github.com/databricks/databricks-sdk-go/apierr"
 	"github.com/databricks/databricks-sdk-go/experimental/mocks"
 	"github.com/databricks/databricks-sdk-go/service/catalog"
+	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/databricks/terraform-provider-databricks/qa"
 	"github.com/stretchr/testify/mock"
 )
@@ -506,7 +506,7 @@ func TestUpdateStorageCredentialsRollback(t *testing.T) {
 						RoleArn: "CHANGED",
 					},
 				},
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "SERVER_ERROR",
 					Message:   "Something unexpected happened",
 				},

--- a/catalog/resource_system_schema_test.go
+++ b/catalog/resource_system_schema_test.go
@@ -4,8 +4,8 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/databricks/databricks-sdk-go/apierr"
 	"github.com/databricks/databricks-sdk-go/service/catalog"
+	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/databricks/terraform-provider-databricks/qa"
 	"github.com/stretchr/testify/assert"
 )
@@ -72,7 +72,7 @@ func TestSystemSchemaCreate_Error(t *testing.T) {
 			{
 				Method:   http.MethodPut,
 				Resource: "/api/2.1/unity-catalog/metastores/abc/systemschemas/access",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},
@@ -157,7 +157,7 @@ func TestSystemSchemaUpdate_Error(t *testing.T) {
 			{
 				Method:   http.MethodPut,
 				Resource: "/api/2.1/unity-catalog/metastores/abc/systemschemas/access",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},
@@ -224,7 +224,7 @@ func TestSystemSchemaRead_Error(t *testing.T) {
 			{
 				Method:   http.MethodGet,
 				Resource: "/api/2.1/unity-catalog/metastores/abc/systemschemas?",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},
@@ -282,7 +282,7 @@ func TestSystemSchemaDelete_Error(t *testing.T) {
 			{
 				Method:   http.MethodDelete,
 				Resource: "/api/2.1/unity-catalog/metastores/abc/systemschemas/access?",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},

--- a/catalog/resource_volume_test.go
+++ b/catalog/resource_volume_test.go
@@ -6,8 +6,8 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/databricks/databricks-sdk-go/apierr"
 	"github.com/databricks/databricks-sdk-go/service/catalog"
+	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/databricks/terraform-provider-databricks/qa"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -154,7 +154,7 @@ func TestVolumesCreateWithoutInitialOwner_Error(t *testing.T) {
 			{
 				Method:   http.MethodPost,
 				Resource: "/api/2.1/unity-catalog/volumes",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},
@@ -216,7 +216,7 @@ func TestVolumesCreateWithInitialOwner_Error(t *testing.T) {
 			{
 				Method:   http.MethodPatch,
 				Resource: "/api/2.1/unity-catalog/volumes/testCatalogName.testSchemaName.testName",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "SERVER_ERROR",
 					Message:   "Something unexpected happened",
 				},
@@ -279,7 +279,7 @@ func TestResourceVolumeRead_Error(t *testing.T) {
 			{
 				Method:   "GET",
 				Resource: "/api/2.1/unity-catalog/volumes/testCatalogName.testSchemaName.testName?",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},
@@ -574,7 +574,7 @@ func TestVolumesUpdateRollback(t *testing.T) {
 					Name:    "testName",
 					Comment: "This is a new test comment.",
 				},
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "SERVER_ERROR",
 					Message:   "Something unexpected happened",
 				},
@@ -628,7 +628,7 @@ func TestVolumesUpdateRollback_Error(t *testing.T) {
 					Name:    "testName",
 					Comment: "This is a new test comment.",
 				},
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "SERVER_ERROR",
 					Message:   serverErrMessage,
 				},
@@ -640,7 +640,7 @@ func TestVolumesUpdateRollback_Error(t *testing.T) {
 				ExpectedRequest: catalog.UpdateVolumeRequestContent{
 					Owner: "testOwnerOld",
 				},
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   rollbackErrMessage,
 				},
@@ -678,7 +678,7 @@ func TestVolumeUpdate_Error(t *testing.T) {
 				ExpectedRequest: catalog.UpdateVolumeRequestContent{
 					Owner: "testOwnerNew",
 				},
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "SERVER_ERROR",
 					Message:   "Something unexpected happened",
 				},
@@ -727,7 +727,7 @@ func TestVolumeDelete_Error(t *testing.T) {
 			{
 				Method:   http.MethodDelete,
 				Resource: "/api/2.1/unity-catalog/volumes/testCatalogName.testSchemaName.testName?",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_STATE",
 					Message:   "Something went wrong",
 				},

--- a/clusters/clusters_api_sdk_test.go
+++ b/clusters/clusters_api_sdk_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/databricks/databricks-sdk-go/apierr"
+	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/databricks/terraform-provider-databricks/qa"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -144,7 +144,7 @@ func TestStartClusterAndGetInfo_StartingError(t *testing.T) {
 			ExpectedRequest: ClusterID{
 				ClusterID: "abc",
 			},
-			Response: apierr.APIErrorBody{
+			Response: common.APIErrorBody{
 				Message: "I am a teapot!",
 			},
 			Status: 418,

--- a/clusters/clusters_api_test.go
+++ b/clusters/clusters_api_test.go
@@ -174,7 +174,7 @@ func TestWaitForClusterStatus_RetryOnNotFound(t *testing.T) {
 		{
 			Method:   "GET",
 			Resource: "/api/2.0/clusters/get?cluster_id=abc",
-			Response: apierr.APIErrorBody{
+			Response: common.APIErrorBody{
 				Message: "Nope",
 			},
 			Status: 404,
@@ -204,7 +204,7 @@ func TestWaitForClusterStatus_StopRetryingEarly(t *testing.T) {
 		{
 			Method:   "GET",
 			Resource: "/api/2.0/clusters/get?cluster_id=abc",
-			Response: apierr.APIErrorBody{
+			Response: common.APIErrorBody{
 				Message: "I am a teapot",
 			},
 			Status: 418,
@@ -643,7 +643,7 @@ func TestStartAndGetInfo_StartingError(t *testing.T) {
 			ExpectedRequest: ClusterID{
 				ClusterID: "abc",
 			},
-			Response: apierr.APIErrorBody{
+			Response: common.APIErrorBody{
 				Message: "I am a teapot!",
 			},
 			Status: 418,
@@ -680,7 +680,7 @@ func TestPermanentDelete_Pinned(t *testing.T) {
 			ExpectedRequest: ClusterID{
 				ClusterID: "abc",
 			},
-			Response: apierr.APIErrorBody{
+			Response: common.APIErrorBody{
 				Message: "unpin the cluster first",
 			},
 			Status: 400,

--- a/clusters/resource_cluster_test.go
+++ b/clusters/resource_cluster_test.go
@@ -5,9 +5,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/databricks/databricks-sdk-go/apierr"
-
 	"github.com/databricks/databricks-sdk-go/service/compute"
+	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/databricks/terraform-provider-databricks/qa"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -439,7 +438,7 @@ func TestResourceClusterCreate_Error(t *testing.T) {
 			{
 				Method:   "POST",
 				Resource: "/api/2.0/clusters/create",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},
@@ -519,7 +518,7 @@ func TestResourceClusterRead_NotFound(t *testing.T) {
 			{
 				Method:   "GET",
 				Resource: "/api/2.0/clusters/get?cluster_id=abc",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					// clusters API is not fully restful, so let's test for that
 					// TODO: https://github.com/databricks/terraform-provider-databricks/issues/2021
 					ErrorCode: "INVALID_STATE",
@@ -541,7 +540,7 @@ func TestResourceClusterRead_Error(t *testing.T) {
 			{
 				Method:   "GET",
 				Resource: "/api/2.0/clusters/get?cluster_id=abc",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},
@@ -1227,7 +1226,7 @@ func TestResourceClusterUpdate_Error(t *testing.T) {
 			{
 				Method:   "GET",
 				Resource: "/api/2.0/clusters/get?cluster_id=abc",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},
@@ -1383,7 +1382,7 @@ func TestResourceClusterDelete_Error(t *testing.T) {
 			{
 				Method:   "POST",
 				Resource: "/api/2.0/clusters/permanent-delete",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},

--- a/common/apierr.go
+++ b/common/apierr.go
@@ -1,0 +1,30 @@
+package common
+
+// APIErrorBody represents an API error returned by Databricks API.
+//
+// Deprecated: this class is meant to disappear as the Terraform provider
+// progressively moves to use the service clients provided by the SDK. Clients
+// should not use this class for any other purpose than testing code that
+// mocks the behavior of Databricks services.
+type APIErrorBody struct {
+	ErrorCode  string        `json:"error_code,omitempty"`
+	Message    string        `json:"message,omitempty"`
+	Details    []ErrorDetail `json:"details,omitempty"`
+	ScimDetail string        `json:"detail,omitempty"`
+	ScimStatus string        `json:"status,omitempty"`
+	ScimType   string        `json:"scimType,omitempty"`
+	API12Error string        `json:"error,omitempty"`
+}
+
+// ErrorDetail represents the details of an API error.
+//
+// Deprecated: this struct is meant to disappear as the Terraform provider
+// progressively moves to use the service clients provided by the SDK. Clients
+// should not use this struct for any other purpose than testing code that
+// mocks the behavior of Databricks services.
+type ErrorDetail struct {
+	Type     string            `json:"@type,omitempty"`
+	Reason   string            `json:"reason,omitempty"`
+	Domain   string            `json:"domain,omitempty"`
+	Metadata map[string]string `json:"metadata,omitempty"`
+}

--- a/jobs/data_job_test.go
+++ b/jobs/data_job_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/databricks/databricks-sdk-go/apierr"
+	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/databricks/terraform-provider-databricks/qa"
 )
 
@@ -215,7 +215,7 @@ func TestDataSourceQueryableJobNoMatchId(t *testing.T) {
 			{
 				Method:   "GET",
 				Resource: "/api/2.0/jobs/get?job_id=567",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "RESOURCE_DOES_NOT_EXIST",
 					Message:   "Job 567 does not exist.",
 				},

--- a/jobs/resource_job_test.go
+++ b/jobs/resource_job_test.go
@@ -1532,7 +1532,7 @@ func TestResourceJobUpdate_ControlRunState_ContinuousUpdateRunNowFailsWith409(t 
 					JobID: 789,
 				},
 				Status: 409,
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "CONFLICT",
 					Message:   "A concurrent request to run the continuous job is already in progress. Please wait for it to complete before issuing a new request.",
 				},
@@ -2127,7 +2127,7 @@ func TestResourceJobRead_NotFound(t *testing.T) {
 			{
 				Method:   "GET",
 				Resource: "/api/2.0/jobs/get?job_id=789",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "NOT_FOUND",
 					Message:   "Item not found",
 				},
@@ -2148,7 +2148,7 @@ func TestResourceJobRead_Error(t *testing.T) {
 			{
 				Method:   "GET",
 				Resource: "/api/2.0/jobs/get?job_id=789",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},

--- a/mlflow/data_mlflow_experiment_test.go
+++ b/mlflow/data_mlflow_experiment_test.go
@@ -5,9 +5,9 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/databricks/databricks-sdk-go/apierr"
 	"github.com/databricks/databricks-sdk-go/service/ml"
 
+	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/databricks/terraform-provider-databricks/qa"
 )
 
@@ -50,7 +50,7 @@ func TestDataSourceExperimentByIdNotFound(t *testing.T) {
 				Method:   "GET",
 				Resource: "/api/2.0/mlflow/experiments/get?experiment_id=0987654321",
 				Status:   404,
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "RESOURCE_DOES_NOT_EXIST",
 					Message:   "Node ID 0987654321 does not exist.",
 				},
@@ -107,7 +107,7 @@ func TestDataSourceExperimentByNameNotFound(t *testing.T) {
 				Method:   "GET",
 				Resource: fmt.Sprintf("/api/2.0/mlflow/experiments/get-by-name?experiment_name=%s", url.QueryEscape(experimentName)),
 				Status:   404,
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "RESOURCE_DOES_NOT_EXIST",
 					Message:   "Node /Users/databricks/non-existent-experiment does not exist.",
 				},
@@ -130,7 +130,7 @@ func TestDataSourceExperimentByNameInvalidPath(t *testing.T) {
 				Method:   "GET",
 				Resource: fmt.Sprintf("/api/2.0/mlflow/experiments/get-by-name?experiment_name=%s", url.QueryEscape(experimentName)),
 				Status:   404,
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "RESOURCE_DOES_NOT_EXIST",
 					Message:   "Got an invalid experiment name 'invalid_path'. An experiment name must be an absolute path within the Databricks workspace, e.g. '/Users/<some-username>/my-experiment'.",
 				},

--- a/mlflow/data_mlflow_model_test.go
+++ b/mlflow/data_mlflow_model_test.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/databricks/databricks-sdk-go/apierr"
 	"github.com/databricks/databricks-sdk-go/service/ml"
+	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/databricks/terraform-provider-databricks/qa"
 )
 
@@ -59,7 +59,7 @@ func TestDataSourceModelNotFound(t *testing.T) {
 				Method:   "GET",
 				Resource: fmt.Sprintf("/api/2.0/mlflow/databricks/registered-models/get?name=%s", modelName),
 				Status:   404,
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "RESOURCE_DOES_NOT_EXIST",
 					Message:   fmt.Sprintf("RegisteredModel '%s' does not exist. It might have been deleted.", modelName),
 				},

--- a/mws/resource_mws_credentials_test.go
+++ b/mws/resource_mws_credentials_test.go
@@ -3,8 +3,7 @@ package mws
 import (
 	"testing"
 
-	"github.com/databricks/databricks-sdk-go/apierr"
-
+	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/databricks/terraform-provider-databricks/qa"
 
 	"github.com/stretchr/testify/assert"
@@ -210,7 +209,7 @@ func TestResourceCredentialsCreate_Error(t *testing.T) {
 			{
 				Method:   "POST",
 				Resource: "/api/2.0/accounts/abc/credentials",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},
@@ -266,7 +265,7 @@ func TestResourceCredentialsRead_NotFound(t *testing.T) {
 			{
 				Method:   "GET",
 				Resource: "/api/2.0/accounts/abc/credentials/cid?",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "NOT_FOUND",
 					Message:   "Item not found",
 				},
@@ -287,7 +286,7 @@ func TestResourceCredentialsRead_Error(t *testing.T) {
 			{
 				Method:   "GET",
 				Resource: "/api/2.0/accounts/abc/credentials/cid?",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},
@@ -326,7 +325,7 @@ func TestResourceCredentialsDelete_Error(t *testing.T) {
 			{
 				Method:   "DELETE",
 				Resource: "/api/2.0/accounts/abc/credentials/cid?",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},

--- a/mws/resource_mws_customer_managed_keys_test.go
+++ b/mws/resource_mws_customer_managed_keys_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/databricks/databricks-sdk-go/apierr"
+	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/databricks/terraform-provider-databricks/qa"
 	"github.com/stretchr/testify/assert"
 )
@@ -75,7 +75,7 @@ func TestResourceCustomerManagedKeyCreate_Error(t *testing.T) {
 					},
 					UseCases: []string{"MANAGED_SERVICE"},
 				},
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},
@@ -160,7 +160,7 @@ func TestResourceCustomerManagedKeyRead_NotFound(t *testing.T) {
 			{
 				Method:   "GET",
 				Resource: "/api/2.0/accounts/abc/customer-managed-keys/cmkid",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					Message: "Invalid endpoint",
 				},
 				Status: 404,

--- a/mws/resource_mws_log_delivery_test.go
+++ b/mws/resource_mws_log_delivery_test.go
@@ -3,7 +3,7 @@ package mws
 import (
 	"testing"
 
-	"github.com/databricks/databricks-sdk-go/apierr"
+	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/databricks/terraform-provider-databricks/qa"
 
 	"github.com/stretchr/testify/assert"
@@ -142,7 +142,7 @@ func TestResourceLogDeliveryCreate_Error(t *testing.T) {
 			{
 				Method:   "POST",
 				Resource: "/api/2.0/accounts/abc/log-delivery",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},
@@ -226,7 +226,7 @@ func TestResourceLogDeliveryRead_Error(t *testing.T) {
 			{
 				Method:   "GET",
 				Resource: "/api/2.0/accounts/abc/log-delivery/nid",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},
@@ -307,7 +307,7 @@ func TestUpdateLogDeliveryError(t *testing.T) {
 			{
 				Method:   "PATCH",
 				Resource: "/api/2.0/accounts/abc/log-delivery/nid",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},
@@ -369,7 +369,7 @@ func TestResourceLogDeliveryDelete_Error(t *testing.T) {
 			{
 				Method:   "PATCH",
 				Resource: "/api/2.0/accounts/abc/log-delivery/nid",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},

--- a/mws/resource_mws_networks_test.go
+++ b/mws/resource_mws_networks_test.go
@@ -3,7 +3,7 @@ package mws
 import (
 	"testing"
 
-	"github.com/databricks/databricks-sdk-go/apierr"
+	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/databricks/terraform-provider-databricks/qa"
 
 	"github.com/stretchr/testify/assert"
@@ -202,7 +202,7 @@ func TestResourceNetworkCreate_Error(t *testing.T) {
 			{
 				Method:   "POST",
 				Resource: "/api/2.0/accounts/abc/networks",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},
@@ -259,7 +259,7 @@ func TestResourceNetworkRead_NotFound(t *testing.T) {
 			{
 				Method:   "GET",
 				Resource: "/api/2.0/accounts/abc/networks/nid",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "NOT_FOUND",
 					Message:   "Item not found",
 				},
@@ -279,7 +279,7 @@ func TestResourceNetworkRead_Error(t *testing.T) {
 			{
 				Method:   "GET",
 				Resource: "/api/2.0/accounts/abc/networks/nid",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},
@@ -315,7 +315,7 @@ func TestResourceNetworkDelete(t *testing.T) {
 			{
 				Method:   "GET",
 				Resource: "/api/2.0/accounts/abc/networks/nid",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "NOT_FOUND",
 					Message:   "Yes, it's not found",
 				},
@@ -336,7 +336,7 @@ func TestResourceNetworkDelete_Error(t *testing.T) {
 			{
 				Method:   "DELETE",
 				Resource: "/api/2.0/accounts/abc/networks/nid",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},

--- a/mws/resource_mws_storage_configurations_test.go
+++ b/mws/resource_mws_storage_configurations_test.go
@@ -3,7 +3,7 @@ package mws
 import (
 	"testing"
 
-	"github.com/databricks/databricks-sdk-go/apierr"
+	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/databricks/terraform-provider-databricks/qa"
 	"github.com/stretchr/testify/assert"
 )
@@ -54,7 +54,7 @@ func TestResourceStorageConfigurationCreate_Error(t *testing.T) {
 			{
 				Method:   "POST",
 				Resource: "/api/2.0/accounts/abc/storage-configurations",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},
@@ -106,7 +106,7 @@ func TestResourceStorageConfigurationRead_NotFound(t *testing.T) {
 			{
 				Method:   "GET",
 				Resource: "/api/2.0/accounts/abc/storage-configurations/scid",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "NOT_FOUND",
 					Message:   "Item not found",
 				},
@@ -126,7 +126,7 @@ func TestResourceStorageConfigurationRead_Error(t *testing.T) {
 			{ // read log output for correct url...
 				Method:   "GET",
 				Resource: "/api/2.0/accounts/abc/storage-configurations/scid",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},
@@ -163,7 +163,7 @@ func TestResourceStorageConfigurationDelete_Error(t *testing.T) {
 			{
 				Method:   "DELETE",
 				Resource: "/api/2.0/accounts/abc/storage-configurations/scid",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},

--- a/mws/resource_mws_vpc_endpoint_test.go
+++ b/mws/resource_mws_vpc_endpoint_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/databricks/databricks-sdk-go/apierr"
+	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/databricks/terraform-provider-databricks/qa"
 
 	"github.com/stretchr/testify/assert"
@@ -132,7 +132,7 @@ func TestResourceVPCEndpointCreate_Error(t *testing.T) {
 			{
 				Method:   "POST",
 				Resource: "/api/2.0/accounts/abc/vpc-endpoints",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},
@@ -185,7 +185,7 @@ func TestResourceVPCEndpointRead_NotFound(t *testing.T) {
 			{
 				Method:   "GET",
 				Resource: "/api/2.0/accounts/abc/vpc-endpoints/veid",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "NOT_FOUND",
 					Message:   "Item not found",
 				},
@@ -205,7 +205,7 @@ func TestResourceVPCEndpoint_Error(t *testing.T) {
 			{
 				Method:   "GET",
 				Resource: "/api/2.0/accounts/abc/vpc-endpoints/veid",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},
@@ -240,7 +240,7 @@ func TestResourceVPCEndpointDelete(t *testing.T) {
 			{
 				Method:   "GET",
 				Resource: "/api/2.0/accounts/abc/vpc-endpoints/veid",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "NOT_FOUND",
 					Message:   "Yes, it's not found",
 				},
@@ -261,7 +261,7 @@ func TestResourceVPCEndpointDelete_Error(t *testing.T) {
 			{
 				Method:   "DELETE",
 				Resource: "/api/2.0/accounts/abc/vpc-endpoints/veid",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},

--- a/mws/resource_mws_workspaces_test.go
+++ b/mws/resource_mws_workspaces_test.go
@@ -199,7 +199,7 @@ func TestResourceWorkspaceCreate_Error_Custom_tags(t *testing.T) {
 						"SoldToCode": "1234",
 					},
 				},
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_PARAMETER_VALUE",
 					Message:   "custom_tags are only allowed for AWS workspaces",
 				},
@@ -532,7 +532,7 @@ func TestResourceWorkspaceCreate_Error(t *testing.T) {
 			{
 				Method:   "POST",
 				Resource: "/api/2.0/accounts/abc/workspaces",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},
@@ -541,7 +541,7 @@ func TestResourceWorkspaceCreate_Error(t *testing.T) {
 			{
 				Method:   "POST",
 				Resource: "/api/2.0/accounts/abc/workspaces",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},
@@ -671,7 +671,7 @@ func TestResourceWorkspaceRead_NotFound(t *testing.T) {
 			{
 				Method:   "GET",
 				Resource: "/api/2.0/accounts/abc/workspaces/1234",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "NOT_FOUND",
 					Message:   "Item not found",
 				},
@@ -691,7 +691,7 @@ func TestResourceWorkspaceRead_Error(t *testing.T) {
 			{ // read log output for correct url...
 				Method:   "GET",
 				Resource: "/api/2.0/accounts/abc/workspaces/1234",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},
@@ -873,7 +873,7 @@ func TestResourceWorkspaceUpdate_Error(t *testing.T) {
 			{
 				Method:   "PATCH",
 				Resource: "/api/2.0/accounts/abc/workspaces/1234",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},
@@ -918,7 +918,7 @@ func TestResourceWorkspaceDelete(t *testing.T) {
 			{
 				Method:   "GET",
 				Resource: "/api/2.0/accounts/abc/workspaces/1234",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "NOT_FOUND",
 					Message:   "Cannot find anything",
 				},
@@ -939,7 +939,7 @@ func TestResourceWorkspaceDelete_Error(t *testing.T) {
 			{
 				Method:   "DELETE",
 				Resource: "/api/2.0/accounts/abc/workspaces/1234",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},

--- a/permissions/resource_access_control_rule_set_test.go
+++ b/permissions/resource_access_control_rule_set_test.go
@@ -5,11 +5,11 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/databricks/databricks-sdk-go/apierr"
 	"github.com/databricks/databricks-sdk-go/service/iam"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/databricks/terraform-provider-databricks/qa"
 )
 
@@ -231,7 +231,7 @@ func TestResourceRuleSetUpdateConflict(t *testing.T) {
 						},
 					},
 				},
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "RESOURCE_CONFLICT",
 					Message:   "Conflict with another RuleSet operation",
 				},

--- a/permissions/resource_permissions_test.go
+++ b/permissions/resource_permissions_test.go
@@ -372,7 +372,7 @@ func TestResourcePermissionsRead_NotFound(t *testing.T) {
 			{
 				Method:   http.MethodGet,
 				Resource: "/api/2.0/permissions/clusters/abc",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "NOT_FOUND",
 					Message:   "Cluster does not exist",
 				},
@@ -394,7 +394,7 @@ func TestResourcePermissionsRead_some_error(t *testing.T) {
 			{
 				Method:   http.MethodGet,
 				Resource: "/api/2.0/permissions/clusters/abc",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},
@@ -460,7 +460,7 @@ func TestResourcePermissionsRead_ErrorOnScimMe(t *testing.T) {
 		{
 			Method:   http.MethodGet,
 			Resource: "/api/2.0/preview/scim/v2/Me",
-			Response: apierr.APIErrorBody{
+			Response: common.APIErrorBody{
 				ErrorCode: "INVALID_REQUEST",
 				Message:   "Internal error happened",
 			},
@@ -614,7 +614,7 @@ func TestResourcePermissionsDelete_error(t *testing.T) {
 						},
 					},
 				},
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},
@@ -965,7 +965,7 @@ func TestResourcePermissionsCreate_NotebookPath_NotExists(t *testing.T) {
 			{
 				Method:   http.MethodGet,
 				Resource: "/api/2.0/workspace/get-status?path=%2FDevelopment%2FInit",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},
@@ -1143,7 +1143,7 @@ func TestResourcePermissionsCreate_error(t *testing.T) {
 			{
 				Method:   http.MethodPut,
 				Resource: "/api/2.0/permissions/clusters/abc",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},

--- a/pipelines/resource_pipeline_test.go
+++ b/pipelines/resource_pipeline_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/databricks/databricks-sdk-go/apierr"
+	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/databricks/terraform-provider-databricks/qa"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -126,7 +126,7 @@ func TestResourcePipelineCreate_Error(t *testing.T) {
 			{
 				Method:   "POST",
 				Resource: "/api/2.0/pipelines",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},
@@ -177,7 +177,7 @@ func TestResourcePipelineCreate_ErrorWhenWaitingFailedCleanup(t *testing.T) {
 			{
 				Method:   "GET",
 				Resource: "/api/2.0/pipelines/abcd",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INTERNAL_ERROR",
 					Message:   "Internal error",
 				},
@@ -228,7 +228,7 @@ func TestResourcePipelineCreate_ErrorWhenWaitingSuccessfulCleanup(t *testing.T) 
 			{
 				Method:   "GET",
 				Resource: "/api/2.0/pipelines/abcd",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "RESOURCE_DOES_NOT_EXIST",
 					Message:   "No such resource",
 				},
@@ -284,7 +284,7 @@ func TestResourcePipelineRead_NotFound(t *testing.T) {
 			{
 				Method:   "GET",
 				Resource: "/api/2.0/pipelines/abcd",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "NOT_FOUND",
 					Message:   "Item not found",
 				},
@@ -304,7 +304,7 @@ func TestResourcePipelineRead_Error(t *testing.T) {
 			{
 				Method:   "GET",
 				Resource: "/api/2.0/pipelines/abcd",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},
@@ -392,7 +392,7 @@ func TestResourcePipelineUpdate_Error(t *testing.T) {
 			{ // read log output for better stub url...
 				Method:   "PUT",
 				Resource: "/api/2.0/pipelines/abcd",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},
@@ -499,7 +499,7 @@ func TestResourcePipelineDelete(t *testing.T) {
 			{
 				Method:   "GET",
 				Resource: "/api/2.0/pipelines/abcd",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "RESOURCE_DOES_NOT_EXIST",
 					Message:   "No such resource",
 				},
@@ -520,7 +520,7 @@ func TestResourcePipelineDelete_Error(t *testing.T) {
 			{
 				Method:   "DELETE",
 				Resource: "/api/2.0/pipelines/abcd?",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},

--- a/policies/resource_cluster_policy_test.go
+++ b/policies/resource_cluster_policy_test.go
@@ -3,8 +3,8 @@ package policies
 import (
 	"testing"
 
-	"github.com/databricks/databricks-sdk-go/apierr"
 	"github.com/databricks/databricks-sdk-go/service/compute"
+	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/databricks/terraform-provider-databricks/qa"
 	"github.com/stretchr/testify/assert"
 )
@@ -43,7 +43,7 @@ func TestResourceClusterPolicyRead_NotFound(t *testing.T) {
 			{ // read log output for correct url...
 				Method:   "GET",
 				Resource: "/api/2.0/policies/clusters/get?policy_id=abc",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "NOT_FOUND",
 					Message:   "Item not found",
 				},
@@ -63,7 +63,7 @@ func TestResourceClusterPolicyRead_Error(t *testing.T) {
 			{ // read log output for correct url...
 				Method:   "GET",
 				Resource: "/api/2.0/policies/clusters/get?policy_id=abc",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},
@@ -244,7 +244,7 @@ func TestResourceClusterPolicyCreateOverrideBuiltin_ErrorListingFamilies(t *test
 			{
 				Method:   "GET",
 				Resource: "/api/2.0/policy-families?",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},
@@ -282,7 +282,7 @@ func TestResourceClusterPolicyCreateOverrideBuiltin_ErrorListingPolicies(t *test
 			{
 				Method:   "GET",
 				Resource: "/api/2.0/policies/clusters/list?",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},
@@ -322,7 +322,7 @@ func TestResourceClusterPolicyCreate_Error(t *testing.T) {
 			{
 				Method:   "POST",
 				Resource: "/api/2.0/policies/clusters/create",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},
@@ -420,7 +420,7 @@ func TestResourceClusterPolicyUpdate_Error(t *testing.T) {
 			{
 				Method:   "POST",
 				Resource: "/api/2.0/policies/clusters/edit",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},
@@ -502,7 +502,7 @@ func TestResourceClusterPolicyDeletePolicyOverride_Error(t *testing.T) {
 			{
 				Method:   "GET",
 				Resource: "/api/2.0/policy-families?",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},
@@ -526,7 +526,7 @@ func TestResourceClusterPolicyDelete_Error(t *testing.T) {
 			{
 				Method:   "POST",
 				Resource: "/api/2.0/policies/clusters/delete",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},

--- a/pools/resource_instance_pool_test.go
+++ b/pools/resource_instance_pool_test.go
@@ -3,8 +3,7 @@ package pools
 import (
 	"testing"
 
-	"github.com/databricks/databricks-sdk-go/apierr"
-
+	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/databricks/terraform-provider-databricks/qa"
 	"github.com/stretchr/testify/assert"
 )
@@ -61,7 +60,7 @@ func TestResourceInstancePoolCreate_Error(t *testing.T) {
 			{
 				Method:   "POST",
 				Resource: "/api/2.0/instance-pools/create",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},
@@ -119,7 +118,7 @@ func TestResourceInstancePoolRead_NotFound(t *testing.T) {
 			{
 				Method:   "GET",
 				Resource: "/api/2.0/instance-pools/get?instance_pool_id=abc",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "NOT_FOUND",
 					Message:   "Item not found",
 				},
@@ -139,7 +138,7 @@ func TestResourceInstancePoolRead_Error(t *testing.T) {
 			{
 				Method:   "GET",
 				Resource: "/api/2.0/instance-pools/get?instance_pool_id=abc",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},
@@ -208,7 +207,7 @@ func TestResourceInstancePoolUpdate_Error(t *testing.T) {
 			{ // read log output for better stub url...
 				Method:   "POST",
 				Resource: "/api/2.0/instance-pools/edit",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},
@@ -256,7 +255,7 @@ func TestResourceInstancePoolDelete_Error(t *testing.T) {
 			{
 				Method:   "POST",
 				Resource: "/api/2.0/instance-pools/delete",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},

--- a/provider/generate_test.go
+++ b/provider/generate_test.go
@@ -59,7 +59,7 @@ func (stub *resourceTestStub) Reads(t *testing.T) {
 				{   // read log output for correct url...
 					Method:   "GET",
 					Resource: "/api/2.0/...", 
-					Response: apierr.APIErrorBody{
+					Response: common.APIErrorBody{
 						ErrorCode: "NOT_FOUND",
 						Message:   "Item not found",
 					},
@@ -79,7 +79,7 @@ func (stub *resourceTestStub) Reads(t *testing.T) {
 				{   // read log output for correct url...
 					Method:   "GET",
 					Resource: "/api/2.0/...", 
-					Response: apierr.APIErrorBody{
+					Response: common.APIErrorBody{
 						ErrorCode: "INVALID_REQUEST",
 						Message:   "Internal error happened",
 					},
@@ -120,7 +120,7 @@ func (stub *resourceTestStub) Creates(t *testing.T) {
 				{   // read log output for better stub url...
 					Method:   "POST",
 					Resource: "/api/2.0/...", 
-					Response: apierr.APIErrorBody{
+					Response: common.APIErrorBody{
 						ErrorCode: "INVALID_REQUEST",
 						Message:   "Internal error happened",
 					},
@@ -165,7 +165,7 @@ func (stub *resourceTestStub) Updates(t *testing.T) {
 				{   // read log output for better stub url...
 					Method:   "POST",
 					Resource: "/api/2.0/.../edit",
-					Response: apierr.APIErrorBody{
+					Response: common.APIErrorBody{
 						ErrorCode: "INVALID_REQUEST",
 						Message:   "Internal error happened",
 					},
@@ -212,7 +212,7 @@ func (stub *resourceTestStub) Deletes(t *testing.T) {
 				{
 					Method:   "POST",
 					Resource: "/api/2.0/.../delete",
-					Response: apierr.APIErrorBody{
+					Response: common.APIErrorBody{
 						ErrorCode: "INVALID_REQUEST",
 						Message:   "Internal error happened",
 					},

--- a/repos/resource_git_credential_test.go
+++ b/repos/resource_git_credential_test.go
@@ -5,8 +5,8 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/databricks/databricks-sdk-go/apierr"
 	"github.com/databricks/databricks-sdk-go/service/workspace"
+	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/databricks/terraform-provider-databricks/qa"
 )
 
@@ -41,7 +41,7 @@ func TestResourceGitCredentialRead_Error(t *testing.T) {
 			{
 				Method:   http.MethodGet,
 				Resource: fmt.Sprintf("/api/2.0/git-credentials/%d?", credID),
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "RESOURCE_DOES_NOT_EXIST",
 					Message:   "Git credential with the given ID could not be found.",
 				},
@@ -131,7 +131,7 @@ func TestResourceGitCredentialUpdate_Error(t *testing.T) {
 					GitUsername:         user,
 					PersonalAccessToken: token,
 				},
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "RESOURCE_DOES_NOT_EXIST",
 					Message:   "Git credential with the given ID could not be found.",
 				},
@@ -205,7 +205,7 @@ func TestResourceGitCredentialCreate_Error(t *testing.T) {
 					GitUsername:         user,
 					PersonalAccessToken: token,
 				},
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_STATE",
 					Message:   "Only one Git credential is supported at this time. If you would like to update your credential, please use the PATCH endpoint.",
 				},
@@ -241,7 +241,7 @@ func TestResourceGitCredentialCreateWithForce(t *testing.T) {
 					GitUsername:         user,
 					PersonalAccessToken: token,
 				},
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_STATE",
 					Message:   "Only one Git credential is supported at this time. If you would like to update your credential, please use the PATCH endpoint.",
 				},
@@ -296,7 +296,7 @@ func TestResourceGitCredentialCreateWithForce_Error_List(t *testing.T) {
 					GitUsername:         user,
 					PersonalAccessToken: token,
 				},
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_STATE",
 					Message:   "Only one Git credential is supported at this time. If you would like to update your credential, please use the PATCH endpoint.",
 				},
@@ -305,7 +305,7 @@ func TestResourceGitCredentialCreateWithForce_Error_List(t *testing.T) {
 			{
 				Method:   http.MethodGet,
 				Resource: "/api/2.0/git-credentials",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "RESOURCE_DOES_NOT_EXIST",
 					Message:   "No such endpoint",
 				},
@@ -337,7 +337,7 @@ func TestResourceGitCredentialCreateWithForce_ErrorEmptyList(t *testing.T) {
 					GitUsername:         user,
 					PersonalAccessToken: token,
 				},
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_STATE",
 					Message:   "Only one Git credential is supported at this time. If you would like to update your credential, please use the PATCH endpoint.",
 				},
@@ -379,7 +379,7 @@ func TestResourceGitCredentialCreateWithForce_ErrorUpdate(t *testing.T) {
 					GitUsername:         user,
 					PersonalAccessToken: token,
 				},
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_STATE",
 					Message:   "Only one Git credential is supported at this time. If you would like to update your credential, please use the PATCH endpoint.",
 				},
@@ -395,7 +395,7 @@ func TestResourceGitCredentialCreateWithForce_ErrorUpdate(t *testing.T) {
 			{
 				Method:   http.MethodPatch,
 				Resource: fmt.Sprintf("/api/2.0/git-credentials/%d", resp.CredentialId),
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "RESOURCE_DOES_NOT_EXIST",
 					Message:   "Git credential with the given ID could not be found.",
 				},

--- a/repos/resource_repo_test.go
+++ b/repos/resource_repo_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/databricks/databricks-sdk-go/apierr"
+	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/databricks/terraform-provider-databricks/qa"
 )
 
@@ -61,7 +61,7 @@ func TestResourceRepoRead_NotFound(t *testing.T) {
 			{
 				Method:   http.MethodGet,
 				Resource: fmt.Sprintf("/api/2.0/repos/%s", repoID),
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "RESOURCE_DOES_NOT_EXIST",
 					Message:   "Repo could not be found",
 				},
@@ -182,7 +182,7 @@ func TestResourceRepoCreateCustomDirectoryError(t *testing.T) {
 				ExpectedRequest: map[string]string{
 					"path": "/Repos/Production",
 				},
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},

--- a/scim/resource_entitlement_test.go
+++ b/scim/resource_entitlement_test.go
@@ -3,7 +3,7 @@ package scim
 import (
 	"testing"
 
-	"github.com/databricks/databricks-sdk-go/apierr"
+	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/databricks/terraform-provider-databricks/qa"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -178,7 +178,7 @@ func TestResourceEntitlementsGroupRead_Error(t *testing.T) {
 				Method:   "GET",
 				Resource: "/api/2.0/preview/scim/v2/Groups/abc?attributes=entitlements",
 				Status:   400,
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ScimDetail: "Something",
 					ScimStatus: "Else",
 				},
@@ -273,7 +273,7 @@ func TestResourceEntitlementsGroupDeleteEmptyEntitlement(t *testing.T) {
 				Method:          "PATCH",
 				Resource:        "/api/2.0/preview/scim/v2/Groups/abc",
 				ExpectedRequest: deleteRequest,
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_PATH",
 					Message:   "invalidPath No such attribute with the name : entitlements in the current resource",
 				},
@@ -420,7 +420,7 @@ func TestResourceEntitlementsUserRead_Error(t *testing.T) {
 				Method:   "GET",
 				Resource: "/api/2.0/preview/scim/v2/Users/abc?attributes=entitlements",
 				Status:   400,
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ScimDetail: "Something",
 					ScimStatus: "Else",
 				},
@@ -441,7 +441,7 @@ func TestResourceEntitlementsUserUpdate_Error(t *testing.T) {
 				Method:   "GET",
 				Resource: "/api/2.0/preview/scim/v2/Users/abc?attributes=entitlements",
 				Status:   400,
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ScimDetail: "Something",
 					ScimStatus: "Else",
 				},
@@ -451,7 +451,7 @@ func TestResourceEntitlementsUserUpdate_Error(t *testing.T) {
 				Resource:        "/api/2.0/preview/scim/v2/Users/abc",
 				ExpectedRequest: updateRequest,
 				Status:          400,
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ScimDetail: "Something",
 					ScimStatus: "Else",
 				},
@@ -630,7 +630,7 @@ func TestResourceEntitlementsSPNRead_Error(t *testing.T) {
 				Method:   "GET",
 				Resource: "/api/2.0/preview/scim/v2/ServicePrincipals/abc?attributes=entitlements",
 				Status:   400,
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ScimDetail: "Something",
 					ScimStatus: "Else",
 				},

--- a/scim/resource_group_member_test.go
+++ b/scim/resource_group_member_test.go
@@ -3,7 +3,7 @@ package scim
 import (
 	"testing"
 
-	"github.com/databricks/databricks-sdk-go/apierr"
+	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/databricks/terraform-provider-databricks/qa"
 	"github.com/stretchr/testify/assert"
 )
@@ -51,7 +51,7 @@ func TestResourceGroupMemberCreate_Error(t *testing.T) {
 			{
 				Method:   "PATCH",
 				Resource: "/api/2.0/preview/scim/v2/Groups/abc",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},
@@ -121,7 +121,7 @@ func TestResourceGroupMemberRead_NotFound(t *testing.T) {
 			{
 				Method:   "GET",
 				Resource: "/api/2.0/preview/scim/v2/Groups/abc?attributes=members",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "NOT_FOUND",
 					Message:   "Item not found",
 				},
@@ -141,7 +141,7 @@ func TestResourceGroupMemberRead_Error(t *testing.T) {
 			{
 				Method:   "GET",
 				Resource: "/api/2.0/preview/scim/v2/Groups/abc?attributes=members",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},
@@ -181,7 +181,7 @@ func TestResourceGroupMemberDelete_Error(t *testing.T) {
 			{
 				Method:   "PATCH",
 				Resource: "/api/2.0/preview/scim/v2/Groups/abc",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},

--- a/scim/resource_group_role_test.go
+++ b/scim/resource_group_role_test.go
@@ -3,7 +3,7 @@ package scim
 import (
 	"testing"
 
-	"github.com/databricks/databricks-sdk-go/apierr"
+	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/databricks/terraform-provider-databricks/qa"
 )
 
@@ -48,7 +48,7 @@ func TestResourceGroupRoleCreate_Error(t *testing.T) {
 			{
 				Method:   "PATCH",
 				Resource: "/api/2.0/preview/scim/v2/Groups/abc",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},
@@ -114,7 +114,7 @@ func TestResourceGroupRoleRead_NotFound(t *testing.T) {
 			{
 				Method:   "GET",
 				Resource: "/api/2.0/preview/scim/v2/Groups/abc?attributes=roles",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "NOT_FOUND",
 					Message:   "Item not found",
 				},
@@ -134,7 +134,7 @@ func TestResourceGroupRoleRead_Error(t *testing.T) {
 			{
 				Method:   "GET",
 				Resource: "/api/2.0/preview/scim/v2/Groups/abc?attributes=roles",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},
@@ -170,7 +170,7 @@ func TestResourceGroupRoleDelete_Error(t *testing.T) {
 			{
 				Method:   "PATCH",
 				Resource: "/api/2.0/preview/scim/v2/Groups/abc",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},

--- a/scim/resource_group_test.go
+++ b/scim/resource_group_test.go
@@ -82,7 +82,7 @@ func TestResourceGroupCreate_Error(t *testing.T) {
 			{
 				Method:   "POST",
 				Resource: "/api/2.0/preview/scim/v2/Groups",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},
@@ -164,7 +164,7 @@ func TestResourceGroupRead_NotFound(t *testing.T) {
 			{
 				Method:   "GET",
 				Resource: "/api/2.0/preview/scim/v2/Groups/abc?attributes=displayName,externalId,entitlements",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "NOT_FOUND",
 					Message:   "Item not found",
 				},
@@ -184,7 +184,7 @@ func TestResourceGroupRead_Error(t *testing.T) {
 			{
 				Method:   "GET",
 				Resource: "/api/2.0/preview/scim/v2/Groups/abc?attributes=displayName,externalId,entitlements",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},
@@ -300,7 +300,7 @@ func TestResourceGroupUpdate_Error(t *testing.T) {
 			{
 				Method:   "GET",
 				Resource: "/api/2.0/preview/scim/v2/Groups/abc?attributes=displayName,entitlements,groups,members,externalId",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},
@@ -338,7 +338,7 @@ func TestResourceGroupDelete_Error(t *testing.T) {
 			{
 				Method:   "DELETE",
 				Resource: "/api/2.0/preview/scim/v2/Groups/abc",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},

--- a/scim/resource_service_principal_test.go
+++ b/scim/resource_service_principal_test.go
@@ -73,7 +73,7 @@ func TestResourceServicePrincipalRead_Error(t *testing.T) {
 				Method:   "GET",
 				Resource: "/api/2.0/preview/scim/v2/ServicePrincipals/abc?attributes=userName,displayName,active,externalId,entitlements",
 				Status:   400,
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ScimDetail: "Something",
 					ScimStatus: "Else",
 				},
@@ -474,7 +474,7 @@ func TestResourceServicePrincipalDelete_NonExistingRepo(t *testing.T) {
 					Path:      "/Repos/abc",
 					Recursive: true,
 				},
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "RESOURCE_DOES_NOT_EXIST",
 					Message:   "Path (/Repos/abc) doesn't exist.",
 				},
@@ -533,7 +533,7 @@ func TestResourceServicePrincipalDelete_NonExistingDir(t *testing.T) {
 					Path:      "/Users/abc",
 					Recursive: true,
 				},
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "RESOURCE_DOES_NOT_EXIST",
 					Message:   "Path (/Users/abc) doesn't exist.",
 				},

--- a/scim/resource_user_test.go
+++ b/scim/resource_user_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/databricks/databricks-sdk-go/apierr"
 	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/databricks/terraform-provider-databricks/workspace"
 
@@ -76,7 +75,7 @@ func TestResourceUserRead_Error(t *testing.T) {
 				Method:   "GET",
 				Resource: "/api/2.0/preview/scim/v2/Users/abc?attributes=userName,displayName,active,externalId,entitlements",
 				Status:   400,
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ScimDetail: "Something",
 					ScimStatus: "Else",
 				},
@@ -515,7 +514,7 @@ func TestResourceUserDelete_NonExistingRepo(t *testing.T) {
 					Path:      "/Repos/abc",
 					Recursive: true,
 				},
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "RESOURCE_DOES_NOT_EXIST",
 					Message:   "Path (/Repos/abc) doesn't exist.",
 				},
@@ -573,7 +572,7 @@ func TestResourceUserDelete_NonExistingDir(t *testing.T) {
 					Path:      "/Users/abc",
 					Recursive: true,
 				},
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "RESOURCE_DOES_NOT_EXIST",
 					Message:   "Path (/Users/abc) doesn't exist.",
 				},
@@ -632,7 +631,7 @@ func TestCreateForceOverwriteCannotListUsers(t *testing.T) {
 			Method:   "GET",
 			Resource: "/api/2.0/preview/scim/v2/Users?excludedAttributes=roles&filter=userName%20eq%20%22me%40example.com%22",
 			Status:   417,
-			Response: apierr.APIErrorBody{
+			Response: common.APIErrorBody{
 				Message: "cannot find user",
 			},
 		},

--- a/secrets/resource_secret_acl_test.go
+++ b/secrets/resource_secret_acl_test.go
@@ -3,8 +3,8 @@ package secrets
 import (
 	"testing"
 
-	"github.com/databricks/databricks-sdk-go/apierr"
 	"github.com/databricks/databricks-sdk-go/service/workspace"
+	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/databricks/terraform-provider-databricks/qa"
 	"github.com/stretchr/testify/assert"
 )
@@ -37,7 +37,7 @@ func TestResourceSecretACLRead_NotFound(t *testing.T) {
 			{
 				Method:   "GET",
 				Resource: "/api/2.0/secrets/acls/get?principal=something&scope=global",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "NOT_FOUND",
 					Message:   "Item not found",
 				},
@@ -57,7 +57,7 @@ func TestResourceSecretACLRead_Error(t *testing.T) {
 			{
 				Method:   "GET",
 				Resource: "/api/2.0/secrets/acls/get?principal=something&scope=global",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},
@@ -142,7 +142,7 @@ func TestResourceSecretACLCreate_Error(t *testing.T) {
 			{ // read log output for better stub url...
 				Method:   "POST",
 				Resource: "/api/2.0/secrets/acls/put",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},
@@ -187,7 +187,7 @@ func TestResourceSecretACLDelete_Error(t *testing.T) {
 			{
 				Method:   "POST",
 				Resource: "/api/2.0/secrets/acls/delete",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},

--- a/secrets/resource_secret_scope_test.go
+++ b/secrets/resource_secret_scope_test.go
@@ -4,8 +4,8 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/databricks/databricks-sdk-go/apierr"
 	"github.com/databricks/databricks-sdk-go/service/workspace"
+	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/databricks/terraform-provider-databricks/qa"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -104,7 +104,7 @@ func TestResourceSecretScopeRead_Error(t *testing.T) {
 			{
 				Method:   "GET",
 				Resource: "/api/2.0/secrets/scopes/list",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},
@@ -244,7 +244,7 @@ func TestResourceSecretScopeCreate_Error(t *testing.T) {
 			{
 				Method:   "POST",
 				Resource: "/api/2.0/secrets/scopes/create",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},
@@ -287,7 +287,7 @@ func TestResourceSecretScopeDelete_Error(t *testing.T) {
 			{
 				Method:   "POST",
 				Resource: "/api/2.0/secrets/scopes/delete",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},

--- a/secrets/resource_secret_test.go
+++ b/secrets/resource_secret_test.go
@@ -3,8 +3,8 @@ package secrets
 import (
 	"testing"
 
-	"github.com/databricks/databricks-sdk-go/apierr"
 	"github.com/databricks/databricks-sdk-go/service/workspace"
+	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/databricks/terraform-provider-databricks/qa"
 	"github.com/stretchr/testify/assert"
 )
@@ -67,7 +67,7 @@ func TestResourceSecretRead_Error(t *testing.T) {
 			{
 				Method:   "GET",
 				Resource: "/api/2.0/secrets/list?scope=foo",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},
@@ -125,7 +125,7 @@ func TestResourceSecretCreate_Error(t *testing.T) {
 			{
 				Method:   "POST",
 				Resource: "/api/2.0/secrets/put",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},
@@ -170,7 +170,7 @@ func TestResourceSecretDelete_Error(t *testing.T) {
 			{
 				Method:   "POST",
 				Resource: "/api/2.0/secrets/delete",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},

--- a/serving/resource_model_serving_test.go
+++ b/serving/resource_model_serving_test.go
@@ -4,8 +4,8 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/databricks/databricks-sdk-go/apierr"
 	"github.com/databricks/databricks-sdk-go/service/serving"
+	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/databricks/terraform-provider-databricks/qa"
 )
 
@@ -277,7 +277,7 @@ func TestModelServingCreate_Error(t *testing.T) {
 			{
 				Method:   http.MethodPost,
 				Resource: "/api/2.0/serving-endpoints",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},
@@ -335,7 +335,7 @@ func TestModelServingCreate_WithErrorOnWait(t *testing.T) {
 			{
 				Method:   http.MethodGet,
 				Resource: "/api/2.0/serving-endpoints/test-endpoint?",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},
@@ -449,7 +449,7 @@ func TestModelServingRead_Error(t *testing.T) {
 			{
 				Method:   http.MethodGet,
 				Resource: "/api/2.0/serving-endpoints/test-endpoint?",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},
@@ -565,7 +565,7 @@ func TestModelServingUpdate_Error(t *testing.T) {
 			{
 				Method:   http.MethodPut,
 				Resource: "/api/2.0/serving-endpoints/test-endpoint/config",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},
@@ -620,7 +620,7 @@ func TestModelServingDelete_Error(t *testing.T) {
 			{
 				Method:   http.MethodDelete,
 				Resource: "/api/2.0/serving-endpoints/test-endpoint?",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},

--- a/sharing/resource_recipient_test.go
+++ b/sharing/resource_recipient_test.go
@@ -4,8 +4,8 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/databricks/databricks-sdk-go/apierr"
 	"github.com/databricks/databricks-sdk-go/service/sharing"
+	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/databricks/terraform-provider-databricks/qa"
 	"github.com/stretchr/testify/assert"
 )
@@ -329,7 +329,7 @@ func TestUpdateRecipientRollback(t *testing.T) {
 				ExpectedRequest: sharing.UpdateRecipient{
 					Comment: "e",
 				},
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "SERVER_ERROR",
 					Message:   "Something unexpected happened",
 				},
@@ -402,7 +402,7 @@ func TestDeleteRecipientError(t *testing.T) {
 			{
 				Method:   http.MethodDelete,
 				Resource: "/api/2.1/unity-catalog/recipients/testRecipient?",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_STATE",
 					Message:   "Something went wrong",
 				},

--- a/sharing/resource_share_test.go
+++ b/sharing/resource_share_test.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/databricks/databricks-sdk-go/apierr"
 	"github.com/databricks/databricks-sdk-go/service/sharing"
+	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/databricks/terraform-provider-databricks/qa"
 )
 
@@ -426,7 +426,7 @@ func TestUpdateShareRollback(t *testing.T) {
 						},
 					},
 				},
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "SERVER_ERROR",
 					Message:   "Something unexpected happened",
 				},
@@ -557,7 +557,7 @@ func TestCreateShare_ThrowError(t *testing.T) {
 				ExpectedRequest: ShareInfo{
 					Name: "a",
 				},
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},
@@ -620,7 +620,7 @@ func TestCreateShareButPatchFails(t *testing.T) {
 						},
 					},
 				},
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},

--- a/storage/resource_file_test.go
+++ b/storage/resource_file_test.go
@@ -4,8 +4,8 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/databricks/databricks-sdk-go/apierr"
 	"github.com/databricks/databricks-sdk-go/service/files"
+	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/databricks/terraform-provider-databricks/qa"
 	"github.com/stretchr/testify/assert"
 )
@@ -94,7 +94,7 @@ func TestResourceFileCreate_Error(t *testing.T) {
 			{
 				Method:   http.MethodPut,
 				Resource: "/api/2.0/fs/files/Volumes/CatalogName/SchemaName/VolumeName/fileName",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},
@@ -185,7 +185,7 @@ func TestResourceFileDelete_Error(t *testing.T) {
 			{
 				Method:   "DELETE",
 				Resource: "/api/2.0/fs/files/Volumes/CatalogName/SchemaName/VolumeName/fileName?",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},

--- a/tokens/resource_token_test.go
+++ b/tokens/resource_token_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/databricks/databricks-sdk-go/apierr"
 
+	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/databricks/terraform-provider-databricks/qa"
 	"github.com/stretchr/testify/assert"
 )
@@ -71,7 +72,7 @@ func TestResourceTokenRead_Error(t *testing.T) {
 			{
 				Method:   "GET",
 				Resource: "/api/2.0/token/list",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},
@@ -137,7 +138,7 @@ func TestResourceTokenCreate_Error(t *testing.T) {
 			{
 				Method:   "POST",
 				Resource: "/api/2.0/token/create",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},
@@ -238,7 +239,7 @@ func TestResourceTokenDelete_Error(t *testing.T) {
 			{
 				Method:   "POST",
 				Resource: "/api/2.0/token/delete",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},

--- a/workspace/resource_directory_test.go
+++ b/workspace/resource_directory_test.go
@@ -6,7 +6,7 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/databricks/databricks-sdk-go/apierr"
+	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/databricks/terraform-provider-databricks/qa"
 
 	"github.com/stretchr/testify/assert"
@@ -70,7 +70,7 @@ func TestResourceDirectoryDelete_NotFound(t *testing.T) {
 				Method:          http.MethodPost,
 				Resource:        "/api/2.0/workspace/delete",
 				ExpectedRequest: DeletePath{Path: path, Recursive: delete_recursive},
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "RESOURCE_DOES_NOT_EXIST",
 					Message:   "Path (/test/path) doesn't exist.",
 				},
@@ -96,7 +96,7 @@ func TestResourceDirectoryRead_NotFound(t *testing.T) {
 			{ // read log output for correct url...
 				Method:   "GET",
 				Resource: fmt.Sprintf("/api/2.0/workspace/get-status?path=%s", url.PathEscape(path)),
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "NOT_FOUND",
 					Message:   "Item not found",
 				},
@@ -117,7 +117,7 @@ func TestResourceDirectoryRead_Error(t *testing.T) {
 			{
 				Method:   "GET",
 				Resource: fmt.Sprintf("/api/2.0/workspace/get-status?path=%s", url.PathEscape(path)),
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},
@@ -175,7 +175,7 @@ func TestResourceDirectoryCreate_Error(t *testing.T) {
 				ExpectedRequest: map[string]string{
 					"path": path,
 				},
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},
@@ -200,7 +200,7 @@ func TestResourceDirectoryDelete_Error(t *testing.T) {
 				Method:          "POST",
 				Resource:        "/api/2.0/workspace/delete",
 				ExpectedRequest: DeletePath{Path: path, Recursive: false},
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},

--- a/workspace/resource_global_init_script_test.go
+++ b/workspace/resource_global_init_script_test.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/databricks/databricks-sdk-go/apierr"
 	"github.com/databricks/databricks-sdk-go/service/compute"
+	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/databricks/terraform-provider-databricks/qa"
 
 	"github.com/stretchr/testify/assert"
@@ -70,7 +70,7 @@ func TestResourceGlobalInitScriptRead_NotFound(t *testing.T) {
 			{ // read log output for correct url...
 				Method:   "GET",
 				Resource: "/api/2.0/global-init-scripts/1234?",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "RESOURCE_DOES_NOT_EXIST",
 					Message:   "The global unit script with ID 1234 does not exist.",
 				},

--- a/workspace/resource_notebook_test.go
+++ b/workspace/resource_notebook_test.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/databricks/databricks-sdk-go/apierr"
+	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/databricks/terraform-provider-databricks/qa"
 
 	"github.com/stretchr/testify/assert"
@@ -63,7 +63,7 @@ func TestResourceNotebookRead_NotFound(t *testing.T) {
 			{ // read log output for correct url...
 				Method:   "GET",
 				Resource: "/api/2.0/workspace/get-status?path=%2Ftest%2Fpath",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "NOT_FOUND",
 					Message:   "Item not found",
 				},
@@ -83,7 +83,7 @@ func TestResourceNotebookRead_Error(t *testing.T) {
 			{
 				Method:   "GET",
 				Resource: "/api/2.0/workspace/get-status?path=%2Ftest%2Fpath",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},
@@ -225,7 +225,7 @@ func TestResourceNotebookCreate_DirectoryCreateError(t *testing.T) {
 				ExpectedRequest: map[string]string{
 					"path": "/foo",
 				},
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},
@@ -357,7 +357,7 @@ func TestResourceNotebookCreate_Error(t *testing.T) {
 			{
 				Method:   http.MethodPost,
 				Resource: "/api/2.0/workspace/import",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},
@@ -382,7 +382,7 @@ func TestResourceNotebookDelete_Error(t *testing.T) {
 			{
 				Method:   "POST",
 				Resource: "/api/2.0/workspace/delete",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},

--- a/workspace/resource_workspace_conf_test.go
+++ b/workspace/resource_workspace_conf_test.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/databricks/databricks-sdk-go/apierr"
+	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/databricks/terraform-provider-databricks/qa"
 	"github.com/stretchr/testify/assert"
 )
@@ -47,7 +47,7 @@ func TestWorkspaceConfCreate_Error(t *testing.T) {
 				ExpectedRequest: map[string]string{
 					"enableIpAccessLists": "true",
 				},
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},
@@ -120,7 +120,7 @@ func TestWorkspaceConfUpdate_Error(t *testing.T) {
 				ExpectedRequest: map[string]string{
 					"enableIpAccessLists": "true",
 				},
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},
@@ -159,7 +159,7 @@ func TestWorkspaceConfRead_Error(t *testing.T) {
 			{
 				Method:   http.MethodGet,
 				Resource: "/api/2.0/workspace-conf?",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},
@@ -208,7 +208,7 @@ func TestWorkspaceConfDelete_Error(t *testing.T) {
 			{
 				Method:   http.MethodPatch,
 				Resource: "/api/2.0/workspace-conf",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},
@@ -230,7 +230,7 @@ func TestWorkspaceConfUpdateOnInvalidConf(t *testing.T) {
 				Method:   http.MethodPatch,
 				Resource: "/api/2.0/workspace-conf",
 				Status:   400,
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "some-invalid-conf is an invalid config key",
 				},

--- a/workspace/resource_workspace_file_test.go
+++ b/workspace/resource_workspace_file_test.go
@@ -4,8 +4,8 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/databricks/databricks-sdk-go/apierr"
 	ws_api "github.com/databricks/databricks-sdk-go/service/workspace"
+	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/databricks/terraform-provider-databricks/qa"
 
 	"github.com/stretchr/testify/assert"
@@ -68,7 +68,7 @@ func TestResourceWorkspaceFileRead_NotFound(t *testing.T) {
 			{ // read log output for correct url...
 				Method:   "GET",
 				Resource: "/api/2.0/workspace/get-status?path=%2Ftest%2Fpath",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "NOT_FOUND",
 					Message:   "Item not found",
 				},
@@ -88,7 +88,7 @@ func TestResourceWorkspaceFileRead_Error(t *testing.T) {
 			{
 				Method:   "GET",
 				Resource: "/api/2.0/workspace/get-status?path=%2Ftest%2Fpath",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},
@@ -223,7 +223,7 @@ func TestResourceWorkspaceFileCreate_DirectoryCreateError(t *testing.T) {
 				ExpectedRequest: map[string]string{
 					"path": "/foo",
 				},
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},
@@ -338,7 +338,7 @@ func TestResourceWorkspaceFileCreate_Error(t *testing.T) {
 					"overwrite": true,
 					"path":      "/path.py",
 				},
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},
@@ -362,7 +362,7 @@ func TestResourceWorkspaceFileDelete_Error(t *testing.T) {
 			{
 				Method:   "POST",
 				Resource: "/api/2.0/workspace/delete",
-				Response: apierr.APIErrorBody{
+				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},


### PR DESCRIPTION
## Changes

Despite being technically public, struct `APIErrorBody` is an internal struct of the Go SDK as it is only used in private functions and not meant to be used outside of its package. Actually, the struct has been entirely removed in [PR 960](https://github.com/databricks/databricks-sdk-go/pull/960) to make that explicit. 

This PR cuts the dependency to the SDK `APIErrorBody` by adding a copy of the struct in the `common` package. That new struct is ultimately meant to disappear as the Terraform provider is migrated to use the service clients provided by the SDK rather than calling the services directly. 

**For Reviewers**: the main change is in `common/apierr.go` all other changes are simple dependency updates. 

## Tests

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [x] covered with integration tests in `internal/acceptance`
- [x] relevant acceptance tests are passing
- [ ] using Go SDK
