### PR TITLE
[Dependency] Bump databricks-sdk-go to 0.44.0

### DIFF
--- a/access/resource_ip_access_list_test.go
+++ b/access/resource_ip_access_list_test.go
@@ -3,7 +3,6 @@ package access
 // REST API: https://docs.databricks.com/dev-tools/api/latest/ip-access-list.html#operation/create-list
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -13,7 +12,6 @@ import (
 	"github.com/databricks/terraform-provider-databricks/qa"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -310,27 +308,4 @@ func TestIPACLDelete_Error(t *testing.T) {
 		Removed:  true,
 		ID:       TestingId,
 	}.ExpectError(t, "Something went wrong")
-}
-
-func TestListIpAccessLists(t *testing.T) {
-	client, server, err := qa.HttpFixtureClient(t, []qa.HTTPFixture{
-		{
-			Method:   "GET",
-			Resource: "/api/2.0/ip-access-lists",
-			Response: map[string]any{},
-		},
-	})
-	require.NoError(t, err)
-
-	w, err := client.WorkspaceClient()
-	require.NoError(t, err)
-
-	defer server.Close()
-	require.NoError(t, err)
-
-	ctx := context.Background()
-	ipLists, err := w.IpAccessLists.Impl().List(ctx)
-
-	require.NoError(t, err)
-	assert.Equal(t, 0, len(ipLists.IpAccessLists))
 }

--- a/catalog/resource_volume_test.go
+++ b/catalog/resource_volume_test.go
@@ -1,7 +1,6 @@
 package catalog
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -10,7 +9,6 @@ import (
 	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/databricks/terraform-provider-databricks/qa"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestVolumesCornerCases(t *testing.T) {
@@ -739,27 +737,4 @@ func TestVolumeDelete_Error(t *testing.T) {
 		Removed:  true,
 		ID:       "testCatalogName.testSchemaName.testName",
 	}.ExpectError(t, "Something went wrong")
-}
-
-func TestVolumesList(t *testing.T) {
-	client, server, err := qa.HttpFixtureClient(t, []qa.HTTPFixture{
-		{
-			Method:   http.MethodGet,
-			Resource: "/api/2.1/unity-catalog/volumes?catalog_name=&schema_name=",
-			Response: map[string]any{},
-		},
-	})
-	require.NoError(t, err)
-
-	w, err := client.WorkspaceClient()
-	require.NoError(t, err)
-
-	defer server.Close()
-	require.NoError(t, err)
-
-	ctx := context.Background()
-	vLists, err := w.Volumes.Impl().List(ctx, catalog.ListVolumesRequest{})
-
-	require.NoError(t, err)
-	assert.Equal(t, 0, len(vLists.Volumes))
 }

--- a/clusters/data_spark_version.go
+++ b/clusters/data_spark_version.go
@@ -21,11 +21,7 @@ func DataSourceSparkVersion() common.Resource {
 		return nil
 	}, func(s map[string]*schema.Schema) map[string]*schema.Schema {
 		common.CustomizeSchemaPath(s, "photon").SetDeprecated("Specify runtime_engine=\"PHOTON\" in the cluster configuration")
-		common.CustomizeSchemaPath(s).AddNewField("graviton", &schema.Schema{
-			Type:       schema.TypeBool,
-			Optional:   true,
-			Deprecated: "Not required anymore - it's automatically enabled on the Graviton-based node types",
-		})
+		common.CustomizeSchemaPath(s, "graviton").SetDeprecated("Not required anymore - it's automatically enabled on the Graviton-based node types")
 		return s
 	})
 }

--- a/common/client.go
+++ b/common/client.go
@@ -22,6 +22,12 @@ type cachedMe struct {
 	mu           sync.Mutex
 }
 
+func newCachedMe(inner iam.CurrentUserService) *cachedMe {
+	return &cachedMe{
+		internalImpl: inner,
+	}
+}
+
 func (a *cachedMe) Me(ctx context.Context) (*iam.User, error) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
@@ -60,7 +66,7 @@ func (c *DatabricksClient) WorkspaceClient() (*databricks.WorkspaceClient, error
 	if err != nil {
 		return nil, err
 	}
-	w.CurrentUser = &cachedMe{internalImpl: w.CurrentUser}
+	w.CurrentUser = newCachedMe(w.CurrentUser)
 	c.cachedWorkspaceClient = w
 	return w, nil
 }

--- a/common/client.go
+++ b/common/client.go
@@ -60,10 +60,7 @@ func (c *DatabricksClient) WorkspaceClient() (*databricks.WorkspaceClient, error
 	if err != nil {
 		return nil, err
 	}
-	internalImpl := w.CurrentUser.Impl()
-	w.CurrentUser.WithImpl(&cachedMe{
-		internalImpl: internalImpl,
-	})
+	w.CurrentUser = &cachedMe{internalImpl: w.CurrentUser}
 	c.cachedWorkspaceClient = w
 	return w, nil
 }

