### PR TITLE
[Fix] cluster key update for `databricks_sql_table` should not force new

### DIFF
--- a/catalog/resource_sql_table_test.go
+++ b/catalog/resource_sql_table_test.go
@@ -415,7 +415,7 @@ func TestResourceSqlTableUpdateTable(t *testing.T) {
 func TestResourceSqlTableUpdateTableAndOwner(t *testing.T) {
 	d, err := qa.ResourceFixture{
 		CommandMock: func(commandStr string) common.CommandResults {
-			assert.Equal(t, "ALTER TABLE `main`.`foo`.`bar` ALTER COLUMN `two` DROP NOT NULL", commandStr)
+
 			return common.CommandResults{
 				ResultType: "",
 				Data:       nil,
@@ -492,6 +492,7 @@ func TestResourceSqlTableUpdateTableAndOwner(t *testing.T) {
 							Type: "string",
 						},
 					},
+					Owner: "old group",
 				},
 			},
 			{
@@ -501,6 +502,13 @@ func TestResourceSqlTableUpdateTableAndOwner(t *testing.T) {
 					ClusterID: "gone",
 				},
 				Status: 404,
+			},
+			{
+				Method:   "PATCH",
+				Resource: "/api/2.1/unity-catalog/tables/main.foo.bar",
+				ExpectedRequest: catalog.UpdateTableRequest{
+					Owner: "new groups",
+				},
 			},
 		}, createClusterForSql...),
 		Resource: ResourceSqlTable(),
@@ -590,13 +598,6 @@ func TestResourceSqlTableUpdateTableClusterKeys(t *testing.T) {
 					ClusterID: "gone",
 				},
 				Status: 404,
-			},
-			{
-				Method:   "PATCH",
-				Resource: "/api/2.1/unity-catalog/tables/main.foo.bar",
-				ExpectedRequest: catalog.UpdateTableRequest{
-					Owner: "new groups",
-				},
 			},
 		}, createClusterForSql...),
 		Resource: ResourceSqlTable(),

--- a/catalog/resource_sql_table_test.go
+++ b/catalog/resource_sql_table_test.go
@@ -126,7 +126,7 @@ func TestResourceSqlTableCreateStatement_Liquid(t *testing.T) {
 	assert.Contains(t, stmt, "USING DELTA")
 	assert.Contains(t, stmt, "LOCATION 's3://ext-main/foo/bar1' WITH (CREDENTIAL `somecred`)")
 	assert.Contains(t, stmt, "COMMENT 'terraform managed'")
-	assert.Contains(t, stmt, "CLUSTER BY (baz, bazz)")
+	assert.Contains(t, stmt, "CLUSTER BY (`baz`,`bazz`)")
 }
 
 func TestResourceSqlTableSerializeProperties(t *testing.T) {
@@ -415,7 +415,7 @@ func TestResourceSqlTableUpdateTable(t *testing.T) {
 func TestResourceSqlTableUpdateTableAndOwner(t *testing.T) {
 	d, err := qa.ResourceFixture{
 		CommandMock: func(commandStr string) common.CommandResults {
-
+			assert.Equal(t, "ALTER TABLE `main`.`foo`.`bar` ALTER COLUMN `two` DROP NOT NULL", commandStr)
 			return common.CommandResults{
 				ResultType: "",
 				Data:       nil,
@@ -492,7 +492,95 @@ func TestResourceSqlTableUpdateTableAndOwner(t *testing.T) {
 							Type: "string",
 						},
 					},
-					Owner: "old group",
+				},
+			},
+			{
+				Method:   "POST",
+				Resource: "/api/2.0/clusters/start",
+				ExpectedRequest: clusters.ClusterID{
+					ClusterID: "gone",
+				},
+				Status: 404,
+			},
+		}, createClusterForSql...),
+		Resource: ResourceSqlTable(),
+		ID:       "main.foo.bar",
+		Update:   true,
+	}.Apply(t)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "bar", d.Get("name"))
+}
+
+func TestResourceSqlTableUpdateTableClusterKeys(t *testing.T) {
+	d, err := qa.ResourceFixture{
+		CommandMock: func(commandStr string) common.CommandResults {
+			assert.Equal(t, "ALTER TABLE `main`.`foo`.`bar` CLUSTER BY (`one`)", commandStr)
+			return common.CommandResults{
+				ResultType: "",
+				Data:       nil,
+			}
+		},
+		HCL: `
+		name               = "bar"
+		catalog_name       = "main"
+		schema_name        = "foo"
+		table_type         = "EXTERNAL"
+		data_source_format = "DELTA"
+		cluster_id         = "gone"
+		column {
+			name      = "one"
+			type      = "string"
+			comment   = "managed comment"
+			nullable  = false
+		}
+		column {
+			name      = "two"
+			type      = "string"
+			nullable  = false
+		}
+		cluster_keys = ["one"]
+		`,
+		InstanceState: map[string]string{
+			"name":               "bar",
+			"catalog_name":       "main",
+			"schema_name":        "foo",
+			"table_type":         "EXTERNAL",
+			"data_source_format": "DELTA",
+			"column.#":           "2",
+			"column.0.name":      "one",
+			"column.0.type":      "string",
+			"column.0.comment":   "old comment",
+			"column.0.nullable":  "false",
+			"column.1.name":      "two",
+			"column.1.type":      "string",
+			"column.1.nullable":  "false",
+		},
+		Fixtures: append([]qa.HTTPFixture{
+			{
+				Method:       "GET",
+				Resource:     "/api/2.1/unity-catalog/tables/main.foo.bar",
+				ReuseRequest: true,
+				Response: SqlTableInfo{
+					Name:                  "bar",
+					CatalogName:           "main",
+					SchemaName:            "foo",
+					TableType:             "EXTERNAL",
+					DataSourceFormat:      "DELTA",
+					StorageCredentialName: "somecred",
+					ColumnInfos: []SqlColumnInfo{
+						{
+							Name:     "one",
+							Type:     "string",
+							Comment:  "managed comment",
+							Nullable: false,
+						},
+						{
+							Name:     "two",
+							Type:     "string",
+							Nullable: false,
+						},
+					},
 				},
 			},
 			{

--- a/docs/resources/sql_table.md
+++ b/docs/resources/sql_table.md
@@ -128,7 +128,7 @@ The following arguments are supported:
 * `comment` - (Optional) User-supplied free-form text. Changing comment is not currently supported on `VIEW` table_type.
 * `options` - (Optional) Map of user defined table options. Change forces creation of a new resource.
 * `properties` - (Optional) Map of table properties.
-* `partitions` - (Optional) a subset of columns to partition the table by. Change forces creation of a new resource. Conflicts with `cluster_keys`.
+* `partitions` - (Optional) a subset of columns to partition the table by. Change forces creation of a new resource. Conflicts with `cluster_keys`. Change forces creation of a new resource.
 
 ### `column` configuration block
 


### PR DESCRIPTION
## Changes
Resolves #3822

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [x] covered with integration tests in `internal/acceptance`
- [x] relevant acceptance tests are passing
- [x] using Go SDK
