### PR TITLE
Make tfsdk struct enums into types.String

### DIFF
--- a/.codegen/model.go.tmpl
+++ b/.codegen/model.go.tmpl
@@ -79,7 +79,7 @@ func (f *{{.PascalName}}) Type() string {
 	{{- else if .ArrayValue }}[]{{template "type" .ArrayValue}}
 	{{- else if .MapValue }}map[string]{{template "type" .MapValue}}
 	{{- else if .IsObject }}{{.PascalName}}
-	{{- else if .Enum }}{{.PascalName}}
+	{{- else if .Enum }}types.String
 	{{- else}}any /* MISSING TYPE */
 	{{- end -}}
 {{- end -}}

--- a/service/billing_tf/model.go
+++ b/service/billing_tf/model.go
@@ -144,7 +144,7 @@ type CreateLogDeliveryConfigurationParams struct {
 	// [View billable usage]: https://docs.databricks.com/administration-guide/account-settings/usage.html
 	// [audit log delivery]: https://docs.databricks.com/administration-guide/account-settings/audit-logs.html
 	// [billable usage log delivery]: https://docs.databricks.com/administration-guide/account-settings/billable-usage-delivery.html
-	LogType LogType `tfsdk:"log_type" tf:""`
+	LogType types.String `tfsdk:"log_type" tf:""`
 	// The file type of log delivery.
 	//
 	// * If `log_type` is `BILLABLE_USAGE`, this value must be `CSV`. Only the
@@ -155,13 +155,13 @@ type CreateLogDeliveryConfigurationParams struct {
 	//
 	// [Configuring audit logs]: https://docs.databricks.com/administration-guide/account-settings/audit-logs.html
 	// [View billable usage]: https://docs.databricks.com/administration-guide/account-settings/usage.html
-	OutputFormat OutputFormat `tfsdk:"output_format" tf:""`
+	OutputFormat types.String `tfsdk:"output_format" tf:""`
 	// Status of log delivery configuration. Set to `ENABLED` (enabled) or
 	// `DISABLED` (disabled). Defaults to `ENABLED`. You can [enable or disable
 	// the configuration](#operation/patch-log-delivery-config-status) later.
 	// Deletion of a configuration is not supported, so disable a log delivery
 	// configuration that is no longer needed.
-	Status LogDeliveryConfigStatus `tfsdk:"status" tf:"optional"`
+	Status types.String `tfsdk:"status" tf:"optional"`
 	// The ID for a method:storage/create that represents the S3 bucket with
 	// bucket policy as described in the main billable usage documentation page.
 	// See [Configure billable usage delivery].
@@ -278,7 +278,7 @@ type ListLogDeliveryRequest struct {
 	// Filter by credential configuration ID.
 	CredentialsId types.String `tfsdk:"-" url:"credentials_id,omitempty"`
 	// Filter by status `ENABLED` or `DISABLED`.
-	Status LogDeliveryConfigStatus `tfsdk:"-" url:"status,omitempty"`
+	Status types.String `tfsdk:"-" url:"status,omitempty"`
 	// Filter by storage configuration ID.
 	StorageConfigurationId types.String `tfsdk:"-" url:"storage_configuration_id,omitempty"`
 }
@@ -356,7 +356,7 @@ type LogDeliveryConfiguration struct {
 	// [View billable usage]: https://docs.databricks.com/administration-guide/account-settings/usage.html
 	// [audit log delivery]: https://docs.databricks.com/administration-guide/account-settings/audit-logs.html
 	// [billable usage log delivery]: https://docs.databricks.com/administration-guide/account-settings/billable-usage-delivery.html
-	LogType LogType `tfsdk:"log_type" tf:"optional"`
+	LogType types.String `tfsdk:"log_type" tf:"optional"`
 	// The file type of log delivery.
 	//
 	// * If `log_type` is `BILLABLE_USAGE`, this value must be `CSV`. Only the
@@ -367,13 +367,13 @@ type LogDeliveryConfiguration struct {
 	//
 	// [Configuring audit logs]: https://docs.databricks.com/administration-guide/account-settings/audit-logs.html
 	// [View billable usage]: https://docs.databricks.com/administration-guide/account-settings/usage.html
-	OutputFormat OutputFormat `tfsdk:"output_format" tf:"optional"`
+	OutputFormat types.String `tfsdk:"output_format" tf:"optional"`
 	// Status of log delivery configuration. Set to `ENABLED` (enabled) or
 	// `DISABLED` (disabled). Defaults to `ENABLED`. You can [enable or disable
 	// the configuration](#operation/patch-log-delivery-config-status) later.
 	// Deletion of a configuration is not supported, so disable a log delivery
 	// configuration that is no longer needed.
-	Status LogDeliveryConfigStatus `tfsdk:"status" tf:"optional"`
+	Status types.String `tfsdk:"status" tf:"optional"`
 	// The ID for a method:storage/create that represents the S3 bucket with
 	// bucket policy as described in the main billable usage documentation page.
 	// See [Configure billable usage delivery].
@@ -419,7 +419,7 @@ type LogDeliveryStatus struct {
 	// `NOT_FOUND`: The log delivery status as the configuration has been
 	// disabled since the release of this feature or there are no workspaces in
 	// the account.
-	Status DeliveryStatus `tfsdk:"status" tf:"optional"`
+	Status types.String `tfsdk:"status" tf:"optional"`
 }
 
 // Log delivery type. Supported values are:
@@ -509,7 +509,7 @@ type UpdateLogDeliveryConfigurationStatusRequest struct {
 	// the configuration](#operation/patch-log-delivery-config-status) later.
 	// Deletion of a configuration is not supported, so disable a log delivery
 	// configuration that is no longer needed.
-	Status LogDeliveryConfigStatus `tfsdk:"status" tf:""`
+	Status types.String `tfsdk:"status" tf:""`
 }
 
 type UpdateResponse struct {

--- a/service/catalog_tf/model.go
+++ b/service/catalog_tf/model.go
@@ -84,7 +84,7 @@ type ArtifactMatcher struct {
 	// The artifact path or maven coordinate
 	Artifact types.String `tfsdk:"artifact" tf:""`
 	// The pattern matching type of the artifact
-	MatchType MatchType `tfsdk:"match_type" tf:""`
+	MatchType types.String `tfsdk:"match_type" tf:""`
 }
 
 // The artifact type
@@ -194,7 +194,7 @@ type CatalogInfo struct {
 	// enabled in the request.
 	BrowseOnly types.Bool `tfsdk:"browse_only" tf:"optional"`
 	// The type of the catalog.
-	CatalogType CatalogType `tfsdk:"catalog_type" tf:"optional"`
+	CatalogType types.String `tfsdk:"catalog_type" tf:"optional"`
 	// User-provided free-form text description.
 	Comment types.String `tfsdk:"comment" tf:"optional"`
 	// The name of the connection to an external data source.
@@ -207,12 +207,12 @@ type CatalogInfo struct {
 	EffectivePredictiveOptimizationFlag *EffectivePredictiveOptimizationFlag `tfsdk:"effective_predictive_optimization_flag" tf:"optional"`
 	// Whether predictive optimization should be enabled for this object and
 	// objects under it.
-	EnablePredictiveOptimization EnablePredictiveOptimization `tfsdk:"enable_predictive_optimization" tf:"optional"`
+	EnablePredictiveOptimization types.String `tfsdk:"enable_predictive_optimization" tf:"optional"`
 	// The full name of the catalog. Corresponds with the name field.
 	FullName types.String `tfsdk:"full_name" tf:"optional"`
 	// Whether the current securable is accessible from all workspaces or a
 	// specific set of workspaces.
-	IsolationMode CatalogIsolationMode `tfsdk:"isolation_mode" tf:"optional"`
+	IsolationMode types.String `tfsdk:"isolation_mode" tf:"optional"`
 	// Unique identifier of parent metastore.
 	MetastoreId types.String `tfsdk:"metastore_id" tf:"optional"`
 	// Name of catalog.
@@ -231,7 +231,7 @@ type CatalogInfo struct {
 	// Status of an asynchronously provisioned resource.
 	ProvisioningInfo *ProvisioningInfo `tfsdk:"provisioning_info" tf:"optional"`
 	// Kind of catalog securable.
-	SecurableKind CatalogInfoSecurableKind `tfsdk:"securable_kind" tf:"optional"`
+	SecurableKind types.String `tfsdk:"securable_kind" tf:"optional"`
 
 	SecurableType types.String `tfsdk:"securable_type" tf:"optional"`
 	// The name of the share under the share provider.
@@ -382,7 +382,7 @@ type ColumnInfo struct {
 	// Full data type specification, JSON-serialized.
 	TypeJson types.String `tfsdk:"type_json" tf:"optional"`
 	// Name of type (INT, STRUCT, MAP, etc.).
-	TypeName ColumnTypeName `tfsdk:"type_name" tf:"optional"`
+	TypeName types.String `tfsdk:"type_name" tf:"optional"`
 	// Digits of precision; required for DecimalTypes.
 	TypePrecision types.Int64 `tfsdk:"type_precision" tf:"optional"`
 	// Digits to right of decimal; Required for DecimalTypes.
@@ -473,13 +473,13 @@ type ConnectionInfo struct {
 	// Unique identifier of the Connection.
 	ConnectionId types.String `tfsdk:"connection_id" tf:"optional"`
 	// The type of connection.
-	ConnectionType ConnectionType `tfsdk:"connection_type" tf:"optional"`
+	ConnectionType types.String `tfsdk:"connection_type" tf:"optional"`
 	// Time at which this connection was created, in epoch milliseconds.
 	CreatedAt types.Int64 `tfsdk:"created_at" tf:"optional"`
 	// Username of connection creator.
 	CreatedBy types.String `tfsdk:"created_by" tf:"optional"`
 	// The type of credential.
-	CredentialType CredentialType `tfsdk:"credential_type" tf:"optional"`
+	CredentialType types.String `tfsdk:"credential_type" tf:"optional"`
 	// Full name of connection.
 	FullName types.String `tfsdk:"full_name" tf:"optional"`
 	// Unique identifier of parent metastore.
@@ -498,7 +498,7 @@ type ConnectionInfo struct {
 	// If the connection is read only.
 	ReadOnly types.Bool `tfsdk:"read_only" tf:"optional"`
 	// Kind of connection securable.
-	SecurableKind ConnectionInfoSecurableKind `tfsdk:"securable_kind" tf:"optional"`
+	SecurableKind types.String `tfsdk:"securable_kind" tf:"optional"`
 
 	SecurableType types.String `tfsdk:"securable_type" tf:"optional"`
 	// Time at which this connection was updated, in epoch milliseconds.
@@ -631,7 +631,7 @@ type CreateConnection struct {
 	// User-provided free-form text description.
 	Comment types.String `tfsdk:"comment" tf:"optional"`
 	// The type of connection.
-	ConnectionType ConnectionType `tfsdk:"connection_type" tf:""`
+	ConnectionType types.String `tfsdk:"connection_type" tf:""`
 	// Name of the connection.
 	Name types.String `tfsdk:"name" tf:""`
 	// A map of key-value properties attached to the securable.
@@ -669,7 +669,7 @@ type CreateFunction struct {
 	// User-provided free-form text description.
 	Comment types.String `tfsdk:"comment" tf:"optional"`
 	// Scalar function return data type.
-	DataType ColumnTypeName `tfsdk:"data_type" tf:""`
+	DataType types.String `tfsdk:"data_type" tf:""`
 	// External function language.
 	ExternalLanguage types.String `tfsdk:"external_language" tf:"optional"`
 	// External function name.
@@ -685,7 +685,7 @@ type CreateFunction struct {
 	// Name of function, relative to parent schema.
 	Name types.String `tfsdk:"name" tf:""`
 	// Function parameter style. **S** is the value for SQL.
-	ParameterStyle CreateFunctionParameterStyle `tfsdk:"parameter_style" tf:""`
+	ParameterStyle types.String `tfsdk:"parameter_style" tf:""`
 	// JSON-serialized key-value pair map, encoded (escaped) as a string.
 	Properties types.String `tfsdk:"properties" tf:"optional"`
 	// Table function return parameters.
@@ -695,7 +695,7 @@ type CreateFunction struct {
 	// __return_params__ of the function cannot be used (as **TABLE** return
 	// type is not supported), and the __sql_data_access__ field must be
 	// **NO_SQL**.
-	RoutineBody CreateFunctionRoutineBody `tfsdk:"routine_body" tf:""`
+	RoutineBody types.String `tfsdk:"routine_body" tf:""`
 	// Function body.
 	RoutineDefinition types.String `tfsdk:"routine_definition" tf:""`
 	// Function dependencies.
@@ -703,11 +703,11 @@ type CreateFunction struct {
 	// Name of parent schema relative to its parent catalog.
 	SchemaName types.String `tfsdk:"schema_name" tf:""`
 	// Function security type.
-	SecurityType CreateFunctionSecurityType `tfsdk:"security_type" tf:""`
+	SecurityType types.String `tfsdk:"security_type" tf:""`
 	// Specific name of the function; Reserved for future use.
 	SpecificName types.String `tfsdk:"specific_name" tf:""`
 	// Function SQL data access.
-	SqlDataAccess CreateFunctionSqlDataAccess `tfsdk:"sql_data_access" tf:""`
+	SqlDataAccess types.String `tfsdk:"sql_data_access" tf:""`
 	// List of schemes whose objects can be referenced without qualification.
 	SqlPath types.String `tfsdk:"sql_path" tf:"optional"`
 }
@@ -973,7 +973,7 @@ type CreateVolumeRequestContent struct {
 	// The storage location on the cloud
 	StorageLocation types.String `tfsdk:"storage_location" tf:"optional"`
 
-	VolumeType VolumeType `tfsdk:"volume_type" tf:""`
+	VolumeType types.String `tfsdk:"volume_type" tf:""`
 }
 
 // The type of credential.
@@ -1280,10 +1280,10 @@ type EffectivePredictiveOptimizationFlag struct {
 	InheritedFromName types.String `tfsdk:"inherited_from_name" tf:"optional"`
 	// The type of the object from which the flag was inherited. If there was no
 	// inheritance, this field is left blank.
-	InheritedFromType EffectivePredictiveOptimizationFlagInheritedFromType `tfsdk:"inherited_from_type" tf:"optional"`
+	InheritedFromType types.String `tfsdk:"inherited_from_type" tf:"optional"`
 	// Whether predictive optimization should be enabled for this object and
 	// objects under it.
-	Value EnablePredictiveOptimization `tfsdk:"value" tf:""`
+	Value types.String `tfsdk:"value" tf:""`
 }
 
 // The type of the object from which the flag was inherited. If there was no
@@ -1323,9 +1323,9 @@ type EffectivePrivilege struct {
 	// The type of the object that conveys this privilege via inheritance. This
 	// field is omitted when privilege is not inherited (it's assigned to the
 	// securable itself).
-	InheritedFromType SecurableType `tfsdk:"inherited_from_type" tf:"optional"`
+	InheritedFromType types.String `tfsdk:"inherited_from_type" tf:"optional"`
 	// The privilege assigned to the principal.
-	Privilege Privilege `tfsdk:"privilege" tf:"optional"`
+	Privilege types.String `tfsdk:"privilege" tf:"optional"`
 }
 
 type EffectivePrivilegeAssignment struct {
@@ -1411,7 +1411,7 @@ type ExternalLocationInfo struct {
 	EncryptionDetails *EncryptionDetails `tfsdk:"encryption_details" tf:"optional"`
 	// Whether the current securable is accessible from all workspaces or a
 	// specific set of workspaces.
-	IsolationMode IsolationMode `tfsdk:"isolation_mode" tf:"optional"`
+	IsolationMode types.String `tfsdk:"isolation_mode" tf:"optional"`
 	// Unique identifier of metastore hosting the external location.
 	MetastoreId types.String `tfsdk:"metastore_id" tf:"optional"`
 	// Name of the external location.
@@ -1475,7 +1475,7 @@ type FunctionInfo struct {
 	// Username of function creator.
 	CreatedBy types.String `tfsdk:"created_by" tf:"optional"`
 	// Scalar function return data type.
-	DataType ColumnTypeName `tfsdk:"data_type" tf:"optional"`
+	DataType types.String `tfsdk:"data_type" tf:"optional"`
 	// External function language.
 	ExternalLanguage types.String `tfsdk:"external_language" tf:"optional"`
 	// External function name.
@@ -1500,7 +1500,7 @@ type FunctionInfo struct {
 	// Username of current owner of function.
 	Owner types.String `tfsdk:"owner" tf:"optional"`
 	// Function parameter style. **S** is the value for SQL.
-	ParameterStyle FunctionInfoParameterStyle `tfsdk:"parameter_style" tf:"optional"`
+	ParameterStyle types.String `tfsdk:"parameter_style" tf:"optional"`
 	// JSON-serialized key-value pair map, encoded (escaped) as a string.
 	Properties types.String `tfsdk:"properties" tf:"optional"`
 	// Table function return parameters.
@@ -1510,7 +1510,7 @@ type FunctionInfo struct {
 	// __return_params__ of the function cannot be used (as **TABLE** return
 	// type is not supported), and the __sql_data_access__ field must be
 	// **NO_SQL**.
-	RoutineBody FunctionInfoRoutineBody `tfsdk:"routine_body" tf:"optional"`
+	RoutineBody types.String `tfsdk:"routine_body" tf:"optional"`
 	// Function body.
 	RoutineDefinition types.String `tfsdk:"routine_definition" tf:"optional"`
 	// Function dependencies.
@@ -1518,11 +1518,11 @@ type FunctionInfo struct {
 	// Name of parent schema relative to its parent catalog.
 	SchemaName types.String `tfsdk:"schema_name" tf:"optional"`
 	// Function security type.
-	SecurityType FunctionInfoSecurityType `tfsdk:"security_type" tf:"optional"`
+	SecurityType types.String `tfsdk:"security_type" tf:"optional"`
 	// Specific name of the function; Reserved for future use.
 	SpecificName types.String `tfsdk:"specific_name" tf:"optional"`
 	// Function SQL data access.
-	SqlDataAccess FunctionInfoSqlDataAccess `tfsdk:"sql_data_access" tf:"optional"`
+	SqlDataAccess types.String `tfsdk:"sql_data_access" tf:"optional"`
 	// List of schemes whose objects can be referenced without qualification.
 	SqlPath types.String `tfsdk:"sql_path" tf:"optional"`
 	// Time at which this function was created, in epoch milliseconds.
@@ -1652,9 +1652,9 @@ type FunctionParameterInfo struct {
 	// Default value of the parameter.
 	ParameterDefault types.String `tfsdk:"parameter_default" tf:"optional"`
 	// The mode of the function parameter.
-	ParameterMode FunctionParameterMode `tfsdk:"parameter_mode" tf:"optional"`
+	ParameterMode types.String `tfsdk:"parameter_mode" tf:"optional"`
 	// The type of function parameter.
-	ParameterType FunctionParameterType `tfsdk:"parameter_type" tf:"optional"`
+	ParameterType types.String `tfsdk:"parameter_type" tf:"optional"`
 	// Ordinal position of column (starting at position 0).
 	Position types.Int64 `tfsdk:"position" tf:""`
 	// Format of IntervalType.
@@ -1662,7 +1662,7 @@ type FunctionParameterInfo struct {
 	// Full data type spec, JSON-serialized.
 	TypeJson types.String `tfsdk:"type_json" tf:"optional"`
 	// Name of type (INT, STRUCT, MAP, etc.).
-	TypeName ColumnTypeName `tfsdk:"type_name" tf:""`
+	TypeName types.String `tfsdk:"type_name" tf:""`
 	// Digits of precision; required on Create for DecimalTypes.
 	TypePrecision types.Int64 `tfsdk:"type_precision" tf:"optional"`
 	// Digits to right of decimal; Required on Create for DecimalTypes.
@@ -1754,7 +1754,7 @@ type GetAccountStorageCredentialRequest struct {
 // Get an artifact allowlist
 type GetArtifactAllowlistRequest struct {
 	// The artifact type of the allowlist.
-	ArtifactType ArtifactType `tfsdk:"-" url:"-"`
+	ArtifactType types.String `tfsdk:"-" url:"-"`
 }
 
 // Get securable workspace bindings
@@ -1796,7 +1796,7 @@ type GetEffectiveRequest struct {
 	// (user or group) are returned.
 	Principal types.String `tfsdk:"-" url:"principal,omitempty"`
 	// Type of securable.
-	SecurableType SecurableType `tfsdk:"-" url:"-"`
+	SecurableType types.String `tfsdk:"-" url:"-"`
 }
 
 // Get an external location
@@ -1826,7 +1826,7 @@ type GetGrantRequest struct {
 	// group) are returned.
 	Principal types.String `tfsdk:"-" url:"principal,omitempty"`
 	// Type of securable.
-	SecurableType SecurableType `tfsdk:"-" url:"-"`
+	SecurableType types.String `tfsdk:"-" url:"-"`
 }
 
 // Get a metastore
@@ -1850,7 +1850,7 @@ type GetMetastoreSummaryResponse struct {
 	// The lifetime of delta sharing recipient token in seconds.
 	DeltaSharingRecipientTokenLifetimeInSeconds types.Int64 `tfsdk:"delta_sharing_recipient_token_lifetime_in_seconds" tf:"optional"`
 	// The scope of Delta Sharing enabled for the metastore.
-	DeltaSharingScope GetMetastoreSummaryResponseDeltaSharingScope `tfsdk:"delta_sharing_scope" tf:"optional"`
+	DeltaSharingScope types.String `tfsdk:"delta_sharing_scope" tf:"optional"`
 	// Globally unique metastore ID across clouds and regions, of the form
 	// `cloud:region:metastore_id`.
 	GlobalMetastoreId types.String `tfsdk:"global_metastore_id" tf:"optional"`
@@ -2424,7 +2424,7 @@ type MetastoreInfo struct {
 	// The lifetime of delta sharing recipient token in seconds.
 	DeltaSharingRecipientTokenLifetimeInSeconds types.Int64 `tfsdk:"delta_sharing_recipient_token_lifetime_in_seconds" tf:"optional"`
 	// The scope of Delta Sharing enabled for the metastore.
-	DeltaSharingScope MetastoreInfoDeltaSharingScope `tfsdk:"delta_sharing_scope" tf:"optional"`
+	DeltaSharingScope types.String `tfsdk:"delta_sharing_scope" tf:"optional"`
 	// Globally unique metastore ID across clouds and regions, of the form
 	// `cloud:region:metastore_id`.
 	GlobalMetastoreId types.String `tfsdk:"global_metastore_id" tf:"optional"`
@@ -2517,7 +2517,7 @@ type ModelVersionInfo struct {
 	// in PENDING_REGISTRATION status, then move to READY status once the model
 	// version files are uploaded and the model version is finalized. Only model
 	// versions in READY status can be loaded for inference or served.
-	Status ModelVersionInfoStatus `tfsdk:"status" tf:"optional"`
+	Status types.String `tfsdk:"status" tf:"optional"`
 	// The storage location on the cloud under which model version data files
 	// are stored
 	StorageLocation types.String `tfsdk:"storage_location" tf:"optional"`
@@ -2565,7 +2565,7 @@ func (f *ModelVersionInfoStatus) Type() string {
 
 type MonitorCronSchedule struct {
 	// Read only field that indicates whether a schedule is paused or not.
-	PauseStatus MonitorCronSchedulePauseStatus `tfsdk:"pause_status" tf:"optional"`
+	PauseStatus types.String `tfsdk:"pause_status" tf:"optional"`
 	// The expression that determines when to run the monitor. See [examples].
 	//
 	// [examples]: https://www.quartz-scheduler.org/documentation/quartz-2.3.0/tutorials/crontrigger.html
@@ -2635,7 +2635,7 @@ type MonitorInferenceLog struct {
 	PredictionProbaCol types.String `tfsdk:"prediction_proba_col" tf:"optional"`
 	// Problem type the model aims to solve. Determines the type of
 	// model-quality metrics that will be computed.
-	ProblemType MonitorInferenceLogProblemType `tfsdk:"problem_type" tf:""`
+	ProblemType types.String `tfsdk:"problem_type" tf:""`
 	// Column that contains the timestamps of requests. The column must be one
 	// of the following: - A ``TimestampType`` column - A column whose values
 	// can be converted to timestamps through the pyspark ``to_timestamp``
@@ -2718,7 +2718,7 @@ type MonitorInfo struct {
 	// Configuration for monitoring snapshot tables.
 	Snapshot *MonitorSnapshot `tfsdk:"snapshot" tf:"optional"`
 	// The status of the monitor.
-	Status MonitorInfoStatus `tfsdk:"status" tf:""`
+	Status types.String `tfsdk:"status" tf:""`
 	// The full name of the table to monitor. Format:
 	// __catalog_name__.__schema_name__.__table_name__.
 	TableName types.String `tfsdk:"table_name" tf:""`
@@ -2784,7 +2784,7 @@ type MonitorMetric struct {
 	// table - CUSTOM_METRIC_TYPE_DERIVED: depend on previously computed
 	// aggregate metrics - CUSTOM_METRIC_TYPE_DRIFT: depend on previously
 	// computed aggregate or derived metrics
-	Type MonitorMetricType `tfsdk:"type" tf:""`
+	Type types.String `tfsdk:"type" tf:""`
 }
 
 // Can only be one of “"CUSTOM_METRIC_TYPE_AGGREGATE"“,
@@ -2847,9 +2847,9 @@ type MonitorRefreshInfo struct {
 	// 1/1/1970 UTC).
 	StartTimeMs types.Int64 `tfsdk:"start_time_ms" tf:""`
 	// The current state of the refresh.
-	State MonitorRefreshInfoState `tfsdk:"state" tf:""`
+	State types.String `tfsdk:"state" tf:""`
 	// The method by which the refresh was triggered.
-	Trigger MonitorRefreshInfoTrigger `tfsdk:"trigger" tf:"optional"`
+	Trigger types.String `tfsdk:"trigger" tf:"optional"`
 }
 
 // The current state of the refresh.
@@ -3041,7 +3041,7 @@ type OnlineTableStatus struct {
 	// ONLINE_CONTINUOUS_UPDATE or the ONLINE_UPDATING_PIPELINE_RESOURCES state.
 	ContinuousUpdateStatus *ContinuousUpdateStatus `tfsdk:"continuous_update_status" tf:"optional"`
 	// The state of the online table.
-	DetailedState OnlineTableState `tfsdk:"detailed_state" tf:"optional"`
+	DetailedState types.String `tfsdk:"detailed_state" tf:"optional"`
 	// Detailed status of an online table. Shown if the online table is in the
 	// OFFLINE_FAILED or the ONLINE_PIPELINE_FAILED state.
 	FailedStatus *FailedStatus `tfsdk:"failed_status" tf:"optional"`
@@ -3058,11 +3058,11 @@ type OnlineTableStatus struct {
 
 type PermissionsChange struct {
 	// The set of privileges to add.
-	Add []Privilege `tfsdk:"add" tf:"optional"`
+	Add []types.String `tfsdk:"add" tf:"optional"`
 	// The principal whose privileges we are changing.
 	Principal types.String `tfsdk:"principal" tf:"optional"`
 	// The set of privileges to remove.
-	Remove []Privilege `tfsdk:"remove" tf:"optional"`
+	Remove []types.String `tfsdk:"remove" tf:"optional"`
 }
 
 type PermissionsList struct {
@@ -3206,7 +3206,7 @@ type PrivilegeAssignment struct {
 	// The principal (user email address or group name).
 	Principal types.String `tfsdk:"principal" tf:"optional"`
 	// The privileges assigned to the principal.
-	Privileges []Privilege `tfsdk:"privileges" tf:"optional"`
+	Privileges []types.String `tfsdk:"privileges" tf:"optional"`
 }
 
 // An object containing map of key-value properties attached to the connection.
@@ -3214,7 +3214,7 @@ type PropertiesKvPairs map[string]types.String
 
 // Status of an asynchronously provisioned resource.
 type ProvisioningInfo struct {
-	State ProvisioningInfoState `tfsdk:"state" tf:"optional"`
+	State types.String `tfsdk:"state" tf:"optional"`
 }
 
 type ProvisioningInfoState string
@@ -3336,7 +3336,7 @@ type SchemaInfo struct {
 	EffectivePredictiveOptimizationFlag *EffectivePredictiveOptimizationFlag `tfsdk:"effective_predictive_optimization_flag" tf:"optional"`
 	// Whether predictive optimization should be enabled for this object and
 	// objects under it.
-	EnablePredictiveOptimization EnablePredictiveOptimization `tfsdk:"enable_predictive_optimization" tf:"optional"`
+	EnablePredictiveOptimization types.String `tfsdk:"enable_predictive_optimization" tf:"optional"`
 	// Full name of schema, in form of __catalog_name__.__schema_name__.
 	FullName types.String `tfsdk:"full_name" tf:"optional"`
 	// Unique identifier of parent metastore.
@@ -3419,7 +3419,7 @@ type SetArtifactAllowlist struct {
 	// A list of allowed artifact match patterns.
 	ArtifactMatchers []ArtifactMatcher `tfsdk:"artifact_matchers" tf:""`
 	// The artifact type of the allowlist.
-	ArtifactType ArtifactType `tfsdk:"-" url:"-"`
+	ArtifactType types.String `tfsdk:"-" url:"-"`
 }
 
 type SetRegisteredModelAliasRequest struct {
@@ -3434,7 +3434,7 @@ type SetRegisteredModelAliasRequest struct {
 // Server-Side Encryption properties for clients communicating with AWS s3.
 type SseEncryptionDetails struct {
 	// The type of key encryption to use (affects headers from s3 client).
-	Algorithm SseEncryptionDetailsAlgorithm `tfsdk:"algorithm" tf:"optional"`
+	Algorithm types.String `tfsdk:"algorithm" tf:"optional"`
 	// When algorithm is **AWS_SSE_KMS** this field specifies the ARN of the SSE
 	// key to use.
 	AwsKmsKeyArn types.String `tfsdk:"aws_kms_key_arn" tf:"optional"`
@@ -3489,7 +3489,7 @@ type StorageCredentialInfo struct {
 	Id types.String `tfsdk:"id" tf:"optional"`
 	// Whether the current securable is accessible from all workspaces or a
 	// specific set of workspaces.
-	IsolationMode IsolationMode `tfsdk:"isolation_mode" tf:"optional"`
+	IsolationMode types.String `tfsdk:"isolation_mode" tf:"optional"`
 	// Unique identifier of parent metastore.
 	MetastoreId types.String `tfsdk:"metastore_id" tf:"optional"`
 	// The credential name. The name must be unique within the metastore.
@@ -3512,7 +3512,7 @@ type SystemSchemaInfo struct {
 	Schema types.String `tfsdk:"schema" tf:"optional"`
 	// The current state of enablement for the system schema. An empty string
 	// means the system schema is available and ready for opt-in.
-	State SystemSchemaInfoState `tfsdk:"state" tf:"optional"`
+	State types.String `tfsdk:"state" tf:"optional"`
 }
 
 // The current state of enablement for the system schema. An empty string means
@@ -3593,7 +3593,7 @@ type TableInfo struct {
 	// Unique ID of the Data Access Configuration to use with the table data.
 	DataAccessConfigurationId types.String `tfsdk:"data_access_configuration_id" tf:"optional"`
 	// Data source format
-	DataSourceFormat DataSourceFormat `tfsdk:"data_source_format" tf:"optional"`
+	DataSourceFormat types.String `tfsdk:"data_source_format" tf:"optional"`
 	// Time at which this table was deleted, in epoch milliseconds. Field is
 	// omitted if table is not deleted.
 	DeletedAt types.Int64 `tfsdk:"deleted_at" tf:"optional"`
@@ -3603,7 +3603,7 @@ type TableInfo struct {
 	EffectivePredictiveOptimizationFlag *EffectivePredictiveOptimizationFlag `tfsdk:"effective_predictive_optimization_flag" tf:"optional"`
 	// Whether predictive optimization should be enabled for this object and
 	// objects under it.
-	EnablePredictiveOptimization EnablePredictiveOptimization `tfsdk:"enable_predictive_optimization" tf:"optional"`
+	EnablePredictiveOptimization types.String `tfsdk:"enable_predictive_optimization" tf:"optional"`
 	// Encryption options that apply to clients connecting to cloud storage.
 	EncryptionDetails *EncryptionDetails `tfsdk:"encryption_details" tf:"optional"`
 	// Full name of table, in form of
@@ -3637,7 +3637,7 @@ type TableInfo struct {
 	// The unique identifier of the table.
 	TableId types.String `tfsdk:"table_id" tf:"optional"`
 
-	TableType TableType `tfsdk:"table_type" tf:"optional"`
+	TableType types.String `tfsdk:"table_type" tf:"optional"`
 	// Time at which this table was last modified, in epoch milliseconds.
 	UpdatedAt types.Int64 `tfsdk:"updated_at" tf:"optional"`
 	// Username of user who last modified the table.
@@ -3666,7 +3666,7 @@ type TableSummary struct {
 	// The full name of the table.
 	FullName types.String `tfsdk:"full_name" tf:"optional"`
 
-	TableType TableType `tfsdk:"table_type" tf:"optional"`
+	TableType types.String `tfsdk:"table_type" tf:"optional"`
 }
 
 type TableType string
@@ -3741,10 +3741,10 @@ type UpdateCatalog struct {
 	Comment types.String `tfsdk:"comment" tf:"optional"`
 	// Whether predictive optimization should be enabled for this object and
 	// objects under it.
-	EnablePredictiveOptimization EnablePredictiveOptimization `tfsdk:"enable_predictive_optimization" tf:"optional"`
+	EnablePredictiveOptimization types.String `tfsdk:"enable_predictive_optimization" tf:"optional"`
 	// Whether the current securable is accessible from all workspaces or a
 	// specific set of workspaces.
-	IsolationMode CatalogIsolationMode `tfsdk:"isolation_mode" tf:"optional"`
+	IsolationMode types.String `tfsdk:"isolation_mode" tf:"optional"`
 	// The name of the catalog.
 	Name types.String `tfsdk:"-" url:"-"`
 	// New name for the catalog.
@@ -3780,7 +3780,7 @@ type UpdateExternalLocation struct {
 	Force types.Bool `tfsdk:"force" tf:"optional"`
 	// Whether the current securable is accessible from all workspaces or a
 	// specific set of workspaces.
-	IsolationMode IsolationMode `tfsdk:"isolation_mode" tf:"optional"`
+	IsolationMode types.String `tfsdk:"isolation_mode" tf:"optional"`
 	// Name of the external location.
 	Name types.String `tfsdk:"-" url:"-"`
 	// New name for the external location.
@@ -3811,7 +3811,7 @@ type UpdateMetastore struct {
 	// The lifetime of delta sharing recipient token in seconds.
 	DeltaSharingRecipientTokenLifetimeInSeconds types.Int64 `tfsdk:"delta_sharing_recipient_token_lifetime_in_seconds" tf:"optional"`
 	// The scope of Delta Sharing enabled for the metastore.
-	DeltaSharingScope UpdateMetastoreDeltaSharingScope `tfsdk:"delta_sharing_scope" tf:"optional"`
+	DeltaSharingScope types.String `tfsdk:"delta_sharing_scope" tf:"optional"`
 	// Unique ID of the metastore.
 	Id types.String `tfsdk:"-" url:"-"`
 	// New name for the metastore.
@@ -3913,7 +3913,7 @@ type UpdatePermissions struct {
 	// Full name of securable.
 	FullName types.String `tfsdk:"-" url:"-"`
 	// Type of securable.
-	SecurableType SecurableType `tfsdk:"-" url:"-"`
+	SecurableType types.String `tfsdk:"-" url:"-"`
 }
 
 type UpdateRegisteredModelRequest struct {
@@ -3935,7 +3935,7 @@ type UpdateSchema struct {
 	Comment types.String `tfsdk:"comment" tf:"optional"`
 	// Whether predictive optimization should be enabled for this object and
 	// objects under it.
-	EnablePredictiveOptimization EnablePredictiveOptimization `tfsdk:"enable_predictive_optimization" tf:"optional"`
+	EnablePredictiveOptimization types.String `tfsdk:"enable_predictive_optimization" tf:"optional"`
 	// Full name of the schema.
 	FullName types.String `tfsdk:"-" url:"-"`
 	// New name for the schema.
@@ -3964,7 +3964,7 @@ type UpdateStorageCredential struct {
 	Force types.Bool `tfsdk:"force" tf:"optional"`
 	// Whether the current securable is accessible from all workspaces or a
 	// specific set of workspaces.
-	IsolationMode IsolationMode `tfsdk:"isolation_mode" tf:"optional"`
+	IsolationMode types.String `tfsdk:"isolation_mode" tf:"optional"`
 	// Name of the storage credential.
 	Name types.String `tfsdk:"-" url:"-"`
 	// New name for the storage credential.
@@ -4049,9 +4049,9 @@ type ValidationResult struct {
 	// Error message would exist when the result does not equal to **PASS**.
 	Message types.String `tfsdk:"message" tf:"optional"`
 	// The operation tested.
-	Operation ValidationResultOperation `tfsdk:"operation" tf:"optional"`
+	Operation types.String `tfsdk:"operation" tf:"optional"`
 	// The results of the tested operation.
-	Result ValidationResultResult `tfsdk:"result" tf:"optional"`
+	Result types.String `tfsdk:"result" tf:"optional"`
 }
 
 // The operation tested.
@@ -4154,7 +4154,7 @@ type VolumeInfo struct {
 	// The unique identifier of the volume
 	VolumeId types.String `tfsdk:"volume_id" tf:"optional"`
 
-	VolumeType VolumeType `tfsdk:"volume_type" tf:"optional"`
+	VolumeType types.String `tfsdk:"volume_type" tf:"optional"`
 }
 
 type VolumeType string
@@ -4185,7 +4185,7 @@ func (f *VolumeType) Type() string {
 }
 
 type WorkspaceBinding struct {
-	BindingType WorkspaceBindingBindingType `tfsdk:"binding_type" tf:"optional"`
+	BindingType types.String `tfsdk:"binding_type" tf:"optional"`
 
 	WorkspaceId types.Int64 `tfsdk:"workspace_id" tf:"optional"`
 }

--- a/service/compute_tf/model.go
+++ b/service/compute_tf/model.go
@@ -71,7 +71,7 @@ type AwsAttributes struct {
 	//
 	// Note: If `first_on_demand` is zero, this availability type will be used
 	// for the entire cluster.
-	Availability AwsAvailability `tfsdk:"availability" tf:"optional"`
+	Availability types.String `tfsdk:"availability" tf:"optional"`
 	// The number of volumes launched for each instance. Users can choose up to
 	// 10 volumes. This feature is only enabled for supported node types. Legacy
 	// node types cannot specify custom EBS volumes. For node types with no
@@ -102,7 +102,7 @@ type AwsAttributes struct {
 	// will be used.
 	EbsVolumeThroughput types.Int64 `tfsdk:"ebs_volume_throughput" tf:"optional"`
 	// The type of EBS volumes that will be launched with this cluster.
-	EbsVolumeType EbsVolumeType `tfsdk:"ebs_volume_type" tf:"optional"`
+	EbsVolumeType types.String `tfsdk:"ebs_volume_type" tf:"optional"`
 	// The first `first_on_demand` nodes of the cluster will be placed on
 	// on-demand instances. If this value is greater than 0, the cluster driver
 	// node in particular will be placed on an on-demand instance. If this value
@@ -190,7 +190,7 @@ type AzureAttributes struct {
 	// `first_on_demand` ones. Note: If `first_on_demand` is zero (which only
 	// happens on pool clusters), this availability type will be used for the
 	// entire cluster.
-	Availability AzureAvailability `tfsdk:"availability" tf:"optional"`
+	Availability types.String `tfsdk:"availability" tf:"optional"`
 	// The first `first_on_demand` nodes of the cluster will be placed on
 	// on-demand instances. This value should be greater than 0, to make sure
 	// the cluster driver node is placed on an on-demand instance. If this value
@@ -277,7 +277,7 @@ type CloneCluster struct {
 }
 
 type CloudProviderNodeInfo struct {
-	Status []CloudProviderNodeStatus `tfsdk:"status" tf:"optional"`
+	Status []types.String `tfsdk:"status" tf:"optional"`
 }
 
 type CloudProviderNodeStatus string
@@ -311,7 +311,7 @@ type ClusterAccessControlRequest struct {
 	// name of the group
 	GroupName types.String `tfsdk:"group_name" tf:"optional"`
 	// Permission level
-	PermissionLevel ClusterPermissionLevel `tfsdk:"permission_level" tf:"optional"`
+	PermissionLevel types.String `tfsdk:"permission_level" tf:"optional"`
 	// application ID of a service principal
 	ServicePrincipalName types.String `tfsdk:"service_principal_name" tf:"optional"`
 	// name of the user
@@ -385,7 +385,7 @@ type ClusterAttributes struct {
 	// `LEGACY_SINGLE_USER`: This mode is for users migrating from legacy
 	// Passthrough on standard clusters. * `LEGACY_SINGLE_USER_STANDARD`: This
 	// mode provides a way that doesn’t have UC nor passthrough enabled.
-	DataSecurityMode DataSecurityMode `tfsdk:"data_security_mode" tf:"optional"`
+	DataSecurityMode types.String `tfsdk:"data_security_mode" tf:"optional"`
 
 	DockerImage *DockerImage `tfsdk:"docker_image" tf:"optional"`
 	// The optional ID of the instance pool for the driver of the cluster
@@ -423,7 +423,7 @@ type ClusterAttributes struct {
 	PolicyId types.String `tfsdk:"policy_id" tf:"optional"`
 	// Decides which runtime engine to be use, e.g. Standard vs. Photon. If
 	// unspecified, the runtime engine is inferred from spark_version.
-	RuntimeEngine RuntimeEngine `tfsdk:"runtime_engine" tf:"optional"`
+	RuntimeEngine types.String `tfsdk:"runtime_engine" tf:"optional"`
 	// Single user name if data_security_mode is `SINGLE_USER`
 	SingleUserName types.String `tfsdk:"single_user_name" tf:"optional"`
 	// An object containing a set of optional, user-specified Spark
@@ -499,7 +499,7 @@ type ClusterDetails struct {
 	// Determines whether the cluster was created by a user through the UI,
 	// created by the Databricks Jobs Scheduler, or through an API request. This
 	// is the same as cluster_creator, but read only.
-	ClusterSource ClusterSource `tfsdk:"cluster_source" tf:"optional"`
+	ClusterSource types.String `tfsdk:"cluster_source" tf:"optional"`
 	// Creator user name. The field won't be included in the response if the
 	// user has already been deleted.
 	CreatorUserName types.String `tfsdk:"creator_user_name" tf:"optional"`
@@ -534,7 +534,7 @@ type ClusterDetails struct {
 	// `LEGACY_SINGLE_USER`: This mode is for users migrating from legacy
 	// Passthrough on standard clusters. * `LEGACY_SINGLE_USER_STANDARD`: This
 	// mode provides a way that doesn’t have UC nor passthrough enabled.
-	DataSecurityMode DataSecurityMode `tfsdk:"data_security_mode" tf:"optional"`
+	DataSecurityMode types.String `tfsdk:"data_security_mode" tf:"optional"`
 	// Tags that are added by Databricks regardless of any `custom_tags`,
 	// including:
 	//
@@ -610,7 +610,7 @@ type ClusterDetails struct {
 	PolicyId types.String `tfsdk:"policy_id" tf:"optional"`
 	// Decides which runtime engine to be use, e.g. Standard vs. Photon. If
 	// unspecified, the runtime engine is inferred from spark_version.
-	RuntimeEngine RuntimeEngine `tfsdk:"runtime_engine" tf:"optional"`
+	RuntimeEngine types.String `tfsdk:"runtime_engine" tf:"optional"`
 	// Single user name if data_security_mode is `SINGLE_USER`
 	SingleUserName types.String `tfsdk:"single_user_name" tf:"optional"`
 	// An object containing a set of optional, user-specified Spark
@@ -654,7 +654,7 @@ type ClusterDetails struct {
 	// received (when the cluster entered a `PENDING` state).
 	StartTime types.Int64 `tfsdk:"start_time" tf:"optional"`
 	// Current state of the cluster.
-	State State `tfsdk:"state" tf:"optional"`
+	State types.String `tfsdk:"state" tf:"optional"`
 	// A message associated with the most recent state transition (e.g., the
 	// reason why the cluster entered a `TERMINATED` state).
 	StateMessage types.String `tfsdk:"state_message" tf:"optional"`
@@ -680,7 +680,7 @@ type ClusterEvent struct {
 	// by the Timeline service.
 	Timestamp types.Int64 `tfsdk:"timestamp" tf:"optional"`
 
-	Type EventType `tfsdk:"type" tf:"optional"`
+	Type types.String `tfsdk:"type" tf:"optional"`
 }
 
 type ClusterLibraryStatuses struct {
@@ -707,7 +707,7 @@ type ClusterPermission struct {
 
 	InheritedFromObject []types.String `tfsdk:"inherited_from_object" tf:"optional"`
 	// Permission level
-	PermissionLevel ClusterPermissionLevel `tfsdk:"permission_level" tf:"optional"`
+	PermissionLevel types.String `tfsdk:"permission_level" tf:"optional"`
 }
 
 // Permission level
@@ -751,7 +751,7 @@ type ClusterPermissions struct {
 type ClusterPermissionsDescription struct {
 	Description types.String `tfsdk:"description" tf:"optional"`
 	// Permission level
-	PermissionLevel ClusterPermissionLevel `tfsdk:"permission_level" tf:"optional"`
+	PermissionLevel types.String `tfsdk:"permission_level" tf:"optional"`
 }
 
 type ClusterPermissionsRequest struct {
@@ -764,7 +764,7 @@ type ClusterPolicyAccessControlRequest struct {
 	// name of the group
 	GroupName types.String `tfsdk:"group_name" tf:"optional"`
 	// Permission level
-	PermissionLevel ClusterPolicyPermissionLevel `tfsdk:"permission_level" tf:"optional"`
+	PermissionLevel types.String `tfsdk:"permission_level" tf:"optional"`
 	// application ID of a service principal
 	ServicePrincipalName types.String `tfsdk:"service_principal_name" tf:"optional"`
 	// name of the user
@@ -789,7 +789,7 @@ type ClusterPolicyPermission struct {
 
 	InheritedFromObject []types.String `tfsdk:"inherited_from_object" tf:"optional"`
 	// Permission level
-	PermissionLevel ClusterPolicyPermissionLevel `tfsdk:"permission_level" tf:"optional"`
+	PermissionLevel types.String `tfsdk:"permission_level" tf:"optional"`
 }
 
 // Permission level
@@ -829,7 +829,7 @@ type ClusterPolicyPermissions struct {
 type ClusterPolicyPermissionsDescription struct {
 	Description types.String `tfsdk:"description" tf:"optional"`
 	// Permission level
-	PermissionLevel ClusterPolicyPermissionLevel `tfsdk:"permission_level" tf:"optional"`
+	PermissionLevel types.String `tfsdk:"permission_level" tf:"optional"`
 }
 
 type ClusterPolicyPermissionsRequest struct {
@@ -958,7 +958,7 @@ type ClusterSpec struct {
 	// `LEGACY_SINGLE_USER`: This mode is for users migrating from legacy
 	// Passthrough on standard clusters. * `LEGACY_SINGLE_USER_STANDARD`: This
 	// mode provides a way that doesn’t have UC nor passthrough enabled.
-	DataSecurityMode DataSecurityMode `tfsdk:"data_security_mode" tf:"optional"`
+	DataSecurityMode types.String `tfsdk:"data_security_mode" tf:"optional"`
 
 	DockerImage *DockerImage `tfsdk:"docker_image" tf:"optional"`
 	// The optional ID of the instance pool for the driver of the cluster
@@ -1007,7 +1007,7 @@ type ClusterSpec struct {
 	PolicyId types.String `tfsdk:"policy_id" tf:"optional"`
 	// Decides which runtime engine to be use, e.g. Standard vs. Photon. If
 	// unspecified, the runtime engine is inferred from spark_version.
-	RuntimeEngine RuntimeEngine `tfsdk:"runtime_engine" tf:"optional"`
+	RuntimeEngine types.String `tfsdk:"runtime_engine" tf:"optional"`
 	// Single user name if data_security_mode is `SINGLE_USER`
 	SingleUserName types.String `tfsdk:"single_user_name" tf:"optional"`
 	// An object containing a set of optional, user-specified Spark
@@ -1056,7 +1056,7 @@ type Command struct {
 	// Running context id
 	ContextId types.String `tfsdk:"contextId" tf:"optional"`
 
-	Language Language `tfsdk:"language" tf:"optional"`
+	Language types.String `tfsdk:"language" tf:"optional"`
 }
 
 type CommandStatus string
@@ -1108,7 +1108,7 @@ type CommandStatusResponse struct {
 
 	Results *Results `tfsdk:"results" tf:"optional"`
 
-	Status CommandStatus `tfsdk:"status" tf:"optional"`
+	Status types.String `tfsdk:"status" tf:"optional"`
 }
 
 type ContextStatus string
@@ -1150,7 +1150,7 @@ type ContextStatusRequest struct {
 type ContextStatusResponse struct {
 	Id types.String `tfsdk:"id" tf:"optional"`
 
-	Status ContextStatus `tfsdk:"status" tf:"optional"`
+	Status types.String `tfsdk:"status" tf:"optional"`
 }
 
 type CreateCluster struct {
@@ -1218,7 +1218,7 @@ type CreateCluster struct {
 	// `LEGACY_SINGLE_USER`: This mode is for users migrating from legacy
 	// Passthrough on standard clusters. * `LEGACY_SINGLE_USER_STANDARD`: This
 	// mode provides a way that doesn’t have UC nor passthrough enabled.
-	DataSecurityMode DataSecurityMode `tfsdk:"data_security_mode" tf:"optional"`
+	DataSecurityMode types.String `tfsdk:"data_security_mode" tf:"optional"`
 
 	DockerImage *DockerImage `tfsdk:"docker_image" tf:"optional"`
 	// The optional ID of the instance pool for the driver of the cluster
@@ -1267,7 +1267,7 @@ type CreateCluster struct {
 	PolicyId types.String `tfsdk:"policy_id" tf:"optional"`
 	// Decides which runtime engine to be use, e.g. Standard vs. Photon. If
 	// unspecified, the runtime engine is inferred from spark_version.
-	RuntimeEngine RuntimeEngine `tfsdk:"runtime_engine" tf:"optional"`
+	RuntimeEngine types.String `tfsdk:"runtime_engine" tf:"optional"`
 	// Single user name if data_security_mode is `SINGLE_USER`
 	SingleUserName types.String `tfsdk:"single_user_name" tf:"optional"`
 	// An object containing a set of optional, user-specified Spark
@@ -1310,7 +1310,7 @@ type CreateContext struct {
 	// Running cluster id
 	ClusterId types.String `tfsdk:"clusterId" tf:"optional"`
 
-	Language Language `tfsdk:"language" tf:"optional"`
+	Language types.String `tfsdk:"language" tf:"optional"`
 }
 
 type CreateInstancePool struct {
@@ -1427,7 +1427,7 @@ type Created struct {
 
 type DataPlaneEventDetails struct {
 	// <needs content added>
-	EventType DataPlaneEventDetailsEventType `tfsdk:"event_type" tf:"optional"`
+	EventType types.String `tfsdk:"event_type" tf:"optional"`
 	// <needs content added>
 	ExecutorFailures types.Int64 `tfsdk:"executor_failures" tf:"optional"`
 	// <needs content added>
@@ -1621,9 +1621,9 @@ type DiskSpec struct {
 }
 
 type DiskType struct {
-	AzureDiskVolumeType DiskTypeAzureDiskVolumeType `tfsdk:"azure_disk_volume_type" tf:"optional"`
+	AzureDiskVolumeType types.String `tfsdk:"azure_disk_volume_type" tf:"optional"`
 
-	EbsVolumeType DiskTypeEbsVolumeType `tfsdk:"ebs_volume_type" tf:"optional"`
+	EbsVolumeType types.String `tfsdk:"ebs_volume_type" tf:"optional"`
 }
 
 type DiskTypeAzureDiskVolumeType string
@@ -1785,7 +1785,7 @@ type EditCluster struct {
 	// `LEGACY_SINGLE_USER`: This mode is for users migrating from legacy
 	// Passthrough on standard clusters. * `LEGACY_SINGLE_USER_STANDARD`: This
 	// mode provides a way that doesn’t have UC nor passthrough enabled.
-	DataSecurityMode DataSecurityMode `tfsdk:"data_security_mode" tf:"optional"`
+	DataSecurityMode types.String `tfsdk:"data_security_mode" tf:"optional"`
 
 	DockerImage *DockerImage `tfsdk:"docker_image" tf:"optional"`
 	// The optional ID of the instance pool for the driver of the cluster
@@ -1834,7 +1834,7 @@ type EditCluster struct {
 	PolicyId types.String `tfsdk:"policy_id" tf:"optional"`
 	// Decides which runtime engine to be use, e.g. Standard vs. Photon. If
 	// unspecified, the runtime engine is inferred from spark_version.
-	RuntimeEngine RuntimeEngine `tfsdk:"runtime_engine" tf:"optional"`
+	RuntimeEngine types.String `tfsdk:"runtime_engine" tf:"optional"`
 	// Single user name if data_security_mode is `SINGLE_USER`
 	SingleUserName types.String `tfsdk:"single_user_name" tf:"optional"`
 	// An object containing a set of optional, user-specified Spark
@@ -1976,7 +1976,7 @@ type EventDetails struct {
 	// clusters, the new attributes of the cluster.
 	Attributes *ClusterAttributes `tfsdk:"attributes" tf:"optional"`
 	// The cause of a change in target size.
-	Cause EventDetailsCause `tfsdk:"cause" tf:"optional"`
+	Cause types.String `tfsdk:"cause" tf:"optional"`
 	// The actual cluster size that was set in the cluster creation or edit.
 	ClusterSize *ClusterSize `tfsdk:"cluster_size" tf:"optional"`
 	// The current number of vCPUs in the cluster.
@@ -2131,7 +2131,7 @@ type GcpAttributes struct {
 	// This field determines whether the instance pool will contain preemptible
 	// VMs, on-demand VMs, or preemptible VMs with a fallback to on-demand VMs
 	// if the former is unavailable.
-	Availability GcpAvailability `tfsdk:"availability" tf:"optional"`
+	Availability types.String `tfsdk:"availability" tf:"optional"`
 	// boot disk size in GB
 	BootDiskSize types.Int64 `tfsdk:"boot_disk_size" tf:"optional"`
 	// If provided, the cluster will impersonate the google service account when
@@ -2252,7 +2252,7 @@ type GetEvents struct {
 	EndTime types.Int64 `tfsdk:"end_time" tf:"optional"`
 	// An optional set of event types to filter on. If empty, all event types
 	// are returned.
-	EventTypes []EventType `tfsdk:"event_types" tf:"optional"`
+	EventTypes []types.String `tfsdk:"event_types" tf:"optional"`
 	// The maximum number of events to include in a page of events. Defaults to
 	// 50, and maximum allowed value is 500.
 	Limit types.Int64 `tfsdk:"limit" tf:"optional"`
@@ -2261,7 +2261,7 @@ type GetEvents struct {
 	// end_time field is required.
 	Offset types.Int64 `tfsdk:"offset" tf:"optional"`
 	// The order to list events in; either "ASC" or "DESC". Defaults to "DESC".
-	Order GetEventsOrder `tfsdk:"order" tf:"optional"`
+	Order types.String `tfsdk:"order" tf:"optional"`
 	// The start time in epoch milliseconds. If empty, returns events starting
 	// from the beginning of time.
 	StartTime types.Int64 `tfsdk:"start_time" tf:"optional"`
@@ -2381,7 +2381,7 @@ type GetInstancePool struct {
 	// :method:clusters/sparkVersions API call.
 	PreloadedSparkVersions []types.String `tfsdk:"preloaded_spark_versions" tf:"optional"`
 	// Current state of the instance pool.
-	State InstancePoolState `tfsdk:"state" tf:"optional"`
+	State types.String `tfsdk:"state" tf:"optional"`
 	// Usage statistics about the instance pool.
 	Stats *InstancePoolStats `tfsdk:"stats" tf:"optional"`
 	// Status of failed pending instances in the pool.
@@ -2527,7 +2527,7 @@ type InitScriptExecutionDetails struct {
 	// The duration of the script execution in seconds.
 	ExecutionDurationSeconds types.Int64 `tfsdk:"execution_duration_seconds" tf:"optional"`
 	// The current status of the script
-	Status InitScriptExecutionDetailsStatus `tfsdk:"status" tf:"optional"`
+	Status types.String `tfsdk:"status" tf:"optional"`
 }
 
 // The current status of the script
@@ -2615,7 +2615,7 @@ type InstancePoolAccessControlRequest struct {
 	// name of the group
 	GroupName types.String `tfsdk:"group_name" tf:"optional"`
 	// Permission level
-	PermissionLevel InstancePoolPermissionLevel `tfsdk:"permission_level" tf:"optional"`
+	PermissionLevel types.String `tfsdk:"permission_level" tf:"optional"`
 	// application ID of a service principal
 	ServicePrincipalName types.String `tfsdk:"service_principal_name" tf:"optional"`
 	// name of the user
@@ -2704,7 +2704,7 @@ type InstancePoolAndStats struct {
 	// :method:clusters/sparkVersions API call.
 	PreloadedSparkVersions []types.String `tfsdk:"preloaded_spark_versions" tf:"optional"`
 	// Current state of the instance pool.
-	State InstancePoolState `tfsdk:"state" tf:"optional"`
+	State types.String `tfsdk:"state" tf:"optional"`
 	// Usage statistics about the instance pool.
 	Stats *InstancePoolStats `tfsdk:"stats" tf:"optional"`
 	// Status of failed pending instances in the pool.
@@ -2716,7 +2716,7 @@ type InstancePoolAwsAttributes struct {
 	//
 	// The default value is defined by
 	// InstancePoolConf.instancePoolDefaultAwsAvailability
-	Availability InstancePoolAwsAttributesAvailability `tfsdk:"availability" tf:"optional"`
+	Availability types.String `tfsdk:"availability" tf:"optional"`
 	// Calculates the bid price for AWS spot instances, as a percentage of the
 	// corresponding instance type's on-demand price. For example, if this field
 	// is set to 50, and the cluster needs a new `r3.xlarge` spot instance, then
@@ -2779,7 +2779,7 @@ type InstancePoolAzureAttributes struct {
 	//
 	// The default value is defined by
 	// InstancePoolConf.instancePoolDefaultAzureAvailability
-	Availability InstancePoolAzureAttributesAvailability `tfsdk:"availability" tf:"optional"`
+	Availability types.String `tfsdk:"availability" tf:"optional"`
 	// The default value and documentation here should be kept consistent with
 	// CommonConf.defaultSpotBidMaxPrice.
 	SpotBidMaxPrice types.Float64 `tfsdk:"spot_bid_max_price" tf:"optional"`
@@ -2820,7 +2820,7 @@ type InstancePoolGcpAttributes struct {
 	// This field determines whether the instance pool will contain preemptible
 	// VMs, on-demand VMs, or preemptible VMs with a fallback to on-demand VMs
 	// if the former is unavailable.
-	GcpAvailability GcpAvailability `tfsdk:"gcp_availability" tf:"optional"`
+	GcpAvailability types.String `tfsdk:"gcp_availability" tf:"optional"`
 	// If provided, each node in the instance pool will have this number of
 	// local SSDs attached. Each local SSD is 375GB in size. Refer to [GCP
 	// documentation] for the supported number of local SSDs for each instance
@@ -2852,7 +2852,7 @@ type InstancePoolPermission struct {
 
 	InheritedFromObject []types.String `tfsdk:"inherited_from_object" tf:"optional"`
 	// Permission level
-	PermissionLevel InstancePoolPermissionLevel `tfsdk:"permission_level" tf:"optional"`
+	PermissionLevel types.String `tfsdk:"permission_level" tf:"optional"`
 }
 
 // Permission level
@@ -2894,7 +2894,7 @@ type InstancePoolPermissions struct {
 type InstancePoolPermissionsDescription struct {
 	Description types.String `tfsdk:"description" tf:"optional"`
 	// Permission level
-	PermissionLevel InstancePoolPermissionLevel `tfsdk:"permission_level" tf:"optional"`
+	PermissionLevel types.String `tfsdk:"permission_level" tf:"optional"`
 }
 
 type InstancePoolPermissionsRequest struct {
@@ -3053,7 +3053,7 @@ type LibraryFullStatus struct {
 	// library.
 	Messages []types.String `tfsdk:"messages" tf:"optional"`
 	// Status of installing the library on the cluster.
-	Status LibraryInstallStatus `tfsdk:"status" tf:"optional"`
+	Status types.String `tfsdk:"status" tf:"optional"`
 }
 
 // The status of a library on a specific cluster.
@@ -3114,10 +3114,10 @@ type ListClusterPoliciesRequest struct {
 	// The cluster policy attribute to sort by. * `POLICY_CREATION_TIME` - Sort
 	// result list by policy creation time. * `POLICY_NAME` - Sort result list
 	// by policy name.
-	SortColumn ListSortColumn `tfsdk:"-" url:"sort_column,omitempty"`
+	SortColumn types.String `tfsdk:"-" url:"sort_column,omitempty"`
 	// The order in which the policies get listed. * `DESC` - Sort result list
 	// in descending order. * `ASC` - Sort result list in ascending order.
-	SortOrder ListSortOrder `tfsdk:"-" url:"sort_order,omitempty"`
+	SortOrder types.String `tfsdk:"-" url:"sort_order,omitempty"`
 }
 
 // List all clusters
@@ -3509,7 +3509,7 @@ type Results struct {
 	// internal field used by SDK
 	Pos types.Int64 `tfsdk:"pos" tf:"optional"`
 
-	ResultType ResultType `tfsdk:"resultType" tf:"optional"`
+	ResultType types.String `tfsdk:"resultType" tf:"optional"`
 	// The table schema
 	Schema []map[string]any `tfsdk:"schema" tf:"optional"`
 	// The summary of the error
@@ -3676,12 +3676,12 @@ func (f *State) Type() string {
 
 type TerminationReason struct {
 	// status code indicating why the cluster was terminated
-	Code TerminationReasonCode `tfsdk:"code" tf:"optional"`
+	Code types.String `tfsdk:"code" tf:"optional"`
 	// list of parameters that provide additional information about why the
 	// cluster was terminated
 	Parameters map[string]types.String `tfsdk:"parameters" tf:"optional"`
 	// type of the termination
-	Type TerminationReasonType `tfsdk:"type" tf:"optional"`
+	Type types.String `tfsdk:"type" tf:"optional"`
 }
 
 // status code indicating why the cluster was terminated

--- a/service/dashboards_tf/model.go
+++ b/service/dashboards_tf/model.go
@@ -37,7 +37,7 @@ type CreateScheduleRequest struct {
 	// The display name for schedule.
 	DisplayName types.String `tfsdk:"display_name" tf:"optional"`
 	// The status indicates whether this schedule is paused or not.
-	PauseStatus SchedulePauseStatus `tfsdk:"pause_status" tf:"optional"`
+	PauseStatus types.String `tfsdk:"pause_status" tf:"optional"`
 }
 
 type CreateSubscriptionRequest struct {
@@ -74,7 +74,7 @@ type Dashboard struct {
 	// ensure that the dashboard has not been modified since the last read.
 	Etag types.String `tfsdk:"etag" tf:"optional"`
 	// The state of the dashboard resource. Used for tracking trashed status.
-	LifecycleState LifecycleState `tfsdk:"lifecycle_state" tf:"optional"`
+	LifecycleState types.String `tfsdk:"lifecycle_state" tf:"optional"`
 	// The workspace path of the folder containing the dashboard. Includes
 	// leading slash and no trailing slash.
 	ParentPath types.String `tfsdk:"parent_path" tf:"optional"`
@@ -215,7 +215,7 @@ type ListDashboardsRequest struct {
 	// Indicates whether to include all metadata from the dashboard in the
 	// response. If unset, the response defaults to `DASHBOARD_VIEW_BASIC` which
 	// only includes summary metadata from the dashboard.
-	View DashboardView `tfsdk:"-" url:"view,omitempty"`
+	View types.String `tfsdk:"-" url:"view,omitempty"`
 }
 
 type ListDashboardsResponse struct {
@@ -315,7 +315,7 @@ type Schedule struct {
 	// last read, and can be optionally provided on delete.
 	Etag types.String `tfsdk:"etag" tf:"optional"`
 	// The status indicates whether this schedule is paused or not.
-	PauseStatus SchedulePauseStatus `tfsdk:"pause_status" tf:"optional"`
+	PauseStatus types.String `tfsdk:"pause_status" tf:"optional"`
 	// UUID identifying the schedule.
 	ScheduleId types.String `tfsdk:"schedule_id" tf:"optional"`
 	// A timestamp indicating when the schedule was last updated.
@@ -437,7 +437,7 @@ type UpdateScheduleRequest struct {
 	// last read, and can be optionally provided on delete.
 	Etag types.String `tfsdk:"etag" tf:"optional"`
 	// The status indicates whether this schedule is paused or not.
-	PauseStatus SchedulePauseStatus `tfsdk:"pause_status" tf:"optional"`
+	PauseStatus types.String `tfsdk:"pause_status" tf:"optional"`
 	// UUID identifying the schedule.
 	ScheduleId types.String `tfsdk:"-" url:"-"`
 }

--- a/service/iam_tf/model.go
+++ b/service/iam_tf/model.go
@@ -20,7 +20,7 @@ type AccessControlRequest struct {
 	// name of the group
 	GroupName types.String `tfsdk:"group_name" tf:"optional"`
 	// Permission level
-	PermissionLevel PermissionLevel `tfsdk:"permission_level" tf:"optional"`
+	PermissionLevel types.String `tfsdk:"permission_level" tf:"optional"`
 	// application ID of a service principal
 	ServicePrincipalName types.String `tfsdk:"service_principal_name" tf:"optional"`
 	// name of the user
@@ -136,7 +136,7 @@ type GetAccountUserRequest struct {
 	// example, `userName`, `name.givenName`, and `emails`.
 	SortBy types.String `tfsdk:"-" url:"sortBy,omitempty"`
 	// The order to sort the results.
-	SortOrder GetSortOrder `tfsdk:"-" url:"sortOrder,omitempty"`
+	SortOrder types.String `tfsdk:"-" url:"sortOrder,omitempty"`
 	// Specifies the index of the first result. First item is number 1.
 	StartIndex types.Int64 `tfsdk:"-" url:"startIndex,omitempty"`
 }
@@ -256,7 +256,7 @@ type GetUserRequest struct {
 	// example, `userName`, `name.givenName`, and `emails`.
 	SortBy types.String `tfsdk:"-" url:"sortBy,omitempty"`
 	// The order to sort the results.
-	SortOrder GetSortOrder `tfsdk:"-" url:"sortOrder,omitempty"`
+	SortOrder types.String `tfsdk:"-" url:"sortOrder,omitempty"`
 	// Specifies the index of the first result. First item is number 1.
 	StartIndex types.Int64 `tfsdk:"-" url:"startIndex,omitempty"`
 }
@@ -295,7 +295,7 @@ type Group struct {
 	// Corresponds to AWS instance profile/arn role.
 	Roles []ComplexValue `tfsdk:"roles" tf:"optional"`
 	// The schema of the group.
-	Schemas []GroupSchema `tfsdk:"schemas" tf:"optional"`
+	Schemas []types.String `tfsdk:"schemas" tf:"optional"`
 }
 
 type GroupSchema string
@@ -342,7 +342,7 @@ type ListAccountGroupsRequest struct {
 	// Attribute to sort the results.
 	SortBy types.String `tfsdk:"-" url:"sortBy,omitempty"`
 	// The order to sort the results.
-	SortOrder ListSortOrder `tfsdk:"-" url:"sortOrder,omitempty"`
+	SortOrder types.String `tfsdk:"-" url:"sortOrder,omitempty"`
 	// Specifies the index of the first result. First item is number 1.
 	StartIndex types.Int64 `tfsdk:"-" url:"startIndex,omitempty"`
 }
@@ -366,7 +366,7 @@ type ListAccountServicePrincipalsRequest struct {
 	// Attribute to sort the results.
 	SortBy types.String `tfsdk:"-" url:"sortBy,omitempty"`
 	// The order to sort the results.
-	SortOrder ListSortOrder `tfsdk:"-" url:"sortOrder,omitempty"`
+	SortOrder types.String `tfsdk:"-" url:"sortOrder,omitempty"`
 	// Specifies the index of the first result. First item is number 1.
 	StartIndex types.Int64 `tfsdk:"-" url:"startIndex,omitempty"`
 }
@@ -391,7 +391,7 @@ type ListAccountUsersRequest struct {
 	// example, `userName`, `name.givenName`, and `emails`.
 	SortBy types.String `tfsdk:"-" url:"sortBy,omitempty"`
 	// The order to sort the results.
-	SortOrder ListSortOrder `tfsdk:"-" url:"sortOrder,omitempty"`
+	SortOrder types.String `tfsdk:"-" url:"sortOrder,omitempty"`
 	// Specifies the index of the first result. First item is number 1.
 	StartIndex types.Int64 `tfsdk:"-" url:"startIndex,omitempty"`
 }
@@ -415,7 +415,7 @@ type ListGroupsRequest struct {
 	// Attribute to sort the results.
 	SortBy types.String `tfsdk:"-" url:"sortBy,omitempty"`
 	// The order to sort the results.
-	SortOrder ListSortOrder `tfsdk:"-" url:"sortOrder,omitempty"`
+	SortOrder types.String `tfsdk:"-" url:"sortOrder,omitempty"`
 	// Specifies the index of the first result. First item is number 1.
 	StartIndex types.Int64 `tfsdk:"-" url:"startIndex,omitempty"`
 }
@@ -426,7 +426,7 @@ type ListGroupsResponse struct {
 	// User objects returned in the response.
 	Resources []Group `tfsdk:"Resources" tf:"optional"`
 	// The schema of the service principal.
-	Schemas []ListResponseSchema `tfsdk:"schemas" tf:"optional"`
+	Schemas []types.String `tfsdk:"schemas" tf:"optional"`
 	// Starting index of all the results that matched the request filters. First
 	// item is number 1.
 	StartIndex types.Int64 `tfsdk:"startIndex" tf:"optional"`
@@ -465,7 +465,7 @@ type ListServicePrincipalResponse struct {
 	// User objects returned in the response.
 	Resources []ServicePrincipal `tfsdk:"Resources" tf:"optional"`
 	// The schema of the List response.
-	Schemas []ListResponseSchema `tfsdk:"schemas" tf:"optional"`
+	Schemas []types.String `tfsdk:"schemas" tf:"optional"`
 	// Starting index of all the results that matched the request filters. First
 	// item is number 1.
 	StartIndex types.Int64 `tfsdk:"startIndex" tf:"optional"`
@@ -492,7 +492,7 @@ type ListServicePrincipalsRequest struct {
 	// Attribute to sort the results.
 	SortBy types.String `tfsdk:"-" url:"sortBy,omitempty"`
 	// The order to sort the results.
-	SortOrder ListSortOrder `tfsdk:"-" url:"sortOrder,omitempty"`
+	SortOrder types.String `tfsdk:"-" url:"sortOrder,omitempty"`
 	// Specifies the index of the first result. First item is number 1.
 	StartIndex types.Int64 `tfsdk:"-" url:"startIndex,omitempty"`
 }
@@ -544,7 +544,7 @@ type ListUsersRequest struct {
 	// example, `userName`, `name.givenName`, and `emails`.
 	SortBy types.String `tfsdk:"-" url:"sortBy,omitempty"`
 	// The order to sort the results.
-	SortOrder ListSortOrder `tfsdk:"-" url:"sortOrder,omitempty"`
+	SortOrder types.String `tfsdk:"-" url:"sortOrder,omitempty"`
 	// Specifies the index of the first result. First item is number 1.
 	StartIndex types.Int64 `tfsdk:"-" url:"startIndex,omitempty"`
 }
@@ -555,7 +555,7 @@ type ListUsersResponse struct {
 	// User objects returned in the response.
 	Resources []User `tfsdk:"Resources" tf:"optional"`
 	// The schema of the List response.
-	Schemas []ListResponseSchema `tfsdk:"schemas" tf:"optional"`
+	Schemas []types.String `tfsdk:"schemas" tf:"optional"`
 	// Starting index of all the results that matched the request filters. First
 	// item is number 1.
 	StartIndex types.Int64 `tfsdk:"startIndex" tf:"optional"`
@@ -591,14 +591,14 @@ type PartialUpdate struct {
 	Operations []Patch `tfsdk:"Operations" tf:"optional"`
 	// The schema of the patch request. Must be
 	// ["urn:ietf:params:scim:api:messages:2.0:PatchOp"].
-	Schemas []PatchSchema `tfsdk:"schemas" tf:"optional"`
+	Schemas []types.String `tfsdk:"schemas" tf:"optional"`
 }
 
 type PasswordAccessControlRequest struct {
 	// name of the group
 	GroupName types.String `tfsdk:"group_name" tf:"optional"`
 	// Permission level
-	PermissionLevel PasswordPermissionLevel `tfsdk:"permission_level" tf:"optional"`
+	PermissionLevel types.String `tfsdk:"permission_level" tf:"optional"`
 	// application ID of a service principal
 	ServicePrincipalName types.String `tfsdk:"service_principal_name" tf:"optional"`
 	// name of the user
@@ -623,7 +623,7 @@ type PasswordPermission struct {
 
 	InheritedFromObject []types.String `tfsdk:"inherited_from_object" tf:"optional"`
 	// Permission level
-	PermissionLevel PasswordPermissionLevel `tfsdk:"permission_level" tf:"optional"`
+	PermissionLevel types.String `tfsdk:"permission_level" tf:"optional"`
 }
 
 // Permission level
@@ -663,7 +663,7 @@ type PasswordPermissions struct {
 type PasswordPermissionsDescription struct {
 	Description types.String `tfsdk:"description" tf:"optional"`
 	// Permission level
-	PermissionLevel PasswordPermissionLevel `tfsdk:"permission_level" tf:"optional"`
+	PermissionLevel types.String `tfsdk:"permission_level" tf:"optional"`
 }
 
 type PasswordPermissionsRequest struct {
@@ -672,7 +672,7 @@ type PasswordPermissionsRequest struct {
 
 type Patch struct {
 	// Type of patch operation.
-	Op PatchOp `tfsdk:"op" tf:"optional"`
+	Op types.String `tfsdk:"op" tf:"optional"`
 	// Selection of patch operation
 	Path types.String `tfsdk:"path" tf:"optional"`
 	// Value to modify
@@ -742,14 +742,14 @@ type Permission struct {
 
 	InheritedFromObject []types.String `tfsdk:"inherited_from_object" tf:"optional"`
 	// Permission level
-	PermissionLevel PermissionLevel `tfsdk:"permission_level" tf:"optional"`
+	PermissionLevel types.String `tfsdk:"permission_level" tf:"optional"`
 }
 
 type PermissionAssignment struct {
 	// Error response associated with a workspace permission assignment, if any.
 	Error types.String `tfsdk:"error" tf:"optional"`
 	// The permissions level of the principal.
-	Permissions []WorkspacePermission `tfsdk:"permissions" tf:"optional"`
+	Permissions []types.String `tfsdk:"permissions" tf:"optional"`
 	// Information about the principal assigned to the workspace.
 	Principal *PrincipalOutput `tfsdk:"principal" tf:"optional"`
 }
@@ -837,13 +837,13 @@ type PermissionOutput struct {
 	// The results of a permissions query.
 	Description types.String `tfsdk:"description" tf:"optional"`
 
-	PermissionLevel WorkspacePermission `tfsdk:"permission_level" tf:"optional"`
+	PermissionLevel types.String `tfsdk:"permission_level" tf:"optional"`
 }
 
 type PermissionsDescription struct {
 	Description types.String `tfsdk:"description" tf:"optional"`
 	// Permission level
-	PermissionLevel PermissionLevel `tfsdk:"permission_level" tf:"optional"`
+	PermissionLevel types.String `tfsdk:"permission_level" tf:"optional"`
 }
 
 type PermissionsRequest struct {
@@ -923,7 +923,7 @@ type ServicePrincipal struct {
 	// Corresponds to AWS instance profile/arn role.
 	Roles []ComplexValue `tfsdk:"roles" tf:"optional"`
 	// The schema of the List response.
-	Schemas []ServicePrincipalSchema `tfsdk:"schemas" tf:"optional"`
+	Schemas []types.String `tfsdk:"schemas" tf:"optional"`
 }
 
 type ServicePrincipalSchema string
@@ -965,7 +965,7 @@ type UpdateWorkspaceAssignments struct {
 	// Array of permissions assignments to update on the workspace. Note that
 	// excluding this field will have the same effect as providing an empty list
 	// which will result in the deletion of all permissions for the principal.
-	Permissions []WorkspacePermission `tfsdk:"permissions" tf:""`
+	Permissions []types.String `tfsdk:"permissions" tf:""`
 	// The ID of the user, service principal, or group.
 	PrincipalId types.Int64 `tfsdk:"-" url:"-"`
 	// The workspace ID.
@@ -995,13 +995,13 @@ type User struct {
 	Groups []ComplexValue `tfsdk:"groups" tf:"optional"`
 	// Databricks user ID. This is automatically set by Databricks. Any value
 	// provided by the client will be ignored.
-	Id types.String `tfsdk:"id" tf:"optional"`
+	Id types.String `tfsdk:"id" tf:"optional" url:"-"`
 
 	Name *Name `tfsdk:"name" tf:"optional"`
 	// Corresponds to AWS instance profile/arn role.
 	Roles []ComplexValue `tfsdk:"roles" tf:"optional"`
 	// The schema of the user.
-	Schemas []UserSchema `tfsdk:"schemas" tf:"optional"`
+	Schemas []types.String `tfsdk:"schemas" tf:"optional"`
 	// Email address of the Databricks user.
 	UserName types.String `tfsdk:"userName" tf:"optional"`
 }

--- a/service/jobs_tf/model.go
+++ b/service/jobs_tf/model.go
@@ -118,7 +118,7 @@ type BaseRun struct {
 	// :method:jobs/submit.
 	//
 	// [dbutils.notebook.run]: https://docs.databricks.com/dev-tools/databricks-utils.html#dbutils-workflow
-	RunType RunType `tfsdk:"run_type" tf:"optional"`
+	RunType types.String `tfsdk:"run_type" tf:"optional"`
 	// The cron schedule that triggered this run if it was triggered by the
 	// periodic scheduler.
 	Schedule *CronSchedule `tfsdk:"schedule" tf:"optional"`
@@ -150,7 +150,7 @@ type BaseRun struct {
 	// failures. * `RUN_JOB_TASK`: Indicates a run that is triggered using a Run
 	// Job task. * `FILE_ARRIVAL`: Indicates a run that is triggered by a file
 	// arrival. * `TABLE`: Indicates a run that is triggered by a table update.
-	Trigger TriggerType `tfsdk:"trigger" tf:"optional"`
+	Trigger types.String `tfsdk:"trigger" tf:"optional"`
 	// Additional details about what triggered the run
 	TriggerInfo *TriggerInfo `tfsdk:"trigger_info" tf:"optional"`
 }
@@ -253,7 +253,7 @@ type ConditionTask struct {
 	// The boolean comparison to task values can be implemented with operators
 	// `EQUAL_TO`, `NOT_EQUAL`. If a task value was set to a boolean value, it
 	// will be serialized to `“true”` or `“false”` for the comparison.
-	Op ConditionTaskOp `tfsdk:"op" tf:""`
+	Op types.String `tfsdk:"op" tf:""`
 	// The right operand of the condition task. Can be either a string value or
 	// a job state or parameter reference.
 	Right types.String `tfsdk:"right" tf:""`
@@ -307,7 +307,7 @@ func (f *ConditionTaskOp) Type() string {
 type Continuous struct {
 	// Indicate whether the continuous execution of the job is paused or not.
 	// Defaults to UNPAUSED.
-	PauseStatus PauseStatus `tfsdk:"pause_status" tf:"optional"`
+	PauseStatus types.String `tfsdk:"pause_status" tf:"optional"`
 }
 
 type CreateJob struct {
@@ -326,7 +326,7 @@ type CreateJob struct {
 	//
 	// * `UI_LOCKED`: The job is in a locked UI state and cannot be modified. *
 	// `EDITABLE`: The job is in an editable state and can be modified.
-	EditMode JobEditMode `tfsdk:"edit_mode" tf:"optional"`
+	EditMode types.String `tfsdk:"edit_mode" tf:"optional"`
 	// An optional set of email addresses that is notified when runs of this job
 	// begin or complete as well as when this job is deleted.
 	EmailNotifications *JobEmailNotifications `tfsdk:"email_notifications" tf:"optional"`
@@ -336,7 +336,7 @@ type CreateJob struct {
 	// Used to tell what is the format of the job. This field is ignored in
 	// Create/Update/Reset calls. When using the Jobs API 2.1 this value is
 	// always set to `"MULTI_TASK"`.
-	Format Format `tfsdk:"format" tf:"optional"`
+	Format types.String `tfsdk:"format" tf:"optional"`
 	// An optional specification for a remote Git repository containing the
 	// source code used by tasks. Version-controlled source code is supported by
 	// notebook, dbt, Python script, and SQL File tasks.
@@ -415,7 +415,7 @@ type CreateResponse struct {
 
 type CronSchedule struct {
 	// Indicate whether this schedule is paused or not.
-	PauseStatus PauseStatus `tfsdk:"pause_status" tf:"optional"`
+	PauseStatus types.String `tfsdk:"pause_status" tf:"optional"`
 	// A Cron expression using Quartz syntax that describes the schedule for a
 	// job. See [Cron Trigger] for details. This field is required.
 	//
@@ -467,7 +467,7 @@ type DbtTask struct {
 	//
 	// * `WORKSPACE`: Project is located in Databricks workspace. * `GIT`:
 	// Project is located in cloud Git provider.
-	Source Source `tfsdk:"source" tf:"optional"`
+	Source types.String `tfsdk:"source" tf:"optional"`
 	// ID of the SQL warehouse to connect to. If provided, we automatically
 	// generate and provide the profile and connection details to dbt. It can be
 	// overridden on a per-command basis by using the `--profiles-dir` command
@@ -506,7 +506,7 @@ type ExportRunRequest struct {
 	// The canonical identifier for the run. This field is required.
 	RunId types.Int64 `tfsdk:"-" url:"run_id"`
 	// Which views to export (CODE, DASHBOARDS, or ALL). Defaults to CODE.
-	ViewsToExport ViewsToExport `tfsdk:"-" url:"views_to_export,omitempty"`
+	ViewsToExport types.String `tfsdk:"-" url:"views_to_export,omitempty"`
 }
 
 type FileArrivalTriggerConfiguration struct {
@@ -703,7 +703,7 @@ type GitSource struct {
 	GitCommit types.String `tfsdk:"git_commit" tf:"optional"`
 	// Unique identifier of the service used to host the Git repository. The
 	// value is case insensitive.
-	GitProvider GitProvider `tfsdk:"git_provider" tf:""`
+	GitProvider types.String `tfsdk:"git_provider" tf:""`
 	// Read-only state of the remote repository at the time the job was run.
 	// This field is only included on job runs.
 	GitSnapshot *GitSnapshot `tfsdk:"git_snapshot" tf:"optional"`
@@ -744,7 +744,7 @@ type JobAccessControlRequest struct {
 	// name of the group
 	GroupName types.String `tfsdk:"group_name" tf:"optional"`
 	// Permission level
-	PermissionLevel JobPermissionLevel `tfsdk:"permission_level" tf:"optional"`
+	PermissionLevel types.String `tfsdk:"permission_level" tf:"optional"`
 	// application ID of a service principal
 	ServicePrincipalName types.String `tfsdk:"service_principal_name" tf:"optional"`
 	// name of the user
@@ -777,7 +777,7 @@ type JobDeployment struct {
 	// The kind of deployment that manages the job.
 	//
 	// * `BUNDLE`: The job is managed by Databricks Asset Bundle.
-	Kind JobDeploymentKind `tfsdk:"kind" tf:""`
+	Kind types.String `tfsdk:"kind" tf:""`
 	// Path of the file that contains deployment metadata.
 	MetadataFilePath types.String `tfsdk:"metadata_file_path" tf:"optional"`
 }
@@ -917,7 +917,7 @@ type JobPermission struct {
 
 	InheritedFromObject []types.String `tfsdk:"inherited_from_object" tf:"optional"`
 	// Permission level
-	PermissionLevel JobPermissionLevel `tfsdk:"permission_level" tf:"optional"`
+	PermissionLevel types.String `tfsdk:"permission_level" tf:"optional"`
 }
 
 // Permission level
@@ -963,7 +963,7 @@ type JobPermissions struct {
 type JobPermissionsDescription struct {
 	Description types.String `tfsdk:"description" tf:"optional"`
 	// Permission level
-	PermissionLevel JobPermissionLevel `tfsdk:"permission_level" tf:"optional"`
+	PermissionLevel types.String `tfsdk:"permission_level" tf:"optional"`
 }
 
 type JobPermissionsRequest struct {
@@ -1001,7 +1001,7 @@ type JobSettings struct {
 	//
 	// * `UI_LOCKED`: The job is in a locked UI state and cannot be modified. *
 	// `EDITABLE`: The job is in an editable state and can be modified.
-	EditMode JobEditMode `tfsdk:"edit_mode" tf:"optional"`
+	EditMode types.String `tfsdk:"edit_mode" tf:"optional"`
 	// An optional set of email addresses that is notified when runs of this job
 	// begin or complete as well as when this job is deleted.
 	EmailNotifications *JobEmailNotifications `tfsdk:"email_notifications" tf:"optional"`
@@ -1011,7 +1011,7 @@ type JobSettings struct {
 	// Used to tell what is the format of the job. This field is ignored in
 	// Create/Update/Reset calls. When using the Jobs API 2.1 this value is
 	// always set to `"MULTI_TASK"`.
-	Format Format `tfsdk:"format" tf:"optional"`
+	Format types.String `tfsdk:"format" tf:"optional"`
 	// An optional specification for a remote Git repository containing the
 	// source code used by tasks. Version-controlled source code is supported by
 	// notebook, dbt, Python script, and SQL File tasks.
@@ -1094,7 +1094,7 @@ type JobSource struct {
 	// disconnected from the remote job specification and is allowed for live
 	// edit. Import the remote job specification again from UI to make the job
 	// fully synced.
-	DirtyState JobSourceDirtyState `tfsdk:"dirty_state" tf:"optional"`
+	DirtyState types.String `tfsdk:"dirty_state" tf:"optional"`
 	// Name of the branch which the job is imported from.
 	ImportFromGitBranch types.String `tfsdk:"import_from_git_branch" tf:""`
 	// Path of the job YAML file that contains the job specification.
@@ -1235,10 +1235,10 @@ type JobsHealthRule struct {
 	// across all streams. This metric is in Private Preview. *
 	// `STREAMING_BACKLOG_FILES`: An estimate of the maximum number of
 	// outstanding files across all streams. This metric is in Private Preview.
-	Metric JobsHealthMetric `tfsdk:"metric" tf:""`
+	Metric types.String `tfsdk:"metric" tf:""`
 	// Specifies the operator used to compare the health metric value with the
 	// specified threshold.
-	Op JobsHealthOperator `tfsdk:"op" tf:""`
+	Op types.String `tfsdk:"op" tf:""`
 	// Specifies the threshold value that the health metric should obey to
 	// satisfy the health rule.
 	Value types.Int64 `tfsdk:"value" tf:""`
@@ -1311,7 +1311,7 @@ type ListRunsRequest struct {
 	PageToken types.String `tfsdk:"-" url:"page_token,omitempty"`
 	// The type of runs to return. For a description of run types, see
 	// :method:jobs/getRun.
-	RunType RunType `tfsdk:"-" url:"run_type,omitempty"`
+	RunType types.String `tfsdk:"-" url:"run_type,omitempty"`
 	// Show runs that started _at or after_ this value. The value must be a UTC
 	// timestamp in milliseconds. Can be combined with _start_time_to_ to filter
 	// by a time range.
@@ -1380,7 +1380,7 @@ type NotebookTask struct {
 	// `git_source` is defined and `WORKSPACE` otherwise. * `WORKSPACE`:
 	// Notebook is located in Databricks workspace. * `GIT`: Notebook is located
 	// in cloud Git provider.
-	Source Source `tfsdk:"source" tf:"optional"`
+	Source types.String `tfsdk:"source" tf:"optional"`
 	// Optional `warehouse_id` to run the notebook on a SQL warehouse. Classic
 	// SQL warehouses are NOT supported, please use serverless or pro SQL
 	// warehouses.
@@ -1421,7 +1421,7 @@ type PeriodicTriggerConfiguration struct {
 	// The interval at which the trigger should run.
 	Interval types.Int64 `tfsdk:"interval" tf:""`
 	// The unit of time for the interval.
-	Unit PeriodicTriggerConfigurationTimeUnit `tfsdk:"unit" tf:""`
+	Unit types.String `tfsdk:"unit" tf:""`
 }
 
 type PeriodicTriggerConfigurationTimeUnit string
@@ -1503,7 +1503,7 @@ type RepairHistoryItem struct {
 	TaskRunIds []types.Int64 `tfsdk:"task_run_ids" tf:"optional"`
 	// The repair history item type. Indicates whether a run is the original run
 	// or a repair run.
-	Type RepairHistoryItemType `tfsdk:"type" tf:"optional"`
+	Type types.String `tfsdk:"type" tf:"optional"`
 }
 
 // The repair history item type. Indicates whether a run is the original run or
@@ -1800,7 +1800,7 @@ type Run struct {
 	// :method:jobs/submit.
 	//
 	// [dbutils.notebook.run]: https://docs.databricks.com/dev-tools/databricks-utils.html#dbutils-workflow
-	RunType RunType `tfsdk:"run_type" tf:"optional"`
+	RunType types.String `tfsdk:"run_type" tf:"optional"`
 	// The cron schedule that triggered this run if it was triggered by the
 	// periodic scheduler.
 	Schedule *CronSchedule `tfsdk:"schedule" tf:"optional"`
@@ -1832,7 +1832,7 @@ type Run struct {
 	// failures. * `RUN_JOB_TASK`: Indicates a run that is triggered using a Run
 	// Job task. * `FILE_ARRIVAL`: Indicates a run that is triggered by a file
 	// arrival. * `TABLE`: Indicates a run that is triggered by a table update.
-	Trigger TriggerType `tfsdk:"trigger" tf:"optional"`
+	Trigger types.String `tfsdk:"trigger" tf:"optional"`
 	// Additional details about what triggered the run
 	TriggerInfo *TriggerInfo `tfsdk:"trigger_info" tf:"optional"`
 }
@@ -1851,7 +1851,7 @@ type RunConditionTask struct {
 	// The boolean comparison to task values can be implemented with operators
 	// `EQUAL_TO`, `NOT_EQUAL`. If a task value was set to a boolean value, it
 	// will be serialized to `“true”` or `“false”` for the comparison.
-	Op ConditionTaskOp `tfsdk:"op" tf:""`
+	Op types.String `tfsdk:"op" tf:""`
 	// The condition expression evaluation result. Filled in if the task was
 	// successfully completed. Can be `"true"` or `"false"`
 	Outcome types.String `tfsdk:"outcome" tf:"optional"`
@@ -2391,12 +2391,12 @@ func (f *RunResultState) Type() string {
 type RunState struct {
 	// A value indicating the run's current lifecycle state. This field is
 	// always available in the response.
-	LifeCycleState RunLifeCycleState `tfsdk:"life_cycle_state" tf:"optional"`
+	LifeCycleState types.String `tfsdk:"life_cycle_state" tf:"optional"`
 	// The reason indicating why the run was queued.
 	QueueReason types.String `tfsdk:"queue_reason" tf:"optional"`
 	// A value indicating the run's result. This field is only available for
 	// terminal lifecycle states.
-	ResultState RunResultState `tfsdk:"result_state" tf:"optional"`
+	ResultState types.String `tfsdk:"result_state" tf:"optional"`
 	// A descriptive message for the current state. This field is unstructured,
 	// and its exact format is subject to change.
 	StateMessage types.String `tfsdk:"state_message" tf:"optional"`
@@ -2508,7 +2508,7 @@ type RunTask struct {
 	// task should be run once its dependencies have been completed. When
 	// omitted, defaults to `ALL_SUCCESS`. See :method:jobs/create for a list of
 	// possible values.
-	RunIf RunIf `tfsdk:"run_if" tf:"optional"`
+	RunIf types.String `tfsdk:"run_if" tf:"optional"`
 	// If run_job_task, indicates that this task must execute another job.
 	RunJobTask *RunJobTask `tfsdk:"run_job_task" tf:"optional"`
 
@@ -2685,7 +2685,7 @@ type SparkPythonTask struct {
 	// * `WORKSPACE`: The Python file is located in a Databricks workspace or at
 	// a cloud filesystem URI. * `GIT`: The Python file is located in a remote
 	// Git repository.
-	Source Source `tfsdk:"source" tf:"optional"`
+	Source types.String `tfsdk:"source" tf:"optional"`
 }
 
 type SparkSubmitTask struct {
@@ -2704,7 +2704,7 @@ type SqlAlertOutput struct {
 	// * UNKNOWN: alert yet to be evaluated * OK: alert evaluated and did not
 	// fulfill trigger conditions * TRIGGERED: alert evaluated and fulfilled
 	// trigger conditions
-	AlertState SqlAlertState `tfsdk:"alert_state" tf:"optional"`
+	AlertState types.String `tfsdk:"alert_state" tf:"optional"`
 	// The link to find the output results.
 	OutputLink types.String `tfsdk:"output_link" tf:"optional"`
 	// The text of the SQL query. Can Run permission of the SQL query associated
@@ -2767,7 +2767,7 @@ type SqlDashboardWidgetOutput struct {
 	// Time (in epoch milliseconds) when execution of the SQL widget starts.
 	StartTime types.Int64 `tfsdk:"start_time" tf:"optional"`
 	// The execution status of the SQL widget.
-	Status SqlDashboardWidgetOutputStatus `tfsdk:"status" tf:"optional"`
+	Status types.String `tfsdk:"status" tf:"optional"`
 	// The canonical identifier of the SQL widget.
 	WidgetId types.String `tfsdk:"widget_id" tf:"optional"`
 	// The title of the SQL widget.
@@ -2892,7 +2892,7 @@ type SqlTaskFile struct {
 	//
 	// * `WORKSPACE`: SQL file is located in Databricks workspace. * `GIT`: SQL
 	// file is located in cloud Git provider.
-	Source Source `tfsdk:"source" tf:"optional"`
+	Source types.String `tfsdk:"source" tf:"optional"`
 }
 
 type SqlTaskQuery struct {
@@ -3031,7 +3031,7 @@ type SubmitTask struct {
 	// task should be run once its dependencies have been completed. When
 	// omitted, defaults to `ALL_SUCCESS`. See :method:jobs/create for a list of
 	// possible values.
-	RunIf RunIf `tfsdk:"run_if" tf:"optional"`
+	RunIf types.String `tfsdk:"run_if" tf:"optional"`
 	// If run_job_task, indicates that this task must execute another job.
 	RunJobTask *RunJobTask `tfsdk:"run_job_task" tf:"optional"`
 	// If spark_jar_task, indicates that this task must run a JAR.
@@ -3074,7 +3074,7 @@ type SubmitTask struct {
 
 type TableUpdateTriggerConfiguration struct {
 	// The table(s) condition based on which to trigger a job run.
-	Condition Condition `tfsdk:"condition" tf:"optional"`
+	Condition types.String `tfsdk:"condition" tf:"optional"`
 	// If set, the trigger starts a run only after the specified amount of time
 	// has passed since the last time the trigger fired. The minimum allowed
 	// value is 60 seconds.
@@ -3166,7 +3166,7 @@ type Task struct {
 	// executed * `ALL_DONE`: All dependencies have been completed *
 	// `AT_LEAST_ONE_FAILED`: At least one dependency failed * `ALL_FAILED`: ALl
 	// dependencies have failed
-	RunIf RunIf `tfsdk:"run_if" tf:"optional"`
+	RunIf types.String `tfsdk:"run_if" tf:"optional"`
 	// If run_job_task, indicates that this task must execute another job.
 	RunJobTask *RunJobTask `tfsdk:"run_job_task" tf:"optional"`
 	// If spark_jar_task, indicates that this task must run a JAR.
@@ -3273,7 +3273,7 @@ type TriggerSettings struct {
 	// File arrival trigger settings.
 	FileArrival *FileArrivalTriggerConfiguration `tfsdk:"file_arrival" tf:"optional"`
 	// Whether this trigger is paused or not.
-	PauseStatus PauseStatus `tfsdk:"pause_status" tf:"optional"`
+	PauseStatus types.String `tfsdk:"pause_status" tf:"optional"`
 	// Periodic trigger settings.
 	Periodic *PeriodicTriggerConfiguration `tfsdk:"periodic" tf:"optional"`
 	// Old table trigger settings name. Deprecated in favor of `table_update`.
@@ -3367,7 +3367,7 @@ type ViewItem struct {
 	// dashboard’s name.
 	Name types.String `tfsdk:"name" tf:"optional"`
 	// Type of the view item.
-	Type ViewType `tfsdk:"type" tf:"optional"`
+	Type types.String `tfsdk:"type" tf:"optional"`
 }
 
 // * `NOTEBOOK`: Notebook view item. * `DASHBOARD`: Dashboard view item.

--- a/service/marketplace_tf/model.go
+++ b/service/marketplace_tf/model.go
@@ -210,7 +210,7 @@ type CreateFileRequest struct {
 
 	FileParent FileParent `tfsdk:"file_parent" tf:""`
 
-	MarketplaceFileType MarketplaceFileType `tfsdk:"marketplace_file_type" tf:""`
+	MarketplaceFileType types.String `tfsdk:"marketplace_file_type" tf:""`
 
 	MimeType types.String `tfsdk:"mime_type" tf:""`
 }
@@ -228,7 +228,7 @@ type CreateInstallationRequest struct {
 
 	ListingId types.String `tfsdk:"-" url:"-"`
 
-	RecipientType DeltaSharingRecipientType `tfsdk:"recipient_type" tf:"optional"`
+	RecipientType types.String `tfsdk:"recipient_type" tf:"optional"`
 	// for git repo installations
 	RepoDetail *RepoInstallation `tfsdk:"repo_detail" tf:"optional"`
 
@@ -261,7 +261,7 @@ type CreatePersonalizationRequest struct {
 
 	ListingId types.String `tfsdk:"-" url:"-"`
 
-	RecipientType DeltaSharingRecipientType `tfsdk:"recipient_type" tf:"optional"`
+	RecipientType types.String `tfsdk:"recipient_type" tf:"optional"`
 }
 
 type CreatePersonalizationRequestResponse struct {
@@ -320,7 +320,7 @@ func (f *DataRefresh) Type() string {
 type DataRefreshInfo struct {
 	Interval types.Int64 `tfsdk:"interval" tf:""`
 
-	Unit DataRefresh `tfsdk:"unit" tf:""`
+	Unit types.String `tfsdk:"unit" tf:""`
 }
 
 // Delete an exchange filter
@@ -427,7 +427,7 @@ type ExchangeFilter struct {
 
 	ExchangeId types.String `tfsdk:"exchange_id" tf:""`
 
-	FilterType ExchangeFilterType `tfsdk:"filter_type" tf:""`
+	FilterType types.String `tfsdk:"filter_type" tf:""`
 
 	FilterValue types.String `tfsdk:"filter_value" tf:""`
 
@@ -492,11 +492,11 @@ type FileInfo struct {
 
 	Id types.String `tfsdk:"id" tf:"optional"`
 
-	MarketplaceFileType MarketplaceFileType `tfsdk:"marketplace_file_type" tf:"optional"`
+	MarketplaceFileType types.String `tfsdk:"marketplace_file_type" tf:"optional"`
 
 	MimeType types.String `tfsdk:"mime_type" tf:"optional"`
 
-	Status FileStatus `tfsdk:"status" tf:"optional"`
+	Status types.String `tfsdk:"status" tf:"optional"`
 	// Populated if status is in a failed state with more information on reason
 	// for the failure.
 	StatusMessage types.String `tfsdk:"status_message" tf:"optional"`
@@ -505,7 +505,7 @@ type FileInfo struct {
 }
 
 type FileParent struct {
-	FileParentType FileParentType `tfsdk:"file_parent_type" tf:"optional"`
+	FileParentType types.String `tfsdk:"file_parent_type" tf:"optional"`
 	// TODO make the following fields required
 	ParentId types.String `tfsdk:"parent_id" tf:"optional"`
 }
@@ -715,7 +715,7 @@ type InstallationDetail struct {
 
 	ListingName types.String `tfsdk:"listing_name" tf:"optional"`
 
-	RecipientType DeltaSharingRecipientType `tfsdk:"recipient_type" tf:"optional"`
+	RecipientType types.String `tfsdk:"recipient_type" tf:"optional"`
 
 	RepoName types.String `tfsdk:"repo_name" tf:"optional"`
 
@@ -723,7 +723,7 @@ type InstallationDetail struct {
 
 	ShareName types.String `tfsdk:"share_name" tf:"optional"`
 
-	Status InstallationStatus `tfsdk:"status" tf:"optional"`
+	Status types.String `tfsdk:"status" tf:"optional"`
 
 	TokenDetail *TokenDetail `tfsdk:"token_detail" tf:"optional"`
 
@@ -889,9 +889,9 @@ type ListListingsForExchangeResponse struct {
 // List listings
 type ListListingsRequest struct {
 	// Matches any of the following asset types
-	Assets []AssetType `tfsdk:"-" url:"assets,omitempty"`
+	Assets []types.String `tfsdk:"-" url:"assets,omitempty"`
 	// Matches any of the following categories
-	Categories []Category `tfsdk:"-" url:"categories,omitempty"`
+	Categories []types.String `tfsdk:"-" url:"categories,omitempty"`
 
 	IsAscending types.Bool `tfsdk:"-" url:"is_ascending,omitempty"`
 	// Filters each listing based on if it is free.
@@ -907,7 +907,7 @@ type ListListingsRequest struct {
 	// Matches any of the following provider ids
 	ProviderIds []types.String `tfsdk:"-" url:"provider_ids,omitempty"`
 	// Criteria for sorting the resulting set of listings.
-	SortBy SortBy `tfsdk:"-" url:"sort_by,omitempty"`
+	SortBy types.String `tfsdk:"-" url:"sort_by,omitempty"`
 	// Matches any of the following tags
 	Tags []ListingTag `tfsdk:"-" url:"tags,omitempty"`
 }
@@ -956,7 +956,7 @@ type Listing struct {
 type ListingDetail struct {
 	// Type of assets included in the listing. eg. GIT_REPO, DATA_TABLE, MODEL,
 	// NOTEBOOK
-	Assets []AssetType `tfsdk:"assets" tf:"optional"`
+	Assets []types.String `tfsdk:"assets" tf:"optional"`
 	// The ending date timestamp for when the data spans
 	CollectionDateEnd types.Int64 `tfsdk:"collection_date_end" tf:"optional"`
 	// The starting date timestamp for when the data spans
@@ -964,7 +964,7 @@ type ListingDetail struct {
 	// Smallest unit of time in the dataset
 	CollectionGranularity *DataRefreshInfo `tfsdk:"collection_granularity" tf:"optional"`
 	// Whether the dataset is free or paid
-	Cost Cost `tfsdk:"cost" tf:"optional"`
+	Cost types.String `tfsdk:"cost" tf:"optional"`
 	// Where/how the data is sourced
 	DataSource types.String `tfsdk:"data_source" tf:"optional"`
 
@@ -1005,11 +1005,11 @@ type ListingDetail struct {
 }
 
 type ListingFulfillment struct {
-	FulfillmentType FulfillmentType `tfsdk:"fulfillment_type" tf:"optional"`
+	FulfillmentType types.String `tfsdk:"fulfillment_type" tf:"optional"`
 
 	ListingId types.String `tfsdk:"listing_id" tf:""`
 
-	RecipientType DeltaSharingRecipientType `tfsdk:"recipient_type" tf:"optional"`
+	RecipientType types.String `tfsdk:"recipient_type" tf:"optional"`
 
 	RepoInfo *RepoInfo `tfsdk:"repo_info" tf:"optional"`
 
@@ -1020,7 +1020,7 @@ type ListingSetting struct {
 	// filters are joined with `or` conjunction.
 	Filters []VisibilityFilter `tfsdk:"filters" tf:"optional"`
 
-	Visibility Visibility `tfsdk:"visibility" tf:"optional"`
+	Visibility types.String `tfsdk:"visibility" tf:"optional"`
 }
 
 type ListingShareType string
@@ -1084,7 +1084,7 @@ func (f *ListingStatus) Type() string {
 
 // Next Number: 26
 type ListingSummary struct {
-	Categories []Category `tfsdk:"categories" tf:"optional"`
+	Categories []types.String `tfsdk:"categories" tf:"optional"`
 
 	CreatedAt types.Int64 `tfsdk:"created_at" tf:"optional"`
 
@@ -1097,7 +1097,7 @@ type ListingSummary struct {
 	// field as opposed to a share
 	GitRepo *RepoInfo `tfsdk:"git_repo" tf:"optional"`
 
-	ListingType ListingType `tfsdk:"listingType" tf:""`
+	ListingType types.String `tfsdk:"listingType" tf:""`
 
 	MetastoreId types.String `tfsdk:"metastore_id" tf:"optional"`
 
@@ -1115,7 +1115,7 @@ type ListingSummary struct {
 
 	Share *ShareInfo `tfsdk:"share" tf:"optional"`
 	// Enums
-	Status ListingStatus `tfsdk:"status" tf:"optional"`
+	Status types.String `tfsdk:"status" tf:"optional"`
 
 	Subtitle types.String `tfsdk:"subtitle" tf:"optional"`
 
@@ -1128,7 +1128,7 @@ type ListingSummary struct {
 
 type ListingTag struct {
 	// Tag name (enum)
-	TagName ListingTagType `tfsdk:"tag_name" tf:"optional"`
+	TagName types.String `tfsdk:"tag_name" tf:"optional"`
 	// String representation of the tag value. Values should be string literals
 	// (no complex types)
 	TagValues []types.String `tfsdk:"tag_values" tf:"optional"`
@@ -1241,11 +1241,11 @@ type PersonalizationRequest struct {
 
 	ProviderId types.String `tfsdk:"provider_id" tf:"optional"`
 
-	RecipientType DeltaSharingRecipientType `tfsdk:"recipient_type" tf:"optional"`
+	RecipientType types.String `tfsdk:"recipient_type" tf:"optional"`
 
 	Share *ShareInfo `tfsdk:"share" tf:"optional"`
 
-	Status PersonalizationRequestStatus `tfsdk:"status" tf:"optional"`
+	Status types.String `tfsdk:"status" tf:"optional"`
 
 	StatusMessage types.String `tfsdk:"status_message" tf:"optional"`
 
@@ -1292,7 +1292,7 @@ type ProviderIconFile struct {
 
 	IconFilePath types.String `tfsdk:"icon_file_path" tf:"optional"`
 
-	IconType ProviderIconType `tfsdk:"icon_type" tf:"optional"`
+	IconType types.String `tfsdk:"icon_type" tf:"optional"`
 }
 
 type ProviderIconType string
@@ -1395,9 +1395,9 @@ type RepoInstallation struct {
 // Search listings
 type SearchListingsRequest struct {
 	// Matches any of the following asset types
-	Assets []AssetType `tfsdk:"-" url:"assets,omitempty"`
+	Assets []types.String `tfsdk:"-" url:"assets,omitempty"`
 	// Matches any of the following categories
-	Categories []Category `tfsdk:"-" url:"categories,omitempty"`
+	Categories []types.String `tfsdk:"-" url:"categories,omitempty"`
 
 	IsAscending types.Bool `tfsdk:"-" url:"is_ascending,omitempty"`
 
@@ -1413,7 +1413,7 @@ type SearchListingsRequest struct {
 	// Fuzzy matches query
 	Query types.String `tfsdk:"-" url:"query"`
 
-	SortBy SortBy `tfsdk:"-" url:"sort_by,omitempty"`
+	SortBy types.String `tfsdk:"-" url:"sort_by,omitempty"`
 }
 
 type SearchListingsResponse struct {
@@ -1425,7 +1425,7 @@ type SearchListingsResponse struct {
 type ShareInfo struct {
 	Name types.String `tfsdk:"name" tf:""`
 
-	Type ListingShareType `tfsdk:"type" tf:""`
+	Type types.String `tfsdk:"type" tf:""`
 }
 
 type SharedDataObject struct {
@@ -1550,7 +1550,7 @@ type UpdatePersonalizationRequestRequest struct {
 
 	Share *ShareInfo `tfsdk:"share" tf:"optional"`
 
-	Status PersonalizationRequestStatus `tfsdk:"status" tf:""`
+	Status types.String `tfsdk:"status" tf:""`
 }
 
 type UpdatePersonalizationRequestResponse struct {
@@ -1613,7 +1613,7 @@ func (f *Visibility) Type() string {
 }
 
 type VisibilityFilter struct {
-	FilterType FilterType `tfsdk:"filterType" tf:"optional"`
+	FilterType types.String `tfsdk:"filterType" tf:"optional"`
 
 	FilterValue types.String `tfsdk:"filterValue" tf:"optional"`
 }

--- a/service/ml_tf/model.go
+++ b/service/ml_tf/model.go
@@ -32,7 +32,7 @@ type Activity struct {
 	//
 	// * `SYSTEM_TRANSITION`: For events performed as a side effect, such as
 	// archiving existing model versions in a stage.
-	ActivityType ActivityType `tfsdk:"activity_type" tf:"optional"`
+	ActivityType types.String `tfsdk:"activity_type" tf:"optional"`
 	// User-provided comment associated with the activity.
 	Comment types.String `tfsdk:"comment" tf:"optional"`
 	// Creation time of the object, as a Unix timestamp in milliseconds.
@@ -47,7 +47,7 @@ type Activity struct {
 	// * `Production`: Production stage.
 	//
 	// * `Archived`: Archived stage.
-	FromStage Stage `tfsdk:"from_stage" tf:"optional"`
+	FromStage types.String `tfsdk:"from_stage" tf:"optional"`
 	// Unique identifier for the object.
 	Id types.String `tfsdk:"id" tf:"optional"`
 	// Time of the object at last update, as a Unix timestamp in milliseconds.
@@ -67,7 +67,7 @@ type Activity struct {
 	// * `Production`: Production stage.
 	//
 	// * `Archived`: Archived stage.
-	ToStage Stage `tfsdk:"to_stage" tf:"optional"`
+	ToStage types.String `tfsdk:"to_stage" tf:"optional"`
 	// The username of the user that created the object.
 	UserId types.String `tfsdk:"user_id" tf:"optional"`
 }
@@ -185,7 +185,7 @@ type ApproveTransitionRequest struct {
 	// * `Production`: Production stage.
 	//
 	// * `Archived`: Archived stage.
-	Stage Stage `tfsdk:"stage" tf:""`
+	Stage types.String `tfsdk:"stage" tf:""`
 	// Version of the model.
 	Version types.String `tfsdk:"version" tf:""`
 }
@@ -231,7 +231,7 @@ func (f *CommentActivityAction) Type() string {
 // Comment details.
 type CommentObject struct {
 	// Array of actions on the activity allowed for the current viewer.
-	AvailableActions []CommentActivityAction `tfsdk:"available_actions" tf:"optional"`
+	AvailableActions []types.String `tfsdk:"available_actions" tf:"optional"`
 	// User-provided comment on the action.
 	Comment types.String `tfsdk:"comment" tf:"optional"`
 	// Creation time of the object, as a Unix timestamp in milliseconds.
@@ -348,7 +348,7 @@ type CreateRegistryWebhook struct {
 	//
 	// * `TRANSITION_REQUEST_TO_ARCHIVED_CREATED`: A user requested a model
 	// version be archived.
-	Events []RegistryWebhookEvent `tfsdk:"events" tf:""`
+	Events []types.String `tfsdk:"events" tf:""`
 
 	HttpUrlSpec *HttpUrlSpec `tfsdk:"http_url_spec" tf:"optional"`
 
@@ -363,7 +363,7 @@ type CreateRegistryWebhook struct {
 	//
 	// * `TEST_MODE`: Webhook can be triggered through the test endpoint, but is
 	// not triggered on a real event.
-	Status RegistryWebhookStatus `tfsdk:"status" tf:"optional"`
+	Status types.String `tfsdk:"status" tf:"optional"`
 }
 
 type CreateRun struct {
@@ -398,7 +398,7 @@ type CreateTransitionRequest struct {
 	// * `Production`: Production stage.
 	//
 	// * `Archived`: Archived stage.
-	Stage Stage `tfsdk:"stage" tf:""`
+	Stage types.String `tfsdk:"stage" tf:""`
 	// Version of the model.
 	Version types.String `tfsdk:"version" tf:""`
 }
@@ -559,7 +559,7 @@ type DeleteTransitionRequestRequest struct {
 	// * `Production`: Production stage.
 	//
 	// * `Archived`: Archived stage.
-	Stage DeleteTransitionRequestStage `tfsdk:"-" url:"stage"`
+	Stage types.String `tfsdk:"-" url:"stage"`
 	// Version of the model.
 	Version types.String `tfsdk:"-" url:"version"`
 }
@@ -629,7 +629,7 @@ type ExperimentAccessControlRequest struct {
 	// name of the group
 	GroupName types.String `tfsdk:"group_name" tf:"optional"`
 	// Permission level
-	PermissionLevel ExperimentPermissionLevel `tfsdk:"permission_level" tf:"optional"`
+	PermissionLevel types.String `tfsdk:"permission_level" tf:"optional"`
 	// application ID of a service principal
 	ServicePrincipalName types.String `tfsdk:"service_principal_name" tf:"optional"`
 	// name of the user
@@ -654,7 +654,7 @@ type ExperimentPermission struct {
 
 	InheritedFromObject []types.String `tfsdk:"inherited_from_object" tf:"optional"`
 	// Permission level
-	PermissionLevel ExperimentPermissionLevel `tfsdk:"permission_level" tf:"optional"`
+	PermissionLevel types.String `tfsdk:"permission_level" tf:"optional"`
 }
 
 // Permission level
@@ -698,7 +698,7 @@ type ExperimentPermissions struct {
 type ExperimentPermissionsDescription struct {
 	Description types.String `tfsdk:"description" tf:"optional"`
 	// Permission level
-	PermissionLevel ExperimentPermissionLevel `tfsdk:"permission_level" tf:"optional"`
+	PermissionLevel types.String `tfsdk:"permission_level" tf:"optional"`
 }
 
 type ExperimentPermissionsRequest struct {
@@ -1012,7 +1012,7 @@ type ListWebhooksRequest struct {
 	// If `events` is specified, any webhook with one or more of the specified
 	// trigger events is included in the output. If `events` is not specified,
 	// webhooks of all event types are included in the output.
-	Events []RegistryWebhookEvent `tfsdk:"-" url:"events,omitempty"`
+	Events []types.String `tfsdk:"-" url:"events,omitempty"`
 	// If not specified, all webhooks associated with the specified events are
 	// listed, regardless of their associated model.
 	ModelName types.String `tfsdk:"-" url:"model_name,omitempty"`
@@ -1136,7 +1136,7 @@ type ModelDatabricks struct {
 	Name types.String `tfsdk:"name" tf:"optional"`
 	// Permission level of the requesting user on the object. For what is
 	// allowed at each level, see [MLflow Model permissions](..).
-	PermissionLevel PermissionLevel `tfsdk:"permission_level" tf:"optional"`
+	PermissionLevel types.String `tfsdk:"permission_level" tf:"optional"`
 	// Array of tags associated with the model.
 	Tags []ModelTag `tfsdk:"tags" tf:"optional"`
 	// The username of the user that created the object.
@@ -1171,7 +1171,7 @@ type ModelVersion struct {
 	// creating `model_version`
 	Source types.String `tfsdk:"source" tf:"optional"`
 	// Current status of `model_version`
-	Status ModelVersionStatus `tfsdk:"status" tf:"optional"`
+	Status types.String `tfsdk:"status" tf:"optional"`
 	// Details on current `status`, if it is pending or failed.
 	StatusMessage types.String `tfsdk:"status_message" tf:"optional"`
 	// Tags: Additional metadata key-value pairs for this `model_version`.
@@ -1194,7 +1194,7 @@ type ModelVersionDatabricks struct {
 	// * `Production`: Production stage.
 	//
 	// * `Archived`: Archived stage.
-	CurrentStage Stage `tfsdk:"current_stage" tf:"optional"`
+	CurrentStage types.String `tfsdk:"current_stage" tf:"optional"`
 	// User-specified description for the object.
 	Description types.String `tfsdk:"description" tf:"optional"`
 	// Time of the object at last update, as a Unix timestamp in milliseconds.
@@ -1203,7 +1203,7 @@ type ModelVersionDatabricks struct {
 	Name types.String `tfsdk:"name" tf:"optional"`
 	// Permission level of the requesting user on the object. For what is
 	// allowed at each level, see [MLflow Model permissions](..).
-	PermissionLevel PermissionLevel `tfsdk:"permission_level" tf:"optional"`
+	PermissionLevel types.String `tfsdk:"permission_level" tf:"optional"`
 	// Unique identifier for the MLflow tracking run associated with the source
 	// model artifacts.
 	RunId types.String `tfsdk:"run_id" tf:"optional"`
@@ -1222,7 +1222,7 @@ type ModelVersionDatabricks struct {
 	// failed.
 	//
 	// * `READY`: Model version is ready for use.
-	Status Status `tfsdk:"status" tf:"optional"`
+	Status types.String `tfsdk:"status" tf:"optional"`
 	// Details on the current status, for example why registration failed.
 	StatusMessage types.String `tfsdk:"status_message" tf:"optional"`
 	// Array of tags that are associated with the model version.
@@ -1316,7 +1316,7 @@ type RegisteredModelAccessControlRequest struct {
 	// name of the group
 	GroupName types.String `tfsdk:"group_name" tf:"optional"`
 	// Permission level
-	PermissionLevel RegisteredModelPermissionLevel `tfsdk:"permission_level" tf:"optional"`
+	PermissionLevel types.String `tfsdk:"permission_level" tf:"optional"`
 	// application ID of a service principal
 	ServicePrincipalName types.String `tfsdk:"service_principal_name" tf:"optional"`
 	// name of the user
@@ -1341,7 +1341,7 @@ type RegisteredModelPermission struct {
 
 	InheritedFromObject []types.String `tfsdk:"inherited_from_object" tf:"optional"`
 	// Permission level
-	PermissionLevel RegisteredModelPermissionLevel `tfsdk:"permission_level" tf:"optional"`
+	PermissionLevel types.String `tfsdk:"permission_level" tf:"optional"`
 }
 
 // Permission level
@@ -1389,7 +1389,7 @@ type RegisteredModelPermissions struct {
 type RegisteredModelPermissionsDescription struct {
 	Description types.String `tfsdk:"description" tf:"optional"`
 	// Permission level
-	PermissionLevel RegisteredModelPermissionLevel `tfsdk:"permission_level" tf:"optional"`
+	PermissionLevel types.String `tfsdk:"permission_level" tf:"optional"`
 }
 
 type RegisteredModelPermissionsRequest struct {
@@ -1436,7 +1436,7 @@ type RegistryWebhook struct {
 	//
 	// * `TRANSITION_REQUEST_TO_ARCHIVED_CREATED`: A user requested a model
 	// version be archived.
-	Events []RegistryWebhookEvent `tfsdk:"events" tf:"optional"`
+	Events []types.String `tfsdk:"events" tf:"optional"`
 
 	HttpUrlSpec *HttpUrlSpecWithoutSecret `tfsdk:"http_url_spec" tf:"optional"`
 	// Webhook ID
@@ -1455,7 +1455,7 @@ type RegistryWebhook struct {
 	//
 	// * `TEST_MODE`: Webhook can be triggered through the test endpoint, but is
 	// not triggered on a real event.
-	Status RegistryWebhookStatus `tfsdk:"status" tf:"optional"`
+	Status types.String `tfsdk:"status" tf:"optional"`
 }
 
 type RegistryWebhookEvent string
@@ -1560,7 +1560,7 @@ type RejectTransitionRequest struct {
 	// * `Production`: Production stage.
 	//
 	// * `Archived`: Archived stage.
-	Stage Stage `tfsdk:"stage" tf:""`
+	Stage types.String `tfsdk:"stage" tf:""`
 	// Version of the model.
 	Version types.String `tfsdk:"version" tf:""`
 }
@@ -1652,7 +1652,7 @@ type RunInfo struct {
 	// Unix timestamp of when the run started in milliseconds.
 	StartTime types.Int64 `tfsdk:"start_time" tf:"optional"`
 	// Current status of the run.
-	Status RunInfoStatus `tfsdk:"status" tf:"optional"`
+	Status types.String `tfsdk:"status" tf:"optional"`
 	// User who initiated the run. This field is deprecated as of MLflow 1.0,
 	// and will be removed in a future MLflow release. Use 'mlflow.user' tag
 	// instead.
@@ -1720,7 +1720,7 @@ type SearchExperiments struct {
 	PageToken types.String `tfsdk:"page_token" tf:"optional"`
 	// Qualifier for type of experiments to be returned. If unspecified, return
 	// only active experiments.
-	ViewType SearchExperimentsViewType `tfsdk:"view_type" tf:"optional"`
+	ViewType types.String `tfsdk:"view_type" tf:"optional"`
 }
 
 type SearchExperimentsResponse struct {
@@ -1838,7 +1838,7 @@ type SearchRuns struct {
 	PageToken types.String `tfsdk:"page_token" tf:"optional"`
 	// Whether to display only active, only deleted, or all runs. Defaults to
 	// only active runs.
-	RunViewType SearchRunsRunViewType `tfsdk:"run_view_type" tf:"optional"`
+	RunViewType types.String `tfsdk:"run_view_type" tf:"optional"`
 }
 
 type SearchRunsResponse struct {
@@ -2044,7 +2044,7 @@ type TestRegistryWebhookRequest struct {
 	// If `event` is specified, the test trigger uses the specified event. If
 	// `event` is not specified, the test trigger uses a randomly chosen event
 	// associated with the webhook.
-	Event RegistryWebhookEvent `tfsdk:"event" tf:"optional"`
+	Event types.String `tfsdk:"event" tf:"optional"`
 	// Webhook ID
 	Id types.String `tfsdk:"id" tf:""`
 }
@@ -2071,7 +2071,7 @@ type TransitionModelVersionStageDatabricks struct {
 	// * `Production`: Production stage.
 	//
 	// * `Archived`: Archived stage.
-	Stage Stage `tfsdk:"stage" tf:""`
+	Stage types.String `tfsdk:"stage" tf:""`
 	// Version of the model.
 	Version types.String `tfsdk:"version" tf:""`
 }
@@ -2079,7 +2079,7 @@ type TransitionModelVersionStageDatabricks struct {
 // Transition request details.
 type TransitionRequest struct {
 	// Array of actions on the activity allowed for the current viewer.
-	AvailableActions []ActivityAction `tfsdk:"available_actions" tf:"optional"`
+	AvailableActions []types.String `tfsdk:"available_actions" tf:"optional"`
 	// User-provided comment associated with the transition request.
 	Comment types.String `tfsdk:"comment" tf:"optional"`
 	// Creation time of the object, as a Unix timestamp in milliseconds.
@@ -2094,7 +2094,7 @@ type TransitionRequest struct {
 	// * `Production`: Production stage.
 	//
 	// * `Archived`: Archived stage.
-	ToStage Stage `tfsdk:"to_stage" tf:"optional"`
+	ToStage types.String `tfsdk:"to_stage" tf:"optional"`
 	// The username of the user that created the object.
 	UserId types.String `tfsdk:"user_id" tf:"optional"`
 }
@@ -2184,7 +2184,7 @@ type UpdateRegistryWebhook struct {
 	//
 	// * `TRANSITION_REQUEST_TO_ARCHIVED_CREATED`: A user requested a model
 	// version be archived.
-	Events []RegistryWebhookEvent `tfsdk:"events" tf:"optional"`
+	Events []types.String `tfsdk:"events" tf:"optional"`
 
 	HttpUrlSpec *HttpUrlSpec `tfsdk:"http_url_spec" tf:"optional"`
 	// Webhook ID
@@ -2199,7 +2199,7 @@ type UpdateRegistryWebhook struct {
 	//
 	// * `TEST_MODE`: Webhook can be triggered through the test endpoint, but is
 	// not triggered on a real event.
-	Status RegistryWebhookStatus `tfsdk:"status" tf:"optional"`
+	Status types.String `tfsdk:"status" tf:"optional"`
 }
 
 type UpdateRun struct {
@@ -2211,7 +2211,7 @@ type UpdateRun struct {
 	// will be removed in a future MLflow version.
 	RunUuid types.String `tfsdk:"run_uuid" tf:"optional"`
 	// Updated status of the run.
-	Status UpdateRunStatus `tfsdk:"status" tf:"optional"`
+	Status types.String `tfsdk:"status" tf:"optional"`
 }
 
 type UpdateRunResponse struct {

--- a/service/pipelines_tf/model.go
+++ b/service/pipelines_tf/model.go
@@ -271,7 +271,7 @@ type GetPipelineResponse struct {
 	// The username of the pipeline creator.
 	CreatorUserName types.String `tfsdk:"creator_user_name" tf:"optional"`
 	// The health of a pipeline.
-	Health GetPipelineResponseHealth `tfsdk:"health" tf:"optional"`
+	Health types.String `tfsdk:"health" tf:"optional"`
 	// The last time the pipeline settings were modified or created.
 	LastModified types.Int64 `tfsdk:"last_modified" tf:"optional"`
 	// Status of the latest updates for the pipeline. Ordered with the newest
@@ -287,7 +287,7 @@ type GetPipelineResponse struct {
 	// `ListPipelines`.
 	Spec *PipelineSpec `tfsdk:"spec" tf:"optional"`
 	// The pipeline state.
-	State PipelineState `tfsdk:"state" tf:"optional"`
+	State types.String `tfsdk:"state" tf:"optional"`
 }
 
 // The health of a pipeline.
@@ -556,7 +556,7 @@ type PipelineAccessControlRequest struct {
 	// name of the group
 	GroupName types.String `tfsdk:"group_name" tf:"optional"`
 	// Permission level
-	PermissionLevel PipelinePermissionLevel `tfsdk:"permission_level" tf:"optional"`
+	PermissionLevel types.String `tfsdk:"permission_level" tf:"optional"`
 	// application ID of a service principal
 	ServicePrincipalName types.String `tfsdk:"service_principal_name" tf:"optional"`
 	// name of the user
@@ -684,7 +684,7 @@ type PipelineClusterAutoscale struct {
 	// minimal impact to the data processing latency of your pipelines. Enhanced
 	// Autoscaling is available for `updates` clusters only. The legacy
 	// autoscaling feature is used for `maintenance` clusters.
-	Mode PipelineClusterAutoscaleMode `tfsdk:"mode" tf:"optional"`
+	Mode types.String `tfsdk:"mode" tf:"optional"`
 }
 
 // Databricks Enhanced Autoscaling optimizes cluster utilization by
@@ -721,7 +721,7 @@ func (f *PipelineClusterAutoscaleMode) Type() string {
 
 type PipelineDeployment struct {
 	// The deployment method that manages the pipeline.
-	Kind DeploymentKind `tfsdk:"kind" tf:"optional"`
+	Kind types.String `tfsdk:"kind" tf:"optional"`
 	// The path to the file containing metadata about the deployment.
 	MetadataFilePath types.String `tfsdk:"metadata_file_path" tf:"optional"`
 }
@@ -734,9 +734,9 @@ type PipelineEvent struct {
 	// A time-based, globally unique id.
 	Id types.String `tfsdk:"id" tf:"optional"`
 	// The severity level of the event.
-	Level EventLevel `tfsdk:"level" tf:"optional"`
+	Level types.String `tfsdk:"level" tf:"optional"`
 	// Maturity level for event_type.
-	MaturityLevel MaturityLevel `tfsdk:"maturity_level" tf:"optional"`
+	MaturityLevel types.String `tfsdk:"maturity_level" tf:"optional"`
 	// The display message associated with the event.
 	Message types.String `tfsdk:"message" tf:"optional"`
 	// Describes where the event originates from.
@@ -765,7 +765,7 @@ type PipelinePermission struct {
 
 	InheritedFromObject []types.String `tfsdk:"inherited_from_object" tf:"optional"`
 	// Permission level
-	PermissionLevel PipelinePermissionLevel `tfsdk:"permission_level" tf:"optional"`
+	PermissionLevel types.String `tfsdk:"permission_level" tf:"optional"`
 }
 
 // Permission level
@@ -811,7 +811,7 @@ type PipelinePermissions struct {
 type PipelinePermissionsDescription struct {
 	Description types.String `tfsdk:"description" tf:"optional"`
 	// Permission level
-	PermissionLevel PipelinePermissionLevel `tfsdk:"permission_level" tf:"optional"`
+	PermissionLevel types.String `tfsdk:"permission_level" tf:"optional"`
 }
 
 type PipelinePermissionsRequest struct {
@@ -928,7 +928,7 @@ type PipelineStateInfo struct {
 	// from the pipeline owner.
 	RunAsUserName types.String `tfsdk:"run_as_user_name" tf:"optional"`
 	// The pipeline state.
-	State PipelineState `tfsdk:"state" tf:"optional"`
+	State types.String `tfsdk:"state" tf:"optional"`
 }
 
 type PipelineTrigger struct {
@@ -984,7 +984,7 @@ type StackFrame struct {
 }
 
 type StartUpdate struct {
-	Cause StartUpdateCause `tfsdk:"cause" tf:"optional"`
+	Cause types.String `tfsdk:"cause" tf:"optional"`
 	// If true, this update will reset all tables before running.
 	FullRefresh types.Bool `tfsdk:"full_refresh" tf:"optional"`
 	// A list of tables to update with fullRefresh. If both refresh_selection
@@ -1079,7 +1079,7 @@ type TableSpecificConfig struct {
 	// ingestion. This setting is only valid for the Salesforce connector
 	SalesforceIncludeFormulaFields types.Bool `tfsdk:"salesforce_include_formula_fields" tf:"optional"`
 	// The SCD type to use to ingest the table.
-	ScdType TableSpecificConfigScdType `tfsdk:"scd_type" tf:"optional"`
+	ScdType types.String `tfsdk:"scd_type" tf:"optional"`
 }
 
 // The SCD type to use to ingest the table.
@@ -1112,7 +1112,7 @@ func (f *TableSpecificConfigScdType) Type() string {
 
 type UpdateInfo struct {
 	// What triggered this update.
-	Cause UpdateInfoCause `tfsdk:"cause" tf:"optional"`
+	Cause types.String `tfsdk:"cause" tf:"optional"`
 	// The ID of the cluster that the update is running on.
 	ClusterId types.String `tfsdk:"cluster_id" tf:"optional"`
 	// The pipeline configuration with system defaults applied where unspecified
@@ -1135,7 +1135,7 @@ type UpdateInfo struct {
 	// before the refresh.
 	RefreshSelection []types.String `tfsdk:"refresh_selection" tf:"optional"`
 	// The update state.
-	State UpdateInfoState `tfsdk:"state" tf:"optional"`
+	State types.String `tfsdk:"state" tf:"optional"`
 	// The ID of this update.
 	UpdateId types.String `tfsdk:"update_id" tf:"optional"`
 	// If true, this update only validates the correctness of pipeline source
@@ -1228,7 +1228,7 @@ func (f *UpdateInfoState) Type() string {
 type UpdateStateInfo struct {
 	CreationTime types.String `tfsdk:"creation_time" tf:"optional"`
 
-	State UpdateStateInfoState `tfsdk:"state" tf:"optional"`
+	State types.String `tfsdk:"state" tf:"optional"`
 
 	UpdateId types.String `tfsdk:"update_id" tf:"optional"`
 }

--- a/service/provisioning_tf/model.go
+++ b/service/provisioning_tf/model.go
@@ -80,7 +80,7 @@ type CreateCustomerManagedKeyRequest struct {
 
 	GcpKeyInfo *CreateGcpKeyInfo `tfsdk:"gcp_key_info" tf:"optional"`
 	// The cases that the key can be used for.
-	UseCases []KeyUseCase `tfsdk:"use_cases" tf:""`
+	UseCases []types.String `tfsdk:"use_cases" tf:""`
 }
 
 type CreateGcpKeyInfo struct {
@@ -216,7 +216,7 @@ type CreateWorkspaceRequest struct {
 	// Pricing].
 	//
 	// [AWS Pricing]: https://databricks.com/product/aws-pricing
-	PricingTier PricingTier `tfsdk:"pricing_tier" tf:"optional"`
+	PricingTier types.String `tfsdk:"pricing_tier" tf:"optional"`
 	// ID of the workspace's private access settings object. Only used for
 	// PrivateLink. This ID must be specified for customers using [AWS
 	// PrivateLink] for either front-end (user-to-workspace connection),
@@ -278,7 +278,7 @@ type CustomerManagedKey struct {
 
 	GcpKeyInfo *GcpKeyInfo `tfsdk:"gcp_key_info" tf:"optional"`
 	// The cases that the key can be used for.
-	UseCases []KeyUseCase `tfsdk:"use_cases" tf:"optional"`
+	UseCases []types.String `tfsdk:"use_cases" tf:"optional"`
 }
 
 // Delete credential configuration
@@ -523,7 +523,7 @@ type GkeConfig struct {
 	//
 	// Set to `PUBLIC_NODE_PUBLIC_MASTER` for a public GKE cluster. The nodes of
 	// a public GKE cluster have public IP addresses.
-	ConnectivityType GkeConfigConnectivityType `tfsdk:"connectivity_type" tf:"optional"`
+	ConnectivityType types.String `tfsdk:"connectivity_type" tf:"optional"`
 	// The IP range from which to allocate GKE cluster master resources. This
 	// field will be ignored if GKE private cluster is not enabled.
 	//
@@ -628,7 +628,7 @@ type Network struct {
 	// The status of this network configuration object in terms of its use in a
 	// workspace: * `UNATTACHED`: Unattached. * `VALID`: Valid. * `BROKEN`:
 	// Broken. * `WARNED`: Warned.
-	VpcStatus VpcStatus `tfsdk:"vpc_status" tf:"optional"`
+	VpcStatus types.String `tfsdk:"vpc_status" tf:"optional"`
 	// Array of warning messages about the network configuration.
 	WarningMessages []NetworkWarning `tfsdk:"warning_messages" tf:"optional"`
 	// Workspace ID associated with this network configuration.
@@ -640,7 +640,7 @@ type NetworkHealth struct {
 	ErrorMessage types.String `tfsdk:"error_message" tf:"optional"`
 	// The AWS resource associated with this error: credentials, VPC, subnet,
 	// security group, or network ACL.
-	ErrorType ErrorType `tfsdk:"error_type" tf:"optional"`
+	ErrorType types.String `tfsdk:"error_type" tf:"optional"`
 }
 
 // If specified, contains the VPC endpoints used to allow cluster communication
@@ -661,7 +661,7 @@ type NetworkWarning struct {
 	WarningMessage types.String `tfsdk:"warning_message" tf:"optional"`
 	// The AWS resource associated with this warning: a subnet or a security
 	// group.
-	WarningType WarningType `tfsdk:"warning_type" tf:"optional"`
+	WarningType types.String `tfsdk:"warning_type" tf:"optional"`
 }
 
 // The pricing tier of the workspace. For pricing tier information, see [AWS
@@ -747,7 +747,7 @@ type PrivateAccessSettings struct {
 	// that are registered in your Databricks account connect to your workspace.
 	// * `ENDPOINT` level access allows only specified VPC endpoints connect to
 	// your workspace. For details, see `allowed_vpc_endpoint_ids`.
-	PrivateAccessLevel PrivateAccessLevel `tfsdk:"private_access_level" tf:"optional"`
+	PrivateAccessLevel types.String `tfsdk:"private_access_level" tf:"optional"`
 	// Databricks private access settings ID.
 	PrivateAccessSettingsId types.String `tfsdk:"private_access_settings_id" tf:"optional"`
 	// The human-readable name of the private access settings object.
@@ -850,7 +850,7 @@ type UpsertPrivateAccessSettingsRequest struct {
 	// that are registered in your Databricks account connect to your workspace.
 	// * `ENDPOINT` level access allows only specified VPC endpoints connect to
 	// your workspace. For details, see `allowed_vpc_endpoint_ids`.
-	PrivateAccessLevel PrivateAccessLevel `tfsdk:"private_access_level" tf:"optional"`
+	PrivateAccessLevel types.String `tfsdk:"private_access_level" tf:"optional"`
 	// Databricks Account API private access settings ID.
 	PrivateAccessSettingsId types.String `tfsdk:"-" url:"-"`
 	// The human-readable name of the private access settings object.
@@ -895,7 +895,7 @@ type VpcEndpoint struct {
 	// that was used when creating this VPC endpoint.
 	//
 	// [endpoint service]: https://docs.aws.amazon.com/vpc/latest/privatelink/endpoint-service.html
-	UseCase EndpointUseCase `tfsdk:"use_case" tf:"optional"`
+	UseCase types.String `tfsdk:"use_case" tf:"optional"`
 	// Databricks VPC endpoint ID. This is the Databricks-specific name of the
 	// VPC endpoint. Do not confuse this with the `aws_vpc_endpoint_id`, which
 	// is the ID within AWS of the VPC endpoint.
@@ -1036,7 +1036,7 @@ type Workspace struct {
 	// Pricing].
 	//
 	// [AWS Pricing]: https://databricks.com/product/aws-pricing
-	PricingTier PricingTier `tfsdk:"pricing_tier" tf:"optional"`
+	PricingTier types.String `tfsdk:"pricing_tier" tf:"optional"`
 	// ID of the workspace's private access settings object. Only used for
 	// PrivateLink. You must specify this ID if you are using [AWS PrivateLink]
 	// for either front-end (user-to-workspace connection), back-end (data plane
@@ -1059,7 +1059,7 @@ type Workspace struct {
 	// The status of the workspace. For workspace creation, usually it is set to
 	// `PROVISIONING` initially. Continue to check the status until the status
 	// is `RUNNING`.
-	WorkspaceStatus WorkspaceStatus `tfsdk:"workspace_status" tf:"optional"`
+	WorkspaceStatus types.String `tfsdk:"workspace_status" tf:"optional"`
 	// Message describing the current workspace status.
 	WorkspaceStatusMessage types.String `tfsdk:"workspace_status_message" tf:"optional"`
 }

--- a/service/serving_tf/model.go
+++ b/service/serving_tf/model.go
@@ -35,7 +35,7 @@ type AmazonBedrockConfig struct {
 	AwsSecretAccessKey types.String `tfsdk:"aws_secret_access_key" tf:""`
 	// The underlying provider in Amazon Bedrock. Supported values (case
 	// insensitive) include: Anthropic, Cohere, AI21Labs, Amazon.
-	BedrockProvider AmazonBedrockConfigBedrockProvider `tfsdk:"bedrock_provider" tf:""`
+	BedrockProvider types.String `tfsdk:"bedrock_provider" tf:""`
 }
 
 // The underlying provider in Amazon Bedrock. Supported values (case
@@ -114,7 +114,7 @@ type AppDeployment struct {
 	// The unique id of the deployment.
 	DeploymentId types.String `tfsdk:"deployment_id" tf:"optional"`
 	// The mode of which the deployment will manage the source code.
-	Mode AppDeploymentMode `tfsdk:"mode" tf:""`
+	Mode types.String `tfsdk:"mode" tf:""`
 	// The workspace file system path of the source code used to create the app
 	// deployment. This is different from
 	// `deployment_artifacts.source_code_path`, which is the path used by the
@@ -201,7 +201,7 @@ type AppDeploymentStatus struct {
 	// Message corresponding with the deployment state.
 	Message types.String `tfsdk:"message" tf:"optional"`
 	// State of the deployment.
-	State AppDeploymentState `tfsdk:"state" tf:"optional"`
+	State types.String `tfsdk:"state" tf:"optional"`
 }
 
 type AppEnvironment struct {
@@ -251,7 +251,7 @@ type AppStatus struct {
 	// Message corresponding with the app state.
 	Message types.String `tfsdk:"message" tf:"optional"`
 	// State of the app.
-	State AppState `tfsdk:"state" tf:"optional"`
+	State types.String `tfsdk:"state" tf:"optional"`
 }
 
 type AutoCaptureConfigInput struct {
@@ -304,7 +304,7 @@ type ChatMessage struct {
 	// The content of the message.
 	Content types.String `tfsdk:"content" tf:"optional"`
 	// The role of the message. One of [system, user, assistant].
-	Role ChatMessageRole `tfsdk:"role" tf:"optional"`
+	Role types.String `tfsdk:"role" tf:"optional"`
 }
 
 // The role of the message. One of [system, user, assistant].
@@ -346,7 +346,7 @@ type CreateAppDeploymentRequest struct {
 	// The name of the app.
 	AppName types.String `tfsdk:"-" url:"-"`
 	// The mode of which the deployment will manage the source code.
-	Mode AppDeploymentMode `tfsdk:"mode" tf:""`
+	Mode types.String `tfsdk:"mode" tf:""`
 	// The workspace file system path of the source code used to create the app
 	// deployment. This is different from
 	// `deployment_artifacts.source_code_path`, which is the path used by the
@@ -420,7 +420,7 @@ type EmbeddingsV1ResponseEmbeddingElement struct {
 	// The index of the embedding in the response.
 	Index types.Int64 `tfsdk:"index" tf:"optional"`
 	// This will always be 'embedding'.
-	Object EmbeddingsV1ResponseEmbeddingElementObject `tfsdk:"object" tf:"optional"`
+	Object types.String `tfsdk:"object" tf:"optional"`
 }
 
 // This will always be 'embedding'.
@@ -514,12 +514,12 @@ type EndpointState struct {
 	// update in progress. Note that if the endpoint's config_update state value
 	// is IN_PROGRESS, another update can not be made until the update completes
 	// or fails."
-	ConfigUpdate EndpointStateConfigUpdate `tfsdk:"config_update" tf:"optional"`
+	ConfigUpdate types.String `tfsdk:"config_update" tf:"optional"`
 	// The state of an endpoint, indicating whether or not the endpoint is
 	// queryable. An endpoint is READY if all of the served entities in its
 	// active configuration are ready. If any of the actively served entities
 	// are in a non-ready state, the endpoint state will be NOT_READY.
-	Ready EndpointStateReady `tfsdk:"ready" tf:"optional"`
+	Ready types.String `tfsdk:"ready" tf:"optional"`
 }
 
 // The state of an endpoint's config update. This informs the user if the
@@ -634,7 +634,7 @@ type ExternalModel struct {
 	// The name of the provider for the external model. Currently, the supported
 	// providers are 'ai21labs', 'anthropic', 'amazon-bedrock', 'cohere',
 	// 'databricks-model-serving', 'openai', and 'palm'.",
-	Provider ExternalModelProvider `tfsdk:"provider" tf:""`
+	Provider types.String `tfsdk:"provider" tf:""`
 	// The task type of the external model.
 	Task types.String `tfsdk:"task" tf:""`
 }
@@ -951,7 +951,7 @@ type QueryEndpointResponse struct {
 	// The type of object returned by the __external/foundation model__ serving
 	// endpoint, one of [text_completion, chat.completion, list (of
 	// embeddings)].
-	Object QueryEndpointResponseObject `tfsdk:"object" tf:"optional"`
+	Object types.String `tfsdk:"object" tf:"optional"`
 	// The predictions returned by the serving endpoint.
 	Predictions []any `tfsdk:"predictions" tf:"optional"`
 	// The name of the served model that served the request. This is useful when
@@ -1001,10 +1001,10 @@ type RateLimit struct {
 	// Key field for a serving endpoint rate limit. Currently, only 'user' and
 	// 'endpoint' are supported, with 'endpoint' being the default if not
 	// specified.
-	Key RateLimitKey `tfsdk:"key" tf:"optional"`
+	Key types.String `tfsdk:"key" tf:"optional"`
 	// Renewal period field for a serving endpoint rate limit. Currently, only
 	// 'minute' is supported.
-	RenewalPeriod RateLimitRenewalPeriod `tfsdk:"renewal_period" tf:""`
+	RenewalPeriod types.String `tfsdk:"renewal_period" tf:""`
 }
 
 // Key field for a serving endpoint rate limit. Currently, only 'user' and
@@ -1251,7 +1251,7 @@ type ServedModelInput struct {
 	// "Medium" (8 - 16 provisioned concurrency), and "Large" (16 - 64
 	// provisioned concurrency). If scale-to-zero is enabled, the lower bound of
 	// the provisioned concurrency for each workload size will be 0.
-	WorkloadSize ServedModelInputWorkloadSize `tfsdk:"workload_size" tf:""`
+	WorkloadSize types.String `tfsdk:"workload_size" tf:""`
 	// The workload type of the served model. The workload type selects which
 	// type of compute to use in the endpoint. The default value for this
 	// parameter is "CPU". For deep learning workloads, GPU acceleration is
@@ -1259,7 +1259,7 @@ type ServedModelInput struct {
 	// available [GPU types].
 	//
 	// [GPU types]: https://docs.databricks.com/machine-learning/model-serving/create-manage-serving-endpoints.html#gpu-workload-types
-	WorkloadType ServedModelInputWorkloadType `tfsdk:"workload_type" tf:"optional"`
+	WorkloadType types.String `tfsdk:"workload_type" tf:"optional"`
 }
 
 // The workload size of the served model. The workload size corresponds to a
@@ -1408,7 +1408,7 @@ type ServedModelState struct {
 	// etc.) DEPLOYMENT_ABORTED indicates that the deployment was terminated
 	// likely due to a failure in bringing up another served entity under the
 	// same endpoint and config version.
-	Deployment ServedModelStateDeployment `tfsdk:"deployment" tf:"optional"`
+	Deployment types.String `tfsdk:"deployment" tf:"optional"`
 	// More information about the state of the served entity, if available.
 	DeploymentStateMessage types.String `tfsdk:"deployment_state_message" tf:"optional"`
 }
@@ -1489,7 +1489,7 @@ type ServingEndpointAccessControlRequest struct {
 	// name of the group
 	GroupName types.String `tfsdk:"group_name" tf:"optional"`
 	// Permission level
-	PermissionLevel ServingEndpointPermissionLevel `tfsdk:"permission_level" tf:"optional"`
+	PermissionLevel types.String `tfsdk:"permission_level" tf:"optional"`
 	// application ID of a service principal
 	ServicePrincipalName types.String `tfsdk:"service_principal_name" tf:"optional"`
 	// name of the user
@@ -1530,7 +1530,7 @@ type ServingEndpointDetailed struct {
 	// The config that the endpoint is attempting to update to.
 	PendingConfig *EndpointPendingConfig `tfsdk:"pending_config" tf:"optional"`
 	// The permission level of the principal making the request.
-	PermissionLevel ServingEndpointDetailedPermissionLevel `tfsdk:"permission_level" tf:"optional"`
+	PermissionLevel types.String `tfsdk:"permission_level" tf:"optional"`
 	// Boolean representing if route optimization has been enabled for the
 	// endpoint
 	RouteOptimized types.Bool `tfsdk:"route_optimized" tf:"optional"`
@@ -1577,7 +1577,7 @@ type ServingEndpointPermission struct {
 
 	InheritedFromObject []types.String `tfsdk:"inherited_from_object" tf:"optional"`
 	// Permission level
-	PermissionLevel ServingEndpointPermissionLevel `tfsdk:"permission_level" tf:"optional"`
+	PermissionLevel types.String `tfsdk:"permission_level" tf:"optional"`
 }
 
 // Permission level
@@ -1621,7 +1621,7 @@ type ServingEndpointPermissions struct {
 type ServingEndpointPermissionsDescription struct {
 	Description types.String `tfsdk:"description" tf:"optional"`
 	// Permission level
-	PermissionLevel ServingEndpointPermissionLevel `tfsdk:"permission_level" tf:"optional"`
+	PermissionLevel types.String `tfsdk:"permission_level" tf:"optional"`
 }
 
 type ServingEndpointPermissionsRequest struct {

--- a/service/settings_tf/model.go
+++ b/service/settings_tf/model.go
@@ -111,9 +111,9 @@ func (f *ClusterAutoRestartMessageMaintenanceWindowDayOfWeek) Type() string {
 }
 
 type ClusterAutoRestartMessageMaintenanceWindowWeekDayBasedSchedule struct {
-	DayOfWeek ClusterAutoRestartMessageMaintenanceWindowDayOfWeek `tfsdk:"day_of_week" tf:"optional"`
+	DayOfWeek types.String `tfsdk:"day_of_week" tf:"optional"`
 
-	Frequency ClusterAutoRestartMessageMaintenanceWindowWeekDayFrequency `tfsdk:"frequency" tf:"optional"`
+	Frequency types.String `tfsdk:"frequency" tf:"optional"`
 
 	WindowStartTime *ClusterAutoRestartMessageMaintenanceWindowWindowStartTime `tfsdk:"window_start_time" tf:"optional"`
 }
@@ -166,7 +166,7 @@ type ClusterAutoRestartMessageMaintenanceWindowWindowStartTime struct {
 // SHIELD feature: CSP
 type ComplianceSecurityProfile struct {
 	// Set by customers when they request Compliance Security Profile (CSP)
-	ComplianceStandards []ComplianceStandard `tfsdk:"compliance_standards" tf:"optional"`
+	ComplianceStandards []types.String `tfsdk:"compliance_standards" tf:"optional"`
 
 	IsEnabled types.Bool `tfsdk:"is_enabled" tf:"optional"`
 }
@@ -245,7 +245,7 @@ type CreateIpAccessList struct {
 	// * `ALLOW`: An allow list. Include this IP or range. * `BLOCK`: A block
 	// list. Exclude this IP or range. IP addresses in the block list are
 	// excluded even if they are included in an allow list.
-	ListType ListType `tfsdk:"list_type" tf:""`
+	ListType types.String `tfsdk:"list_type" tf:""`
 }
 
 // An IP access list was successfully created.
@@ -287,7 +287,7 @@ type CreatePrivateEndpointRuleRequest struct {
 	// The sub-resource type (group ID) of the target resource. Note that to
 	// connect to workspace root storage (root DBFS), you need two endpoints,
 	// one for `blob` and one for `dfs`.
-	GroupId CreatePrivateEndpointRuleRequestGroupId `tfsdk:"group_id" tf:""`
+	GroupId types.String `tfsdk:"group_id" tf:""`
 	// Your Network Connectvity Configuration ID.
 	NetworkConnectivityConfigId types.String `tfsdk:"-" url:"-"`
 	// The Azure resource ID of the target resource.
@@ -348,7 +348,7 @@ type CreateTokenResponse struct {
 type CspEnablementAccount struct {
 	// Set by customers when they request Compliance Security Profile (CSP)
 	// Invariants are enforced in Settings policy.
-	ComplianceStandards []ComplianceStandard `tfsdk:"compliance_standards" tf:"optional"`
+	ComplianceStandards []types.String `tfsdk:"compliance_standards" tf:"optional"`
 	// Enforced = it cannot be overriden at workspace level.
 	IsEnforced types.Bool `tfsdk:"is_enforced" tf:"optional"`
 }
@@ -570,7 +570,7 @@ type ExchangeToken struct {
 	// The scopes of access granted in the token.
 	Scopes []types.String `tfsdk:"scopes" tf:"optional"`
 	// The type of this exchange token
-	TokenType TokenType `tfsdk:"tokenType" tf:"optional"`
+	TokenType types.String `tfsdk:"tokenType" tf:"optional"`
 }
 
 // Exchange a token with the IdP
@@ -580,7 +580,7 @@ type ExchangeTokenRequest struct {
 	// Array of scopes for the token request.
 	Scopes []types.String `tfsdk:"scopes" tf:""`
 	// A list of token types being requested
-	TokenType []TokenType `tfsdk:"tokenType" tf:""`
+	TokenType []types.String `tfsdk:"tokenType" tf:""`
 }
 
 // Exhanged tokens were successfully returned.
@@ -769,7 +769,7 @@ type IpAccessListInfo struct {
 	// * `ALLOW`: An allow list. Include this IP or range. * `BLOCK`: A block
 	// list. Exclude this IP or range. IP addresses in the block list are
 	// excluded even if they are included in an allow list.
-	ListType ListType `tfsdk:"list_type" tf:"optional"`
+	ListType types.String `tfsdk:"list_type" tf:"optional"`
 	// Update timestamp in milliseconds.
 	UpdatedAt types.Int64 `tfsdk:"updated_at" tf:"optional"`
 	// User ID of the user who updated this list.
@@ -885,7 +885,7 @@ type NccAzurePrivateEndpointRule struct {
 	// DISCONNECTED: Connection was removed by the private link resource owner,
 	// the private endpoint becomes informative and should be deleted for
 	// clean-up.
-	ConnectionState NccAzurePrivateEndpointRuleConnectionState `tfsdk:"connection_state" tf:"optional"`
+	ConnectionState types.String `tfsdk:"connection_state" tf:"optional"`
 	// Time in epoch milliseconds when this object was created.
 	CreationTime types.Int64 `tfsdk:"creation_time" tf:"optional"`
 	// Whether this private endpoint is deactivated.
@@ -897,7 +897,7 @@ type NccAzurePrivateEndpointRule struct {
 	// The sub-resource type (group ID) of the target resource. Note that to
 	// connect to workspace root storage (root DBFS), you need two endpoints,
 	// one for `blob` and one for `dfs`.
-	GroupId NccAzurePrivateEndpointRuleGroupId `tfsdk:"group_id" tf:"optional"`
+	GroupId types.String `tfsdk:"group_id" tf:"optional"`
 	// The ID of a network connectivity configuration, which is the parent
 	// resource of this private endpoint rule object.
 	NetworkConnectivityConfigId types.String `tfsdk:"network_connectivity_config_id" tf:"optional"`
@@ -1070,7 +1070,7 @@ type PersonalComputeMessage struct {
 	// users or groups to be added to the ACLs of that workspace’s Personal
 	// Compute default policy before they will be able to create compute
 	// resources through that policy.
-	Value PersonalComputeMessageEnum `tfsdk:"value" tf:""`
+	Value types.String `tfsdk:"value" tf:""`
 }
 
 // ON: Grants all users in all workspaces access to the Personal Compute default
@@ -1153,14 +1153,14 @@ type ReplaceIpAccessList struct {
 	// * `ALLOW`: An allow list. Include this IP or range. * `BLOCK`: A block
 	// list. Exclude this IP or range. IP addresses in the block list are
 	// excluded even if they are included in an allow list.
-	ListType ListType `tfsdk:"list_type" tf:""`
+	ListType types.String `tfsdk:"list_type" tf:""`
 }
 
 type ReplaceResponse struct {
 }
 
 type RestrictWorkspaceAdminsMessage struct {
-	Status RestrictWorkspaceAdminsMessageStatus `tfsdk:"status" tf:""`
+	Status types.String `tfsdk:"status" tf:""`
 }
 
 type RestrictWorkspaceAdminsMessageStatus string
@@ -1231,7 +1231,7 @@ type TokenAccessControlRequest struct {
 	// name of the group
 	GroupName types.String `tfsdk:"group_name" tf:"optional"`
 	// Permission level
-	PermissionLevel TokenPermissionLevel `tfsdk:"permission_level" tf:"optional"`
+	PermissionLevel types.String `tfsdk:"permission_level" tf:"optional"`
 	// application ID of a service principal
 	ServicePrincipalName types.String `tfsdk:"service_principal_name" tf:"optional"`
 	// name of the user
@@ -1274,7 +1274,7 @@ type TokenPermission struct {
 
 	InheritedFromObject []types.String `tfsdk:"inherited_from_object" tf:"optional"`
 	// Permission level
-	PermissionLevel TokenPermissionLevel `tfsdk:"permission_level" tf:"optional"`
+	PermissionLevel types.String `tfsdk:"permission_level" tf:"optional"`
 }
 
 // Permission level
@@ -1314,7 +1314,7 @@ type TokenPermissions struct {
 type TokenPermissionsDescription struct {
 	Description types.String `tfsdk:"description" tf:"optional"`
 	// Permission level
-	PermissionLevel TokenPermissionLevel `tfsdk:"permission_level" tf:"optional"`
+	PermissionLevel types.String `tfsdk:"permission_level" tf:"optional"`
 }
 
 type TokenPermissionsRequest struct {
@@ -1456,7 +1456,7 @@ type UpdateIpAccessList struct {
 	// * `ALLOW`: An allow list. Include this IP or range. * `BLOCK`: A block
 	// list. Exclude this IP or range. IP addresses in the block list are
 	// excluded even if they are included in an allow list.
-	ListType ListType `tfsdk:"list_type" tf:"optional"`
+	ListType types.String `tfsdk:"list_type" tf:"optional"`
 }
 
 // Details required to update a setting.

--- a/service/sharing_tf/model.go
+++ b/service/sharing_tf/model.go
@@ -159,7 +159,7 @@ type ColumnInfo struct {
 	// Full data type specification, JSON-serialized.
 	TypeJson types.String `tfsdk:"type_json" tf:"optional"`
 	// Name of type (INT, STRUCT, MAP, etc.).
-	TypeName ColumnTypeName `tfsdk:"type_name" tf:"optional"`
+	TypeName types.String `tfsdk:"type_name" tf:"optional"`
 	// Digits of precision; required for DecimalTypes.
 	TypePrecision types.Int64 `tfsdk:"type_precision" tf:"optional"`
 	// Digits to right of decimal; Required for DecimalTypes.
@@ -255,7 +255,7 @@ type CreateCleanRoom struct {
 
 type CreateProvider struct {
 	// The delta sharing authentication type.
-	AuthenticationType AuthenticationType `tfsdk:"authentication_type" tf:""`
+	AuthenticationType types.String `tfsdk:"authentication_type" tf:""`
 	// Description about the provider.
 	Comment types.String `tfsdk:"comment" tf:"optional"`
 	// The name of the Provider.
@@ -267,7 +267,7 @@ type CreateProvider struct {
 
 type CreateRecipient struct {
 	// The delta sharing authentication type.
-	AuthenticationType AuthenticationType `tfsdk:"authentication_type" tf:""`
+	AuthenticationType types.String `tfsdk:"authentication_type" tf:""`
 	// Description about the recipient.
 	Comment types.String `tfsdk:"comment" tf:"optional"`
 	// The global Unity Catalog metastore id provided by the data recipient.
@@ -442,7 +442,7 @@ type PartitionValue struct {
 	// The name of the partition column.
 	Name types.String `tfsdk:"name" tf:"optional"`
 	// The operator to apply for the value.
-	Op PartitionValueOp `tfsdk:"op" tf:"optional"`
+	Op types.String `tfsdk:"op" tf:"optional"`
 	// The key of a Delta Sharing recipient's property. For example
 	// `databricks-account-id`. When this field is set, field `value` can not be
 	// set.
@@ -594,12 +594,12 @@ type PrivilegeAssignment struct {
 	// The principal (user email address or group name).
 	Principal types.String `tfsdk:"principal" tf:"optional"`
 	// The privileges assigned to the principal.
-	Privileges []Privilege `tfsdk:"privileges" tf:"optional"`
+	Privileges []types.String `tfsdk:"privileges" tf:"optional"`
 }
 
 type ProviderInfo struct {
 	// The delta sharing authentication type.
-	AuthenticationType AuthenticationType `tfsdk:"authentication_type" tf:"optional"`
+	AuthenticationType types.String `tfsdk:"authentication_type" tf:"optional"`
 	// Cloud vendor of the provider's UC metastore. This field is only present
 	// when the __authentication_type__ is **DATABRICKS**.
 	Cloud types.String `tfsdk:"cloud" tf:"optional"`
@@ -648,7 +648,7 @@ type RecipientInfo struct {
 	// token is already retrieved.
 	ActivationUrl types.String `tfsdk:"activation_url" tf:"optional"`
 	// The delta sharing authentication type.
-	AuthenticationType AuthenticationType `tfsdk:"authentication_type" tf:"optional"`
+	AuthenticationType types.String `tfsdk:"authentication_type" tf:"optional"`
 	// Cloud vendor of the recipient's Unity Catalog Metstore. This field is
 	// only present when the __authentication_type__ is **DATABRICKS**`.
 	Cloud types.String `tfsdk:"cloud" tf:"optional"`
@@ -804,10 +804,10 @@ type SharedDataObject struct {
 	// NOTEBOOK_FILE, optional for updating, ignored for other types.
 	Content types.String `tfsdk:"content" tf:"optional"`
 	// The type of the data object.
-	DataObjectType SharedDataObjectDataObjectType `tfsdk:"data_object_type" tf:"optional"`
+	DataObjectType types.String `tfsdk:"data_object_type" tf:"optional"`
 	// Whether to enable or disable sharing of data history. If not specified,
 	// the default is **DISABLED**.
-	HistoryDataSharingStatus SharedDataObjectHistoryDataSharingStatus `tfsdk:"history_data_sharing_status" tf:"optional"`
+	HistoryDataSharingStatus types.String `tfsdk:"history_data_sharing_status" tf:"optional"`
 	// A fully qualified name that uniquely identifies a data object.
 	//
 	// For example, a table's fully qualified name is in the format of
@@ -829,7 +829,7 @@ type SharedDataObject struct {
 	// NOTE: The start_version should be <= the `current` version of the object.
 	StartVersion types.Int64 `tfsdk:"start_version" tf:"optional"`
 	// One of: **ACTIVE**, **PERMISSION_DENIED**.
-	Status SharedDataObjectStatus `tfsdk:"status" tf:"optional"`
+	Status types.String `tfsdk:"status" tf:"optional"`
 	// A user-provided new name for the data object within the share. If this
 	// new name is not provided, the object's original name will be used as the
 	// `string_shared_as` name. The `string_shared_as` name must be unique
@@ -935,7 +935,7 @@ func (f *SharedDataObjectStatus) Type() string {
 
 type SharedDataObjectUpdate struct {
 	// One of: **ADD**, **REMOVE**, **UPDATE**.
-	Action SharedDataObjectUpdateAction `tfsdk:"action" tf:"optional"`
+	Action types.String `tfsdk:"action" tf:"optional"`
 	// The data object that is being added, removed, or updated.
 	DataObject *SharedDataObject `tfsdk:"data_object" tf:"optional"`
 }

--- a/service/sql_tf/model.go
+++ b/service/sql_tf/model.go
@@ -20,7 +20,7 @@ type AccessControl struct {
 	GroupName types.String `tfsdk:"group_name" tf:"optional"`
 	// * `CAN_VIEW`: Can view the query * `CAN_RUN`: Can run the query *
 	// `CAN_EDIT`: Can edit the query * `CAN_MANAGE`: Can manage the query
-	PermissionLevel PermissionLevel `tfsdk:"permission_level" tf:"optional"`
+	PermissionLevel types.String `tfsdk:"permission_level" tf:"optional"`
 
 	UserName types.String `tfsdk:"user_name" tf:"optional"`
 }
@@ -47,7 +47,7 @@ type Alert struct {
 	// State of the alert. Possible values are: `unknown` (yet to be evaluated),
 	// `triggered` (evaluated and fulfilled trigger conditions), or `ok`
 	// (evaluated and did not fulfill trigger conditions).
-	State AlertState `tfsdk:"state" tf:"optional"`
+	State types.String `tfsdk:"state" tf:"optional"`
 	// Timestamp when the alert was last updated.
 	UpdatedAt types.String `tfsdk:"updated_at" tf:"optional"`
 
@@ -70,7 +70,7 @@ type AlertOptions struct {
 	// [here]: https://docs.databricks.com/sql/user/alerts/index.html
 	CustomSubject types.String `tfsdk:"custom_subject" tf:"optional"`
 	// State that alert evaluates to when query result is empty.
-	EmptyResultState AlertOptionsEmptyResultState `tfsdk:"empty_result_state" tf:"optional"`
+	EmptyResultState types.String `tfsdk:"empty_result_state" tf:"optional"`
 	// Whether or not the alert is muted. If an alert is muted, it will not
 	// notify users and notification destinations when triggered.
 	Muted types.Bool `tfsdk:"muted" tf:"optional"`
@@ -214,7 +214,7 @@ type CancelExecutionResponse struct {
 type Channel struct {
 	DbsqlVersion types.String `tfsdk:"dbsql_version" tf:"optional"`
 
-	Name ChannelName `tfsdk:"name" tf:"optional"`
+	Name types.String `tfsdk:"name" tf:"optional"`
 }
 
 // Channel information for the SQL warehouse at the time of query execution
@@ -222,9 +222,10 @@ type ChannelInfo struct {
 	// DBSQL Version the channel is mapped to
 	DbsqlVersion types.String `tfsdk:"dbsql_version" tf:"optional"`
 	// Name of the channel
-	Name ChannelName `tfsdk:"name" tf:"optional"`
+	Name types.String `tfsdk:"name" tf:"optional"`
 }
 
+// Name of the channel
 type ChannelName string
 
 const ChannelNameChannelNameCurrent ChannelName = `CHANNEL_NAME_CURRENT`
@@ -267,7 +268,7 @@ type ColumnInfo struct {
 	TypeIntervalType types.String `tfsdk:"type_interval_type" tf:"optional"`
 	// The name of the base data type. This doesn't include details for complex
 	// types such as STRUCT, MAP or ARRAY.
-	TypeName ColumnInfoTypeName `tfsdk:"type_name" tf:"optional"`
+	TypeName types.String `tfsdk:"type_name" tf:"optional"`
 	// Specifies the number of digits in a number. This applies to the DECIMAL
 	// type.
 	TypePrecision types.Int64 `tfsdk:"type_precision" tf:"optional"`
@@ -424,7 +425,7 @@ type CreateWarehouseRequest struct {
 	// characters.
 	Name types.String `tfsdk:"name" tf:"optional"`
 	// Configurations whether the warehouse should use spot instances.
-	SpotInstancePolicy SpotInstancePolicy `tfsdk:"spot_instance_policy" tf:"optional"`
+	SpotInstancePolicy types.String `tfsdk:"spot_instance_policy" tf:"optional"`
 	// A set of key-value pairs that will be tagged on all resources (e.g., AWS
 	// instances and EBS volumes) associated with this SQL warehouse.
 	//
@@ -433,7 +434,7 @@ type CreateWarehouseRequest struct {
 	// Warehouse type: `PRO` or `CLASSIC`. If you want to use serverless
 	// compute, you must set to `PRO` and also set the field
 	// `enable_serverless_compute` to `true`.
-	WarehouseType CreateWarehouseRequestWarehouseType `tfsdk:"warehouse_type" tf:"optional"`
+	WarehouseType types.String `tfsdk:"warehouse_type" tf:"optional"`
 }
 
 // Warehouse type: `PRO` or `CLASSIC`. If you want to use serverless compute,
@@ -523,7 +524,7 @@ type Dashboard struct {
 	Parent types.String `tfsdk:"parent" tf:"optional"`
 	// * `CAN_VIEW`: Can view the query * `CAN_RUN`: Can run the query *
 	// `CAN_EDIT`: Can edit the query * `CAN_MANAGE`: Can manage the query
-	PermissionTier PermissionLevel `tfsdk:"permission_tier" tf:"optional"`
+	PermissionTier types.String `tfsdk:"permission_tier" tf:"optional"`
 	// URL slug. Usually mirrors the query name with dashes (`-`) instead of
 	// spaces. Appears in the URL for this query.
 	Slug types.String `tfsdk:"slug" tf:"optional"`
@@ -547,7 +548,7 @@ type DashboardEditContent struct {
 	// Sets the **Run as** role for the object. Must be set to one of `"viewer"`
 	// (signifying "run as viewer" behavior) or `"owner"` (signifying "run as
 	// owner" behavior)
-	RunAsRole RunAsRole `tfsdk:"run_as_role" tf:"optional"`
+	RunAsRole types.String `tfsdk:"run_as_role" tf:"optional"`
 
 	Tags []types.String `tfsdk:"tags" tf:"optional"`
 }
@@ -573,7 +574,7 @@ type DashboardPostContent struct {
 	// Sets the **Run as** role for the object. Must be set to one of `"viewer"`
 	// (signifying "run as viewer" behavior) or `"owner"` (signifying "run as
 	// owner" behavior)
-	RunAsRole RunAsRole `tfsdk:"run_as_role" tf:"optional"`
+	RunAsRole types.String `tfsdk:"run_as_role" tf:"optional"`
 
 	Tags []types.String `tfsdk:"tags" tf:"optional"`
 }
@@ -762,7 +763,7 @@ type EditWarehouseRequest struct {
 	// characters.
 	Name types.String `tfsdk:"name" tf:"optional"`
 	// Configurations whether the warehouse should use spot instances.
-	SpotInstancePolicy SpotInstancePolicy `tfsdk:"spot_instance_policy" tf:"optional"`
+	SpotInstancePolicy types.String `tfsdk:"spot_instance_policy" tf:"optional"`
 	// A set of key-value pairs that will be tagged on all resources (e.g., AWS
 	// instances and EBS volumes) associated with this SQL warehouse.
 	//
@@ -771,7 +772,7 @@ type EditWarehouseRequest struct {
 	// Warehouse type: `PRO` or `CLASSIC`. If you want to use serverless
 	// compute, you must set to `PRO` and also set the field
 	// `enable_serverless_compute` to `true`.
-	WarehouseType EditWarehouseRequestWarehouseType `tfsdk:"warehouse_type" tf:"optional"`
+	WarehouseType types.String `tfsdk:"warehouse_type" tf:"optional"`
 }
 
 // Warehouse type: `PRO` or `CLASSIC`. If you want to use serverless compute,
@@ -824,7 +825,7 @@ type EndpointHealth struct {
 	// Deprecated. split into summary and details for security
 	Message types.String `tfsdk:"message" tf:"optional"`
 	// Health status of the warehouse.
-	Status Status `tfsdk:"status" tf:"optional"`
+	Status types.String `tfsdk:"status" tf:"optional"`
 	// A short summary of the health status in case of degraded/failed
 	// warehouses.
 	Summary types.String `tfsdk:"summary" tf:"optional"`
@@ -893,9 +894,9 @@ type EndpointInfo struct {
 	// ODBC parameters for the SQL warehouse
 	OdbcParams *OdbcParams `tfsdk:"odbc_params" tf:"optional"`
 	// Configurations whether the warehouse should use spot instances.
-	SpotInstancePolicy SpotInstancePolicy `tfsdk:"spot_instance_policy" tf:"optional"`
+	SpotInstancePolicy types.String `tfsdk:"spot_instance_policy" tf:"optional"`
 	// State of the warehouse
-	State State `tfsdk:"state" tf:"optional"`
+	State types.String `tfsdk:"state" tf:"optional"`
 	// A set of key-value pairs that will be tagged on all resources (e.g., AWS
 	// instances and EBS volumes) associated with this SQL warehouse.
 	//
@@ -904,7 +905,7 @@ type EndpointInfo struct {
 	// Warehouse type: `PRO` or `CLASSIC`. If you want to use serverless
 	// compute, you must set to `PRO` and also set the field
 	// `enable_serverless_compute` to `true`.
-	WarehouseType EndpointInfoWarehouseType `tfsdk:"warehouse_type" tf:"optional"`
+	WarehouseType types.String `tfsdk:"warehouse_type" tf:"optional"`
 }
 
 // Warehouse type: `PRO` or `CLASSIC`. If you want to use serverless compute,
@@ -988,7 +989,7 @@ type ExecuteStatementRequest struct {
 	// 2. These are presigned URLs with a specific expiration, indicated in the
 	// response. The behavior when attempting to use an expired link is cloud
 	// specific.
-	Disposition Disposition `tfsdk:"disposition" tf:"optional"`
+	Disposition types.String `tfsdk:"disposition" tf:"optional"`
 	// Statement execution supports three result formats: `JSON_ARRAY`
 	// (default), `ARROW_STREAM`, and `CSV`.
 	//
@@ -1025,7 +1026,7 @@ type ExecuteStatementRequest struct {
 	//
 	// [Apache Arrow streaming format]: https://arrow.apache.org/docs/format/Columnar.html#ipc-streaming-format
 	// [RFC 4180]: https://www.rfc-editor.org/rfc/rfc4180
-	Format Format `tfsdk:"format" tf:"optional"`
+	Format types.String `tfsdk:"format" tf:"optional"`
 	// When `wait_timeout > 0s`, the call will block up to the specified time.
 	// If the statement execution doesn't finish within this time,
 	// `on_wait_timeout` determines whether the execution should continue or be
@@ -1034,7 +1035,7 @@ type ExecuteStatementRequest struct {
 	// polling with :method:statementexecution/getStatement. When set to
 	// `CANCEL`, the statement execution is canceled and the call returns with a
 	// `CANCELED` state.
-	OnWaitTimeout ExecuteStatementRequestOnWaitTimeout `tfsdk:"on_wait_timeout" tf:"optional"`
+	OnWaitTimeout types.String `tfsdk:"on_wait_timeout" tf:"optional"`
 	// A list of parameters to pass into a SQL statement containing parameter
 	// markers. A parameter consists of a name, a value, and optionally a type.
 	// To represent a NULL value, the `value` field may be omitted or set to
@@ -1232,7 +1233,7 @@ type GetDbsqlPermissionRequest struct {
 	// Object ID. An ACL is returned for the object with this UUID.
 	ObjectId types.String `tfsdk:"-" url:"-"`
 	// The type of object permissions to check.
-	ObjectType ObjectTypePlural `tfsdk:"-" url:"-"`
+	ObjectType types.String `tfsdk:"-" url:"-"`
 }
 
 // Get a query definition.
@@ -1245,7 +1246,7 @@ type GetResponse struct {
 	// An object's type and UUID, separated by a forward slash (/) character.
 	ObjectId types.String `tfsdk:"object_id" tf:"optional"`
 	// A singular noun object type.
-	ObjectType ObjectType `tfsdk:"object_type" tf:"optional"`
+	ObjectType types.String `tfsdk:"object_type" tf:"optional"`
 }
 
 // Get status, manifest, and result first chunk
@@ -1367,9 +1368,9 @@ type GetWarehouseResponse struct {
 	// ODBC parameters for the SQL warehouse
 	OdbcParams *OdbcParams `tfsdk:"odbc_params" tf:"optional"`
 	// Configurations whether the warehouse should use spot instances.
-	SpotInstancePolicy SpotInstancePolicy `tfsdk:"spot_instance_policy" tf:"optional"`
+	SpotInstancePolicy types.String `tfsdk:"spot_instance_policy" tf:"optional"`
 	// State of the warehouse
-	State State `tfsdk:"state" tf:"optional"`
+	State types.String `tfsdk:"state" tf:"optional"`
 	// A set of key-value pairs that will be tagged on all resources (e.g., AWS
 	// instances and EBS volumes) associated with this SQL warehouse.
 	//
@@ -1378,7 +1379,7 @@ type GetWarehouseResponse struct {
 	// Warehouse type: `PRO` or `CLASSIC`. If you want to use serverless
 	// compute, you must set to `PRO` and also set the field
 	// `enable_serverless_compute` to `true`.
-	WarehouseType GetWarehouseResponseWarehouseType `tfsdk:"warehouse_type" tf:"optional"`
+	WarehouseType types.String `tfsdk:"warehouse_type" tf:"optional"`
 }
 
 // Warehouse type: `PRO` or `CLASSIC`. If you want to use serverless compute,
@@ -1436,7 +1437,7 @@ type GetWorkspaceWarehouseConfigResponse struct {
 	// AWS Only: Instance profile used to pass IAM role to the cluster
 	InstanceProfileArn types.String `tfsdk:"instance_profile_arn" tf:"optional"`
 	// Security policy for warehouses
-	SecurityPolicy GetWorkspaceWarehouseConfigResponseSecurityPolicy `tfsdk:"security_policy" tf:"optional"`
+	SecurityPolicy types.String `tfsdk:"security_policy" tf:"optional"`
 	// SQL configuration parameters
 	SqlConfigurationParameters *RepeatedEndpointConfPairs `tfsdk:"sql_configuration_parameters" tf:"optional"`
 }
@@ -1474,7 +1475,7 @@ func (f *GetWorkspaceWarehouseConfigResponseSecurityPolicy) Type() string {
 // Get dashboard objects
 type ListDashboardsRequest struct {
 	// Name of dashboard attribute to order by.
-	Order ListOrder `tfsdk:"-" url:"order,omitempty"`
+	Order types.String `tfsdk:"-" url:"order,omitempty"`
 	// Page number to retrieve.
 	Page types.Int64 `tfsdk:"-" url:"page,omitempty"`
 	// Number of dashboards to return per page.
@@ -1713,7 +1714,7 @@ type Parameter struct {
 	// The text displayed in a parameter picking widget.
 	Title types.String `tfsdk:"title" tf:"optional"`
 	// Parameters can have several different types.
-	Type ParameterType `tfsdk:"type" tf:"optional"`
+	Type types.String `tfsdk:"type" tf:"optional"`
 	// The default value for this parameter.
 	Value any `tfsdk:"value" tf:"optional"`
 }
@@ -1875,7 +1876,7 @@ type Query struct {
 	Parent types.String `tfsdk:"parent" tf:"optional"`
 	// * `CAN_VIEW`: Can view the query * `CAN_RUN`: Can run the query *
 	// `CAN_EDIT`: Can edit the query * `CAN_MANAGE`: Can manage the query
-	PermissionTier PermissionLevel `tfsdk:"permission_tier" tf:"optional"`
+	PermissionTier types.String `tfsdk:"permission_tier" tf:"optional"`
 	// The text of the query to be run.
 	Query types.String `tfsdk:"query" tf:"optional"`
 	// A SHA-256 hash of the query text along with the authenticated user ID.
@@ -1883,7 +1884,7 @@ type Query struct {
 	// Sets the **Run as** role for the object. Must be set to one of `"viewer"`
 	// (signifying "run as viewer" behavior) or `"owner"` (signifying "run as
 	// owner" behavior)
-	RunAsRole RunAsRole `tfsdk:"run_as_role" tf:"optional"`
+	RunAsRole types.String `tfsdk:"run_as_role" tf:"optional"`
 
 	Tags []types.String `tfsdk:"tags" tf:"optional"`
 	// The timestamp at which this query was last updated.
@@ -1919,7 +1920,7 @@ type QueryEditContent struct {
 	// Sets the **Run as** role for the object. Must be set to one of `"viewer"`
 	// (signifying "run as viewer" behavior) or `"owner"` (signifying "run as
 	// owner" behavior)
-	RunAsRole RunAsRole `tfsdk:"run_as_role" tf:"optional"`
+	RunAsRole types.String `tfsdk:"run_as_role" tf:"optional"`
 
 	Tags []types.String `tfsdk:"tags" tf:"optional"`
 }
@@ -1930,7 +1931,7 @@ type QueryFilter struct {
 	// A list of statement IDs.
 	StatementIds []types.String `tfsdk:"statement_ids" tf:"optional" url:"statement_ids,omitempty"`
 
-	Statuses []QueryStatus `tfsdk:"statuses" tf:"optional" url:"statuses,omitempty"`
+	Statuses []types.String `tfsdk:"statuses" tf:"optional" url:"statuses,omitempty"`
 	// A list of user IDs who ran the queries.
 	UserIds []types.Int64 `tfsdk:"user_ids" tf:"optional" url:"user_ids,omitempty"`
 	// A list of warehouse IDs.
@@ -1962,7 +1963,7 @@ type QueryInfo struct {
 	// Metrics about query execution.
 	Metrics *QueryMetrics `tfsdk:"metrics" tf:"optional"`
 	// Whether plans exist for the execution, or the reason why they are missing
-	PlansState PlansState `tfsdk:"plans_state" tf:"optional"`
+	PlansState types.String `tfsdk:"plans_state" tf:"optional"`
 	// The time the query ended.
 	QueryEndTimeMs types.Int64 `tfsdk:"query_end_time_ms" tf:"optional"`
 	// The query ID.
@@ -1976,12 +1977,12 @@ type QueryInfo struct {
 	// URL to the query plan.
 	SparkUiUrl types.String `tfsdk:"spark_ui_url" tf:"optional"`
 	// Type of statement for this query
-	StatementType QueryStatementType `tfsdk:"statement_type" tf:"optional"`
+	StatementType types.String `tfsdk:"statement_type" tf:"optional"`
 	// Query status with one the following values: * `QUEUED`: Query has been
 	// received and queued. * `RUNNING`: Query has started. * `CANCELED`: Query
 	// has been cancelled by the user. * `FAILED`: Query has failed. *
 	// `FINISHED`: Query has completed.
-	Status QueryStatus `tfsdk:"status" tf:"optional"`
+	Status types.String `tfsdk:"status" tf:"optional"`
 	// The ID of the user who ran the query.
 	UserId types.Int64 `tfsdk:"user_id" tf:"optional"`
 	// The email address or username of the user who ran the query.
@@ -2103,7 +2104,7 @@ type QueryPostContent struct {
 	// Sets the **Run as** role for the object. Must be set to one of `"viewer"`
 	// (signifying "run as viewer" behavior) or `"owner"` (signifying "run as
 	// owner" behavior)
-	RunAsRole RunAsRole `tfsdk:"run_as_role" tf:"optional"`
+	RunAsRole types.String `tfsdk:"run_as_role" tf:"optional"`
 
 	Tags []types.String `tfsdk:"tags" tf:"optional"`
 }
@@ -2276,7 +2277,7 @@ type ResultManifest struct {
 	// Array of result set chunk metadata.
 	Chunks []BaseChunkInfo `tfsdk:"chunks" tf:"optional"`
 
-	Format Format `tfsdk:"format" tf:"optional"`
+	Format types.String `tfsdk:"format" tf:"optional"`
 	// The schema is an ordered list of column descriptions.
 	Schema *ResultSchema `tfsdk:"schema" tf:"optional"`
 	// The total number of bytes in the result set. This field is not available
@@ -2329,7 +2330,7 @@ func (f *RunAsRole) Type() string {
 }
 
 type ServiceError struct {
-	ErrorCode ServiceErrorCode `tfsdk:"error_code" tf:"optional"`
+	ErrorCode types.String `tfsdk:"error_code" tf:"optional"`
 	// A brief summary of the error condition.
 	Message types.String `tfsdk:"message" tf:"optional"`
 }
@@ -2392,7 +2393,7 @@ type SetRequest struct {
 	// request's POST content.
 	ObjectId types.String `tfsdk:"-" url:"-"`
 	// The type of object permission to set.
-	ObjectType ObjectTypePlural `tfsdk:"-" url:"-"`
+	ObjectType types.String `tfsdk:"-" url:"-"`
 }
 
 type SetResponse struct {
@@ -2400,7 +2401,7 @@ type SetResponse struct {
 	// An object's type and UUID, separated by a forward slash (/) character.
 	ObjectId types.String `tfsdk:"object_id" tf:"optional"`
 	// A singular noun object type.
-	ObjectType ObjectType `tfsdk:"object_type" tf:"optional"`
+	ObjectType types.String `tfsdk:"object_type" tf:"optional"`
 }
 
 type SetWorkspaceWarehouseConfigRequest struct {
@@ -2426,7 +2427,7 @@ type SetWorkspaceWarehouseConfigRequest struct {
 	// AWS Only: Instance profile used to pass IAM role to the cluster
 	InstanceProfileArn types.String `tfsdk:"instance_profile_arn" tf:"optional"`
 	// Security policy for warehouses
-	SecurityPolicy SetWorkspaceWarehouseConfigRequestSecurityPolicy `tfsdk:"security_policy" tf:"optional"`
+	SecurityPolicy types.String `tfsdk:"security_policy" tf:"optional"`
 	// SQL configuration parameters
 	SqlConfigurationParameters *RepeatedEndpointConfPairs `tfsdk:"sql_configuration_parameters" tf:"optional"`
 }
@@ -2615,7 +2616,7 @@ type StatementStatus struct {
 	// come from explicit cancel call, or timeout with `on_wait_timeout=CANCEL`
 	// - `CLOSED`: execution successful, and statement closed; result no longer
 	// available for fetch
-	State StatementState `tfsdk:"state" tf:"optional"`
+	State types.String `tfsdk:"state" tf:"optional"`
 }
 
 // Health status of the warehouse.
@@ -2660,7 +2661,7 @@ type StopWarehouseResponse struct {
 }
 
 type Success struct {
-	Message SuccessMessage `tfsdk:"message" tf:"optional"`
+	Message types.String `tfsdk:"message" tf:"optional"`
 }
 
 type SuccessMessage string
@@ -2690,12 +2691,12 @@ func (f *SuccessMessage) Type() string {
 
 type TerminationReason struct {
 	// status code indicating why the cluster was terminated
-	Code TerminationReasonCode `tfsdk:"code" tf:"optional"`
+	Code types.String `tfsdk:"code" tf:"optional"`
 	// list of parameters that provide additional information about why the
 	// cluster was terminated
 	Parameters map[string]types.String `tfsdk:"parameters" tf:"optional"`
 	// type of the termination
-	Type TerminationReasonType `tfsdk:"type" tf:"optional"`
+	Type types.String `tfsdk:"type" tf:"optional"`
 }
 
 // status code indicating why the cluster was terminated
@@ -2931,7 +2932,7 @@ type TransferOwnershipRequest struct {
 	// The ID of the object on which to change ownership.
 	ObjectId TransferOwnershipObjectId `tfsdk:"-" url:"-"`
 	// The type of object on which to change ownership.
-	ObjectType OwnableObjectType `tfsdk:"-" url:"-"`
+	ObjectType types.String `tfsdk:"-" url:"-"`
 }
 
 type UpdateResponse struct {
@@ -2976,7 +2977,7 @@ type WarehouseAccessControlRequest struct {
 	// name of the group
 	GroupName types.String `tfsdk:"group_name" tf:"optional"`
 	// Permission level
-	PermissionLevel WarehousePermissionLevel `tfsdk:"permission_level" tf:"optional"`
+	PermissionLevel types.String `tfsdk:"permission_level" tf:"optional"`
 	// application ID of a service principal
 	ServicePrincipalName types.String `tfsdk:"service_principal_name" tf:"optional"`
 	// name of the user
@@ -3001,7 +3002,7 @@ type WarehousePermission struct {
 
 	InheritedFromObject []types.String `tfsdk:"inherited_from_object" tf:"optional"`
 	// Permission level
-	PermissionLevel WarehousePermissionLevel `tfsdk:"permission_level" tf:"optional"`
+	PermissionLevel types.String `tfsdk:"permission_level" tf:"optional"`
 }
 
 // Permission level
@@ -3045,7 +3046,7 @@ type WarehousePermissions struct {
 type WarehousePermissionsDescription struct {
 	Description types.String `tfsdk:"description" tf:"optional"`
 	// Permission level
-	PermissionLevel WarehousePermissionLevel `tfsdk:"permission_level" tf:"optional"`
+	PermissionLevel types.String `tfsdk:"permission_level" tf:"optional"`
 }
 
 type WarehousePermissionsRequest struct {
@@ -3059,7 +3060,7 @@ type WarehouseTypePair struct {
 	// value for warehouse_type in CreateWarehouse and EditWarehouse
 	Enabled types.Bool `tfsdk:"enabled" tf:"optional"`
 	// Warehouse type: `PRO` or `CLASSIC`.
-	WarehouseType WarehouseTypePairWarehouseType `tfsdk:"warehouse_type" tf:"optional"`
+	WarehouseType types.String `tfsdk:"warehouse_type" tf:"optional"`
 }
 
 // Warehouse type: `PRO` or `CLASSIC`.

--- a/service/vectorsearch_tf/model.go
+++ b/service/vectorsearch_tf/model.go
@@ -23,7 +23,7 @@ type ColumnInfo struct {
 
 type CreateEndpoint struct {
 	// Type of endpoint.
-	EndpointType EndpointType `tfsdk:"endpoint_type" tf:""`
+	EndpointType types.String `tfsdk:"endpoint_type" tf:""`
 	// Name of endpoint
 	Name types.String `tfsdk:"name" tf:""`
 }
@@ -44,7 +44,7 @@ type CreateVectorIndexRequest struct {
 	// underlying data in the Delta Table changes. - `DIRECT_ACCESS`: An index
 	// that supports direct read and write of vectors and metadata through our
 	// REST and SDK APIs. With this model, the user manages index updates.
-	IndexType VectorIndexType `tfsdk:"index_type" tf:""`
+	IndexType types.String `tfsdk:"index_type" tf:""`
 	// Name of the index
 	Name types.String `tfsdk:"name" tf:""`
 	// Primary key of the index
@@ -107,7 +107,7 @@ type DeleteDataVectorIndexResponse struct {
 	// Result of the upsert or delete operation.
 	Result *DeleteDataResult `tfsdk:"result" tf:"optional"`
 	// Status of the delete operation.
-	Status DeleteDataStatus `tfsdk:"status" tf:"optional"`
+	Status types.String `tfsdk:"status" tf:"optional"`
 }
 
 // Delete an endpoint
@@ -146,7 +146,7 @@ type DeltaSyncVectorIndexSpecRequest struct {
 	// available when the update started. - `CONTINUOUS`: If the pipeline uses
 	// continuous execution, the pipeline processes new data as it arrives in
 	// the source table to keep vector index fresh.
-	PipelineType PipelineType `tfsdk:"pipeline_type" tf:"optional"`
+	PipelineType types.String `tfsdk:"pipeline_type" tf:"optional"`
 	// The name of the source table.
 	SourceTable types.String `tfsdk:"source_table" tf:"optional"`
 }
@@ -169,7 +169,7 @@ type DeltaSyncVectorIndexSpecResponse struct {
 	// available when the update started. - `CONTINUOUS`: If the pipeline uses
 	// continuous execution, the pipeline processes new data as it arrives in
 	// the source table to keep vector index fresh.
-	PipelineType PipelineType `tfsdk:"pipeline_type" tf:"optional"`
+	PipelineType types.String `tfsdk:"pipeline_type" tf:"optional"`
 	// The name of the source table.
 	SourceTable types.String `tfsdk:"source_table" tf:"optional"`
 }
@@ -210,7 +210,7 @@ type EndpointInfo struct {
 	// Current status of the endpoint
 	EndpointStatus *EndpointStatus `tfsdk:"endpoint_status" tf:"optional"`
 	// Type of endpoint.
-	EndpointType EndpointType `tfsdk:"endpoint_type" tf:"optional"`
+	EndpointType types.String `tfsdk:"endpoint_type" tf:"optional"`
 	// Unique identifier of the endpoint
 	Id types.String `tfsdk:"id" tf:"optional"`
 	// Timestamp of last update to the endpoint
@@ -228,7 +228,7 @@ type EndpointStatus struct {
 	// Additional status message
 	Message types.String `tfsdk:"message" tf:"optional"`
 	// Current state of the endpoint
-	State EndpointStatusState `tfsdk:"state" tf:"optional"`
+	State types.String `tfsdk:"state" tf:"optional"`
 }
 
 // Current state of the endpoint
@@ -353,7 +353,7 @@ type MiniVectorIndex struct {
 	// underlying data in the Delta Table changes. - `DIRECT_ACCESS`: An index
 	// that supports direct read and write of vectors and metadata through our
 	// REST and SDK APIs. With this model, the user manages index updates.
-	IndexType VectorIndexType `tfsdk:"index_type" tf:"optional"`
+	IndexType types.String `tfsdk:"index_type" tf:"optional"`
 	// Name of the index
 	Name types.String `tfsdk:"name" tf:"optional"`
 	// Primary key of the index
@@ -548,7 +548,7 @@ type UpsertDataVectorIndexResponse struct {
 	// Result of the upsert or delete operation.
 	Result *UpsertDataResult `tfsdk:"result" tf:"optional"`
 	// Status of the upsert operation.
-	Status UpsertDataStatus `tfsdk:"status" tf:"optional"`
+	Status types.String `tfsdk:"status" tf:"optional"`
 }
 
 type Value struct {
@@ -581,7 +581,7 @@ type VectorIndex struct {
 	// underlying data in the Delta Table changes. - `DIRECT_ACCESS`: An index
 	// that supports direct read and write of vectors and metadata through our
 	// REST and SDK APIs. With this model, the user manages index updates.
-	IndexType VectorIndexType `tfsdk:"index_type" tf:"optional"`
+	IndexType types.String `tfsdk:"index_type" tf:"optional"`
 	// Name of the index
 	Name types.String `tfsdk:"name" tf:"optional"`
 	// Primary key of the index

--- a/service/workspace_tf/model.go
+++ b/service/workspace_tf/model.go
@@ -18,7 +18,7 @@ import (
 
 type AclItem struct {
 	// The permission level applied to the principal.
-	Permission AclPermission `tfsdk:"permission" tf:""`
+	Permission types.String `tfsdk:"permission" tf:""`
 	// The principal in which the permission is applied.
 	Principal types.String `tfsdk:"principal" tf:""`
 }
@@ -128,7 +128,7 @@ type CreateScope struct {
 	Scope types.String `tfsdk:"scope" tf:""`
 	// The backend type the scope will be created with. If not specified, will
 	// default to `DATABRICKS`
-	ScopeBackendType ScopeBackendType `tfsdk:"scope_backend_type" tf:"optional"`
+	ScopeBackendType types.String `tfsdk:"scope_backend_type" tf:"optional"`
 }
 
 type CreateScopeResponse struct {
@@ -256,7 +256,7 @@ type ExportRequest struct {
 	// Markdown format. - `AUTO`: The object or directory is exported depending
 	// on the objects type. Directory exports will include notebooks and
 	// workspace files.
-	Format ExportFormat `tfsdk:"-" url:"format,omitempty"`
+	Format types.String `tfsdk:"-" url:"format,omitempty"`
 	// The absolute path of the object or directory. Exporting a directory is
 	// only supported for the `DBC`, `SOURCE`, and `AUTO` format.
 	Path types.String `tfsdk:"-" url:"path"`
@@ -373,10 +373,10 @@ type Import struct {
 	// notebook is imported in Databricks archive format. Required for
 	// directories. - `R_MARKDOWN`: The notebook is imported from R Markdown
 	// format.
-	Format ImportFormat `tfsdk:"format" tf:"optional"`
+	Format types.String `tfsdk:"format" tf:"optional"`
 	// The language of the object. This value is set only if the object type is
 	// `NOTEBOOK`.
-	Language Language `tfsdk:"language" tf:"optional"`
+	Language types.String `tfsdk:"language" tf:"optional"`
 	// The flag that specifies whether to overwrite existing object. It is
 	// `false` by default. For `DBC` format, `overwrite` is not supported since
 	// it may contain a directory.
@@ -550,7 +550,7 @@ type ObjectInfo struct {
 	CreatedAt types.Int64 `tfsdk:"created_at" tf:"optional"`
 	// The language of the object. This value is set only if the object type is
 	// `NOTEBOOK`.
-	Language Language `tfsdk:"language" tf:"optional"`
+	Language types.String `tfsdk:"language" tf:"optional"`
 	// Only applicable to files, the last modified UTC timestamp.
 	ModifiedAt types.Int64 `tfsdk:"modified_at" tf:"optional"`
 	// Unique identifier for the object.
@@ -560,7 +560,7 @@ type ObjectInfo struct {
 	// - `NOTEBOOK`: document that contains runnable code, visualizations, and
 	// explanatory text. - `DIRECTORY`: directory - `LIBRARY`: library - `FILE`:
 	// file - `REPO`: repository - `DASHBOARD`: Lakeview dashboard
-	ObjectType ObjectType `tfsdk:"object_type" tf:"optional"`
+	ObjectType types.String `tfsdk:"object_type" tf:"optional"`
 	// The absolute path of the object.
 	Path types.String `tfsdk:"path" tf:"optional"`
 	// A unique identifier for the object that is consistent across all
@@ -618,7 +618,7 @@ func (f *ObjectType) Type() string {
 
 type PutAcl struct {
 	// The permission level applied to the principal.
-	Permission AclPermission `tfsdk:"permission" tf:""`
+	Permission types.String `tfsdk:"permission" tf:""`
 	// The principal in which the permission is applied.
 	Principal types.String `tfsdk:"principal" tf:""`
 	// The name of the scope to apply permissions to.
@@ -646,7 +646,7 @@ type RepoAccessControlRequest struct {
 	// name of the group
 	GroupName types.String `tfsdk:"group_name" tf:"optional"`
 	// Permission level
-	PermissionLevel RepoPermissionLevel `tfsdk:"permission_level" tf:"optional"`
+	PermissionLevel types.String `tfsdk:"permission_level" tf:"optional"`
 	// application ID of a service principal
 	ServicePrincipalName types.String `tfsdk:"service_principal_name" tf:"optional"`
 	// name of the user
@@ -693,7 +693,7 @@ type RepoPermission struct {
 
 	InheritedFromObject []types.String `tfsdk:"inherited_from_object" tf:"optional"`
 	// Permission level
-	PermissionLevel RepoPermissionLevel `tfsdk:"permission_level" tf:"optional"`
+	PermissionLevel types.String `tfsdk:"permission_level" tf:"optional"`
 }
 
 // Permission level
@@ -739,7 +739,7 @@ type RepoPermissions struct {
 type RepoPermissionsDescription struct {
 	Description types.String `tfsdk:"description" tf:"optional"`
 	// Permission level
-	PermissionLevel RepoPermissionLevel `tfsdk:"permission_level" tf:"optional"`
+	PermissionLevel types.String `tfsdk:"permission_level" tf:"optional"`
 }
 
 type RepoPermissionsRequest struct {
@@ -784,7 +784,7 @@ type SecretMetadata struct {
 
 type SecretScope struct {
 	// The type of secret scope backend.
-	BackendType ScopeBackendType `tfsdk:"backend_type" tf:"optional"`
+	BackendType types.String `tfsdk:"backend_type" tf:"optional"`
 	// The metadata for the secret scope if the type is `AZURE_KEYVAULT`
 	KeyvaultMetadata *AzureKeyVaultSecretScopeMetadata `tfsdk:"keyvault_metadata" tf:"optional"`
 	// A unique name to identify the secret scope.
@@ -848,7 +848,7 @@ type WorkspaceObjectAccessControlRequest struct {
 	// name of the group
 	GroupName types.String `tfsdk:"group_name" tf:"optional"`
 	// Permission level
-	PermissionLevel WorkspaceObjectPermissionLevel `tfsdk:"permission_level" tf:"optional"`
+	PermissionLevel types.String `tfsdk:"permission_level" tf:"optional"`
 	// application ID of a service principal
 	ServicePrincipalName types.String `tfsdk:"service_principal_name" tf:"optional"`
 	// name of the user
@@ -873,7 +873,7 @@ type WorkspaceObjectPermission struct {
 
 	InheritedFromObject []types.String `tfsdk:"inherited_from_object" tf:"optional"`
 	// Permission level
-	PermissionLevel WorkspaceObjectPermissionLevel `tfsdk:"permission_level" tf:"optional"`
+	PermissionLevel types.String `tfsdk:"permission_level" tf:"optional"`
 }
 
 // Permission level
@@ -919,7 +919,7 @@ type WorkspaceObjectPermissions struct {
 type WorkspaceObjectPermissionsDescription struct {
 	Description types.String `tfsdk:"description" tf:"optional"`
 	// Permission level
-	PermissionLevel WorkspaceObjectPermissionLevel `tfsdk:"permission_level" tf:"optional"`
+	PermissionLevel types.String `tfsdk:"permission_level" tf:"optional"`
 }
 
 type WorkspaceObjectPermissionsRequest struct {


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
- These enums have to be strings instead of the indirect types that they used to be, otherwise `.get` and `.set` does not work properly
- First part of making the acceptance test work as specified here https://github.com/databricks/terraform-provider-databricks/pull/3841

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
