### PR TITLE
[Feature] Add `workspace_path` attribute to `databricks_notebook` resource and data source

### DIFF
--- a/docs/data-sources/notebook.md
+++ b/docs/data-sources/notebook.md
@@ -29,3 +29,4 @@ This data source exports the following attributes:
 * `language` - notebook language
 * `object_id` - notebook object ID
 * `object_type` - notebook object type
+* `workspace_path` - path on Workspace File System (WSFS) in form of `/Workspace` + `path`

--- a/docs/resources/notebook.md
+++ b/docs/resources/notebook.md
@@ -60,6 +60,7 @@ In addition to all arguments above, the following attributes are exported:
 * `id` -  Path of notebook on workspace
 * `url` - Routable URL of the notebook
 * `object_id` -  Unique identifier for a NOTEBOOK
+* `workspace_path` - path on Workspace File System (WSFS) in form of `/Workspace` + `path`
 
 ## Access Control
 

--- a/workspace/data_notebook.go
+++ b/workspace/data_notebook.go
@@ -46,6 +46,10 @@ func DataSourceNotebook() common.Resource {
 			Optional: true,
 			Computed: true,
 		},
+		"workspace_path": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
 	}
 	return common.Resource{
 		Schema: s,
@@ -74,6 +78,7 @@ func DataSourceNotebook() common.Resource {
 			if err != nil {
 				return err
 			}
+			d.Set("workspace_path", "/Workspace"+objectStatus.Path)
 			return nil
 		},
 	}

