### PR TITLE
[Doc] Fixed documentation for `databricks_schemas` data source and `databricks_metastore_assignment` resource

### DIFF
--- a/docs/data-sources/schema.md
+++ b/docs/data-sources/schema.md
@@ -15,8 +15,8 @@ data "databricks_schemas" "all" {
   catalog_name = "sandbox"
 }
 
-data "databricks_schema" {
-  for_each = data.datatbricks_schemas.all.ids
+data "databricks_schema" "this" {
+  for_each = data.databricks_schemas.all.ids
   name     = each.value
 }
 ```

--- a/docs/resources/metastore_assignment.md
+++ b/docs/resources/metastore_assignment.md
@@ -30,7 +30,7 @@ The following arguments are required:
 
 * `metastore_id` - Unique identifier of the parent Metastore
 * `workspace_id` - id of the workspace for the assignment
-* `default_catalog_name` - (Optional) Default catalog used for this assignment, default to `hive_metastore`
+* `default_catalog_name` - (Deprecated) Default catalog used for this assignment. Please use [databricks_default_namespace_setting](default_namespace_setting.md) instead.
 
 ## Attribute Reference
 


### PR DESCRIPTION
## Changes
- Fixed typos in `databricks_schemas` data sources doc. Resolve #3849
- Clarified `default_catalog_name` attribute is deprecated. Resolve #3850

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] relevant change in `docs/` folder