### PR TITLE
[Exporter] Adding more retries for SCIM API calls

### DIFF
--- a/exporter/importables.go
+++ b/exporter/importables.go
@@ -1023,7 +1023,7 @@ var resourcesMap map[string]importable = map[string]importable{
 			if err != nil {
 				return err
 			}
-			ic.emitGroups(u)
+			ic.emitGroups(*u)
 			ic.emitRoles("user", u.ID, u.Roles)
 			return nil
 		},
@@ -1081,7 +1081,7 @@ var resourcesMap map[string]importable = map[string]importable{
 			if err != nil {
 				return err
 			}
-			ic.emitGroups(u)
+			ic.emitGroups(*u)
 			ic.emitRoles("service_principal", u.ID, u.Roles)
 			if ic.accountLevel {
 				ic.Emit(&resource{


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

There were issue when SCIM API failed to return list of users (because of the incorrect status code or something like that, so Go SDK didn't retry it) and this lead to marking all workspace objects (notebooks/files/...) as ignored because user wasn't found.  Also, when the list of users wasn't retrieved, the process didn't stop, and we generated incomplete Terraform code.

This PR improves the situation by following:

- Adding retries around Users/SPs/Groups SCIM API calls
- Exit with the error code when we aren't able to fetch the list of the users or service principals

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
