### PR TITLE
[Exporter] Fix generation of `autotermination_minutes = 0`

### DIFF
--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -1029,6 +1029,22 @@ func TestImportingClusters(t *testing.T) {
 			err := ic.Run()
 			os.Unsetenv("EXPORTER_PARALLELISM_default")
 			assert.NoError(t, err)
+			content, err := os.ReadFile(tmpDir + "/compute.tf")
+			assert.NoError(t, err)
+			contentStr := string(content)
+			assert.True(t, strings.Contains(contentStr, `resource "databricks_cluster" "test1_test1"`))
+			assert.True(t, strings.Contains(contentStr, `resource "databricks_cluster" "test_cluster_policy_test2"`))
+			assert.True(t, strings.Contains(contentStr, `policy_id                    = databricks_cluster_policy.users_cluster_policy.id`))
+			assert.True(t, strings.Contains(contentStr, `autotermination_minutes = 0`))
+			assert.True(t, strings.Contains(contentStr, `autotermination_minutes = 120`))
+			assert.True(t, strings.Contains(contentStr, `library {
+    jar = databricks_dbfs_file._0eee4efe7411a5bdca65d7b79188026c_test_jar.dbfs_path
+  }`))
+			assert.True(t, strings.Contains(contentStr, `init_scripts {
+    dbfs {
+      destination = databricks_dbfs_file._0eee4efe7411a5bdca65d7b79188026c_test_jar.dbfs_path
+    }
+  }`))
 		})
 }
 
@@ -2898,7 +2914,6 @@ func TestNotificationDestinationExport(t *testing.T) {
 		content, err := os.ReadFile(tmpDir + "/settings.tf")
 		assert.NoError(t, err)
 		contentStr := string(content)
-		log.Printf("[DEBUG] contentStr: %s", contentStr)
 		assert.True(t, strings.Contains(contentStr, `resource "databricks_notification_destination" "pagerdruty_456"`))
 		assert.True(t, strings.Contains(contentStr, `resource "databricks_notification_destination" "teams_345"`))
 		assert.True(t, strings.Contains(contentStr, `resource "databricks_notification_destination" "email_123" {

--- a/exporter/test-data/get-cluster-test2-response.json
+++ b/exporter/test-data/get-cluster-test2-response.json
@@ -3,7 +3,6 @@
     "max_workers": 2,
     "min_workers": 1
   },
-  "autotermination_minutes": 10,
   "azure_attributes": {
     "availability": "ON_DEMAND_AZURE",
     "first_on_demand": 1,

--- a/exporter/util_compute.go
+++ b/exporter/util_compute.go
@@ -3,7 +3,6 @@ package exporter
 import (
 	"fmt"
 	"log"
-	"reflect"
 	"regexp"
 
 	"github.com/databricks/terraform-provider-databricks/common"
@@ -188,12 +187,6 @@ func makeShouldOmitFieldForCluster(regex *regexp.Regexp) func(ic *importContext,
 			}
 		}
 		raw := d.Get(pathString)
-		if raw != nil {
-			v := reflect.ValueOf(raw)
-			if as.Optional && v.IsZero() {
-				return true
-			}
-		}
 		workerInstPoolID := d.Get(prefix + "instance_pool_id").(string)
 		switch pathString {
 		case prefix + "node_type_id":


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

The code that evaluated if field should be skipped or not, was incorrectly omitting zero value for `autotermination_minutes` attribute.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
