### PR TITLE
[Exporter] Ignore DLT pipelines deployed via DABs

### DIFF
--- a/exporter/importables.go
+++ b/exporter/importables.go
@@ -32,6 +32,7 @@ import (
 	"github.com/databricks/terraform-provider-databricks/jobs"
 	"github.com/databricks/terraform-provider-databricks/mws"
 	"github.com/databricks/terraform-provider-databricks/permissions"
+	tfpipelines "github.com/databricks/terraform-provider-databricks/pipelines"
 	"github.com/databricks/terraform-provider-databricks/repos"
 	tfsharing "github.com/databricks/terraform-provider-databricks/sharing"
 	tfsql "github.com/databricks/terraform-provider-databricks/sql"
@@ -1976,7 +1977,7 @@ var resourcesMap map[string]importable = map[string]importable{
 			return nil
 		},
 		Import: func(ic *importContext, r *resource) error {
-			var pipeline pipelines.PipelineSpec
+			var pipeline tfpipelines.Pipeline
 			s := ic.Resources["databricks_pipeline"].Schema
 			common.DataToStructPointer(r.Data, s, &pipeline)
 			if pipeline.Catalog != "" && pipeline.Target != "" {
@@ -1985,15 +1986,17 @@ var resourcesMap map[string]importable = map[string]importable{
 					ID:       pipeline.Catalog + "." + pipeline.Target,
 				})
 			}
-			for _, lib := range pipeline.Libraries {
-				if lib.Notebook != nil {
-					ic.emitNotebookOrRepo(lib.Notebook.Path)
+			if pipeline.Deployment == nil || pipeline.Deployment.Kind == "BUNDLE" {
+				for _, lib := range pipeline.Libraries {
+					if lib.Notebook != nil {
+						ic.emitNotebookOrRepo(lib.Notebook.Path)
+					}
+					if lib.File != nil {
+						ic.emitNotebookOrRepo(lib.File.Path)
+					}
+					ic.emitIfDbfsFile(lib.Jar)
+					ic.emitIfDbfsFile(lib.Whl)
 				}
-				if lib.File != nil {
-					ic.emitNotebookOrRepo(lib.File.Path)
-				}
-				ic.emitIfDbfsFile(lib.Jar)
-				ic.emitIfDbfsFile(lib.Whl)
 			}
 			// Emit clusters
 			for _, cluster := range pipeline.Clusters {
@@ -2046,9 +2049,17 @@ var resourcesMap map[string]importable = map[string]importable{
 			return defaultShouldOmitFieldFunc(ic, pathString, as, d)
 		},
 		Ignore: func(ic *importContext, r *resource) bool {
-			numLibraries := r.Data.Get("library.#").(int)
+			var pipeline tfpipelines.Pipeline
+			s := ic.Resources["databricks_pipeline"].Schema
+			common.DataToStructPointer(r.Data, s, &pipeline)
+			if pipeline.Deployment != nil && pipeline.Deployment.Kind == "BUNDLE" {
+				log.Printf("[WARN] Ignoring DLT Pipeline with ID %s as deployed with DABs", r.ID)
+				ic.addIgnoredResource(fmt.Sprintf("databricks_pipeline. id=%s", r.ID))
+				return true
+			}
+			numLibraries := len(pipeline.Libraries)
 			if numLibraries == 0 {
-				log.Printf("[WARN] Ignoring DLT Pipeline with ID %s", r.ID)
+				log.Printf("[WARN] Ignoring DLT Pipeline with ID %s due to the lack of libraries", r.ID)
 				ic.addIgnoredResource(fmt.Sprintf("databricks_pipeline. id=%s", r.ID))
 			}
 			return numLibraries == 0

--- a/exporter/importables_test.go
+++ b/exporter/importables_test.go
@@ -294,9 +294,30 @@ func TestRepoIgnore(t *testing.T) {
 func TestDLTIgnore(t *testing.T) {
 	ic := importContextForTest()
 	d := dlt_pipelines.ResourcePipeline().ToResource().TestResourceData()
+	scm := dlt_pipelines.ResourcePipeline().Schema
+
 	d.SetId("12345")
 	r := &resource{ID: "12345", Data: d}
 	// job without libraries
+	assert.True(t, resourcesMap["databricks_pipeline"].Ignore(ic, r))
+	assert.Equal(t, 1, len(ic.ignoredResources))
+
+	// job deployed by DABs
+	d.MarkNewResource()
+	pipeline := dlt_pipelines.Pipeline{
+		PipelineSpec: pipelines.PipelineSpec{
+			Deployment: &pipelines.PipelineDeployment{
+				Kind: "BUNDLE",
+			},
+		},
+	}
+	err := common.StructToData(pipeline, scm, d)
+	require.NoError(t, err)
+
+	r = &resource{ID: "12345", Data: d}
+	for k := range ic.ignoredResources {
+		delete(ic.ignoredResources, k)
+	}
 	assert.True(t, resourcesMap["databricks_pipeline"].Ignore(ic, r))
 	assert.Equal(t, 1, len(ic.ignoredResources))
 }


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

When we deploy resources with DABs it's expected that source code exists outside of the workspace, so we don't need to export it and related resources (libraries).

Fixes #3436

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [x] using Go SDK
