### PR TITLE
[Fix] reading `databricks_metastore_assignment` when importing resource

### DIFF
--- a/catalog/resource_metastore_assignment.go
+++ b/catalog/resource_metastore_assignment.go
@@ -76,6 +76,8 @@ func ResourceMetastoreAssignment() common.Resource {
 					return err
 				}
 				d.Set("metastore_id", ma.MetastoreId)
+				d.Set("default_catalog_name", ma.DefaultCatalogName)
+				d.Set("workspace_id", workspaceId)
 				return nil
 			})
 		},

--- a/catalog/resource_metastore_assignment_test.go
+++ b/catalog/resource_metastore_assignment_test.go
@@ -43,6 +43,29 @@ func TestMetastoreAssignment_Create(t *testing.T) {
 	}.ApplyNoError(t)
 }
 
+func TestMetastoreAssignment_Import(t *testing.T) {
+	qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "GET",
+				Resource: "/api/2.1/unity-catalog/current-metastore-assignment",
+				Response: catalog.MetastoreAssignment{
+					MetastoreId:        "a",
+					WorkspaceId:        123,
+					DefaultCatalogName: "test_metastore",
+				},
+			},
+		},
+		Resource: ResourceMetastoreAssignment(),
+		Read:     true,
+		ID:       "123|a",
+	}.ApplyAndExpectData(t, map[string]any{
+		"workspace_id":         123,
+		"metastore_id":         "a",
+		"default_catalog_name": "test_metastore",
+	})
+}
+
 func TestMetastoreAssignmentAccount_Create(t *testing.T) {
 	qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{

--- a/docs/resources/metastore_assignment.md
+++ b/docs/resources/metastore_assignment.md
@@ -36,7 +36,7 @@ The following arguments are required:
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - ID of this metastore assignment in form of `<metastore_id>|<metastore_id>`.
+* `id` - ID of this metastore assignment in form of `<workspace_id>|<metastore_id>`.
 
 ## Import
 


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

The `Read` method on workspace level wasn't filling all attributes and this led to the configuration drift after import.

Fixes #3756 

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
