### PR TITLE
Update init test and migrate imports for plugin framework

### DIFF
--- a/aws/resource_instance_profile.go
+++ b/aws/resource_instance_profile.go
@@ -12,8 +12,8 @@ import (
 
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 // InstanceProfileInfo contains the ARN for aws instance profiles

--- a/clusters/clusters_api.go
+++ b/clusters/clusters_api.go
@@ -13,8 +13,8 @@ import (
 	"github.com/databricks/databricks-sdk-go/service/compute"
 
 	"github.com/databricks/terraform-provider-databricks/common"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 // AutoScale is a struct the describes auto scaling for clusters

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -9,7 +9,7 @@ import (
 	"github.com/databricks/terraform-provider-databricks/clusters"
 	"github.com/databricks/terraform-provider-databricks/common"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 // Command is the struct that contains what the 1.2 api returns for the commands api

--- a/go.mod
+++ b/go.mod
@@ -53,6 +53,7 @@ require (
 	github.com/hashicorp/logutils v1.0.0 // indirect
 	github.com/hashicorp/terraform-exec v0.21.0 // indirect
 	github.com/hashicorp/terraform-json v0.22.1 // indirect
+	github.com/hashicorp/terraform-plugin-testing v1.9.0 // indirect
 	github.com/hashicorp/terraform-registry-address v0.2.3 // indirect
 	github.com/hashicorp/terraform-svchost v0.1.1 // indirect
 	github.com/hashicorp/yamux v0.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -142,6 +142,8 @@ github.com/hashicorp/terraform-plugin-mux v0.16.0 h1:RCzXHGDYwUwwqfYYWJKBFaS3fQs
 github.com/hashicorp/terraform-plugin-mux v0.16.0/go.mod h1:PF79mAsPc8CpusXPfEVa4X8PtkB+ngWoiUClMrNZlYo=
 github.com/hashicorp/terraform-plugin-sdk/v2 v2.34.0 h1:kJiWGx2kiQVo97Y5IOGR4EMcZ8DtMswHhUuFibsCQQE=
 github.com/hashicorp/terraform-plugin-sdk/v2 v2.34.0/go.mod h1:sl/UoabMc37HA6ICVMmGO+/0wofkVIRxf+BMb/dnoIg=
+github.com/hashicorp/terraform-plugin-testing v1.9.0 h1:xOsQRqqlHKXpFq6etTxih3ubdK3HVDtfE1IY7Rpd37o=
+github.com/hashicorp/terraform-plugin-testing v1.9.0/go.mod h1:fhhVx/8+XNJZTD5o3b4stfZ6+q7z9+lIWigIYdT6/44=
 github.com/hashicorp/terraform-registry-address v0.2.3 h1:2TAiKJ1A3MAkZlH1YI/aTVcLZRu7JseiXNRHbOAyoTI=
 github.com/hashicorp/terraform-registry-address v0.2.3/go.mod h1:lFHA76T8jfQteVfT7caREqguFrW3c4MFSPhZB7HHgUM=
 github.com/hashicorp/terraform-svchost v0.1.1 h1:EZZimZ1GxdqFRinZ1tpJwVxxt49xc/S52uzrw4x0jKQ=

--- a/internal/acceptance/account_rule_set_test.go
+++ b/internal/acceptance/account_rule_set_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/databricks/databricks-sdk-go/service/iam"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/databricks/terraform-provider-databricks/common"

--- a/internal/acceptance/dashboard_test.go
+++ b/internal/acceptance/dashboard_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/databricks/databricks-sdk-go/service/dashboards"
 	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/databricks/terraform-provider-databricks/qa"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/acceptance/data_aws_crossaccount_policy_test.go
+++ b/internal/acceptance/data_aws_crossaccount_policy_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 func TestMwsAccDataSourceAwsCrossaccountPolicy(t *testing.T) {

--- a/internal/acceptance/data_catalog_test.go
+++ b/internal/acceptance/data_catalog_test.go
@@ -3,7 +3,7 @@ package acceptance
 import (
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/stretchr/testify/require"
 )
 

--- a/internal/acceptance/data_current_config_test.go
+++ b/internal/acceptance/data_current_config_test.go
@@ -3,7 +3,7 @@ package acceptance
 import (
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/acceptance/data_current_metastore_test.go
+++ b/internal/acceptance/data_current_metastore_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 func TestUcAccDataSourceCurrentMetastore(t *testing.T) {

--- a/internal/acceptance/data_external_locations_test.go
+++ b/internal/acceptance/data_external_locations_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 func TestUcAccDataSourceExternalLocations(t *testing.T) {

--- a/internal/acceptance/data_group_test.go
+++ b/internal/acceptance/data_group_test.go
@@ -3,7 +3,7 @@ package acceptance
 import (
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/acceptance/data_metastore_test.go
+++ b/internal/acceptance/data_metastore_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 func TestUcAccDataSourceMetastore(t *testing.T) {

--- a/internal/acceptance/data_metastores_test.go
+++ b/internal/acceptance/data_metastores_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 func TestUcAccDataSourceMetastores(t *testing.T) {

--- a/internal/acceptance/data_mlflow_experiment_test.go
+++ b/internal/acceptance/data_mlflow_experiment_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 func TestAccDataSourceMlflowExperiment(t *testing.T) {

--- a/internal/acceptance/data_mlflow_model_test.go
+++ b/internal/acceptance/data_mlflow_model_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 func TestAccDataMlflowModel(t *testing.T) {

--- a/internal/acceptance/data_mws_credentials_test.go
+++ b/internal/acceptance/data_mws_credentials_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 func TestAccDataSourceMwsCredentials(t *testing.T) {

--- a/internal/acceptance/data_mws_workspaces_test.go
+++ b/internal/acceptance/data_mws_workspaces_test.go
@@ -3,7 +3,7 @@ package acceptance
 import (
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"testing"
 )

--- a/internal/acceptance/data_pipelines_test.go
+++ b/internal/acceptance/data_pipelines_test.go
@@ -3,7 +3,7 @@ package acceptance
 import (
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"testing"
 )

--- a/internal/acceptance/data_schema_test.go
+++ b/internal/acceptance/data_schema_test.go
@@ -3,7 +3,7 @@ package acceptance
 import (
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/stretchr/testify/require"
 )
 

--- a/internal/acceptance/data_schemas_test.go
+++ b/internal/acceptance/data_schemas_test.go
@@ -3,7 +3,7 @@ package acceptance
 import (
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/acceptance/data_shares_test.go
+++ b/internal/acceptance/data_shares_test.go
@@ -4,7 +4,7 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/acceptance/data_storage_credential_test.go
+++ b/internal/acceptance/data_storage_credential_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/stretchr/testify/require"
 )
 

--- a/internal/acceptance/data_storage_credentials_test.go
+++ b/internal/acceptance/data_storage_credentials_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 func TestUcAccDataSourceStorageCredentials(t *testing.T) {

--- a/internal/acceptance/data_table_test.go
+++ b/internal/acceptance/data_table_test.go
@@ -3,7 +3,7 @@ package acceptance
 import (
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/stretchr/testify/require"
 )
 

--- a/internal/acceptance/data_tables_test.go
+++ b/internal/acceptance/data_tables_test.go
@@ -4,7 +4,7 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/acceptance/data_user_test.go
+++ b/internal/acceptance/data_user_test.go
@@ -3,7 +3,7 @@ package acceptance
 import (
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/acceptance/data_volume_test.go
+++ b/internal/acceptance/data_volume_test.go
@@ -3,7 +3,7 @@ package acceptance
 import (
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/stretchr/testify/require"
 )
 

--- a/internal/acceptance/data_volumes_test.go
+++ b/internal/acceptance/data_volumes_test.go
@@ -4,7 +4,7 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/acceptance/default_namespace_test.go
+++ b/internal/acceptance/default_namespace_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/databricks/databricks-sdk-go/apierr"
 	"github.com/databricks/databricks-sdk-go/service/settings"
 	"github.com/databricks/terraform-provider-databricks/common"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/acceptance/entitlements_test.go
+++ b/internal/acceptance/entitlements_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/databricks/databricks-sdk-go"
 	"github.com/databricks/databricks-sdk-go/logger"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/internal/acceptance/group_test.go
+++ b/internal/acceptance/group_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/databricks/terraform-provider-databricks/qa"
 	"github.com/databricks/terraform-provider-databricks/scim"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
 	"testing"
 )

--- a/internal/acceptance/init_test.go
+++ b/internal/acceptance/init_test.go
@@ -24,9 +24,7 @@ import (
 	dbproviderlogger "github.com/databricks/terraform-provider-databricks/logger"
 	"github.com/databricks/terraform-provider-databricks/provider"
 	"github.com/databricks/terraform-provider-databricks/qa"
-	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
-	"github.com/hashicorp/terraform-plugin-mux/tf5to6server"
 	"github.com/hashicorp/terraform-plugin-mux/tf6muxserver"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	terraform_sdk_v2 "github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -149,21 +147,7 @@ func run(t *testing.T, steps []step) {
 		"databricks": func() (tfprotov6.ProviderServer, error) {
 			ctx := context.Background()
 
-			upgradedSdkServer, err := tf5to6server.UpgradeServer(
-				context.Background(),
-				sdkPluginProvider.GRPCProvider,
-			)
-
-			if err != nil {
-				return nil, err
-			}
-
-			providers := []func() tfprotov6.ProviderServer{
-				providerserver.NewProtocol6(provider.GetDatabricksProviderPluginFramework()), // Example terraform-plugin-framework provider
-				func() tfprotov6.ProviderServer {
-					return upgradedSdkServer
-				},
-			}
+			providers := provider.GetProviderServer()
 
 			muxServer, err := tf6muxserver.NewMuxServer(ctx, providers...)
 

--- a/internal/acceptance/init_test.go
+++ b/internal/acceptance/init_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/databricks/terraform-provider-databricks/provider"
 	"github.com/databricks/terraform-provider-databricks/qa"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
-	"github.com/hashicorp/terraform-plugin-mux/tf6muxserver"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	terraform_sdk_v2 "github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -147,15 +146,13 @@ func run(t *testing.T, steps []step) {
 		"databricks": func() (tfprotov6.ProviderServer, error) {
 			ctx := context.Background()
 
-			providers := provider.GetProviderServer()
-
-			muxServer, err := tf6muxserver.NewMuxServer(ctx, providers...)
+			providerServer, err := provider.GetProviderServer(ctx)
 
 			if err != nil {
 				return nil, err
 			}
 
-			return muxServer.ProviderServer(), nil
+			return providerServer, nil
 		},
 	}
 

--- a/internal/acceptance/init_test.go
+++ b/internal/acceptance/init_test.go
@@ -24,9 +24,14 @@ import (
 	dbproviderlogger "github.com/databricks/terraform-provider-databricks/logger"
 	"github.com/databricks/terraform-provider-databricks/provider"
 	"github.com/databricks/terraform-provider-databricks/qa"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-framework/providerserver"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-mux/tf5to6server"
+	"github.com/hashicorp/terraform-plugin-mux/tf6muxserver"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	terraform_sdk_v2 "github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 func init() {
@@ -138,7 +143,38 @@ func run(t *testing.T, steps []step) {
 		t.Skip("Acceptance tests skipped unless env 'CLOUD_ENV' is set")
 	}
 	t.Parallel()
-	provider := provider.DatabricksProvider()
+	sdkPluginProvider := provider.DatabricksProvider()
+
+	protoV6ProviderFactories := map[string]func() (tfprotov6.ProviderServer, error){
+		"databricks": func() (tfprotov6.ProviderServer, error) {
+			ctx := context.Background()
+
+			upgradedSdkServer, err := tf5to6server.UpgradeServer(
+				context.Background(),
+				sdkPluginProvider.GRPCProvider,
+			)
+
+			if err != nil {
+				return nil, err
+			}
+
+			providers := []func() tfprotov6.ProviderServer{
+				providerserver.NewProtocol6(provider.GetDatabricksProviderPluginFramework()), // Example terraform-plugin-framework provider
+				func() tfprotov6.ProviderServer {
+					return upgradedSdkServer
+				},
+			}
+
+			muxServer, err := tf6muxserver.NewMuxServer(ctx, providers...)
+
+			if err != nil {
+				return nil, err
+			}
+
+			return muxServer.ProviderServer(), nil
+		},
+	}
+
 	cwd, err := os.Getwd()
 	if err != nil {
 		t.Skip(err.Error())
@@ -164,13 +200,11 @@ func run(t *testing.T, steps []step) {
 		thisStep := s
 		stepCheck := thisStep.Check
 		stepPreConfig := s.PreConfig
-		providerFactories := map[string]func() (*schema.Provider, error){
-			"databricks": func() (*schema.Provider, error) {
-				return provider, nil
-			},
-		}
+		var providerFactories map[string]func() (*schema.Provider, error)
 		if thisStep.ProviderFactories != nil {
 			providerFactories = thisStep.ProviderFactories
+			// If there's step override, then unset the protoV6 factories.
+			protoV6ProviderFactories = nil
 		}
 		ts = append(ts, resource.TestStep{
 			PreConfig: func() {
@@ -195,9 +229,10 @@ func run(t *testing.T, steps []step) {
 			ImportStateVerify:         s.ImportStateVerify,
 			ExpectError:               s.ExpectError,
 			ProviderFactories:         providerFactories,
+			ProtoV6ProviderFactories:  protoV6ProviderFactories,
 			Check: func(state *terraform.State) error {
 				// get configured client from provider
-				client := provider.Meta().(*common.DatabricksClient)
+				client := sdkPluginProvider.Meta().(*common.DatabricksClient)
 
 				// Default check for all runs. Asserts that the read operation succeeds.
 				for n, is := range state.RootModule().Resources {
@@ -207,10 +242,16 @@ func run(t *testing.T, steps []step) {
 					if p[0] == "data" {
 						continue
 					}
-					r := provider.ResourcesMap[p[0]]
-					dia := r.ReadContext(ctx, r.Data(is.Primary), client)
-					if dia != nil {
-						return fmt.Errorf("%v", dia)
+
+					// Convert InstanceState from terraform-plugin-framework to terraform-plugin-sdk v2
+					sdkInstanceState := convertToSDKInstanceState(is.Primary)
+
+					if r, ok := sdkPluginProvider.ResourcesMap[p[0]]; ok {
+						// Only checking for sdkv2 resources.
+						dia := r.ReadContext(ctx, r.Data(sdkInstanceState), client)
+						if dia != nil {
+							return fmt.Errorf("%v", dia)
+						}
 					}
 				}
 				if stepCheck != nil {
@@ -228,6 +269,16 @@ func run(t *testing.T, steps []step) {
 			return nil
 		},
 	})
+}
+
+// Function to convert from terraform-plugin-framework InstanceState to terraform-plugin-sdk v2 InstanceState
+func convertToSDKInstanceState(is *terraform.InstanceState) *terraform_sdk_v2.InstanceState {
+	return &terraform_sdk_v2.InstanceState{
+		ID:         is.ID,
+		Attributes: is.Attributes,
+		Meta:       is.Meta,
+		Tainted:    is.Tainted,
+	}
 }
 
 // resourceCheck calls back a function with client and resource id

--- a/internal/acceptance/model_serving_test.go
+++ b/internal/acceptance/model_serving_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 )
 
 func TestAccModelServing(t *testing.T) {

--- a/internal/acceptance/mounts_test.go
+++ b/internal/acceptance/mounts_test.go
@@ -8,7 +8,7 @@ import (
 	"golang.org/x/exp/maps"
 
 	"github.com/databricks/databricks-sdk-go"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/acceptance/mws_workspaces_test.go
+++ b/internal/acceptance/mws_workspaces_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/databricks/terraform-provider-databricks/tokens"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/internal/acceptance/permissions_test.go
+++ b/internal/acceptance/permissions_test.go
@@ -10,9 +10,9 @@ import (
 	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/databricks/terraform-provider-databricks/permissions"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/acceptance/restrict_workspace_admins_test.go
+++ b/internal/acceptance/restrict_workspace_admins_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/databricks/databricks-sdk-go/apierr"
 	"github.com/databricks/databricks-sdk-go/service/settings"
 	"github.com/databricks/terraform-provider-databricks/common"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/acceptance/secret_acl_test.go
+++ b/internal/acceptance/secret_acl_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/databricks/databricks-sdk-go"
 
 	"github.com/databricks/terraform-provider-databricks/common"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/acceptance/secret_scope_test.go
+++ b/internal/acceptance/secret_scope_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/databricks/terraform-provider-databricks/common"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/acceptance/service_principal_test.go
+++ b/internal/acceptance/service_principal_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/databricks/databricks-sdk-go"
 	"github.com/databricks/databricks-sdk-go/apierr"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 const azureSpn = `resource "databricks_service_principal" "this" {

--- a/internal/acceptance/sql_endpoint_test.go
+++ b/internal/acceptance/sql_endpoint_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/databricks/databricks-sdk-go"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/acceptance/sql_global_config_test.go
+++ b/internal/acceptance/sql_global_config_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/databricks/databricks-sdk-go/qa/lock"
 	"github.com/databricks/databricks-sdk-go/qa/lock/core"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/acceptance/tf_provider_test.go
+++ b/internal/acceptance/tf_provider_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 
 	"github.com/databricks/terraform-provider-databricks/provider"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 func noOpProvider() *schema.Provider {

--- a/internal/acceptance/user_test.go
+++ b/internal/acceptance/user_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/databricks/databricks-sdk-go/service/iam"
 
 	"github.com/databricks/terraform-provider-databricks/qa"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 // https://github.com/databricks/terraform-provider-databricks/issues/1097

--- a/internal/acceptance/vector_search_test.go
+++ b/internal/acceptance/vector_search_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 )
 
 func TestUcAccVectorSearchEndpoint(t *testing.T) {

--- a/internal/acceptance/workspace_conf_test.go
+++ b/internal/acceptance/workspace_conf_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/databricks/databricks-sdk-go"
 	"github.com/databricks/databricks-sdk-go/service/settings"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/jobs/resource_job.go
+++ b/jobs/resource_job.go
@@ -14,9 +14,9 @@ import (
 	"github.com/databricks/databricks-sdk-go/service/compute"
 	"github.com/databricks/databricks-sdk-go/service/jobs"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
 	"github.com/databricks/databricks-sdk-go/apierr"
 	"github.com/databricks/terraform-provider-databricks/clusters"

--- a/libraries/libraries_api_sdk.go
+++ b/libraries/libraries_api_sdk.go
@@ -11,7 +11,7 @@ import (
 	"github.com/databricks/databricks-sdk-go"
 	"github.com/databricks/databricks-sdk-go/apierr"
 	"github.com/databricks/databricks-sdk-go/service/compute"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 // Given a compute.Wait struct, returns library statuses based on the input parameter.

--- a/main.go
+++ b/main.go
@@ -9,10 +9,7 @@ import (
 	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/databricks/terraform-provider-databricks/exporter"
 	"github.com/databricks/terraform-provider-databricks/provider"
-	"github.com/hashicorp/terraform-plugin-framework/providerserver"
-	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6/tf6server"
-	"github.com/hashicorp/terraform-plugin-mux/tf5to6server"
 	"github.com/hashicorp/terraform-plugin-mux/tf6muxserver"
 )
 
@@ -40,24 +37,7 @@ func main() {
 
 	log.Printf(startMessageFormat, common.Version())
 
-	sdkPluginProvider := provider.DatabricksProvider()
-
-	upgradedSdkPluginProvider, err := tf5to6server.UpgradeServer(
-		context.Background(),
-		sdkPluginProvider.GRPCProvider,
-	)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	pluginFrameworkProvider := provider.GetDatabricksProviderPluginFramework()
-
-	providers := []func() tfprotov6.ProviderServer{
-		func() tfprotov6.ProviderServer {
-			return upgradedSdkPluginProvider
-		},
-		providerserver.NewProtocol6(pluginFrameworkProvider),
-	}
+	providers := provider.GetProviderServer()
 
 	ctx := context.Background()
 	muxServer, err := tf6muxserver.NewMuxServer(ctx, providers...)

--- a/main.go
+++ b/main.go
@@ -9,8 +9,8 @@ import (
 	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/databricks/terraform-provider-databricks/exporter"
 	"github.com/databricks/terraform-provider-databricks/provider"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6/tf6server"
-	"github.com/hashicorp/terraform-plugin-mux/tf6muxserver"
 )
 
 const startMessageFormat = `Databricks Terraform Provider
@@ -37,11 +37,8 @@ func main() {
 
 	log.Printf(startMessageFormat, common.Version())
 
-	providers := provider.GetProviderServer()
-
 	ctx := context.Background()
-	muxServer, err := tf6muxserver.NewMuxServer(ctx, providers...)
-
+	providerServer, err := provider.GetProviderServer(ctx)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -53,7 +50,7 @@ func main() {
 
 	err = tf6server.Serve(
 		"registry.terraform.io/databricks/databricks",
-		muxServer.ProviderServer,
+		func() tfprotov6.ProviderServer { return providerServer },
 		serveOpts...,
 	)
 

--- a/mws/resource_mws_networks.go
+++ b/mws/resource_mws_networks.go
@@ -9,9 +9,9 @@ import (
 	"github.com/databricks/databricks-sdk-go/apierr"
 	"github.com/databricks/terraform-provider-databricks/common"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 // NewNetworksAPI creates MWSNetworksAPI instance from provider meta

--- a/mws/resource_mws_vpc_endpoint.go
+++ b/mws/resource_mws_vpc_endpoint.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/databricks/terraform-provider-databricks/common"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 // NewVPCEndpointAPI creates VPCEndpointAPI instance from provider meta

--- a/mws/resource_mws_workspaces.go
+++ b/mws/resource_mws_workspaces.go
@@ -19,8 +19,8 @@ import (
 
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 // DefaultProvisionTimeout is the amount of minutes terraform will wait

--- a/pipelines/resource_pipeline.go
+++ b/pipelines/resource_pipeline.go
@@ -7,9 +7,9 @@ import (
 	"regexp"
 	"time"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
 	"github.com/databricks/databricks-sdk-go/apierr"
 	"github.com/databricks/databricks-sdk-go/marshal"

--- a/provider/provider_factory.go
+++ b/provider/provider_factory.go
@@ -7,9 +7,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-plugin-mux/tf5to6server"
+	"github.com/hashicorp/terraform-plugin-mux/tf6muxserver"
 )
 
-func GetProviderServer() []func() tfprotov6.ProviderServer {
+func GetProviderServer(ctx context.Context) (tfprotov6.ProviderServer, error) {
 	sdkPluginProvider := DatabricksProvider()
 
 	upgradedSdkPluginProvider, err := tf5to6server.UpgradeServer(
@@ -29,5 +30,11 @@ func GetProviderServer() []func() tfprotov6.ProviderServer {
 		providerserver.NewProtocol6(pluginFrameworkProvider),
 	}
 
-	return providers
+	muxServer, err := tf6muxserver.NewMuxServer(ctx, providers...)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return muxServer.ProviderServer(), nil
 }

--- a/provider/provider_factory.go
+++ b/provider/provider_factory.go
@@ -1,0 +1,33 @@
+package provider
+
+import (
+	"context"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-framework/providerserver"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-mux/tf5to6server"
+)
+
+func GetProviderServer() []func() tfprotov6.ProviderServer {
+	sdkPluginProvider := DatabricksProvider()
+
+	upgradedSdkPluginProvider, err := tf5to6server.UpgradeServer(
+		context.Background(),
+		sdkPluginProvider.GRPCProvider,
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	pluginFrameworkProvider := GetDatabricksProviderPluginFramework()
+
+	providers := []func() tfprotov6.ProviderServer{
+		func() tfprotov6.ProviderServer {
+			return upgradedSdkPluginProvider
+		},
+		providerserver.NewProtocol6(pluginFrameworkProvider),
+	}
+
+	return providers
+}

--- a/qa/testing.go
+++ b/qa/testing.go
@@ -26,9 +26,9 @@ import (
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
- Part of https://github.com/databricks/terraform-provider-databricks/pull/3841
- Migrated imports following the documentation [here](https://developer.hashicorp.com/terraform/plugin/testing/migrating)
  - 
<img width="688" alt="image" src="https://github.com/user-attachments/assets/f2f14175-f3f8-47b7-a19f-1f0fca13eb47">

- Made `run` in `init_test` able to take both plugin framework resources as well as sdkv2 resources

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [x] covered with integration tests in `internal/acceptance`
- [x] relevant acceptance tests are passing
- [x] using Go SDK
