### PR TITLE
Make plugin framework infra functions work for Enum types

### DIFF
--- a/common/reflect_resource_plugin_framework.go
+++ b/common/reflect_resource_plugin_framework.go
@@ -127,6 +127,9 @@ func tfSdkToGoSdkSingleField(srcField reflect.Value, destField reflect.Value, sr
 			destMap.SetMapIndex(destMapKey, destMapValue)
 		}
 		destField.Set(destMap)
+	} else if srcField.Kind() == reflect.String {
+		// This case is only for the Enum types.
+		destField.SetString(srcField.String())
 	} else {
 		panic(fmt.Errorf("unknown type for field: %s", srcField.Type().Name()))
 	}
@@ -227,12 +230,17 @@ func goSdkToTfSdkSingleField(srcField reflect.Value, destField reflect.Value, sr
 			destField.Set(reflect.ValueOf(types.Float64Null()))
 		}
 	case reflect.String:
-		strVal := srcFieldValue.(string)
-		// check if alwaysAdd is false or the value is zero or if the field is in the forceSendFields list
-		if alwaysAdd || !(strVal == "" && !checkTheStringInForceSendFields(srcFieldName, forceSendField)) {
-			destField.Set(reflect.ValueOf(types.StringValue(strVal)))
+		if srcField.Type().Name() != "string" {
+			// This case is for Enum Types.
+			destField.Set(reflect.ValueOf(srcFieldValue))
 		} else {
-			destField.Set(reflect.ValueOf(types.StringNull()))
+			strVal := srcFieldValue.(string)
+			// check if alwaysAdd is false or the value is zero or if the field is in the forceSendFields list
+			if alwaysAdd || !(strVal == "" && !checkTheStringInForceSendFields(srcFieldName, forceSendField)) {
+				destField.Set(reflect.ValueOf(types.StringValue(strVal)))
+			} else {
+				destField.Set(reflect.ValueOf(types.StringNull()))
+			}
 		}
 	case reflect.Struct:
 		// resolve the nested struct by recursively calling the function
@@ -379,6 +387,9 @@ func pluginFrameworkTypeToSchema(v reflect.Value) map[string]schema.Attribute {
 				nestedScm := pluginFrameworkTypeToSchema(sv)
 				scm[fieldName] = schema.SingleNestedAttribute{Attributes: nestedScm, Optional: isOptional, Required: !isOptional}
 			}
+		} else if kind == reflect.String {
+			// This case is for Enum types.
+			scm[fieldName] = schema.StringAttribute{Optional: isOptional, Required: !isOptional}
 		} else {
 			panic(fmt.Errorf("unknown type for field: %s", typeField.Name))
 		}

--- a/common/reflect_resource_plugin_framework_test.go
+++ b/common/reflect_resource_plugin_framework_test.go
@@ -24,8 +24,17 @@ type DummyTfSdk struct {
 	NestedMap         map[string]DummyNestedTfSdk `tfsdk:"nested_map" tf:"optional"`
 	Repeated          []types.Int64               `tfsdk:"repeated" tf:"optional"`
 	Attributes        map[string]types.String     `tfsdk:"attributes" tf:"optional"`
+	EnumField         TestEnum                    `tfsdk:"enum_field" tf:"optional"`
 	Irrelevant        types.String                `tfsdk:"-"`
 }
+
+type TestEnum string
+
+const TestEnumA TestEnum = `TEST_ENUM_A`
+
+const TestEnumB TestEnum = `TEST_ENUM_B`
+
+const TestEnumC TestEnum = `TEST_ENUM_C`
 
 type DummyNestedTfSdk struct {
 	Name    types.String `tfsdk:"name" tf:"optional"`
@@ -46,6 +55,7 @@ type DummyGoSdk struct {
 	NestedMap         map[string]DummyNestedGoSdk `json:"nested_map"`
 	Repeated          []int64                     `json:"repeated"`
 	Attributes        map[string]string           `json:"attributes"`
+	EnumField         TestEnum                    `json:"enum_field"`
 	ForceSendFields   []string                    `json:"-"`
 }
 
@@ -124,6 +134,7 @@ var tfSdkStruct = DummyTfSdk{
 		},
 	},
 	Attributes: map[string]types.String{"key": types.StringValue("value")},
+	EnumField:  TestEnumA,
 	Repeated:   []types.Int64{types.Int64Value(12), types.Int64Value(34)},
 }
 


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
- Make the two converter functions + StructToSchema work for Enum types
- We do not need to use `types.String` for Enum types as they do not have a force send zero value problem
- Adding a unit test test case

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
