### PR TITLE
[Internal] Fix integration tests

### DIFF
--- a/internal/acceptance/mws_network_connectivity_config_test.go
+++ b/internal/acceptance/mws_network_connectivity_config_test.go
@@ -5,6 +5,7 @@ import (
 )
 
 func TestMwsAccNetworkConnectivityConfig(t *testing.T) {
+	loadDebugEnvIfRunsFromIDE(t, "account")
 	if isAzure(t) {
 		accountLevel(t, step{
 			Template: `

--- a/internal/acceptance/mws_network_connectivity_config_test.go
+++ b/internal/acceptance/mws_network_connectivity_config_test.go
@@ -5,7 +5,6 @@ import (
 )
 
 func TestMwsAccNetworkConnectivityConfig(t *testing.T) {
-	loadDebugEnvIfRunsFromIDE(t, "account")
 	if isAzure(t) {
 		accountLevel(t, step{
 			Template: `

--- a/internal/acceptance/sql_endpoint_test.go
+++ b/internal/acceptance/sql_endpoint_test.go
@@ -21,7 +21,7 @@ func TestAccSQLEndpoint(t *testing.T) {
 			tags {
 				custom_tags {
 					key   = "Owner"
-					value = "eng-dev-ecosystem-team@databricks.com"
+					value = "eng-dev-ecosystem-team_at_databricks.com"
 				}
 			}
 		}`,
@@ -37,7 +37,7 @@ func TestAccSQLEndpoint(t *testing.T) {
 			tags {
 				custom_tags {
 					key   = "Owner"
-					value = "eng-dev-ecosystem-team@databricks.com"
+					value = "eng-dev-ecosystem-team_at_databricks.com"
 				}
 			}
 		}`,

--- a/internal/acceptance/workspace_conf_test.go
+++ b/internal/acceptance/workspace_conf_test.go
@@ -20,7 +20,7 @@ func assertEnableIpAccessList(t *testing.T, expected string) {
 	})
 	require.NoError(t, err)
 	assert.Len(t, *conf, 1)
-	assert.Equal(t, (*conf)["enableIpAccessLists"], expected)
+	assert.Equal(t, expected, (*conf)["enableIpAccessLists"])
 }
 
 func TestAccWorkspaceConfFullLifecycle(t *testing.T) {
@@ -70,11 +70,11 @@ func TestAccWorkspaceConfFullLifecycle(t *testing.T) {
 			}`,
 		Check: func(s *terraform.State) error {
 			// Assert server side configuration is updated
-			assertEnableIpAccessList(t, "true")
+			assertEnableIpAccessList(t, "TRue")
 
 			// Assert state is persisted
 			conf := s.RootModule().Resources["databricks_workspace_conf.this"]
-			assert.Equal(t, "true", conf.Primary.Attributes["custom_config.enableIpAccessLists"])
+			assert.Equal(t, "TRue", conf.Primary.Attributes["custom_config.enableIpAccessLists"])
 			return nil
 		},
 	})


### PR DESCRIPTION
## Changes
TestAccSQLEndpoint and TestAccWorkspaceConfFullLifecycle are currently failing on `main`. The former fails in GCP because @ is not allowed in a tag, so I've replaced it with _at_. The latter fails because of some checks of capitalization which I've fixed in this PR.

Finally, TestMwsAccNetworkConnectivityConfig is failing on main but is a regression server-side. The test passed on commit 7a2fc352f77101b89c3692ab34c82606605cceed when it ran on August 8, but it now fails on the same commit.

## Tests
Ran these integration tests locally, they pass.

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
