### PR TITLE
[Fix] Fixed reading of permissions for SQL objects

### DIFF
--- a/docs/resources/permissions.md
+++ b/docs/resources/permissions.md
@@ -739,7 +739,7 @@ resource "databricks_group" "eng" {
   display_name = "Engineering"
 }
 
-resource "databricks_permissions" "endpoint_usage" {
+resource "databricks_permissions" "query_usage" {
   sql_query_id = "3244325"
 
   access_control {
@@ -767,7 +767,7 @@ resource "databricks_group" "eng" {
   display_name = "Engineering"
 }
 
-resource "databricks_permissions" "endpoint_usage" {
+resource "databricks_permissions" "alert_usage" {
   sql_alert_id = "3244325"
 
   access_control {

--- a/internal/acceptance/sql_alert_test.go
+++ b/internal/acceptance/sql_alert_test.go
@@ -13,6 +13,14 @@ func TestAccAlert(t *testing.T) {
 			query = "SELECT 1 AS p1, 2 as p2"
 		}
 
+        resource "databricks_permissions" "alert_usage" {
+			sql_alert_id = databricks_sql_alert.alert.id
+			access_control {
+              group_name       = "users"
+              permission_level = "CAN_RUN"
+			}
+		}
+
 		resource "databricks_sql_alert" "alert" {
 			query_id = databricks_sql_query.this.id
 			name = "tf-alert-{var.RANDOM}"
@@ -29,6 +37,14 @@ func TestAccAlert(t *testing.T) {
 			data_source_id = "{env.TEST_DEFAULT_WAREHOUSE_DATASOURCE_ID}"
 			name = "tf-{var.RANDOM}"
 			query = "SELECT 1 AS p1, 2 as p2"
+		}
+
+        resource "databricks_permissions" "alert_usage" {
+			sql_alert_id = databricks_sql_alert.alert.id
+			access_control {
+              group_name       = "users"
+              permission_level = "CAN_RUN"
+			}
 		}
 
 		resource "databricks_sql_alert" "alert" {

--- a/internal/acceptance/sql_dashboard_test.go
+++ b/internal/acceptance/sql_dashboard_test.go
@@ -41,6 +41,22 @@ func TestAccDashboard(t *testing.T) {
 			}
 		}
 
+        resource "databricks_permissions" "sql_dashboard_usage" {
+            sql_dashboard_id = databricks_sql_dashboard.d1.id
+            access_control {
+              group_name       = "users"
+              permission_level = "CAN_RUN"
+            }
+        }
+
+        resource "databricks_permissions" "query_usage" {
+            sql_query_id = databricks_sql_query.q1.id
+            access_control {
+              group_name       = "users"
+              permission_level = "CAN_RUN"
+            }
+        }
+
 		resource "databricks_sql_query" "q1" {
 			data_source_id = "{env.TEST_DEFAULT_WAREHOUSE_DATASOURCE_ID}"
 			name = "tf-{var.RANDOM}-query"

--- a/permissions/resource_permissions_test.go
+++ b/permissions/resource_permissions_test.go
@@ -336,7 +336,7 @@ func TestResourcePermissionsRead_SQLA_Asset(t *testing.T) {
 				Method:   http.MethodGet,
 				Resource: "/api/2.0/preview/sql/permissions/dashboards/abc",
 				Response: ObjectACL{
-					ObjectID:   "/sql/dashboards/abc",
+					ObjectID:   "dashboards/abc",
 					ObjectType: "dashboard",
 					AccessControlList: []AccessControl{
 						{
@@ -812,7 +812,7 @@ func TestResourcePermissionsCreate_SQLA_Asset(t *testing.T) {
 				Method:   http.MethodGet,
 				Resource: "/api/2.0/preview/sql/permissions/dashboards/abc",
 				Response: ObjectACL{
-					ObjectID:   "/sql/dashboards/abc",
+					ObjectID:   "dashboards/abc",
 					ObjectType: "dashboard",
 					AccessControlList: []AccessControl{
 						{
@@ -871,7 +871,7 @@ func TestResourcePermissionsCreate_SQLA_Endpoint(t *testing.T) {
 				Method:   http.MethodGet,
 				Resource: "/api/2.0/permissions/sql/warehouses/abc",
 				Response: ObjectACL{
-					ObjectID:   "/sql/dashboards/abc",
+					ObjectID:   "dashboards/abc",
 					ObjectType: "dashboard",
 					AccessControlList: []AccessControl{
 						{
@@ -934,7 +934,7 @@ func TestResourcePermissionsCreate_SQLA_Endpoint_WithOwner(t *testing.T) {
 				Method:   http.MethodGet,
 				Resource: "/api/2.0/permissions/sql/warehouses/abc",
 				Response: ObjectACL{
-					ObjectID:   "/sql/dashboards/abc",
+					ObjectID:   "dashboards/abc",
 					ObjectType: "dashboard",
 					AccessControlList: []AccessControl{
 						{
@@ -1651,7 +1651,7 @@ func TestResourcePermissionsCreate_Sql_Queries(t *testing.T) {
 				Method:   http.MethodGet,
 				Resource: "/api/2.0/preview/sql/permissions/queries/id111",
 				Response: ObjectACL{
-					ObjectID:   "/sql/queries/id111",
+					ObjectID:   "queries/id111",
 					ObjectType: "query",
 					AccessControlList: []AccessControl{
 						{
@@ -1711,7 +1711,7 @@ func TestResourcePermissionsUpdate_Sql_Queries(t *testing.T) {
 				Method:   http.MethodGet,
 				Resource: "/api/2.0/preview/sql/permissions/queries/id111",
 				Response: ObjectACL{
-					ObjectID:   "/sql/queries/id111",
+					ObjectID:   "queries/id111",
 					ObjectType: "query",
 					AccessControlList: []AccessControl{
 						{


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

The `object_id` for legacy SQL objects didn't have a correct format, and now requires a special handling.

The error wasn't caught because we didn't have integration tests for SQL objects permissions, and object IDs in the unit test weren't matching to actual payload.

Fixes #3799 

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [x] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
