### PR TITLE
Support read only in plugin framework CustomizableSchema

### DIFF
--- a/common/customizable_schema_plugin_framework.go
+++ b/common/customizable_schema_plugin_framework.go
@@ -287,6 +287,88 @@ func (s *CustomizableSchemaPluginFramework) SetDeprecated(msg string, path ...st
 	return s
 }
 
+func (s *CustomizableSchemaPluginFramework) SetComputed(path ...string) *CustomizableSchemaPluginFramework {
+	cb := func(attr schema.Attribute) schema.Attribute {
+		// Get the concrete value stored in the interface
+		v := reflect.ValueOf(attr)
+
+		// Make a new addressable value and copy the original value into it
+		newAttr := reflect.New(v.Type()).Elem()
+		newAttr.Set(v)
+		v = newAttr
+
+		field := v.FieldByName("Computed")
+		if field.IsValid() && field.CanSet() {
+			if field.Kind() == reflect.Bool {
+				field.SetBool(true)
+			} else {
+				panic(fmt.Sprintf("Computed is not a bool field in %T", attr))
+			}
+		} else {
+			panic(fmt.Sprintf("Computed field not found or cannot be set in %T", attr))
+		}
+
+		return v.Interface().(schema.Attribute)
+	}
+
+	navigateSchemaWithCallback(&s.attr, cb, path...)
+	return s
+}
+
+// SetReadOnly sets the schema to be read-only (i.e. computed, non-optional).
+// This should be used for fields that are not user-configurable but are returned
+// by the platform.
+func (s *CustomizableSchemaPluginFramework) SetReadOnly(path ...string) *CustomizableSchemaPluginFramework {
+	cb := func(attr schema.Attribute) schema.Attribute {
+		// Get the concrete value stored in the interface
+		v := reflect.ValueOf(attr)
+
+		// Make a new addressable value and copy the original value into it
+		newAttr := reflect.New(v.Type()).Elem()
+		newAttr.Set(v)
+		v = newAttr
+
+		field := v.FieldByName("Computed")
+		if field.IsValid() && field.CanSet() {
+			if field.Kind() == reflect.Bool {
+				field.SetBool(true)
+			} else {
+				panic(fmt.Sprintf("Computed is not a bool field in %T", attr))
+			}
+		} else {
+			panic(fmt.Sprintf("Computed field not found or cannot be set in %T", attr))
+		}
+
+		field = v.FieldByName("Optional")
+		if field.IsValid() && field.CanSet() {
+			if field.Kind() == reflect.Bool {
+				field.SetBool(false)
+			} else {
+				panic(fmt.Sprintf("Optional is not a bool field in %T", attr))
+			}
+		} else {
+			panic(fmt.Sprintf("Optional field not found or cannot be set in %T", attr))
+		}
+
+		field = v.FieldByName("Required")
+		if field.IsValid() && field.CanSet() {
+			if field.Kind() == reflect.Bool {
+				field.SetBool(false)
+			} else {
+				panic(fmt.Sprintf("Required is not a bool field in %T", attr))
+			}
+		} else {
+			panic(fmt.Sprintf("Required field not found or cannot be set in %T", attr))
+		}
+
+		return v.Interface().(schema.Attribute)
+	}
+
+	navigateSchemaWithCallback(&s.attr, cb, path...)
+
+	return s
+}
+
 // Given a attribute map, navigate through the given path, panics if the path is not valid.
 func MustSchemaAttributePath(attrs map[string]schema.Attribute, path ...string) schema.Attribute {
 	attr := ConstructCustomizableSchema(attrs).attr

--- a/common/customizable_schema_plugin_framework_test.go
+++ b/common/customizable_schema_plugin_framework_test.go
@@ -55,6 +55,7 @@ func TestCustomizeSchema(t *testing.T) {
 		c.SetOptional("description")
 		c.SetSensitive("nested", "name")
 		c.SetDeprecated("deprecated", "map")
+		c.SetReadOnly("map")
 		c.AddValidator(stringLengthBetweenValidator{}, "description")
 		return c
 	})
@@ -64,6 +65,9 @@ func TestCustomizeSchema(t *testing.T) {
 	assert.True(t, MustSchemaAttributePath(scm.Attributes, "nested", "name").IsSensitive())
 	assert.True(t, MustSchemaAttributePath(scm.Attributes, "map").GetDeprecationMessage() == "deprecated")
 	assert.True(t, scm.Attributes["description"].IsOptional())
+	assert.True(t, !scm.Attributes["map"].IsOptional())
+	assert.True(t, !scm.Attributes["map"].IsRequired())
+	assert.True(t, scm.Attributes["map"].IsComputed())
 	attr := MustSchemaAttributePath(scm.Attributes, "nested").(schema.SingleNestedAttribute).Attributes
 	_, ok := attr["to_be_removed"]
 	assert.True(t, len(MustSchemaAttributePath(scm.Attributes, "description").(schema.StringAttribute).Validators) == 1)

--- a/pluginframework/resource_quality_monitor.go
+++ b/pluginframework/resource_quality_monitor.go
@@ -58,13 +58,12 @@ func (r *QualityMonitorResource) Schema(ctx context.Context, req resource.Schema
 			c.SetRequired("assets_dir")
 			c.SetRequired("output_schema_name")
 			c.SetRequired("table_name")
-			// TODO: Uncomment this once SetReadOnly is supported in the plugin framework
-			// c.SetReadOnly("monitor_version")
-			// c.SetReadOnly("drift_metrics_table_name")
-			// c.SetReadOnly("profile_metrics_table_name")
-			// c.SetReadOnly("status")
-			// c.SetReadOnly("dashboard_id")
-			// c.SetReadOnly("schedule", "pause_status")
+			c.SetReadOnly("monitor_version")
+			c.SetReadOnly("drift_metrics_table_name")
+			c.SetReadOnly("profile_metrics_table_name")
+			c.SetReadOnly("status")
+			c.SetReadOnly("dashboard_id")
+			c.SetReadOnly("schedule", "pause_status")
 			return c
 		}),
 	}


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
- Support `SetReadOnly` in `CustomizableSchema` for terraform plugin framework

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [x] covered with integration tests in `internal/acceptance`
- [x] relevant acceptance tests are passing
- [x] using Go SDK