--- a/workspace/data_notebook_test.go
+++ b/workspace/data_notebook_test.go
@@ -5,12 +5,10 @@ import (
 
 	"github.com/databricks/databricks-sdk-go/apierr"
 	"github.com/databricks/terraform-provider-databricks/qa"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestDataSourceNotebook(t *testing.T) {
-	d, err := qa.ResourceFixture{
+	qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   "GET",
@@ -38,10 +36,11 @@ func TestDataSourceNotebook(t *testing.T) {
 			"path":   "/a/b/c",
 			"format": "SOURCE",
 		},
-	}.Apply(t)
-	require.NoError(t, err)
-	assert.Equal(t, "/a/b/c", d.Id())
-	assert.Equal(t, "SGVsbG8gd29ybGQK", d.Get("content"))
+	}.ApplyAndExpectData(t, map[string]any{
+		"id":             "/a/b/c",
+		"content":        "SGVsbG8gd29ybGQK",
+		"workspace_path": "/Workspace/a/b/c",
+	})
 }
 
 func TestDataSourceNotebook_ErrorExport(t *testing.T) {

--- a/workspace/resource_notebook.go
+++ b/workspace/resource_notebook.go
@@ -249,6 +249,10 @@ func ResourceNotebook() common.Resource {
 			Optional: true,
 			Computed: true,
 		},
+		"workspace_path": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
 	})
 	s["content_base64"].RequiredWith = []string{"language"}
 	return common.Resource{
@@ -308,6 +312,7 @@ func ResourceNotebook() common.Resource {
 				return err
 			}
 			d.Set("url", c.FormatURL("#workspace", d.Id()))
+			d.Set("workspace_path", "/Workspace"+objectStatus.Path)
 			return common.StructToData(objectStatus, s, d)
 		},
 		Update: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {

--- a/workspace/resource_notebook_test.go
+++ b/workspace/resource_notebook_test.go
@@ -13,7 +13,7 @@ import (
 func TestResourceNotebookRead(t *testing.T) {
 	path := "/test/path.py"
 	objectID := 12345
-	d, err := qa.ResourceFixture{
+	qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   http.MethodGet,
@@ -30,17 +30,18 @@ func TestResourceNotebookRead(t *testing.T) {
 		Read:     true,
 		New:      true,
 		ID:       path,
-	}.Apply(t)
-	assert.NoError(t, err)
-	assert.Equal(t, path, d.Id())
-	assert.Equal(t, path, d.Get("path"))
-	assert.Equal(t, "PYTHON", d.Get("language"))
-	assert.Equal(t, objectID, d.Get("object_id"))
+	}.ApplyAndExpectData(t, map[string]any{
+		"path":           path,
+		"object_id":      objectID,
+		"language":       "PYTHON",
+		"id":             path,
+		"workspace_path": "/Workspace" + path,
+	})
 }
 
 func TestResourceNotebookDelete(t *testing.T) {
 	path := "/test/path.py"
-	d, err := qa.ResourceFixture{
+	qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:          http.MethodPost,
@@ -52,9 +53,9 @@ func TestResourceNotebookDelete(t *testing.T) {
 		Resource: ResourceNotebook(),
 		Delete:   true,
 		ID:       path,
-	}.Apply(t)
-	assert.NoError(t, err)
-	assert.Equal(t, path, d.Id())
+	}.ApplyAndExpectData(t, map[string]any{
+		"id": path,
+	})
 }
 
 func TestResourceNotebookRead_NotFound(t *testing.T) {
@@ -99,7 +100,7 @@ func TestResourceNotebookRead_Error(t *testing.T) {
 }
 
 func TestResourceNotebookCreate_DirectoryExist(t *testing.T) {
-	d, err := qa.ResourceFixture{
+	qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   "POST",
@@ -144,13 +145,14 @@ func TestResourceNotebookCreate_DirectoryExist(t *testing.T) {
 			"path":           "/foo/path.py",
 		},
 		Create: true,
-	}.Apply(t)
-	assert.NoError(t, err)
-	assert.Equal(t, "/foo/path.py", d.Id())
+	}.ApplyAndExpectData(t, map[string]any{
+		"path": "/foo/path.py",
+		"id":   "/foo/path.py",
+	})
 }
 
 func TestResourceNotebookCreate_DirectoryDoesntExist(t *testing.T) {
-	d, err := qa.ResourceFixture{
+	qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   "POST",
@@ -211,9 +213,10 @@ func TestResourceNotebookCreate_DirectoryDoesntExist(t *testing.T) {
 			"path":           "/foo/path.py",
 		},
 		Create: true,
-	}.Apply(t)
-	assert.NoError(t, err)
-	assert.Equal(t, "/foo/path.py", d.Id())
+	}.ApplyAndExpectData(t, map[string]any{
+		"path": "/foo/path.py",
+		"id":   "/foo/path.py",
+	})
 }
 
 func TestResourceNotebookCreate_DirectoryCreateError(t *testing.T) {
@@ -260,7 +263,7 @@ func TestResourceNotebookCreate_DirectoryCreateError(t *testing.T) {
 }
 
 func TestResourceNotebookCreateSource_Jupyter(t *testing.T) {
-	d, err := qa.ResourceFixture{
+	qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   http.MethodPost,
@@ -308,13 +311,13 @@ func TestResourceNotebookCreateSource_Jupyter(t *testing.T) {
 			"path":   "/Mars",
 		},
 		Create: true,
-	}.Apply(t)
-	assert.NoError(t, err)
-	assert.Equal(t, "/Mars", d.Id())
+	}.ApplyAndExpectData(t, map[string]any{
+		"id": "/Mars",
+	})
 }
 
 func TestResourceNotebookCreateSource(t *testing.T) {
-	d, err := qa.ResourceFixture{
+	qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   http.MethodPost,
@@ -346,9 +349,9 @@ func TestResourceNotebookCreateSource(t *testing.T) {
 			"path":   "/Dashboard",
 		},
 		Create: true,
-	}.Apply(t)
-	assert.NoError(t, err)
-	assert.Equal(t, "/Dashboard", d.Id())
+	}.ApplyAndExpectData(t, map[string]any{
+		"id": "/Dashboard",
+	})
 }
 
 func TestResourceNotebookCreate_Error(t *testing.T) {


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

This unifies these resources/data sources with other workspace objects - it will be useful to support it as we adopt `/Workspace/...` paths in jobs and other resources

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
