### PR TITLE
[Exporter] Add support for `databricks_notification_destination`

### DIFF
--- a/docs/guides/experimental-exporter.md
+++ b/docs/guides/experimental-exporter.md
@@ -125,6 +125,7 @@ Services are just logical groups of resources used for filtering and organizatio
 * `pools` - **listing** [instance pools](../resources/instance_pool.md).
 * `repos` - **listing** [databricks_repo](../resources/repo.md)
 * `secrets` - **listing** [databricks_secret_scope](../resources/secret_scope.md) along with [keys](../resources/secret.md) and [ACLs](../resources/secret_acl.md).
+* `settings` - **listing** [databricks_notification_destination](../resources/notification_destination.md).
 * `sql-alerts` - **listing** [databricks_sql_alert](../resources/sql_alert.md).
 * `sql-dashboards` - **listing** [databricks_sql_dashboard](../resources/sql_dashboard.md) along with associated [databricks_sql_widget](../resources/sql_widget.md) and [databricks_sql_visualization](../resources/sql_visualization.md).
 * `sql-endpoints` - **listing** [databricks_sql_endpoint](../resources/sql_endpoint.md) along with [databricks_sql_global_config](../resources/sql_global_config.md).
@@ -177,7 +178,7 @@ Exporter aims to generate HCL code for most of the resources within the Databric
 | [databricks_dbfs_file](../resources/dbfs_file.md) | Yes | No | Yes | No |
 | [databricks_external_location](../resources/external_location.md) | Yes | Yes | Yes | No |
 | [databricks_file](../resources/file.md) | Yes | No | Yes | No |
-| [databricks_global_init_script](../resources/global_init_script.md) | Yes | Yes | Yes | No |
+| [databricks_global_init_script](../resources/global_init_script.md) | Yes | Yes | Yes\*\* | No |
 | [databricks_grants](../resources/grants.md) | Yes | No | Yes | No |
 | [databricks_group](../resources/group.md) | Yes | No | Yes | Yes |
 | [databricks_group_instance_profile](../resources/group_instance_profile.md) | Yes | No | Yes | No |
@@ -185,7 +186,7 @@ Exporter aims to generate HCL code for most of the resources within the Databric
 | [databricks_group_role](../resources/group_role.md) | Yes | No | Yes | Yes |
 | [databricks_instance_pool](../resources/instance_pool.md) | Yes | No | Yes | No |
 | [databricks_instance_profile](../resources/instance_profile.md) | Yes | No | Yes | No |
-| [databricks_ip_access_list](../resources/ip_access_list.md) | Yes | Yes | Yes | No |
+| [databricks_ip_access_list](../resources/ip_access_list.md) | Yes | Yes | Yes\*\* | No |
 | [databricks_job](../resources/job.md) | Yes | No | Yes | No |
 | [databricks_library](../resources/library.md) | Yes\* | No | Yes | No |
 | [databricks_metastore](../resources/metastore.md) | Yes | Yes | No | Yes |
@@ -196,6 +197,7 @@ Exporter aims to generate HCL code for most of the resources within the Databric
 | [databricks_model_serving](../resources/model_serving) | Yes | Yes | Yes | No |
 | [databricks_mws_permission_assignment](../resources/mws_permission_assignment.md) | Yes | No | No | Yes |
 | [databricks_notebook](../resources/notebook.md) | Yes | Yes | Yes | No |
+| [databricks_notification_destination](../resources/notification_destination.md) | Yes | No | Yes\*\* | No |
 | [databricks_obo_token](../resources/obo_token.md) | Not Applicable | No | No | No |
 | [databricks_online_table](../resources/online_table.md) | Yes | Yes | Yes | No |
 | [databricks_permissions](../resources/permissions.md) | Yes | No | Yes | No |
@@ -227,9 +229,10 @@ Exporter aims to generate HCL code for most of the resources within the Databric
 | [databricks_user_role](../resources/user_role.md) | Yes | No | Yes | Yes |
 | [databricks_volume](../resources/volume.md) | Yes | Yes | Yes | No |
 | [databricks_workspace_binding](../resources/workspace_binding.md) | Yes | No | Yes | No |
