### PR TITLE
[Internal] Add tag for SQL warehouse used in Online Table tests

### DIFF
--- a/internal/acceptance/online_table_test.go
+++ b/internal/acceptance/online_table_test.go
@@ -30,6 +30,12 @@ resource "databricks_catalog" "sandbox" {
 	cluster_size     = "2X-Small"
 	max_num_clusters = 1
 	warehouse_type   = "PRO"
+	tags {
+		custom_tags {
+			key   = "Owner"
+			value = "eng-dev-ecosystem-team_at_databricks.com"
+		}
+	}
   }
   
   resource "databricks_sql_table" "table" {


### PR DESCRIPTION
## Changes
The TestUcAccOnlineTable test fails because it uses a SQL warehouse that does not have an owner tag, as required by policy for our internal accounts. This PR adds this tag.

## Tests
Ran the test locally, and it passes.

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
