### PR TITLE
[Fix] Fixed read method of `databricks_entitlements` resource

### DIFF
--- a/scim/resource_entitlement.go
+++ b/scim/resource_entitlement.go
@@ -49,6 +49,7 @@ func ResourceEntitlements() common.Resource {
 				if err != nil {
 					return err
 				}
+				d.Set("group_id", split[1])
 				group.Entitlements.generateEmpty(d)
 				return group.Entitlements.readIntoData(d)
 			case "user":
@@ -56,6 +57,7 @@ func ResourceEntitlements() common.Resource {
 				if err != nil {
 					return err
 				}
+				d.Set("user_id", split[1])
 				user.Entitlements.generateEmpty(d)
 				return user.Entitlements.readIntoData(d)
 			case "spn":
@@ -63,6 +65,7 @@ func ResourceEntitlements() common.Resource {
 				if err != nil {
 					return err
 				}
+				d.Set("service_principal_id", split[1])
 				spn.Entitlements.generateEmpty(d)
 				return spn.Entitlements.readIntoData(d)
 			}

--- a/scim/resource_entitlement_test.go
+++ b/scim/resource_entitlement_test.go
@@ -148,6 +148,25 @@ func TestResourceEntitlementsGroupRead(t *testing.T) {
 	})
 }
 
+func TestResourceEntitlementsGroupImport(t *testing.T) {
+	qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "GET",
+				Resource: "/api/2.0/preview/scim/v2/Groups/abc?attributes=entitlements",
+				Response: oldGroup,
+			},
+		},
+		Resource: ResourceEntitlements(),
+		New:      true,
+		Read:     true,
+		ID:       "group/abc",
+	}.ApplyAndExpectData(t, map[string]any{
+		"group_id":             "abc",
+		"allow_cluster_create": true,
+	})
+}
+
 func TestResourceEntitlementsGroupReadEmpty(t *testing.T) {
 	qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{


### PR DESCRIPTION
## Changes
- Populate missing ids when importing `databricks_entitlements` resource. Resolve #3856

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
