### PR TITLE
[Exporter] Add support for Vector Search assets

### DIFF
--- a/docs/guides/experimental-exporter.md
+++ b/docs/guides/experimental-exporter.md
@@ -145,6 +145,7 @@ Services are just logical groups of resources used for filtering and organizatio
 * `uc-tables` - **listing** (*we can't list directly, only via dependencies to top-level object*) [databricks_sql_table](../resources/sql_table.md) resource.
 * `uc-volumes` - **listing** (*we can't list directly, only via dependencies to top-level object*) [databricks_volume](../resources/volume.md)
 * `users` - [databricks_user](../resources/user.md) and [databricks_service_principal](../resources/service_principal.md) are written to their own file, simply because of their amount. If you use SCIM provisioning, migrating workspaces is the only use case for importing `users` service.
+* `vector-search` - **listing** exports [databricks_vector_search_endpoint](../resources/vector_search_endpoint.md) and [databricks_vector_search_index](../resources/vector_search_index.md)
 * `workspace` - **listing** [databricks_workspace_conf](../resources/workspace_conf.md) and [databricks_global_init_script](../resources/global_init_script.md)
 
 ## Secrets
@@ -225,6 +226,8 @@ Exporter aims to generate HCL code for most of the resources within the Databric
 | [databricks_user](../resources/user.md) | Yes | No | Yes | Yes |
 | [databricks_user_instance_profile](../resources/user_instance_profile.md) | No | No | No | No |
 | [databricks_user_role](../resources/user_role.md) | Yes | No | Yes | Yes |
+| [databricks_vector_search_endpoint](../resources/vector_search_endpoint.md) | Yes | No | Yes | No |
+| [databricks_vector_search_index](../resources/vector_search_index.md) | Yes | No | Yes | No |
 | [databricks_volume](../resources/volume.md) | Yes | Yes | Yes | No |
 | [databricks_workspace_binding](../resources/workspace_binding.md) | Yes | No | Yes | No |
 | [databricks_workspace_conf](../resources/workspace_conf.md) | Yes (partial) | No | Yes | No |

--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/databricks/databricks-sdk-go/service/settings"
 	"github.com/databricks/databricks-sdk-go/service/sharing"
 	"github.com/databricks/databricks-sdk-go/service/sql"
+	sdk_vs "github.com/databricks/databricks-sdk-go/service/vectorsearch"
 	sdk_workspace "github.com/databricks/databricks-sdk-go/service/workspace"
 	"github.com/databricks/terraform-provider-databricks/aws"
 	"github.com/databricks/terraform-provider-databricks/clusters"
@@ -305,6 +306,13 @@ var emptyRepos = qa.HTTPFixture{
 	Response:     repos.ReposListResponse{},
 }
 
+var emptyVectorSearch = qa.HTTPFixture{
+	Method:       "GET",
+	ReuseRequest: true,
+	Resource:     "/api/2.0/vector-search/endpoints?",
+	Response:     sdk_vs.ListEndpointResponse{},
+}
+
 var emptyShares = qa.HTTPFixture{
 	Method:       "GET",
 	ReuseRequest: true,
@@ -484,6 +492,7 @@ func TestImportingUsersGroupsSecretScopes(t *testing.T) {
 			emptySqlEndpoints,
 			emptySqlQueries,
 			emptySqlAlerts,
+			emptyVectorSearch,
 			emptyPipelines,
 			emptyClusterPolicies,
 			emptyPolicyFamilies,
@@ -757,6 +766,7 @@ func TestImportingNoResourcesError(t *testing.T) {
 			emptyIpAccessLIst,
 			emptyWorkspace,
 			emptySqlEndpoints,
+			emptyVectorSearch,
 			emptySqlQueries,
 			emptySqlDashboards,
 			emptySqlAlerts,

--- a/exporter/importables.go
+++ b/exporter/importables.go
@@ -24,6 +24,7 @@ import (
 	"github.com/databricks/databricks-sdk-go/service/settings"
 	"github.com/databricks/databricks-sdk-go/service/sharing"
 	"github.com/databricks/databricks-sdk-go/service/sql"
+	"github.com/databricks/databricks-sdk-go/service/vectorsearch"
 	sdk_workspace "github.com/databricks/databricks-sdk-go/service/workspace"
 	tfcatalog "github.com/databricks/terraform-provider-databricks/catalog"
 	"github.com/databricks/terraform-provider-databricks/clusters"
@@ -2590,6 +2591,10 @@ var resourcesMap map[string]importable = map[string]importable{
 						// TODO: it's better to use SecurableKind if it will be added to the Go SDK
 						switch table.DataSourceFormat {
 						case "VECTOR_INDEX_FORMAT":
+							ic.Emit(&resource{
+								Resource: "databricks_vector_search_index",
+								ID:       table.FullName,
+							})
 						case "MYSQL_FORMAT":
 							ic.EmitIfUpdatedAfterMillis(&resource{
 								Resource:  "databricks_online_table",
@@ -3286,8 +3291,7 @@ var resourcesMap map[string]importable = map[string]importable{
 		WorkspaceLevel: true,
 		Service:        "uc-online-tables",
 		Import: func(ic *importContext, r *resource) error {
-			tableFullName := r.ID
-			ic.emitUCGrantsWithOwner("table/"+tableFullName, r)
+			ic.emitUCGrantsWithOwner("table/"+r.ID, r)
 			ic.Emit(&resource{
 				Resource: "databricks_sql_table",
 				ID:       r.Data.Get("spec.0.source_table_full_name").(string),
@@ -3302,6 +3306,94 @@ var resourcesMap map[string]importable = map[string]importable{
 			{Path: "schema_name", Resource: "databricks_schema", Match: "name",
 				IsValidApproximation: isMatchingCatalogAndSchema, SkipDirectLookup: true},
 			{Path: "spec.source_table_full_name", Resource: "databricks_sql_table"},
+		},
+	},
+	"databricks_vector_search_endpoint": {
+		WorkspaceLevel: true,
+		Service:        "vector-search",
+		List: func(ic *importContext) error {
+			endpoints, err := ic.workspaceClient.VectorSearchEndpoints.ListEndpointsAll(ic.Context, vectorsearch.ListEndpointsRequest{})
+			if err != nil {
+				log.Printf("[ERROR] listing vector search endpoints: %s", err.Error())
+				return err
+			}
+			for _, ep := range endpoints {
+				ic.EmitIfUpdatedAfterMillis(&resource{
+					Resource: "databricks_vector_search_endpoint",
+					ID:       ep.Name,
+				}, ep.LastUpdatedTimestamp, fmt.Sprintf("vector search endpoint '%s'", ep.Name))
+
+			}
+			return nil
+		},
+		Import: func(ic *importContext, r *resource) error {
+			indexes, err := ic.workspaceClient.VectorSearchIndexes.ListIndexesAll(ic.Context, vectorsearch.ListIndexesRequest{
+				EndpointName: r.ID,
+			})
+			if err != nil {
+				log.Printf("[ERROR] listing vector search indexes for endpoint %s: %s", r.ID, err.Error())
+				return err
+			}
+			for _, idx := range indexes {
+				ic.Emit(&resource{
+					Resource: "databricks_vector_search_index",
+					ID:       idx.Name,
+				})
+			}
+			return nil
+		},
+	},
+	"databricks_vector_search_index": {
+		WorkspaceLevel: true,
+		Service:        "vector-search",
+		Import: func(ic *importContext, r *resource) error {
+			ic.emitUCGrantsWithOwner("table/"+r.ID, r)
+			s := ic.Resources["databricks_vector_search_index"].Schema
+			var vsi vectorsearch.VectorIndex
+			common.DataToStructPointer(r.Data, s, &vsi)
+			if vsi.EndpointName != "" {
+				ic.Emit(&resource{
+					Resource: "databricks_vector_search_endpoint",
+					ID:       vsi.EndpointName,
+				})
+			}
+			if vsi.DeltaSyncIndexSpec != nil {
+				ic.Emit(&resource{
+					Resource: "databricks_sql_table",
+					ID:       vsi.DeltaSyncIndexSpec.SourceTable,
+				})
+				if vsi.DeltaSyncIndexSpec.EmbeddingWritebackTable != "" {
+					ic.Emit(&resource{
+						Resource: "databricks_sql_table",
+						ID:       vsi.DeltaSyncIndexSpec.EmbeddingWritebackTable,
+					})
+				}
+				for _, col := range vsi.DeltaSyncIndexSpec.EmbeddingSourceColumns {
+					if col.EmbeddingModelEndpointName != "" {
+						ic.Emit(&resource{
+							Resource: "databricks_model_serving",
+							ID:       col.EmbeddingModelEndpointName,
+						})
+					}
+				}
+			}
+			if vsi.DirectAccessIndexSpec != nil {
+				for _, col := range vsi.DirectAccessIndexSpec.EmbeddingSourceColumns {
+					if col.EmbeddingModelEndpointName != "" {
+						ic.Emit(&resource{
+							Resource: "databricks_model_serving",
+							ID:       col.EmbeddingModelEndpointName,
+						})
+					}
+				}
+			}
+			return nil
+		},
+		Depends: []reference{
+			{Path: "delta_sync_index_spec.source_table", Resource: "databricks_sql_table"},
+			{Path: "endpoint_name", Resource: "databricks_vector_search_endpoint"},
+			{Path: "delta_sync_index_spec.embedding_source_columns.embedding_model_endpoint_name", Resource: "databricks_model_serving"},
+			{Path: "direct_access_index_spec.embedding_source_columns.embedding_model_endpoint_name", Resource: "databricks_model_serving"},
 		},
 	},
 }

--- a/exporter/importables_test.go
+++ b/exporter/importables_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/databricks/databricks-sdk-go/service/iam"
 	sdk_jobs "github.com/databricks/databricks-sdk-go/service/jobs"
 	"github.com/databricks/databricks-sdk-go/service/sharing"
+	sdk_vs "github.com/databricks/databricks-sdk-go/service/vectorsearch"
 	sdk_workspace "github.com/databricks/databricks-sdk-go/service/workspace"
 	tfcatalog "github.com/databricks/terraform-provider-databricks/catalog"
 	"github.com/databricks/terraform-provider-databricks/clusters"
@@ -33,6 +34,7 @@ import (
 	"github.com/databricks/terraform-provider-databricks/secrets"
 	tfsharing "github.com/databricks/terraform-provider-databricks/sharing"
 	"github.com/databricks/terraform-provider-databricks/storage"
+	tf_vs "github.com/databricks/terraform-provider-databricks/vectorsearch"
 	"github.com/databricks/terraform-provider-databricks/workspace"
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/stretchr/testify/assert"
@@ -2270,5 +2272,140 @@ func TestImportUcOnlineTable(t *testing.T) {
 		require.Equal(t, 2, len(ic.testEmits))
 		assert.True(t, ic.testEmits["databricks_sql_table[<unknown>] (id: main.tmp.tbl)"])
 		assert.True(t, ic.testEmits["databricks_grants[<unknown>] (id: table/main.tmp.tbl_ot)"])
+	})
+}
+
+func TestImportVectorSearchEndpointList(t *testing.T) {
+	qa.HTTPFixturesApply(t, []qa.HTTPFixture{
+		{
+			Method:   "GET",
+			Resource: "/api/2.0/vector-search/endpoints?",
+			Response: sdk_vs.ListEndpointResponse{
+				Endpoints: []sdk_vs.EndpointInfo{
+					{
+						Name:                 "test",
+						LastUpdatedTimestamp: 1234567890,
+					},
+					{
+						Name:                 "test2",
+						LastUpdatedTimestamp: 2234567890,
+					},
+				},
+			},
+		},
+	}, func(ctx context.Context, client *common.DatabricksClient) {
+		ic := importContextForTestWithClient(ctx, client)
+		tmpDir := fmt.Sprintf("/tmp/tf-%s", qa.RandomName())
+		defer os.RemoveAll(tmpDir)
+		os.Mkdir(tmpDir, 0700)
+		ic.Directory = tmpDir
+		ic.enableServices("vector-search")
+		ic.currentMetastore = currentMetastoreResponse
+
+		err := resourcesMap["databricks_vector_search_endpoint"].List(ic)
+		assert.NoError(t, err)
+		require.Equal(t, 2, len(ic.testEmits))
+		assert.True(t, ic.testEmits["databricks_vector_search_endpoint[<unknown>] (id: test)"])
+		assert.True(t, ic.testEmits["databricks_vector_search_endpoint[<unknown>] (id: test2)"])
+	})
+}
+
+func TestImportVectorSearchEndpoint(t *testing.T) {
+	vseName := "test"
+	qa.HTTPFixturesApply(t, []qa.HTTPFixture{
+		{
+			Method:   "GET",
+			Resource: "/api/2.0/vector-search/indexes?endpoint_name=test",
+			Response: sdk_vs.ListVectorIndexesResponse{
+				VectorIndexes: []sdk_vs.MiniVectorIndex{
+					{
+						Name: "idx1",
+					},
+					{
+						Name: "idx2",
+					},
+				},
+			},
+		},
+	}, func(ctx context.Context, client *common.DatabricksClient) {
+		ic := importContextForTestWithClient(ctx, client)
+		tmpDir := fmt.Sprintf("/tmp/tf-%s", qa.RandomName())
+		defer os.RemoveAll(tmpDir)
+		os.Mkdir(tmpDir, 0700)
+		ic.Directory = tmpDir
+		ic.enableServices("vector-search")
+		ic.currentMetastore = currentMetastoreResponse
+
+		d := tf_vs.ResourceVectorSearchEndpoint().ToResource().TestResourceData()
+		vse := sdk_vs.EndpointInfo{
+			Name: vseName,
+		}
+		d.SetId(vseName)
+		d.MarkNewResource()
+		scm := tf_vs.ResourceVectorSearchEndpoint().Schema
+		err := common.StructToData(vse, scm, d)
+		require.NoError(t, err)
+
+		err = resourcesMap["databricks_vector_search_endpoint"].Import(ic, &resource{
+			ID:   vseName,
+			Data: d,
+		})
+		assert.NoError(t, err)
+		require.Equal(t, 2, len(ic.testEmits))
+		assert.True(t, ic.testEmits["databricks_vector_search_index[<unknown>] (id: idx1)"])
+		assert.True(t, ic.testEmits["databricks_vector_search_index[<unknown>] (id: idx2)"])
+	})
+}
+
+func TestImportVectorSearchIndex(t *testing.T) {
+	qa.HTTPFixturesApply(t, []qa.HTTPFixture{}, func(ctx context.Context, client *common.DatabricksClient) {
+		ic := importContextForTestWithClient(ctx, client)
+		tmpDir := fmt.Sprintf("/tmp/tf-%s", qa.RandomName())
+		defer os.RemoveAll(tmpDir)
+		os.Mkdir(tmpDir, 0700)
+		ic.Directory = tmpDir
+		ic.enableServices("vector-search,uc-tables,uc-grants,model-serving")
+		ic.currentMetastore = currentMetastoreResponse
+
+		vsiName := "main.tmp.vsi"
+		d := tf_vs.ResourceVectorSearchIndex().ToResource().TestResourceData()
+		ot := sdk_vs.VectorIndex{
+			Name:         vsiName,
+			PrimaryKey:   "id",
+			EndpointName: "vs",
+			DeltaSyncIndexSpec: &sdk_vs.DeltaSyncVectorIndexSpecResponse{
+				SourceTable: "main.tmp.tbl",
+				EmbeddingSourceColumns: []sdk_vs.EmbeddingSourceColumn{
+					{
+						Name:                       "col1",
+						EmbeddingModelEndpointName: "test",
+					},
+				},
+			},
+			DirectAccessIndexSpec: &sdk_vs.DirectAccessVectorIndexSpec{
+				EmbeddingSourceColumns: []sdk_vs.EmbeddingSourceColumn{
+					{
+						Name:                       "col1",
+						EmbeddingModelEndpointName: "test",
+					},
+				},
+			},
+		}
+		d.SetId(vsiName)
+		d.MarkNewResource()
+		scm := tf_vs.ResourceVectorSearchIndex().Schema
+		err := common.StructToData(ot, scm, d)
+		require.NoError(t, err)
+
+		err = resourcesMap["databricks_vector_search_index"].Import(ic, &resource{
+			ID:   vsiName,
+			Data: d,
+		})
+		assert.NoError(t, err)
+		require.Equal(t, 4, len(ic.testEmits))
+		assert.True(t, ic.testEmits["databricks_grants[<unknown>] (id: table/main.tmp.vsi)"])
+		assert.True(t, ic.testEmits["databricks_vector_search_endpoint[<unknown>] (id: vs)"])
+		assert.True(t, ic.testEmits["databricks_sql_table[<unknown>] (id: main.tmp.tbl)"])
+		assert.True(t, ic.testEmits["databricks_model_serving[<unknown>] (id: test)"])
 	})
 }


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

This PR adds support for exporting of `databricks_vector_search_endpoint` and `databricks_vector_search_index` resources.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
