### PR TITLE
[Internal] Updated Changelog for Release v1.48.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Version changelog
 
+## 1.48.3
+
+### Internal Changes 
+ * Bump Go SDK to `0.43.2` ([#3750](https://github.com/databricks/terraform-provider-databricks/pull/3750))
+ * Added new `APIErrorBody` struct and update deps ([#3745](https://github.com/databricks/terraform-provider-databricks/pull/3745))
+
 ## 1.48.2
 
 ### New Features and Improvements


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
This updates the changelog for Release v1.48.3 that was done over the PR: https://github.com/databricks/terraform-provider-databricks/pull/3767 which will not be merged.

Release has been done: https://github.com/databricks/terraform-provider-databricks/releases/tag/v1.48.3

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
