### PR TITLE
[Exporter] Fix to support Serverless DLT

### DIFF
--- a/exporter/importables.go
+++ b/exporter/importables.go
@@ -2023,10 +2023,15 @@ var resourcesMap map[string]importable = map[string]importable{
 			if res := dltClusterRegex.FindStringSubmatch(pathString); res != nil { // analyze DLT clusters
 				return makeShouldOmitFieldForCluster(dltClusterRegex)(ic, pathString, as, d)
 			}
-			if pathString == "storage" {
+			switch pathString {
+			case "storage":
 				return dltDefaultStorageRegex.FindStringSubmatch(d.Get("storage").(string)) != nil
+			case "edition":
+				return d.Get("edition").(string) == ""
+			case "creator_user_name":
+				return true
 			}
-			return pathString == "creator_user_name" || defaultShouldOmitFieldFunc(ic, pathString, as, d)
+			return defaultShouldOmitFieldFunc(ic, pathString, as, d)
 		},
 		Ignore: func(ic *importContext, r *resource) bool {
 			numLibraries := r.Data.Get("library.#").(int)


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

When Serverless DLT pipeline is created, the `edition` isn't set on it, leading to
generation of `edition = ""` that leads to error in plan/apply.   This PR fixes that

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
