### PR TITLE
[Exporter] Add retry on "Operation timed out" error

### DIFF
--- a/exporter/util.go
+++ b/exporter/util.go
@@ -390,7 +390,7 @@ func getEnvAsInt(envName string, defaultValue int) int {
 var (
 	maxRetries        = 5
 	retryDelaySeconds = 2
-	retriableErrors   = []string{"deadline exceeded", "Error handling request", "Timed out after "}
+	retriableErrors   = []string{"deadline exceeded", "Error handling request", "Timed out after ", "Operation timed out"}
 )
 
 func isRetryableError(err string, i int) bool {


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

This happens sometimes when reading notebooks so we need to retry it

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
