### PR TITLE
[Fix] don't update `databricks_metastore` during creation if not required

### DIFF
--- a/catalog/resource_metastore.go
+++ b/catalog/resource_metastore.go
@@ -67,15 +67,15 @@ func ResourceMetastore() common.Resource {
 			common.DataToStructPointer(d, s, &create)
 			common.DataToStructPointer(d, s, &update)
 			updateForceSendFields(&update)
+			emptyRequest, err := common.IsRequestEmpty(update)
+			if err != nil {
+				return err
+			}
 			return c.AccountOrWorkspaceRequest(func(acc *databricks.AccountClient) error {
 				mi, err := acc.Metastores.Create(ctx,
 					catalog.AccountsCreateMetastore{
 						MetastoreInfo: &create,
 					})
-				if err != nil {
-					return err
-				}
-				emptyRequest, err := common.IsRequestEmpty(update)
 				if err != nil {
 					return err
 				}
@@ -97,6 +97,9 @@ func ResourceMetastore() common.Resource {
 					return err
 				}
 				d.SetId(mi.MetastoreId)
+				if emptyRequest {
+					return nil
+				}
 				update.Id = mi.MetastoreId
 				_, err = w.Metastores.Update(ctx, update)
 				if err != nil {

--- a/catalog/resource_metastore_test.go
+++ b/catalog/resource_metastore_test.go
@@ -26,11 +26,6 @@ func TestCreateMetastore(t *testing.T) {
 			}).Return(&catalog.MetastoreInfo{
 				MetastoreId: "abc",
 			}, nil)
-			e.Update(mock.Anything, catalog.UpdateMetastore{
-				Id: "abc",
-			}).Return(&catalog.MetastoreInfo{
-				Name: "a",
-			}, nil)
 			e.GetById(mock.Anything, "abc").Return(&catalog.MetastoreInfo{
 				StorageRoot: "s3://b/abc",
 				Name:        "a",


### PR DESCRIPTION
## Changes
- don't update `databricks_metastore` during creation if not required. This was previously done for account-level provider. Extend this to workspace-level provider

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] covered with integration tests in `internal/acceptance`
- [x] relevant acceptance tests are passing
- [x] using Go SDK
