### PR TITLE
[Fix] Ignore managed property for liquid clustering integration test

### DIFF
--- a/catalog/resource_sql_table.go
+++ b/catalog/resource_sql_table.go
@@ -82,6 +82,9 @@ func parseComment(s string) string {
 // This needs to be replaced with something a bit more robust in the future
 func sqlTableIsManagedProperty(key string) bool {
 	managedProps := map[string]bool{
+		// Property set if the table uses `cluster_keys`.
+		"clusteringColumns": true,
+
 		"delta.lastCommitTimestamp":                                true,
 		"delta.lastUpdateVersion":                                  true,
 		"delta.minReaderVersion":                                   true,


### PR DESCRIPTION
## Changes

This property is automatically added if the SQL table uses `cluster_keys`.

## Tests

- [x] relevant acceptance tests are passing

I ran:
```sh
$ go test ./internal/acceptance -timeout 30m -v -run TestUcAccResourceSqlTable_Liquid
```
