### PR TITLE
Add "Owner" tag to test cluster in acceptance test

### DIFF
--- a/internal/acceptance/cluster_test.go
+++ b/internal/acceptance/cluster_test.go
@@ -88,7 +88,10 @@ func awsClusterTemplate(availability string) string {
 			num_workers = 1
 			autotermination_minutes = 10
 			aws_attributes {
-				availability     = "%s"
+				availability = "%s"
+			}
+			custom_tags = {
+				"Owner" = "eng-dev-ecosystem-team@databricks.com"
 			}
 			node_type_id = "i3.xlarge"
 		}


### PR DESCRIPTION
## Changes

This ensures proper attribution in our test infrastructure.

## Tests

- [x] `make test` run locally
- [x] relevant acceptance tests are passing
