### PR TITLE
[Fix] Add "Owner" tag to test SQL endpoint in acceptance test

### DIFF
--- a/internal/acceptance/sql_table_test.go
+++ b/internal/acceptance/sql_table_test.go
@@ -170,6 +170,13 @@ func TestUcAccResourceSqlTable_WarehousePartition(t *testing.T) {
 			name = "tf-{var.RANDOM}"
 			cluster_size = "2X-Small"
 			max_num_clusters = 1
+
+			tags {
+				custom_tags {
+					key   = "Owner"
+					value = "eng-dev-ecosystem-team@databricks.com"
+				}
+			}
 		}
 
 		resource "databricks_schema" "this" {


### PR DESCRIPTION
## Changes

This ensures proper attribution in our test infrastructure.

The same fix for the SQL endpoint test was applied in #3774.

## Tests

- [x] relevant acceptance tests are passing
