### PR TITLE
[Fix] Automatically assign `IS_OWNER` permission to sql warehouse if not specified

### DIFF
--- a/docs/resources/permissions.md
+++ b/docs/resources/permissions.md
@@ -623,6 +623,10 @@ resource "databricks_permissions" "token_usage" {
 
 [SQL warehouses](https://docs.databricks.com/sql/user/security/access-control/sql-endpoint-acl.html) have four possible permissions: `CAN_USE`, `CAN_MONITOR`, `CAN_MANAGE` and `IS_OWNER`:
 
+- The creator of a warehouse has `IS_OWNER` permission. Destroying `databricks_permissions` resource for a warehouse would revert ownership to the creator.
+- A warehouse must have exactly one owner. If a resource is changed and no owner is specified, the currently authenticated principal would become the new owner of the warehouse. Nothing would change, per se, if the warehouse was created through Terraform.
+- A warehouse cannot have a group as an owner.
+
 ```hcl
 data "databricks_current_user" "me" {}
 

--- a/permissions/resource_permissions.go
+++ b/permissions/resource_permissions.go
@@ -137,7 +137,7 @@ func isOwnershipWorkaroundNecessary(objectID string) bool {
 	return strings.HasPrefix(objectID, "/jobs") || strings.HasPrefix(objectID, "/pipelines") || strings.HasPrefix(objectID, "/sql/warehouses")
 }
 
-// Check if an error is 404
+// Suppress the error if it is 404
 func ignoreNotFound(err error) error {
 	var apiErr *apierr.APIError
 	if !errors.As(err, &apiErr) {

--- a/permissions/resource_permissions_test.go
+++ b/permissions/resource_permissions_test.go
@@ -914,6 +914,94 @@ func TestResourcePermissionsCreate_SQLA_Endpoint(t *testing.T) {
 	assert.Equal(t, "CAN_USE", firstElem["permission_level"])
 }
 
+func TestResourcePermissionsCreate_SQLA_Endpoint_WithOwnerError(t *testing.T) {
+	d, err := qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			me,
+			{
+				Method:   "PUT",
+				Resource: "/api/2.0/permissions/sql/warehouses/abc",
+				ExpectedRequest: AccessControlChangeList{
+					AccessControlList: []AccessControlChange{
+						{
+							UserName:        TestingUser,
+							PermissionLevel: "CAN_USE",
+						},
+						{
+							UserName:        TestingAdminUser,
+							PermissionLevel: "IS_OWNER",
+						},
+						{
+							UserName:        TestingAdminUser,
+							PermissionLevel: "CAN_MANAGE",
+						},
+					},
+				},
+				Response: apierr.APIError{
+					ErrorCode: "INVALID_PARAMETER_VALUE",
+					Message:   "PUT requests for warehouse *** with no existing owner must provide a new owner.",
+				},
+				Status: 400,
+			},
+			{
+				Method:   "PUT",
+				Resource: "/api/2.0/permissions/sql/warehouses/abc",
+				ExpectedRequest: AccessControlChangeList{
+					AccessControlList: []AccessControlChange{
+						{
+							UserName:        TestingUser,
+							PermissionLevel: "CAN_USE",
+						},
+						{
+							UserName:        TestingAdminUser,
+							PermissionLevel: "CAN_MANAGE",
+						},
+					},
+				},
+			},
+			{
+				Method:   http.MethodGet,
+				Resource: "/api/2.0/permissions/sql/warehouses/abc",
+				Response: ObjectACL{
+					ObjectID:   "dashboards/abc",
+					ObjectType: "dashboard",
+					AccessControlList: []AccessControl{
+						{
+							UserName:        TestingUser,
+							PermissionLevel: "CAN_USE",
+						},
+						{
+							UserName:        TestingAdminUser,
+							PermissionLevel: "IS_OWNER",
+						},
+						{
+							UserName:        TestingAdminUser,
+							PermissionLevel: "CAN_MANAGE",
+						},
+					},
+				},
+			},
+		},
+		Resource: ResourcePermissions(),
+		State: map[string]any{
+			"sql_endpoint_id": "abc",
+			"access_control": []any{
+				map[string]any{
+					"user_name":        TestingUser,
+					"permission_level": "CAN_USE",
+				},
+			},
+		},
+		Create: true,
+	}.Apply(t)
+	assert.NoError(t, err)
+	ac := d.Get("access_control").(*schema.Set)
+	require.Equal(t, 1, len(ac.List()))
+	firstElem := ac.List()[0].(map[string]any)
+	assert.Equal(t, TestingUser, firstElem["user_name"])
+	assert.Equal(t, "CAN_USE", firstElem["permission_level"])
+}
+
 func TestResourcePermissionsCreate_SQLA_Endpoint_WithOwner(t *testing.T) {
 	d, err := qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{

--- a/permissions/resource_permissions_test.go
+++ b/permissions/resource_permissions_test.go
@@ -862,6 +862,10 @@ func TestResourcePermissionsCreate_SQLA_Endpoint(t *testing.T) {
 						},
 						{
 							UserName:        TestingAdminUser,
+							PermissionLevel: "IS_OWNER",
+						},
+						{
+							UserName:        TestingAdminUser,
 							PermissionLevel: "CAN_MANAGE",
 						},
 					},
@@ -877,6 +881,10 @@ func TestResourcePermissionsCreate_SQLA_Endpoint(t *testing.T) {
 						{
 							UserName:        TestingUser,
 							PermissionLevel: "CAN_USE",
+						},
+						{
+							UserName:        TestingAdminUser,
+							PermissionLevel: "IS_OWNER",
 						},
 						{
 							UserName:        TestingAdminUser,

--- a/permissions/resource_permissions_test.go
+++ b/permissions/resource_permissions_test.go
@@ -410,7 +410,7 @@ func TestResourcePermissionsRead_NotFound(t *testing.T) {
 			{
 				Method:   http.MethodGet,
 				Resource: "/api/2.0/permissions/clusters/abc",
-				Response: common.APIErrorBody{
+				Response: apierr.APIError{
 					ErrorCode: "NOT_FOUND",
 					Message:   "Cluster does not exist",
 				},
@@ -432,7 +432,7 @@ func TestResourcePermissionsRead_some_error(t *testing.T) {
 			{
 				Method:   http.MethodGet,
 				Resource: "/api/2.0/permissions/clusters/abc",
-				Response: common.APIErrorBody{
+				Response: apierr.APIError{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},
@@ -498,7 +498,7 @@ func TestResourcePermissionsRead_ErrorOnScimMe(t *testing.T) {
 		{
 			Method:   http.MethodGet,
 			Resource: "/api/2.0/preview/scim/v2/Me",
-			Response: common.APIErrorBody{
+			Response: apierr.APIError{
 				ErrorCode: "INVALID_REQUEST",
 				Message:   "Internal error happened",
 			},
@@ -652,7 +652,7 @@ func TestResourcePermissionsDelete_error(t *testing.T) {
 						},
 					},
 				},
-				Response: common.APIErrorBody{
+				Response: apierr.APIError{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},
@@ -1011,7 +1011,7 @@ func TestResourcePermissionsCreate_NotebookPath_NotExists(t *testing.T) {
 			{
 				Method:   http.MethodGet,
 				Resource: "/api/2.0/workspace/get-status?path=%2FDevelopment%2FInit",
-				Response: common.APIErrorBody{
+				Response: apierr.APIError{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},
@@ -1189,7 +1189,7 @@ func TestResourcePermissionsCreate_error(t *testing.T) {
 			{
 				Method:   http.MethodPut,
 				Resource: "/api/2.0/permissions/clusters/abc",
-				Response: common.APIErrorBody{
+				Response: apierr.APIError{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},


### PR DESCRIPTION
## Changes
- SQL warehouses supports specifying `IS_OWNER` permission and therefore requires the same workaround as jobs & pipelines.
- Resolves #3730

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [x] covered with integration tests in `internal/acceptance`
- [x] relevant acceptance tests are passing
- [x] using Go SDK
