### PR TITLE
Add quality monitor acceptance test for plugin framework

### DIFF
--- a/internal/acceptance/quality_monitor_test.go
+++ b/internal/acceptance/quality_monitor_test.go
@@ -149,3 +149,107 @@ func TestUcAccUpdateQualityMonitor(t *testing.T) {
 		`,
 	})
 }
+
+func TestUcAccQualityMonitorPluginFramework(t *testing.T) {
+	if os.Getenv("GOOGLE_CREDENTIALS") != "" {
+		t.Skipf("databricks_quality_monitor resource is not available on GCP")
+	}
+	unityWorkspaceLevel(t, step{
+		Template: commonPartQualityMonitoring + `
+
+			resource "databricks_lakehouse_monitor_pluginframework" "testMonitorInference" {
+				table_name = databricks_sql_table.myInferenceTable.id
+				assets_dir = "/Shared/provider-test/databricks_quality_monitoring/${databricks_sql_table.myInferenceTable.name}"
+				output_schema_name = databricks_schema.things.id
+				inference_log = {
+				  granularities = ["1 day"]
+				  timestamp_col = "timestamp"
+				  prediction_col = "prediction"
+				  model_id_col = "model_id"
+				  problem_type = "PROBLEM_TYPE_REGRESSION"
+				} 
+			}
+
+			resource "databricks_sql_table" "myTimeseries" {
+				catalog_name = databricks_catalog.sandbox.id
+				schema_name = databricks_schema.things.name
+				name = "bar{var.STICKY_RANDOM}_timeseries"
+				table_type = "MANAGED"
+				data_source_format = "DELTA"
+
+				column {
+					name = "timestamp"
+					type = "int"
+				}
+			}
+
+			resource "databricks_lakehouse_monitor_pluginframework" "testMonitorTimeseries" {
+				table_name = databricks_sql_table.myTimeseries.id
+				assets_dir = "/Shared/provider-test/databricks_quality_monitoring/${databricks_sql_table.myTimeseries.name}"
+				output_schema_name = databricks_schema.things.id
+				time_series = {
+				  granularities = ["1 day"]
+				  timestamp_col = "timestamp"
+				} 
+			}
+
+			resource "databricks_sql_table" "mySnapshot" {
+				catalog_name = databricks_catalog.sandbox.id
+				schema_name = databricks_schema.things.name
+				name = "bar{var.STICKY_RANDOM}_snapshot"
+				table_type = "MANAGED"
+				data_source_format = "DELTA"
+
+				column {
+					name = "timestamp"
+					type = "int"
+				}
+			}
+
+			resource "databricks_lakehouse_monitor_pluginframework" "testMonitorSnapshot" {
+				table_name = databricks_sql_table.mySnapshot.id
+				assets_dir = "/Shared/provider-test/databricks_quality_monitoring/${databricks_sql_table.myTimeseries.name}"
+				output_schema_name = databricks_schema.things.id
+				snapshot = {
+				} 
+			}
+		`,
+	})
+}
+
+func TestUcAccUpdateQualityMonitorPluginFramework(t *testing.T) {
+	if os.Getenv("GOOGLE_CREDENTIALS") != "" {
+		t.Skipf("databricks_quality_monitor resource is not available on GCP")
+	}
+	unityWorkspaceLevel(t, step{
+		Template: commonPartQualityMonitoring + `
+			resource "databricks_lakehouse_monitor_pluginframework" "testMonitorInference" {
+				table_name = databricks_sql_table.myInferenceTable.id
+				assets_dir = "/Shared/provider-test/databricks_quality_monitoring/${databricks_sql_table.myInferenceTable.name}"
+				output_schema_name = databricks_schema.things.id
+				inference_log = {
+				  granularities = ["1 day"]
+				  timestamp_col = "timestamp"
+				  prediction_col = "prediction"
+				  model_id_col = "model_id"
+				  problem_type = "PROBLEM_TYPE_REGRESSION"
+				}
+			}
+		`,
+	}, step{
+		Template: commonPartQualityMonitoring + `
+		resource "databricks_lakehouse_monitor_pluginframework" "testMonitorInference" {
+			table_name = databricks_sql_table.myInferenceTable.id
+			assets_dir = "/Shared/provider-test/databricks_quality_monitoring/${databricks_sql_table.myInferenceTable.name}"
+			output_schema_name = databricks_schema.things.id
+			inference_log = {
+				granularities = ["1 hour"]
+				timestamp_col = "timestamp"
+				prediction_col = "prediction"
+				model_id_col = "model_id"
+				problem_type = "PROBLEM_TYPE_REGRESSION"
+			}
+		}
+		`,
+	})
+}


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
- Add two more test cases replicating existing test case for quality monitor resource, but for the plugin framework
- Manually executed the tests to make sure they are passing
- Taking out the manual read check at the end of each test step as suggested [here](https://github.com/databricks/terraform-provider-databricks/pull/3867#discussion_r1709278870) because the type casting for clients is causing issue for plugin framework tests 

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [x] covered with integration tests in `internal/acceptance`
- [x] relevant acceptance tests are passing
- [x] using Go SDK
