### PR TITLE
Update resource quality monitor in plugin framework

### DIFF
--- a/pluginframework/resource_quality_monitor.go
+++ b/pluginframework/resource_quality_monitor.go
@@ -3,7 +3,6 @@ package pluginframework
 import (
 	"context"
 	"fmt"
-	"go/types"
 	"time"
 
 	"github.com/databricks/databricks-sdk-go"
@@ -13,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 )
 

--- a/pluginframework/resource_quality_monitor.go
+++ b/pluginframework/resource_quality_monitor.go
@@ -9,6 +9,7 @@ import (
 	"github.com/databricks/databricks-sdk-go/service/catalog"
 	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/databricks/terraform-provider-databricks/service/catalog_tf"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
@@ -53,8 +54,10 @@ func (r *QualityMonitorResource) Schema(ctx context.Context, req resource.Schema
 	resp.Schema = schema.Schema{
 		Description: "Terraform schema for Databricks Lakehouse Monitor. MonitorInfo struct is used to create the schema",
 		Attributes: common.PluginFrameworkResourceStructToSchemaMap(catalog_tf.MonitorInfo{}, func(c common.CustomizableSchemaPluginFramework) common.CustomizableSchemaPluginFramework {
-			c.AddNewField("skip_builtin_dashboard", schema.BoolAttribute{Optional: true, Required: false})
-			c.AddNewField("warehouse_id", schema.StringAttribute{Optional: true, Required: false})
+			// TODO: Re-enable these customizations after we make a decision about how to handle them.
+			// NOTE: Currently these cannot be done directly since req.Plan.Get() will panic due to object an struct mismatch.
+			// c.AddNewField("skip_builtin_dashboard", schema.BoolAttribute{Optional: true, Required: false})
+			// c.AddNewField("warehouse_id", schema.StringAttribute{Optional: true, Required: false})
 			c.SetRequired("assets_dir")
 			c.SetRequired("output_schema_name")
 			c.SetRequired("table_name")
@@ -90,15 +93,15 @@ func (r *QualityMonitorResource) Create(ctx context.Context, req resource.Create
 		resp.Diagnostics.AddError("Failed to get workspace client", err.Error())
 		return
 	}
-	var createMonitorTfSDK catalog_tf.CreateMonitor
-	diags := req.Plan.Get(ctx, &createMonitorTfSDK)
+	var monitorInfoTfSDK catalog_tf.MonitorInfo
+	diags := req.Plan.Get(ctx, &monitorInfoTfSDK)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
 	var createMonitorGoSDK catalog.CreateMonitor
-	err = common.TfSdkToGoSdkStruct(createMonitorTfSDK, &createMonitorGoSDK, ctx)
+	err = common.TfSdkToGoSdkStruct(monitorInfoTfSDK, &createMonitorGoSDK, ctx)
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to convert Tf SDK struct to Go SDK struct", err.Error())
 		return
@@ -110,9 +113,24 @@ func (r *QualityMonitorResource) Create(ctx context.Context, req resource.Create
 	}
 	err = WaitForMonitor(w, ctx, endpoint.TableName)
 	if err != nil {
+		resp.Diagnostics.AddError("Failed to wait for newly created monitor", err.Error())
+		return
+	}
+
+	// Get the created monitor.
+	new_endpoint, err := w.QualityMonitors.GetByTableName(ctx, createMonitorGoSDK.TableName)
+	if err != nil {
 		resp.Diagnostics.AddError("Failed to get newly created monitor", err.Error())
 		return
 	}
+
+	var newMonitorInfoTfSDK catalog_tf.MonitorInfo
+	err = common.GoSdkToTfSdkStruct(new_endpoint, &newMonitorInfoTfSDK, ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("Failed to convert Go SDK struct to TF SDK struct", err.Error())
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, newMonitorInfoTfSDK)...)
 }
 
 func (r *QualityMonitorResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
@@ -122,7 +140,7 @@ func (r *QualityMonitorResource) Read(ctx context.Context, req resource.ReadRequ
 		return
 	}
 	var getMonitor catalog_tf.GetQualityMonitorRequest
-	diags := req.State.Get(ctx, &getMonitor)
+	diags := req.State.GetAttribute(ctx, path.Root("table_name"), &getMonitor.TableName)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -150,15 +168,21 @@ func (r *QualityMonitorResource) Update(ctx context.Context, req resource.Update
 		resp.Diagnostics.AddError("Failed to get workspace client", err.Error())
 		return
 	}
-	var updateMonitorTfSDK catalog_tf.UpdateMonitor
-	diags := req.Plan.Get(ctx, &updateMonitorTfSDK)
+	var monitorInfoTfSDK catalog_tf.MonitorInfo
+	diags := req.Plan.Get(ctx, &monitorInfoTfSDK)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	// Plan is not adding `dashboard_id`, but it is in the state.
+	diags = req.State.GetAttribute(ctx, path.Root("dashboard_id"), &monitorInfoTfSDK.DashboardId)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
 	var updateMonitorGoSDK catalog.UpdateMonitor
-	err = common.TfSdkToGoSdkStruct(updateMonitorTfSDK, &updateMonitorGoSDK, ctx)
+	err = common.TfSdkToGoSdkStruct(monitorInfoTfSDK, &updateMonitorGoSDK, ctx)
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to convert Tf SDK struct to Go SDK struct", err.Error())
 		return
@@ -170,9 +194,24 @@ func (r *QualityMonitorResource) Update(ctx context.Context, req resource.Update
 	}
 	err = WaitForMonitor(w, ctx, updateMonitorGoSDK.TableName)
 	if err != nil {
-		resp.Diagnostics.AddError("Failed to get updated monitor", err.Error())
+		resp.Diagnostics.AddError("Failed to wait for updated monitor", err.Error())
 		return
 	}
+
+	// Get the created monitor.
+	new_endpoint, err := w.QualityMonitors.GetByTableName(ctx, updateMonitorGoSDK.TableName)
+	if err != nil {
+		resp.Diagnostics.AddError("Failed to get newly created monitor", err.Error())
+		return
+	}
+
+	var newMonitorInfoTfSDK catalog_tf.MonitorInfo
+	err = common.GoSdkToTfSdkStruct(new_endpoint, &newMonitorInfoTfSDK, ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("Failed to convert Go SDK struct to TF SDK struct", err.Error())
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, newMonitorInfoTfSDK)...)
 }
 
 func (r *QualityMonitorResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
@@ -182,7 +221,7 @@ func (r *QualityMonitorResource) Delete(ctx context.Context, req resource.Delete
 		return
 	}
 	var deleteRequest catalog_tf.DeleteQualityMonitorRequest
-	diags := req.State.Get(ctx, &deleteRequest)
+	diags := req.State.GetAttribute(ctx, path.Root("table_name"), &deleteRequest.TableName)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/pluginframework/resource_quality_monitor.go
+++ b/pluginframework/resource_quality_monitor.go
@@ -112,7 +112,7 @@ func (r *QualityMonitorResource) Create(ctx context.Context, req resource.Create
 	}
 	endpoint, err := w.QualityMonitors.Create(ctx, createMonitorGoSDK)
 	if err != nil {
-		resp.Diagnostics.AddError("Failed to get create monitor", err.Error())
+		resp.Diagnostics.AddError("Failed to get created monitor", err.Error())
 		return
 	}
 	err = WaitForMonitor(w, ctx, endpoint.TableName)


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
- Part of making acceptance test pass: https://github.com/databricks/terraform-provider-databricks/pull/3841
- Update `ResourceQualityMonitor` to make it pass acceptance test
  - Commented out adding two new fields temporarily because we need to have those fields in the tfsdk struct, otherwise `.get()` and `.set()` don't work
  - Updated the target struct for `.get` calls to be `MonitorInfo` because terraform requires that to be consistent with the schema
  - Added logic at the end of `Create` and `Update` to read the latest `monitorInfo` and set the state

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [x] covered with integration tests in `internal/acceptance`
- [x] relevant acceptance tests are passing
- [x] using Go SDK
