### PR TITLE
[Fix] Make `cluster_name_contains` optional in `databricks_clusters` data source

### DIFF
--- a/clusters/data_clusters.go
+++ b/clusters/data_clusters.go
@@ -13,7 +13,7 @@ func DataSourceClusters() common.Resource {
 	return common.WorkspaceData(func(ctx context.Context, data *struct {
 		Id                  string   `json:"id,omitempty" tf:"computed"`
 		Ids                 []string `json:"ids,omitempty" tf:"computed,slice_set"`
-		ClusterNameContains string   `json:"cluster_name_contains"`
+		ClusterNameContains string   `json:"cluster_name_contains,omitempty"`
 	}, w *databricks.WorkspaceClient) error {
 		clusters, err := w.Clusters.ListAll(ctx, compute.ListClustersRequest{})
 		if err != nil {

--- a/internal/acceptance/data_clusters_test.go
+++ b/internal/acceptance/data_clusters_test.go
@@ -1,0 +1,22 @@
+package acceptance
+
+import (
+	"testing"
+)
+
+func TestAccDataSourceClustersNoFilter(t *testing.T) {
+	workspaceLevel(t, step{
+		Template: `
+		data "databricks_clusters" "this" {
+		} `,
+	})
+}
+
+func TestAccDataSourceClustersWithFilter(t *testing.T) {
+	workspaceLevel(t, step{
+		Template: `
+		data "databricks_clusters" "this" {
+			cluster_name_contains = "Default"
+		}`,
+	})
+}


### PR DESCRIPTION
## Changes
This PR fixes a small regression introduced during the migration of the `databricks_clusters` resource to the Go SDK. That change accidentally made `cluster_name_contains` mandatory for this data source. This PR makes this field optional again.

## Tests
Added integration tests to verify that we can optionally specify this field.

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
