### PR TITLE
[Fix] Integration test for restrict workspace admins setting

### DIFF
--- a/internal/acceptance/restrict_workspace_admins_test.go
+++ b/internal/acceptance/restrict_workspace_admins_test.go
@@ -21,7 +21,7 @@ func TestAccRestrictWorkspaceAdminsSetting(t *testing.T) {
 		}
 	}
 	`
-	workspaceLevel(t, step{
+	unityWorkspaceLevel(t, step{
 		Template: template,
 		Check: resourceCheckWithState("databricks_restrict_workspace_admins_setting.this",
 			func(ctx context.Context, client *common.DatabricksClient, state *terraform.InstanceState) error {


### PR DESCRIPTION
## Changes

This test requires the authenticated user to be an account administrator. Our non-UC test environments don't use identity federation and are therefore by definition not account admins.

Require a UC test environment to get around this limitation.

## Tests

- [x] relevant acceptance tests are passing