--- a/exporter/importables.go
+++ b/exporter/importables.go
@@ -1536,12 +1536,11 @@ var resourcesMap map[string]importable = map[string]importable{
 			return d.Get("list_type").(string) + "_" + d.Get("label").(string)
 		},
 		List: func(ic *importContext) error {
-			ipListsResp, err := ic.workspaceClient.IpAccessLists.Impl().List(ic.Context)
+			ipLists, err := ic.workspaceClient.IpAccessLists.ListAll(ic.Context)
 
 			if err != nil {
 				return err
 			}
-			ipLists := ipListsResp.IpAccessLists
 			for offset, ipList := range ipLists {
 				ic.EmitIfUpdatedAfterMillis(&resource{
 					Resource: "databricks_ip_access_list",

--- a/exporter/util.go
+++ b/exporter/util.go
@@ -556,7 +556,7 @@ func dltIsMatchingCatalogAndSchema(ic *importContext, res *resource, ra *resourc
 }
 
 func (ic *importContext) emitWorkspaceBindings(securableType, securableName string) {
-	bindings, err := ic.workspaceClient.WorkspaceBindings.GetBindings(ic.Context, catalog.GetBindingsRequest{
+	bindings, err := ic.workspaceClient.WorkspaceBindings.GetBindingsAll(ic.Context, catalog.GetBindingsRequest{
 		SecurableName: securableName,
 		SecurableType: catalog.GetBindingsSecurableType(securableType),
 	})
@@ -564,7 +564,7 @@ func (ic *importContext) emitWorkspaceBindings(securableType, securableName stri
 		log.Printf("[ERROR] listing %s bindings for %s: %s", securableType, securableName, err.Error())
 		return
 	}
-	for _, binding := range bindings.Bindings {
+	for _, binding := range bindings {
 		id := fmt.Sprintf("%d|%s|%s", binding.WorkspaceId, securableType, securableName)
 		// We were creating Data instance explicitly because of the bug in the databricks_catalog_workspace_binding
 		// implementation. Technically, after the fix is merged we can remove this, but we're keeping it as-is now

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/databricks/terraform-provider-databricks
 go 1.22
 
 require (
-	github.com/databricks/databricks-sdk-go v0.43.3-0.20240725113401-33ef9dbf3727
+	github.com/databricks/databricks-sdk-go v0.44.0
 	github.com/golang-jwt/jwt/v4 v4.5.0
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/hcl v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -26,8 +26,6 @@ github.com/cloudflare/circl v1.3.7/go.mod h1:sRTcRWXGLrKw6yIGJ+l7amYJFfAXbZG0kBS
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cyphar/filepath-securejoin v0.2.4 h1:Ugdm7cg7i6ZK6x3xDF1oEu1nfkyfH53EtKeQYTC3kyg=
 github.com/cyphar/filepath-securejoin v0.2.4/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxGGx79pTxQpKOJNYHHl4=
-github.com/databricks/databricks-sdk-go v0.43.3-0.20240725113401-33ef9dbf3727 h1:EwEUcWBPFBsosUGpyiiMXYbOfn+i5PM5hatP6gsDyXQ=
-github.com/databricks/databricks-sdk-go v0.43.3-0.20240725113401-33ef9dbf3727/go.mod h1:ds+zbv5mlQG7nFEU5ojLtgN/u0/9YzZmKQES/CfedzU=
 github.com/databricks/databricks-sdk-go v0.44.0 h1:9/FZACv4EFQIOYxfwYVKnY7v46xio9FKCw9tpKB2O/s=
 github.com/databricks/databricks-sdk-go v0.44.0/go.mod h1:ds+zbv5mlQG7nFEU5ojLtgN/u0/9YzZmKQES/CfedzU=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/go.sum
+++ b/go.sum
@@ -28,6 +28,8 @@ github.com/cyphar/filepath-securejoin v0.2.4 h1:Ugdm7cg7i6ZK6x3xDF1oEu1nfkyfH53E
 github.com/cyphar/filepath-securejoin v0.2.4/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxGGx79pTxQpKOJNYHHl4=
 github.com/databricks/databricks-sdk-go v0.43.3-0.20240725113401-33ef9dbf3727 h1:EwEUcWBPFBsosUGpyiiMXYbOfn+i5PM5hatP6gsDyXQ=
 github.com/databricks/databricks-sdk-go v0.43.3-0.20240725113401-33ef9dbf3727/go.mod h1:ds+zbv5mlQG7nFEU5ojLtgN/u0/9YzZmKQES/CfedzU=
+github.com/databricks/databricks-sdk-go v0.44.0 h1:9/FZACv4EFQIOYxfwYVKnY7v46xio9FKCw9tpKB2O/s=
+github.com/databricks/databricks-sdk-go v0.44.0/go.mod h1:ds+zbv5mlQG7nFEU5ojLtgN/u0/9YzZmKQES/CfedzU=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
## Changes
This PR bumps the Databricks SDK for Go to v0.44.0.

This version removes the Impl()/WithImpl() methods of the SDK. The cachedMe implementation is slightly dependent on this interface, so I changed how it is initialized to work with the new version of the SDK. Additionally, there were two tests depending on this and one line in the exporter. The tests are probably left-over from when the provider contained its own client implementation, but now that it uses the SDK's client for these resources, they can be removed. 

The only difference in schema is:
```
@ ["provider_schemas","registry.terraform.io/databricks/databricks","resource_schemas","databricks_cluster_policy","block","attributes","name","required"]
- true
@ ["provider_schemas","registry.terraform.io/databricks/databricks","resource_schemas","databricks_cluster_policy","block","attributes","name","optional"]
+ true

```

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
