### PR TITLE
[Fix] Remove not necessary field in `databricks_job` schema

### DIFF
--- a/jobs/resource_job.go
+++ b/jobs/resource_job.go
@@ -503,7 +503,6 @@ type JobSettingsResource struct {
 	DbtTask                *DbtTask             `json:"dbt_task,omitempty" tf:"group:task_type"`
 	RunJobTask             *RunJobTask          `json:"run_job_task,omitempty" tf:"group:task_type"`
 	Libraries              []compute.Library    `json:"libraries,omitempty" tf:"alias:library"`
-	TimeoutSeconds         int32                `json:"timeout_seconds,omitempty"`
 	MaxRetries             int32                `json:"max_retries,omitempty"`
 	MinRetryIntervalMillis int32                `json:"min_retry_interval_millis,omitempty"`
 	RetryOnTimeout         bool                 `json:"retry_on_timeout,omitempty"`


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

The `TimeoutSeconds` field was shadowing the same field in the parent struct, but it wasn't filled, leading to the configuration drift.

Resolves #3878

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
