### PR TITLE
[Exporter] Don't export model serving endpoints with foundational models

### DIFF
--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -2303,8 +2303,9 @@ func TestImportingModelServing(t *testing.T) {
 				},
 			},
 			{
-				Method:   "GET",
-				Resource: "/api/2.0/serving-endpoints/abc?",
+				Method:       "GET",
+				Resource:     "/api/2.0/serving-endpoints/abc?",
+				ReuseRequest: true,
 				Response: serving.ServingEndpointDetailed{
 					Name: "abc",
 					Id:   "1234",


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

We need to skip model serving endpoints that serve foundational models because they are provided by Databricks and we don't have ability to create serving endpoint for foundational models.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
