### PR TITLE
[Internal] Update jd version from latest to 1.8.1

### DIFF
--- a/.github/workflows/schema.yml
+++ b/.github/workflows/schema.yml
@@ -53,7 +53,7 @@ jobs:
           terraform_wrapper: false
 
       - name: "Install jd"
-        run: go install github.com/josephburnett/jd@latest
+        run: go install github.com/josephburnett/jd@v1.8.1
 
       - run: make diff-schema
         env:


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
- `compute_diff` CI check was failing consistently due to a new version introduced by jd [yesterday](https://github.com/josephburnett/jd/releases)
- Downgraded to the LKG version for now to make the CI checks run again

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
