### PR TITLE
[Exporter] Improve code generation for SQL Endpoints

### DIFF
--- a/exporter/context.go
+++ b/exporter/context.go
@@ -1651,7 +1651,7 @@ func (ic *importContext) dataToHcl(i importable, path []string,
 			// In case when have zero value, but there is non-zero default, we also need to produce it
 			shouldSkip = false
 		}
-		if shouldSkip {
+		if shouldSkip && (i.ShouldGenerateField == nil || !i.ShouldGenerateField(ic, pathString, as, d)) {
 			continue
 		}
 		switch as.Type {

--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -1917,6 +1917,13 @@ func TestImportingSqlObjects(t *testing.T) {
 
 			err := ic.Run()
 			assert.NoError(t, err)
+
+			content, err := os.ReadFile(tmpDir + "/sql-endpoints.tf")
+			assert.NoError(t, err)
+			contentStr := string(content)
+			assert.True(t, strings.Contains(contentStr, `enable_serverless_compute = false`))
+			assert.True(t, strings.Contains(contentStr, `resource "databricks_sql_endpoint" "test" {`))
+			assert.False(t, strings.Contains(contentStr, `tags {`))
 		})
 }
 

--- a/exporter/model.go
+++ b/exporter/model.go
@@ -153,6 +153,8 @@ type importable struct {
 	Ignore func(ic *importContext, r *resource) bool
 	// Function to check if the field in the given resource should be omitted or not
 	ShouldOmitField func(ic *importContext, pathString string, as *schema.Schema, d *schema.ResourceData) bool
+	// Function to check if the field in the given resource should be generated or not independently of the value
+	ShouldGenerateField func(ic *importContext, pathString string, as *schema.Schema, d *schema.ResourceData) bool
 	// Defines which API version should be used for this specific resource
 	ApiVersion common.ApiVersion
 	// Defines if specific service is account level resource


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

Changes include:

- Always generate `enable_serverless_compute` attribute for `databricks_sql_endpoint` and `databricks_sql_global_config` - this is required when there is a mix of serverless & non-serverless SQL endpoints
- Don't generate `channel` when it's empty or is current
- Don't generate `tags` block when there are no tags
- Importable can define `ShouldGenerateField` function to specify if the code for a field should be generated even if it's `omitempty` and having the zero or default value.  This was required for generation of `enable_serverless_compute = false` that is marked as `omitempty`

Fixes #3758

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
