### PR TITLE
[Fix] Fix crash when destroying `databricks_compliance_security_profile_workspace_setting`

### DIFF
--- a/docs/resources/compliance_security_profile_setting.md
+++ b/docs/resources/compliance_security_profile_setting.md
@@ -6,6 +6,8 @@ subcategory: "Settings"
 
 -> **Note** This resource could be only used with workspace-level provider!
 
+-> **Note** This setting can NOT be disabled once it is enabled.
+
 The `databricks_compliance_security_profile_workspace_setting` resource allows you to control whether to enable the 
 compliance security profile for the current workspace. Enabling it on a workspace is permanent. By default, it is 
 turned off. This setting can NOT be disabled once it is enabled.

--- a/settings/generic_setting.go
+++ b/settings/generic_setting.go
@@ -9,6 +9,7 @@ import (
 	"github.com/databricks/databricks-sdk-go"
 	"github.com/databricks/databricks-sdk-go/apierr"
 	"github.com/databricks/terraform-provider-databricks/common"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -133,6 +134,10 @@ func (w workspaceSetting[T]) Update(ctx context.Context, c *databricks.Workspace
 	return w.updateFunc(ctx, c, t)
 }
 func (w workspaceSetting[T]) Delete(ctx context.Context, c *databricks.WorkspaceClient, etag string) (string, error) {
+	if w.deleteFunc == nil {
+		tflog.Warn(ctx, "The `delete` function isn't defined for this resource. Most probably it's not supported.")
+		return etag, nil
+	}
 	return w.deleteFunc(ctx, c, etag)
 }
 func (w workspaceSetting[T]) GetETag(t *T) string {
@@ -203,6 +208,10 @@ func (w accountSetting[T]) Update(ctx context.Context, c *databricks.AccountClie
 	return w.updateFunc(ctx, c, t)
 }
 func (w accountSetting[T]) Delete(ctx context.Context, c *databricks.AccountClient, etag string) (string, error) {
+	if w.deleteFunc == nil {
+		tflog.Warn(ctx, "The `delete` function isn't defined for this resource. Most probably it's not supported.")
+		return etag, nil
+	}
 	return w.deleteFunc(ctx, c, etag)
 }
 func (w accountSetting[T]) GetETag(t *T) string {

--- a/settings/resource_compliance_security_profile_setting.go
+++ b/settings/resource_compliance_security_profile_setting.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/databricks/databricks-sdk-go"
 	"github.com/databricks/databricks-sdk-go/service/settings"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 // Enhanced Security Monitoring setting
@@ -31,5 +32,9 @@ var complianceSecurityProfileSetting = workspaceSetting[settings.ComplianceSecur
 			return "", err
 		}
 		return res.Etag, err
+	},
+	deleteFunc: func(ctx context.Context, w *databricks.WorkspaceClient, etag string) (string, error) {
+		tflog.Warn(ctx, "databricks_compliance_security_profile_workspace_setting couldn't be disabled!")
+		return etag, nil
 	},
 }

--- a/settings/resource_compliance_security_profile_setting_test.go
+++ b/settings/resource_compliance_security_profile_setting_test.go
@@ -256,3 +256,21 @@ func TestQueryUpdateComplianceSecurityProfileSettingWithConflict(t *testing.T) {
 	assert.Equal(t, true, res["is_enabled"])
 	assert.Equal(t, "HIPAA", res["compliance_standards"].([]interface{})[0])
 }
+
+func TestDeleteComplianceSecurityProfileSetting(t *testing.T) {
+	qa.ResourceFixture{
+		Resource: testComplianceSecurityProfileSetting,
+		Delete:   true,
+		HCL: `
+			compliance_security_profile_workspace {
+				is_enabled = true
+				compliance_standards = ["HIPAA", "PCI_DSS"]
+			}
+			etag = "etag1"
+		`,
+		ID: defaultSettingId,
+	}.ApplyAndExpectData(t, map[string]any{
+		etagAttrName: "etag1",
+		"id":         defaultSettingId,
+	})
+}


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->


The `databricks_compliance_security_profile_workspace_setting` didn't have a `deleteFunc` defined and this lead to the crash when destroying the resource.  This PR fixes this issue in two places:

1. Adding explicit `deleteFunc` that will just print warning into the log
1. Checking that `deleteFunc` is not null in `workspaceSetting` and `accountSetting` implementations to avoid similar problems in the future.

Fixes #3675

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