-| [databricks_workspace_conf](../resources/workspace_conf.md) | Yes (partial) | No | Yes | No |
+| [databricks_workspace_conf](../resources/workspace_conf.md) | Yes (partial) | No | Yes\*\* | No |
 | [databricks_workspace_file](../resources/workspace_file.md) | Yes | Yes | Yes | No |
 
 Notes:
 
 * \* - libraries are exported as blocks inside the cluster definition instead of generating `databricks_library` resources.  This is done to decrease the number of generated resources.
+* \*\* - requires workspace admin permission.

--- a/docs/resources/notification_destination.md
+++ b/docs/resources/notification_destination.md
@@ -97,3 +97,4 @@ The following arguments are supported:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The unique ID of the Notification Destination.
+* `destination_type` - the type of Notification Destination.

--- a/exporter/importables.go
+++ b/exporter/importables.go
@@ -33,6 +33,7 @@ import (
 	"github.com/databricks/terraform-provider-databricks/mws"
 	"github.com/databricks/terraform-provider-databricks/permissions"
 	"github.com/databricks/terraform-provider-databricks/repos"
+	tfsettings "github.com/databricks/terraform-provider-databricks/settings"
 	tfsharing "github.com/databricks/terraform-provider-databricks/sharing"
 	tfsql "github.com/databricks/terraform-provider-databricks/sql"
 	sql_api "github.com/databricks/terraform-provider-databricks/sql/api"
@@ -433,12 +434,31 @@ var resourcesMap map[string]importable = map[string]importable{
 			{Path: "task.sql_task.dashboard.dashboard_id", Resource: "databricks_sql_dashboard"},
 			{Path: "task.sql_task.query.query_id", Resource: "databricks_sql_query"},
 			{Path: "task.sql_task.warehouse_id", Resource: "databricks_sql_endpoint"},
+			{Path: "task.webhook_notifications.on_duration_warning_threshold_exceeded.id", Resource: "databricks_notification_destination"},
+			{Path: "task.webhook_notifications.on_failure.id", Resource: "databricks_notification_destination"},
+			{Path: "task.webhook_notifications.on_start.id", Resource: "databricks_notification_destination"},
+			{Path: "task.webhook_notifications.on_success.id", Resource: "databricks_notification_destination"},
+			{Path: "task.webhook_notifications.on_streaming_backlog_exceeded.id", Resource: "databricks_notification_destination"},
+			{Path: "task.email_notifications.on_duration_warning_threshold_exceeded", Resource: "databricks_user",
+				Match: "user_name", MatchType: MatchCaseInsensitive},
+			{Path: "task.email_notifications.on_failure", Resource: "databricks_user", Match: "user_name", MatchType: MatchCaseInsensitive},
+			{Path: "task.email_notifications.on_start", Resource: "databricks_user", Match: "user_name", MatchType: MatchCaseInsensitive},
+			{Path: "task.email_notifications.on_success", Resource: "databricks_user", Match: "user_name", MatchType: MatchCaseInsensitive},
+			{Path: "task.email_notifications.on_streaming_backlog_exceeded", Resource: "databricks_user",
+				Match: "user_name", MatchType: MatchCaseInsensitive},
 			{Path: "run_as.user_name", Resource: "databricks_user", Match: "user_name", MatchType: MatchCaseInsensitive},
+			{Path: "webhook_notifications.on_duration_warning_threshold_exceeded.id", Resource: "databricks_notification_destination"},
+			{Path: "webhook_notifications.on_failure.id", Resource: "databricks_notification_destination"},
+			{Path: "webhook_notifications.on_start.id", Resource: "databricks_notification_destination"},
+			{Path: "webhook_notifications.on_success.id", Resource: "databricks_notification_destination"},
+			{Path: "webhook_notifications.on_streaming_backlog_exceeded.id", Resource: "databricks_notification_destination"},
 			{Path: "email_notifications.on_duration_warning_threshold_exceeded", Resource: "databricks_user",
 				Match: "user_name", MatchType: MatchCaseInsensitive},
 			{Path: "email_notifications.on_failure", Resource: "databricks_user", Match: "user_name", MatchType: MatchCaseInsensitive},
 			{Path: "email_notifications.on_start", Resource: "databricks_user", Match: "user_name", MatchType: MatchCaseInsensitive},
 			{Path: "email_notifications.on_success", Resource: "databricks_user", Match: "user_name", MatchType: MatchCaseInsensitive},
+			{Path: "email_notifications.on_streaming_backlog_exceeded", Resource: "databricks_user",
+				Match: "user_name", MatchType: MatchCaseInsensitive},
 			{Path: "task.library.whl", Resource: "databricks_repo", Match: "workspace_path",
 				MatchType: MatchPrefix, SearchValueTransformFunc: appendEndingSlashToDirName},
 			{Path: "task.new_cluster.init_scripts.workspace.destination", Resource: "databricks_repo", Match: "workspace_path",
@@ -580,6 +600,21 @@ var resourcesMap map[string]importable = map[string]importable{
 					ID:       task.ExistingClusterId,
 				})
 				ic.emitLibraries(task.Libraries)
+
+				if task.WebhookNotifications != nil {
+					ic.emitJobsDestinationNotifications(task.WebhookNotifications.OnFailure)
+					ic.emitJobsDestinationNotifications(task.WebhookNotifications.OnSuccess)
+					ic.emitJobsDestinationNotifications(task.WebhookNotifications.OnDurationWarningThresholdExceeded)
+					ic.emitJobsDestinationNotifications(task.WebhookNotifications.OnStart)
+					ic.emitJobsDestinationNotifications(task.WebhookNotifications.OnStreamingBacklogExceeded)
+				}
+				if task.EmailNotifications != nil {
+					ic.emitListOfUsers(task.EmailNotifications.OnDurationWarningThresholdExceeded)
+					ic.emitListOfUsers(task.EmailNotifications.OnFailure)
+					ic.emitListOfUsers(task.EmailNotifications.OnStart)
+					ic.emitListOfUsers(task.EmailNotifications.OnSuccess)
+					ic.emitListOfUsers(task.EmailNotifications.OnStreamingBacklogExceeded)
+				}
 			}
 			for _, jc := range job.JobClusters {
 				ic.importCluster(&jc.NewCluster)
@@ -605,6 +640,14 @@ var resourcesMap map[string]importable = map[string]importable{
 				ic.emitListOfUsers(job.EmailNotifications.OnFailure)
 				ic.emitListOfUsers(job.EmailNotifications.OnStart)
 				ic.emitListOfUsers(job.EmailNotifications.OnSuccess)
+				ic.emitListOfUsers(job.EmailNotifications.OnStreamingBacklogExceeded)
+			}
+			if job.WebhookNotifications != nil {
+				ic.emitJobsDestinationNotifications(job.WebhookNotifications.OnFailure)
+				ic.emitJobsDestinationNotifications(job.WebhookNotifications.OnSuccess)
+				ic.emitJobsDestinationNotifications(job.WebhookNotifications.OnDurationWarningThresholdExceeded)
+				ic.emitJobsDestinationNotifications(job.WebhookNotifications.OnStart)
+				ic.emitJobsDestinationNotifications(job.WebhookNotifications.OnStreamingBacklogExceeded)
 			}
 
 			return ic.importLibraries(r.Data, s)
@@ -3305,6 +3348,91 @@ var resourcesMap map[string]importable = map[string]importable{
 			{Path: "parent_path", Resource: "databricks_directory"},
 			{Path: "parent_path", Resource: "databricks_user", Match: "home"},
 			{Path: "parent_path", Resource: "databricks_service_principal"},
+		},
+	},
+	"databricks_notification_destination": {
+		WorkspaceLevel: true,
+		Service:        "settings",
+		Name: func(ic *importContext, d *schema.ResourceData) string {
+			name := d.Get("display_name").(string)
+			if name != "" {
+				name += "_"
+			}
+			id := d.Id()
+			if len(id) >= 8 {
+				id = id[:8]
+			}
+			return nameNormalizationRegex.ReplaceAllString(fmt.Sprintf("%s_%s", name, id), "_")
+		},
+		List: func(ic *importContext) error {
+			if !ic.meAdmin {
+				return fmt.Errorf("notifications can be imported only by admin")
+			}
+			notifications, err := ic.workspaceClient.NotificationDestinations.ListAll(ic.Context, settings.ListNotificationDestinationsRequest{})
+			if err != nil {
+				return err
+			}
+			for _, n := range notifications {
+				ic.Emit(&resource{
+					Resource: "databricks_notification_destination",
+					ID:       n.Id,
+				})
+			}
+			return nil
+		},
+		Import: func(ic *importContext, r *resource) error {
+			var notificationDestination tfsettings.NDStruct
+			s := ic.Resources["databricks_notification_destination"].Schema
+			common.DataToStructPointer(r.Data, s, &notificationDestination)
+			if notificationDestination.DestinationType == "EMAIL" && notificationDestination.Config != nil &&
+				notificationDestination.Config.Email != nil {
+				for _, email := range notificationDestination.Config.Email.Addresses {
+					ic.emitUserOrServicePrincipal(email)
+				}
+			}
+			return nil
+		},
+		ShouldOmitField: func(ic *importContext, pathString string, as *schema.Schema, d *schema.ResourceData) bool {
+			var notificationDestination tfsettings.NDStruct
+			s := ic.Resources["databricks_notification_destination"].Schema
+			common.DataToStructPointer(d, s, &notificationDestination)
+			if notificationDestination.Config != nil {
+				switch notificationDestination.DestinationType {
+				case "WEBHOOK":
+					if notificationDestination.Config.GenericWebhook != nil {
+						switch pathString {
+						case "config.0.generic_webhook.0.url":
+							return !notificationDestination.Config.GenericWebhook.UrlSet
+						case "config.0.generic_webhook.0.username":
+							return !notificationDestination.Config.GenericWebhook.UsernameSet
+						case "config.0.generic_webhook.0.password":
+							return !notificationDestination.Config.GenericWebhook.PasswordSet
+						}
+					}
+				case "SLACK":
+					if notificationDestination.Config.Slack != nil && pathString == "config.0.slack.0.url" {
+						return !notificationDestination.Config.Slack.UrlSet
+					}
+				case "PAGERDUTY":
+					if notificationDestination.Config.Pagerduty != nil && pathString == "config.0.pagerduty.0.integration_key" {
+						return !notificationDestination.Config.Pagerduty.IntegrationKeySet
+					}
+				case "MICROSOFT_TEAMS":
+					if notificationDestination.Config.MicrosoftTeams != nil && pathString == "config.0.microsoft_teams.0.url" {
+						return !notificationDestination.Config.MicrosoftTeams.UrlSet
+					}
+				}
+			}
+			return defaultShouldOmitFieldFunc(ic, pathString, as, d)
+		},
+		Depends: []reference{
+			{Path: "config.email.addresses", Resource: "databricks_user", Match: "user_name", MatchType: MatchCaseInsensitive},
+			{Path: "config.microsoft_teams.url", Variable: true},
+			{Path: "config.pagerduty.integration_key", Variable: true},
+			{Path: "config.generic_webhook.url", Variable: true},
+			{Path: "config.generic_webhook.username", Variable: true},
+			{Path: "config.generic_webhook.password", Variable: true},
+			{Path: "config.slack.url", Variable: true},
 		},
 	},
 	"databricks_online_table": {

--- a/exporter/util.go
+++ b/exporter/util.go
@@ -26,6 +26,7 @@ import (
 	"github.com/databricks/databricks-sdk-go/service/catalog"
 	"github.com/databricks/databricks-sdk-go/service/compute"
 	"github.com/databricks/databricks-sdk-go/service/iam"
+	sdk_jobs "github.com/databricks/databricks-sdk-go/service/jobs"
 
 	"golang.org/x/exp/slices"
 
@@ -1616,4 +1617,13 @@ func isMatchingSecurableTypeAndName(ic *importContext, res *resource, ra *resour
 	res_securable_name := res.Data.Get("securable_name").(string)
 	ra_name, _ := ra.Get("name")
 	return ra.Type == ("databricks_"+res_securable_type) && ra_name.(string) == res_securable_name
+}
+
+func (ic *importContext) emitJobsDestinationNotifications(notifications []sdk_jobs.Webhook) {
+	for _, notification := range notifications {
+		ic.Emit(&resource{
+			Resource: "databricks_notification_destination",
+			ID:       notification.Id,
+		})
+	}
 }


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

Now we can export `databricks_notification_destination` resources.

Extended `databricks_job` to emit email notifications on the task level, and webhooks on job and task levels

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [x] using Go SDK
