### PR TITLE
[Feature] Automatically create `parent_path` folder if it doesn't exist

### DIFF
--- a/dashboards/resource_dashboard.go
+++ b/dashboards/resource_dashboard.go
@@ -77,18 +77,16 @@ func ResourceDashboard() common.Resource {
 			d.Set("md5", md5Hash)
 			newDashboardRequest.SerializedDashboard = content
 			createdDashboard, err := w.Lakeview.Create(ctx, newDashboardRequest)
-			if err != nil {
-				if isParentDoesntExistError(err) {
-					log.Printf("[DEBUG] Parent folder '%s' doesn't exist, creating...", newDashboardRequest.ParentPath)
-					err = w.Workspace.MkdirsByPath(ctx, newDashboardRequest.ParentPath)
-					if err != nil {
-						return err
-					}
-					createdDashboard, err = w.Lakeview.Create(ctx, newDashboardRequest)
-				}
+			if err != nil && isParentDoesntExistError(err) {
+				log.Printf("[DEBUG] Parent folder '%s' doesn't exist, creating...", newDashboardRequest.ParentPath)
+				err = w.Workspace.MkdirsByPath(ctx, newDashboardRequest.ParentPath)
 				if err != nil {
 					return err
 				}
+				createdDashboard, err = w.Lakeview.Create(ctx, newDashboardRequest)
+			}
+			if err != nil {
+				return err
 			}
 
 			d.Set("etag", createdDashboard.Etag)

--- a/docs/resources/dashboard.md
+++ b/docs/resources/dashboard.md
@@ -49,7 +49,7 @@ The following arguments are supported:
 * `serialized_dashboard` - (Optional) The contents of the dashboard in serialized string form. Conflicts with `file_path`.
 * `file_path` - (Optional) The path to the dashboard JSON file. Conflicts with `serialized_dashboard`.
 * `embed_credentials` - (Optional) Whether to embed credentials in the dashboard. Default is `true`.
-* `parent_path` - (Required) The workspace path of the folder containing the dashboard. Includes leading slash and no trailing slash.
+* `parent_path` - (Required) The workspace path of the folder containing the dashboard. Includes leading slash and no trailing slash.  If folder doesn't exist, it will be created.
 
 ## Attribute Reference
 


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

This makes behavior consistent with other workspace objects - notebooks, workspace files, etc.

I have the skeleton of the test for it, but it doesn't work because I can't mock the same API call two times with different return results

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [x] using Go SDK
