### PR TITLE
[Fix] Handle cluster deletion in `databricks_library` read

### DIFF
--- a/clusters/resource_library.go
+++ b/clusters/resource_library.go
@@ -3,6 +3,7 @@ package clusters
 import (
 	"context"
 	"fmt"
+	"log"
 	"strings"
 
 	"github.com/databricks/databricks-sdk-go/apierr"
@@ -79,6 +80,11 @@ func ResourceLibrary() common.Resource {
 				IsRefresh: true,
 			}, d.Timeout(schema.TimeoutRead))
 			if err != nil {
+				err = common.IgnoreNotFoundError(err)
+				if err == nil {
+					log.Printf("[WARN] %s is not found, ignoring it", clusterID)
+					d.SetId("")
+				}
 				return err
 			}
 			for _, v := range cll.LibraryStatuses {

--- a/clusters/resource_library_test.go
+++ b/clusters/resource_library_test.go
@@ -3,6 +3,7 @@ package clusters
 import (
 	"testing"
 
+	"github.com/databricks/databricks-sdk-go/apierr"
 	"github.com/databricks/databricks-sdk-go/service/compute"
 	"github.com/databricks/terraform-provider-databricks/qa"
 )
@@ -101,5 +102,26 @@ func TestLibraryDelete(t *testing.T) {
 		},
 		Delete: true,
 		ID:     "abc/whl:foo.whl",
+	}.ApplyNoError(t)
+}
+
+func TestLibraryDeleteClusterNotFound(t *testing.T) {
+	qa.ResourceFixture{
+		Resource: ResourceLibrary(),
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:       "GET",
+				Resource:     "/api/2.1/clusters/get?cluster_id=abc",
+				ReuseRequest: true,
+				Response: apierr.APIError{
+					ErrorCode: "NOT_FOUND",
+					Message:   "Cluster does not exist",
+				},
+				Status: 404,
+			},
+		},
+		Delete:  true,
+		Removed: true,
+		ID:      "abc/whl:foo.whl",
 	}.ApplyNoError(t)
 }

--- a/common/util.go
+++ b/common/util.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"crypto/md5"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -11,6 +12,8 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+
+	"github.com/databricks/databricks-sdk-go/apierr"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -85,4 +88,19 @@ func ReadSerializedJsonContent(jsonStr, filePath string) (serJSON string, md5Has
 	}
 	md5Hash = CalculateMd5Hash(content)
 	return string(content), md5Hash, nil
+}
+
+// Suppress the error if it is 404
+func IgnoreNotFoundError(err error) error {
+	var apiErr *apierr.APIError
+	if !errors.As(err, &apiErr) {
+		return err
+	}
+	if apiErr.StatusCode == 404 {
+		return nil
+	}
+	if strings.Contains(apiErr.Message, "does not exist") {
+		return nil
+	}
+	return err
 }

--- a/common/util_test.go
+++ b/common/util_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/databricks/databricks-sdk-go/apierr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/stretchr/testify/assert"
 )
@@ -65,5 +66,19 @@ func TestReadSerializedJsonContent(t *testing.T) {
 	os.WriteFile(fileName, []byte("hello"), 0644)
 	_, md5Hash, err = ReadSerializedJsonContent("", fileName)
 	assert.Equal(t, fmt.Sprintf("%x", md5.Sum([]byte("hello"))), md5Hash)
+	assert.NoError(t, err)
+}
+
+func TestIgnoreNotFoundError(t *testing.T) {
+	err := IgnoreNotFoundError(nil)
+	assert.NoError(t, err)
+
+	err = IgnoreNotFoundError(fmt.Errorf("error"))
+	assert.EqualError(t, err, "error")
+
+	err = IgnoreNotFoundError(apierr.NotFound("error"))
+	assert.NoError(t, err)
+
+	err = IgnoreNotFoundError(apierr.ReadError(403, fmt.Errorf("cluster xyz does not exist")))
 	assert.NoError(t, err)
 }


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

We now don't return an error when reading a library that belongs to the cluster deleted outside of the Terraform.

Resolves #3679

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
