### PR TITLE
[Internal] Migrate Share resource to Go SDK

### DIFF
--- a/common/resource.go
+++ b/common/resource.go
@@ -381,30 +381,31 @@ func genericDatabricksData[T, P, C any](
 	var dummy T
 	var other P
 	otherFields := StructToSchema(other, nil)
-	s := StructToSchema(dummy, func(m map[string]*schema.Schema) map[string]*schema.Schema {
-		// For WorkspaceData and AccountData, a single data type is used to represent all of the fields of
-		// the resource, so its configuration is correct. For the *WithParams methods, the SdkType parameter
-		// is copied directly from the resource definition, which means that all fields from that type are
-		// computed and optional, and the fields from OtherFields are overlaid on top of the schema generated
-		// by SdkType.
-		if hasOther {
-			for k := range m {
-				m[k].Computed = true
-				m[k].Required = false
-				m[k].Optional = true
-			}
-			for k, v := range otherFields {
-				m[k] = v
-			}
+
+	s := StructToSchema(dummy, nil)
+	// For WorkspaceData and AccountData, a single data type is used to represent all of the fields of
+	// the resource, so its configuration is correct. For the *WithParams methods, the SdkType parameter
+	// is copied directly from the resource definition, which means that all fields from that type are
+	// computed and optional, and the fields from OtherFields are overlaid on top of the schema generated
+	// by SdkType.
+	if hasOther {
+		for k := range s {
+			s[k].Computed = true
+			s[k].Required = false
+			s[k].Optional = true
 		}
-		// `id` attribute must be marked as computed, otherwise it's not set!
-		if v, ok := m["id"]; ok {
-			v.Computed = true
-			v.Required = false
+		for k, v := range otherFields {
+			s[k] = v
 		}
-		// allow c
-		return customizeSchemaFunc(m)
-	})
+	}
+	// `id` attribute must be marked as computed, otherwise it's not set!
+	if v, ok := s["id"]; ok {
+		v.Computed = true
+		v.Required = false
+	}
+	// allow c
+	s = customizeSchemaFunc(s)
+
 	return Resource{
 		Schema: s,
 		Read: func(ctx context.Context, d *schema.ResourceData, client *DatabricksClient) (err error) {

--- a/exporter/importables_test.go
+++ b/exporter/importables_test.go
@@ -1828,23 +1828,25 @@ func TestImportShare(t *testing.T) {
 	d := tfsharing.ResourceShare().ToResource().TestResourceData()
 	scm := tfsharing.ResourceShare().Schema
 	share := tfsharing.ShareInfo{
-		Name: "stest",
-		Objects: []tfsharing.SharedDataObject{
-			{
-				DataObjectType: "TABLE",
-				Name:           "ctest.stest.table1",
-			},
-			{
-				DataObjectType: "MODEL",
-				Name:           "ctest.stest.model1",
-			},
-			{
-				DataObjectType: "VOLUME",
-				Name:           "ctest.stest.vol1",
-			},
-			{
-				DataObjectType: "NOTEBOOK",
-				Name:           "Test",
+		ShareInfo: sharing.ShareInfo{
+			Name: "stest",
+			Objects: []sharing.SharedDataObject{
+				{
+					DataObjectType: "TABLE",
+					Name:           "ctest.stest.table1",
+				},
+				{
+					DataObjectType: "MODEL",
+					Name:           "ctest.stest.model1",
+				},
+				{
+					DataObjectType: "VOLUME",
+					Name:           "ctest.stest.vol1",
+				},
+				{
+					DataObjectType: "NOTEBOOK",
+					Name:           "Test",
+				},
 			},
 		},
 	}

--- a/sharing/data_share.go
+++ b/sharing/data_share.go
@@ -3,20 +3,28 @@ package sharing
 import (
 	"context"
 
+	"github.com/databricks/databricks-sdk-go/service/sharing"
 	"github.com/databricks/terraform-provider-databricks/common"
 )
 
 func DataSourceShare() common.Resource {
 	type ShareDetail struct {
-		Name      string             `json:"name,omitempty" tf:"computed"`
-		Objects   []SharedDataObject `json:"objects,omitempty" tf:"computed,slice_set,alias:object"`
-		CreatedAt int64              `json:"created_at,omitempty" tf:"computed"`
-		CreatedBy string             `json:"created_by,omitempty" tf:"computed"`
+		Name      string                     `json:"name,omitempty" tf:"computed"`
+		Objects   []sharing.SharedDataObject `json:"objects,omitempty" tf:"computed,slice_set,alias:object"`
+		CreatedAt int64                      `json:"created_at,omitempty" tf:"computed"`
+		CreatedBy string                     `json:"created_by,omitempty" tf:"computed"`
 	}
 	return common.DataResource(ShareDetail{}, func(ctx context.Context, e any, c *common.DatabricksClient) error {
 		data := e.(*ShareDetail)
-		sharesAPI := NewSharesAPI(ctx, c)
-		share, err := sharesAPI.get(data.Name)
+		client, err := c.WorkspaceClient()
+		if err != nil {
+			return err
+		}
+
+		share, err := client.Shares.Get(ctx, sharing.GetShareRequest{
+			Name:              data.Name,
+			IncludeSharedData: true,
+		})
 		if err != nil {
 			return err
 		}

--- a/sharing/data_share.go
+++ b/sharing/data_share.go
@@ -3,7 +3,6 @@ package sharing
 import (
 	"context"
 
-	"github.com/databricks/databricks-sdk-go"
 	"github.com/databricks/databricks-sdk-go/service/sharing"
 	"github.com/databricks/terraform-provider-databricks/common"
 )
@@ -15,19 +14,23 @@ func DataSourceShare() common.Resource {
 		CreatedAt int64                      `json:"created_at,omitempty" tf:"computed"`
 		CreatedBy string                     `json:"created_by,omitempty" tf:"computed"`
 	}
+	return common.DataResource(ShareDetail{}, func(ctx context.Context, e any, c *common.DatabricksClient) error {
+		data := e.(*ShareDetail)
+		client, err := c.WorkspaceClient()
+		if err != nil {
+			return err
+		}
 
-	return common.WorkspaceDataWithParams(func(ctx context.Context, data ShareInfo, c *databricks.WorkspaceClient) (*ShareDetail, error) {
-		var shareInfo *ShareDetail = &ShareDetail{}
-		share, err := c.Shares.Get(ctx, sharing.GetShareRequest{
+		share, err := client.Shares.Get(ctx, sharing.GetShareRequest{
 			Name:              data.Name,
 			IncludeSharedData: true,
 		})
 		if err != nil {
-			return nil, err
+			return err
 		}
-		shareInfo.Objects = share.Objects
-		shareInfo.CreatedAt = share.CreatedAt
-		shareInfo.CreatedBy = share.CreatedBy
-		return shareInfo, nil
+		data.Objects = share.Objects
+		data.CreatedAt = share.CreatedAt
+		data.CreatedBy = share.CreatedBy
+		return nil
 	})
 }

--- a/sharing/data_share_test.go
+++ b/sharing/data_share_test.go
@@ -62,7 +62,7 @@ func TestShareData(t *testing.T) {
 			"cdf_enabled":                 false,
 			"status":                      "ACTIVE",
 			"history_data_sharing_status": "DISABLED",
-			"partitions":                  []interface{}{},
+			"partition":                   []interface{}{},
 		},
 		d.Get("object").(*schema.Set).List()[0])
 }

--- a/sharing/data_share_test.go
+++ b/sharing/data_share_test.go
@@ -3,6 +3,7 @@ package sharing
 import (
 	"testing"
 
+	"github.com/databricks/databricks-sdk-go/service/sharing"
 	"github.com/databricks/terraform-provider-databricks/qa"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/stretchr/testify/assert"
@@ -14,21 +15,21 @@ func TestShareData(t *testing.T) {
 			{
 				Method:   "GET",
 				Resource: "/api/2.1/unity-catalog/shares/a?include_shared_data=true",
-				Response: ShareInfo{
+				Response: sharing.ShareInfo{
 					Name: "a",
-					Objects: []SharedDataObject{
+					Objects: []sharing.SharedDataObject{
 						{
 							Name:                     "a",
 							DataObjectType:           "TABLE",
 							Comment:                  "c",
-							CDFEnabled:               false,
+							CdfEnabled:               false,
 							StartVersion:             0,
 							SharedAs:                 "",
 							AddedAt:                  0,
 							AddedBy:                  "",
 							HistoryDataSharingStatus: "DISABLED",
 							Status:                   "ACTIVE",
-							Partitions:               []Partition{},
+							Partitions:               []sharing.Partition{},
 						},
 					},
 					CreatedBy: "bob",
@@ -52,14 +53,16 @@ func TestShareData(t *testing.T) {
 			"added_at":                    0,
 			"added_by":                    "",
 			"comment":                     "c",
+			"content":                     "",
 			"data_object_type":            "TABLE",
 			"name":                        "a",
 			"shared_as":                   "",
 			"start_version":               0,
+			"string_shared_as":            "",
 			"cdf_enabled":                 false,
 			"status":                      "ACTIVE",
 			"history_data_sharing_status": "DISABLED",
-			"partition":                   []interface{}{},
+			"partitions":                  []interface{}{},
 		},
 		d.Get("object").(*schema.Set).List()[0])
 }

--- a/sharing/data_shares_test.go
+++ b/sharing/data_shares_test.go
@@ -3,6 +3,7 @@ package sharing
 import (
 	"testing"
 
+	"github.com/databricks/databricks-sdk-go/service/sharing"
 	"github.com/databricks/terraform-provider-databricks/qa"
 )
 
@@ -15,17 +16,18 @@ func TestSharesData(t *testing.T) {
 				Response: Shares{
 					Shares: []ShareInfo{
 						{
-							Name: "a",
-							Objects: []SharedDataObject{
-								{
-									Name:           "a",
-									DataObjectType: "TABLE",
-									Comment:        "c",
+							sharing.ShareInfo{
+								Name: "a",
+								Objects: []sharing.SharedDataObject{
+									{
+										Name:           "a",
+										DataObjectType: "TABLE",
+										Comment:        "c",
+									},
 								},
-							},
-							CreatedAt: 0,
-							CreatedBy: "",
-						},
+								CreatedAt: 0,
+								CreatedBy: "",
+							}},
 					},
 				},
 			},

--- a/sharing/resource_share.go
+++ b/sharing/resource_share.go
@@ -16,6 +16,7 @@ type ShareInfo struct {
 }
 
 func (ShareInfo) CustomizeSchema(s *common.CustomizableSchema) *common.CustomizableSchema {
+	s.SchemaPath("name").SetRequired()
 	s.SchemaPath("name").SetForceNew()
 	s.SchemaPath("name").SetCustomSuppressDiff(common.EqualFoldDiffSuppress)
 	s.SchemaPath("owner").SetSuppressDiff()
@@ -24,6 +25,8 @@ func (ShareInfo) CustomizeSchema(s *common.CustomizableSchema) *common.Customiza
 	s.SchemaPath("updated_at").SetComputed()
 	s.SchemaPath("updated_by").SetComputed()
 
+	s.SchemaPath("object").SetRequired()
+	s.SchemaPath("object", "data_object_type").SetRequired()
 	s.SchemaPath("object", "shared_as").SetSuppressDiff()
 	s.SchemaPath("object", "cdf_enabled").SetSuppressDiff()
 	s.SchemaPath("object", "start_version").SetSuppressDiff()
@@ -31,6 +34,12 @@ func (ShareInfo) CustomizeSchema(s *common.CustomizableSchema) *common.Customiza
 	s.SchemaPath("object", "status").SetComputed()
 	s.SchemaPath("object", "added_at").SetComputed()
 	s.SchemaPath("object", "added_by").SetComputed()
+
+	s.SchemaPath("object", "partition").SetMinItems(1)
+	s.SchemaPath("object", "partition", "value", "name").SetRequired()
+	s.SchemaPath("object", "partition", "value", "op").SetRequired()
+	s.SchemaPath("object", "partition", "value", "value").SetRequired()
+	s.SchemaPath("object", "partition", "value", "recipient_property_key").SetRequired()
 
 	return s
 }
@@ -42,6 +51,9 @@ func (ShareInfo) Aliases() map[string]map[string]string {
 		},
 		"sharing.SharedDataObject": {
 			"partitions": "partition",
+		},
+		"sharing.Parition": {
+			"values": "value",
 		},
 	}
 }

--- a/sharing/resource_share.go
+++ b/sharing/resource_share.go
@@ -54,23 +54,8 @@ func (ShareInfo) Aliases() map[string]map[string]string {
 	}
 }
 
-type ShareDataChange struct {
-	sharing.SharedDataObjectUpdate
-}
-
 type Shares struct {
 	Shares []ShareInfo `json:"shares"`
-}
-
-type Partition struct {
-	Values []PartitionValue `json:"values" tf:"alias:value"`
-}
-
-type PartitionValue struct {
-	Name                 string `json:"name"`
-	Op                   string `json:"op"`
-	RecipientPropertyKey string `json:"recipient_property_key,omitempty"`
-	Value                string `json:"value,omitempty"`
 }
 
 func (si *ShareInfo) sortSharesByName() {

--- a/sharing/resource_share.go
+++ b/sharing/resource_share.go
@@ -90,8 +90,6 @@ func (si *ShareInfo) suppressCDFEnabledDiff() {
 
 func (a SharesAPI) get(name string) (si ShareInfo, err error) {
 	err = a.client.Get(a.context, "/unity-catalog/shares/"+name+"?include_shared_data=true", nil, &si)
-	si.sortSharesByName()
-	si.suppressCDFEnabledDiff()
 	return
 }
 
@@ -228,6 +226,8 @@ func ResourceShare() common.Resource {
 			if err != nil {
 				return err
 			}
+			beforeSi.sortSharesByName()
+			beforeSi.suppressCDFEnabledDiff()
 			var afterSi ShareInfo
 			common.DataToStructPointer(d, shareSchema, &afterSi)
 			changes := beforeSi.Diff(afterSi)

--- a/sharing/resource_share.go
+++ b/sharing/resource_share.go
@@ -16,6 +16,7 @@ type ShareInfo struct {
 }
 
 func (ShareInfo) CustomizeSchema(s *common.CustomizableSchema) *common.CustomizableSchema {
+	s.SchemaPath("name").SetRequired()
 	s.SchemaPath("name").SetForceNew()
 	s.SchemaPath("name").SetCustomSuppressDiff(common.EqualFoldDiffSuppress)
 	s.SchemaPath("owner").SetSuppressDiff()
@@ -24,6 +25,8 @@ func (ShareInfo) CustomizeSchema(s *common.CustomizableSchema) *common.Customiza
 	s.SchemaPath("updated_at").SetComputed()
 	s.SchemaPath("updated_by").SetComputed()
 
+	s.SchemaPath("object").SetMinItems(1)
+	s.SchemaPath("object", "data_object_type").SetRequired()
 	s.SchemaPath("object", "shared_as").SetSuppressDiff()
 	s.SchemaPath("object", "cdf_enabled").SetSuppressDiff()
 	s.SchemaPath("object", "start_version").SetSuppressDiff()
@@ -31,6 +34,8 @@ func (ShareInfo) CustomizeSchema(s *common.CustomizableSchema) *common.Customiza
 	s.SchemaPath("object", "status").SetComputed()
 	s.SchemaPath("object", "added_at").SetComputed()
 	s.SchemaPath("object", "added_by").SetComputed()
+	s.SchemaPath("object", "partition", "value", "op").SetRequired()
+	s.SchemaPath("object", "partition", "value", "name").SetRequired()
 
 	return s
 }
@@ -42,6 +47,9 @@ func (ShareInfo) Aliases() map[string]map[string]string {
 		},
 		"sharing.SharedDataObject": {
 			"partitions": "partition",
+		},
+		"sharing.Partition": {
+			"values": "value",
 		},
 	}
 }

--- a/sharing/resource_share.go
+++ b/sharing/resource_share.go
@@ -25,11 +25,10 @@ func (ShareInfo) CustomizeSchema(s *common.CustomizableSchema) *common.Customiza
 	s.SchemaPath("updated_by").SetComputed()
 
 	s.SchemaPath("object", "shared_as").SetSuppressDiff()
-	s.SchemaPath("object", "string_shared_as").SetComputed()
 	s.SchemaPath("object", "cdf_enabled").SetSuppressDiff()
 	s.SchemaPath("object", "start_version").SetSuppressDiff()
 	s.SchemaPath("object", "history_data_sharing_status").SetSuppressDiff()
-	s.SchemaPath("object", "status").SetReadOnly()
+	s.SchemaPath("object", "status").SetComputed()
 	s.SchemaPath("object", "added_at").SetComputed()
 	s.SchemaPath("object", "added_by").SetComputed()
 
@@ -43,9 +42,6 @@ func (ShareInfo) Aliases() map[string]map[string]string {
 		},
 		"sharing.SharedDataObject": {
 			"partitions": "partition",
-		},
-		"sharing.Partition": {
-			"values": "value",
 		},
 	}
 }

--- a/sharing/resource_share.go
+++ b/sharing/resource_share.go
@@ -208,11 +208,20 @@ func ResourceShare() common.Resource {
 			return nil
 		},
 		Read: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
-			si, err := NewSharesAPI(ctx, c).get(d.Id())
+			client, err := c.WorkspaceClient()
 			if err != nil {
 				return err
 			}
-			return common.StructToData(si, shareSchema, d)
+
+			shareInfo, err := client.Shares.Get(ctx, sharing.GetShareRequest{
+				Name:              d.Id(),
+				IncludeSharedData: true,
+			})
+			if err != nil {
+				return err
+			}
+
+			return common.StructToData(shareInfo, shareSchema, d)
 		},
 		Update: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
 			beforeSi, err := NewSharesAPI(ctx, c).get(d.Id())

--- a/sharing/resource_share.go
+++ b/sharing/resource_share.go
@@ -25,10 +25,11 @@ func (ShareInfo) CustomizeSchema(s *common.CustomizableSchema) *common.Customiza
 	s.SchemaPath("updated_by").SetComputed()
 
 	s.SchemaPath("object", "shared_as").SetSuppressDiff()
+	s.SchemaPath("object", "string_shared_as").SetComputed()
 	s.SchemaPath("object", "cdf_enabled").SetSuppressDiff()
 	s.SchemaPath("object", "start_version").SetSuppressDiff()
 	s.SchemaPath("object", "history_data_sharing_status").SetSuppressDiff()
-	s.SchemaPath("object", "status").SetComputed()
+	s.SchemaPath("object", "status").SetReadOnly()
 	s.SchemaPath("object", "added_at").SetComputed()
 	s.SchemaPath("object", "added_by").SetComputed()
 
@@ -42,6 +43,9 @@ func (ShareInfo) Aliases() map[string]map[string]string {
 		},
 		"sharing.SharedDataObject": {
 			"partitions": "partition",
+		},
+		"sharing.Partition": {
+			"values": "value",
 		},
 	}
 }

--- a/sharing/resource_share.go
+++ b/sharing/resource_share.go
@@ -203,11 +203,14 @@ func ResourceShare() common.Resource {
 				Name:              d.Id(),
 				IncludeSharedData: true,
 			})
+			var si = ShareInfo{*shareInfo}
+			si.sortSharesByName()
+			si.suppressCDFEnabledDiff()
 			if err != nil {
 				return err
 			}
 
-			return common.StructToData(shareInfo, shareSchema, d)
+			return common.StructToData(si, shareSchema, d)
 		},
 		Update: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
 			client, err := c.WorkspaceClient()

--- a/sharing/resource_share.go
+++ b/sharing/resource_share.go
@@ -16,7 +16,6 @@ type ShareInfo struct {
 }
 
 func (ShareInfo) CustomizeSchema(s *common.CustomizableSchema) *common.CustomizableSchema {
-	s.SchemaPath("name").SetRequired()
 	s.SchemaPath("name").SetForceNew()
 	s.SchemaPath("name").SetCustomSuppressDiff(common.EqualFoldDiffSuppress)
 	s.SchemaPath("owner").SetSuppressDiff()
@@ -25,8 +24,6 @@ func (ShareInfo) CustomizeSchema(s *common.CustomizableSchema) *common.Customiza
 	s.SchemaPath("updated_at").SetComputed()
 	s.SchemaPath("updated_by").SetComputed()
 
-	s.SchemaPath("object").SetRequired()
-	s.SchemaPath("object", "data_object_type").SetRequired()
 	s.SchemaPath("object", "shared_as").SetSuppressDiff()
 	s.SchemaPath("object", "cdf_enabled").SetSuppressDiff()
 	s.SchemaPath("object", "start_version").SetSuppressDiff()
@@ -34,12 +31,6 @@ func (ShareInfo) CustomizeSchema(s *common.CustomizableSchema) *common.Customiza
 	s.SchemaPath("object", "status").SetComputed()
 	s.SchemaPath("object", "added_at").SetComputed()
 	s.SchemaPath("object", "added_by").SetComputed()
-
-	s.SchemaPath("object", "partition").SetMinItems(1)
-	s.SchemaPath("object", "partition", "value", "name").SetRequired()
-	s.SchemaPath("object", "partition", "value", "op").SetRequired()
-	s.SchemaPath("object", "partition", "value", "value").SetRequired()
-	s.SchemaPath("object", "partition", "value", "recipient_property_key").SetRequired()
 
 	return s
 }
@@ -51,9 +42,6 @@ func (ShareInfo) Aliases() map[string]map[string]string {
 		},
 		"sharing.SharedDataObject": {
 			"partitions": "partition",
-		},
-		"sharing.Parition": {
-			"values": "value",
 		},
 	}
 }

--- a/sharing/resource_share_test.go
+++ b/sharing/resource_share_test.go
@@ -12,109 +12,79 @@ import (
 
 func TestDiffShareInfo(t *testing.T) {
 	empty := ShareInfo{
-		Name:    "b",
-		Objects: []SharedDataObject{},
+		ShareInfo: sharing.ShareInfo{
+			Name:    "b",
+			Objects: []sharing.SharedDataObject{},
+		},
 	}
 	firstShare := ShareInfo{
-		Name: "b",
-		Objects: []SharedDataObject{
-			{
-				Name:           "main.b",
-				DataObjectType: "TABLE",
-				Comment:        "c",
-			},
-			{
-				Name:           "main.a",
-				DataObjectType: "TABLE",
-				Comment:        "c",
-			},
-		},
+		ShareInfo: sharing.ShareInfo{
+			Name: "b",
+			Objects: []sharing.SharedDataObject{
+				{
+					Name:           "main.b",
+					DataObjectType: "TABLE",
+					Comment:        "c",
+				},
+				{
+					Name:           "main.a",
+					DataObjectType: "TABLE",
+					Comment:        "c",
+				},
+			}},
 	}
 	secondShare := ShareInfo{
-		Name: "b",
-		Objects: []SharedDataObject{
-			{
-				Name:           "main.c",
-				DataObjectType: "TABLE",
-				Comment:        "d",
-			},
-			{
-				Name:           "main.a",
-				DataObjectType: "TABLE",
-				Comment:        "c",
-			},
-		},
+		ShareInfo: sharing.ShareInfo{
+			Name: "b",
+			Objects: []sharing.SharedDataObject{
+				{
+					Name:           "main.c",
+					DataObjectType: "TABLE",
+					Comment:        "d",
+				},
+				{
+					Name:           "main.a",
+					DataObjectType: "TABLE",
+					Comment:        "c",
+				},
+			}},
 	}
 	thirdShare := ShareInfo{
-		Name: "b",
-		Objects: []SharedDataObject{
-			{
-				Name:           "main.c",
-				DataObjectType: "TABLE",
-				Comment:        "d",
-			},
-			{
-				Name:           "main.b",
-				DataObjectType: "TABLE",
-				Comment:        "d",
-			},
-		},
+		ShareInfo: sharing.ShareInfo{
+			Name: "b",
+			Objects: []sharing.SharedDataObject{
+				{
+					Name:           "main.c",
+					DataObjectType: "TABLE",
+					Comment:        "d",
+				},
+				{
+					Name:           "main.b",
+					DataObjectType: "TABLE",
+					Comment:        "d",
+				},
+			}},
 	}
 	fourthShare := ShareInfo{
-		Name: "d",
-		Objects: []SharedDataObject{
-			{
-				Name:           "main.b",
-				DataObjectType: "TABLE",
-				Comment:        "d",
-			},
-			{
-				Name:           "main.a",
-				DataObjectType: "TABLE",
-				Comment:        "c",
-			},
-		},
+		ShareInfo: sharing.ShareInfo{
+			Name: "d",
+			Objects: []sharing.SharedDataObject{
+				{
+					Name:           "main.b",
+					DataObjectType: "TABLE",
+					Comment:        "d",
+				},
+				{
+					Name:           "main.a",
+					DataObjectType: "TABLE",
+					Comment:        "c",
+				},
+			}},
 	}
-	diffAdd := []ShareDataChange{
+	diffAdd := []sharing.SharedDataObjectUpdate{
 		{
 			Action: ShareAdd,
-			DataObject: SharedDataObject{
-				Name:           "main.b",
-				DataObjectType: "TABLE",
-				Comment:        "c",
-			},
-		},
-		{
-			Action: ShareAdd,
-			DataObject: SharedDataObject{
-				Name:           "main.a",
-				DataObjectType: "TABLE",
-				Comment:        "c",
-			},
-		},
-	}
-	diffRemove := []ShareDataChange{
-		{
-			Action: ShareRemove,
-			DataObject: SharedDataObject{
-				Name:           "main.b",
-				DataObjectType: "TABLE",
-				Comment:        "c",
-			},
-		},
-		{
-			Action: ShareRemove,
-			DataObject: SharedDataObject{
-				Name:           "main.a",
-				DataObjectType: "TABLE",
-				Comment:        "c",
-			},
-		},
-	}
-	diff12 := []ShareDataChange{
-		{
-			Action: ShareRemove,
-			DataObject: SharedDataObject{
+			DataObject: &sharing.SharedDataObject{
 				Name:           "main.b",
 				DataObjectType: "TABLE",
 				Comment:        "c",
@@ -122,17 +92,53 @@ func TestDiffShareInfo(t *testing.T) {
 		},
 		{
 			Action: ShareAdd,
-			DataObject: SharedDataObject{
+			DataObject: &sharing.SharedDataObject{
+				Name:           "main.a",
+				DataObjectType: "TABLE",
+				Comment:        "c",
+			},
+		},
+	}
+	diffRemove := []sharing.SharedDataObjectUpdate{
+		{
+			Action: ShareRemove,
+			DataObject: &sharing.SharedDataObject{
+				Name:           "main.b",
+				DataObjectType: "TABLE",
+				Comment:        "c",
+			},
+		},
+		{
+			Action: ShareRemove,
+			DataObject: &sharing.SharedDataObject{
+				Name:           "main.a",
+				DataObjectType: "TABLE",
+				Comment:        "c",
+			},
+		},
+	}
+	diff12 := []sharing.SharedDataObjectUpdate{
+		{
+			Action: ShareRemove,
+			DataObject: &sharing.SharedDataObject{
+				Name:           "main.b",
+				DataObjectType: "TABLE",
+				Comment:        "c",
+			},
+		},
+		{
+			Action: ShareAdd,
+			DataObject: &sharing.SharedDataObject{
 				Name:           "main.c",
 				DataObjectType: "TABLE",
 				Comment:        "d",
 			},
 		},
 	}
-	diff13 := []ShareDataChange{
+	diff13 := []sharing.SharedDataObjectUpdate{
 		{
 			Action: ShareRemove,
-			DataObject: SharedDataObject{
+			DataObject: &sharing.SharedDataObject{
 				Name:           "main.a",
 				DataObjectType: "TABLE",
 				Comment:        "c",
@@ -140,7 +146,7 @@ func TestDiffShareInfo(t *testing.T) {
 		},
 		{
 			Action: ShareAdd,
-			DataObject: SharedDataObject{
+			DataObject: &sharing.SharedDataObject{
 				Name:           "main.c",
 				DataObjectType: "TABLE",
 				Comment:        "d",
@@ -148,24 +154,24 @@ func TestDiffShareInfo(t *testing.T) {
 		},
 		{
 			Action: ShareUpdate,
-			DataObject: SharedDataObject{
+			DataObject: &sharing.SharedDataObject{
 				Name:           "main.b",
 				DataObjectType: "TABLE",
 				Comment:        "d",
 			},
 		},
 	}
-	diff14 := []ShareDataChange{
+	diff14 := []sharing.SharedDataObjectUpdate{
 		{
 			Action: ShareUpdate,
-			DataObject: SharedDataObject{
+			DataObject: &sharing.SharedDataObject{
 				Name:           "main.b",
 				DataObjectType: "TABLE",
 				Comment:        "d",
 			},
 		},
 	}
-	assert.Equal(t, firstShare.Diff(firstShare), []ShareDataChange{}, "Should not have difference")
+	assert.Equal(t, firstShare.Diff(firstShare), []sharing.SharedDataObjectUpdate{}, "Should not have difference")
 	assert.Equal(t, empty.Diff(firstShare), diffAdd, "Should have 2 ADDs")
 	assert.Equal(t, firstShare.Diff(empty), diffRemove, "Should have 2 REMOVEs")
 	assert.Equal(t, firstShare.Diff(secondShare), diff12, "Should have 1 ADD and 1 REMOVE")
@@ -184,21 +190,24 @@ func TestCreateShare(t *testing.T) {
 				Method:   "POST",
 				Resource: "/api/2.1/unity-catalog/shares",
 				ExpectedRequest: ShareInfo{
-					Name: "a",
+					ShareInfo: sharing.ShareInfo{
+						Name: "a",
+					},
 				},
 				Response: ShareInfo{
-					Name: "a",
-				},
+					ShareInfo: sharing.ShareInfo{
+						Name: "a",
+					}},
 			},
 			{
 				Method:   "PATCH",
 				Resource: "/api/2.1/unity-catalog/shares/a",
-				ExpectedRequest: ShareUpdates{
+				ExpectedRequest: sharing.UpdateShare{
 					Owner: "admin",
-					Updates: []ShareDataChange{
+					Updates: []sharing.SharedDataObjectUpdate{
 						{
 							Action: "ADD",
-							DataObject: SharedDataObject{
+							DataObject: &sharing.SharedDataObject{
 								Name:           "main.a",
 								DataObjectType: "TABLE",
 								Comment:        "c",
@@ -206,7 +215,7 @@ func TestCreateShare(t *testing.T) {
 						},
 						{
 							Action: "ADD",
-							DataObject: SharedDataObject{
+							DataObject: &sharing.SharedDataObject{
 								Name:           "main.b",
 								DataObjectType: "TABLE",
 								Comment:        "c",
@@ -215,27 +224,30 @@ func TestCreateShare(t *testing.T) {
 					},
 				},
 				Response: ShareInfo{
-					Name: "a",
+					ShareInfo: sharing.ShareInfo{
+						Name: "a",
+					},
 				},
 			},
 			{
 				Method:   "GET",
 				Resource: "/api/2.1/unity-catalog/shares/a?include_shared_data=true",
 				Response: ShareInfo{
-					Name:  "a",
-					Owner: "admin",
-					Objects: []SharedDataObject{
-						{
-							Name:           "main.a",
-							DataObjectType: "TABLE",
-							Comment:        "c",
-						},
-						{
-							Name:           "main.b",
-							DataObjectType: "TABLE",
-							Comment:        "c",
-						},
-					},
+					ShareInfo: sharing.ShareInfo{
+						Name:  "a",
+						Owner: "admin",
+						Objects: []sharing.SharedDataObject{
+							{
+								Name:           "main.a",
+								DataObjectType: "TABLE",
+								Comment:        "c",
+							},
+							{
+								Name:           "main.b",
+								DataObjectType: "TABLE",
+								Comment:        "c",
+							},
+						}},
 				},
 			},
 		},
@@ -265,17 +277,18 @@ func TestUpdateShare(t *testing.T) {
 				Method:   "GET",
 				Resource: "/api/2.1/unity-catalog/shares/abc?include_shared_data=true",
 				Response: ShareInfo{
-					Name: "abc",
-					Objects: []SharedDataObject{
-						{
-							Name:           "d",
-							DataObjectType: "TABLE",
-							Comment:        "d",
-							SharedAs:       "",
-							AddedAt:        0,
-							AddedBy:        "",
-						},
-					},
+					ShareInfo: sharing.ShareInfo{
+						Name: "abc",
+						Objects: []sharing.SharedDataObject{
+							{
+								Name:           "d",
+								DataObjectType: "TABLE",
+								Comment:        "d",
+								SharedAs:       "",
+								AddedAt:        0,
+								AddedBy:        "",
+							},
+						}},
 				},
 			},
 			{
@@ -288,11 +301,11 @@ func TestUpdateShare(t *testing.T) {
 			{
 				Method:   "PATCH",
 				Resource: "/api/2.1/unity-catalog/shares/abc",
-				ExpectedRequest: ShareUpdates{
-					Updates: []ShareDataChange{
+				ExpectedRequest: sharing.UpdateShare{
+					Updates: []sharing.SharedDataObjectUpdate{
 						{
 							Action: "REMOVE",
-							DataObject: SharedDataObject{
+							DataObject: &sharing.SharedDataObject{
 								Comment:        "d",
 								DataObjectType: "TABLE",
 								Name:           "d",
@@ -300,7 +313,7 @@ func TestUpdateShare(t *testing.T) {
 						},
 						{
 							Action: "ADD",
-							DataObject: SharedDataObject{
+							DataObject: &sharing.SharedDataObject{
 								Comment:        "c",
 								DataObjectType: "TABLE",
 								Name:           "a",
@@ -308,7 +321,7 @@ func TestUpdateShare(t *testing.T) {
 						},
 						{
 							Action: "ADD",
-							DataObject: SharedDataObject{
+							DataObject: &sharing.SharedDataObject{
 								Comment:        "c",
 								DataObjectType: "TABLE",
 								Name:           "b",
@@ -321,26 +334,27 @@ func TestUpdateShare(t *testing.T) {
 				Method:   "GET",
 				Resource: "/api/2.1/unity-catalog/shares/abc?include_shared_data=true",
 				Response: ShareInfo{
-					Name:  "abc",
-					Owner: "admin",
-					Objects: []SharedDataObject{
-						{
-							Name:           "a",
-							DataObjectType: "TABLE",
-							Comment:        "c",
-							SharedAs:       "",
-							AddedAt:        0,
-							AddedBy:        "",
-						},
-						{
-							Name:           "b",
-							DataObjectType: "TABLE",
-							Comment:        "c",
-							SharedAs:       "",
-							AddedAt:        0,
-							AddedBy:        "",
-						},
-					},
+					sharing.ShareInfo{
+						Name:  "abc",
+						Owner: "admin",
+						Objects: []sharing.SharedDataObject{
+							{
+								Name:           "a",
+								DataObjectType: "TABLE",
+								Comment:        "c",
+								SharedAs:       "",
+								AddedAt:        0,
+								AddedBy:        "",
+							},
+							{
+								Name:           "b",
+								DataObjectType: "TABLE",
+								Comment:        "c",
+								SharedAs:       "",
+								AddedAt:        0,
+								AddedBy:        "",
+							},
+						}},
 				},
 			},
 		},
@@ -375,17 +389,18 @@ func TestUpdateShareRollback(t *testing.T) {
 				Method:   "GET",
 				Resource: "/api/2.1/unity-catalog/shares/abc?include_shared_data=true",
 				Response: ShareInfo{
-					Name: "abc",
-					Objects: []SharedDataObject{
-						{
-							Name:           "d",
-							DataObjectType: "TABLE",
-							Comment:        "d",
-							SharedAs:       "",
-							AddedAt:        0,
-							AddedBy:        "",
-						},
-					},
+					sharing.ShareInfo{
+						Name: "abc",
+						Objects: []sharing.SharedDataObject{
+							{
+								Name:           "d",
+								DataObjectType: "TABLE",
+								Comment:        "d",
+								SharedAs:       "",
+								AddedAt:        0,
+								AddedBy:        "",
+							},
+						}},
 				},
 			},
 			{
@@ -398,11 +413,11 @@ func TestUpdateShareRollback(t *testing.T) {
 			{
 				Method:   "PATCH",
 				Resource: "/api/2.1/unity-catalog/shares/abc",
-				ExpectedRequest: ShareUpdates{
-					Updates: []ShareDataChange{
+				ExpectedRequest: sharing.UpdateShare{
+					Updates: []sharing.SharedDataObjectUpdate{
 						{
 							Action: "REMOVE",
-							DataObject: SharedDataObject{
+							DataObject: &sharing.SharedDataObject{
 								Comment:        "d",
 								DataObjectType: "TABLE",
 								Name:           "d",
@@ -410,7 +425,7 @@ func TestUpdateShareRollback(t *testing.T) {
 						},
 						{
 							Action: "ADD",
-							DataObject: SharedDataObject{
+							DataObject: &sharing.SharedDataObject{
 								Comment:        "c",
 								DataObjectType: "TABLE",
 								Name:           "a",
@@ -418,7 +433,7 @@ func TestUpdateShareRollback(t *testing.T) {
 						},
 						{
 							Action: "ADD",
-							DataObject: SharedDataObject{
+							DataObject: &sharing.SharedDataObject{
 								Comment:        "c",
 								DataObjectType: "TABLE",
 								Name:           "b",
@@ -443,26 +458,27 @@ func TestUpdateShareRollback(t *testing.T) {
 				Method:   "GET",
 				Resource: "/api/2.1/unity-catalog/shares/abc?include_shared_data=true",
 				Response: ShareInfo{
-					Name:  "abc",
-					Owner: "admin",
-					Objects: []SharedDataObject{
-						{
-							Name:           "a",
-							DataObjectType: "TABLE",
-							Comment:        "c",
-							SharedAs:       "",
-							AddedAt:        0,
-							AddedBy:        "",
-						},
-						{
-							Name:           "b",
-							DataObjectType: "TABLE",
-							Comment:        "c",
-							SharedAs:       "",
-							AddedAt:        0,
-							AddedBy:        "",
-						},
-					},
+					sharing.ShareInfo{
+						Name:  "abc",
+						Owner: "admin",
+						Objects: []sharing.SharedDataObject{
+							{
+								Name:           "a",
+								DataObjectType: "TABLE",
+								Comment:        "c",
+								SharedAs:       "",
+								AddedAt:        0,
+								AddedBy:        "",
+							},
+							{
+								Name:           "b",
+								DataObjectType: "TABLE",
+								Comment:        "c",
+								SharedAs:       "",
+								AddedAt:        0,
+								AddedBy:        "",
+							},
+						}},
 				},
 			},
 		},
@@ -499,35 +515,37 @@ func TestUpdateShare_NoChanges(t *testing.T) {
 				Method:   "GET",
 				Resource: "/api/2.1/unity-catalog/shares/abc?include_shared_data=true",
 				Response: ShareInfo{
-					Name: "abc",
-					Objects: []SharedDataObject{
-						{
-							Name:           "d",
-							DataObjectType: "TABLE",
-							Comment:        "c",
-							SharedAs:       "",
-							AddedAt:        0,
-							AddedBy:        "",
+					sharing.ShareInfo{
+						Name: "abc",
+						Objects: []sharing.SharedDataObject{
+							{
+								Name:           "d",
+								DataObjectType: "TABLE",
+								Comment:        "c",
+								SharedAs:       "",
+								AddedAt:        0,
+								AddedBy:        "",
+							},
 						},
-					},
-				},
+					}},
 			},
 			{
 				Method:   "GET",
 				Resource: "/api/2.1/unity-catalog/shares/abc?include_shared_data=true",
 				Response: ShareInfo{
-					Name: "abc",
-					Objects: []SharedDataObject{
-						{
-							Name:           "d",
-							DataObjectType: "TABLE",
-							Comment:        "c",
-							SharedAs:       "",
-							AddedAt:        0,
-							AddedBy:        "",
+					sharing.ShareInfo{
+						Name: "abc",
+						Objects: []sharing.SharedDataObject{
+							{
+								Name:           "d",
+								DataObjectType: "TABLE",
+								Comment:        "c",
+								SharedAs:       "",
+								AddedAt:        0,
+								AddedBy:        "",
+							},
 						},
-					},
-				},
+					}},
 			},
 		},
 		ID:          "abc",
@@ -555,7 +573,9 @@ func TestCreateShare_ThrowError(t *testing.T) {
 				Method:   "POST",
 				Resource: "/api/2.1/unity-catalog/shares",
 				ExpectedRequest: ShareInfo{
-					Name: "a",
+					sharing.ShareInfo{
+						Name: "a",
+					},
 				},
 				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
@@ -591,20 +611,24 @@ func TestCreateShareButPatchFails(t *testing.T) {
 				Method:   "POST",
 				Resource: "/api/2.1/unity-catalog/shares",
 				ExpectedRequest: ShareInfo{
-					Name: "a",
+					sharing.ShareInfo{
+						Name: "a",
+					},
 				},
 				Response: ShareInfo{
-					Name: "a",
+					sharing.ShareInfo{
+						Name: "a",
+					},
 				},
 			},
 			{
 				Method:   "PATCH",
 				Resource: "/api/2.1/unity-catalog/shares/a",
-				ExpectedRequest: ShareUpdates{
-					Updates: []ShareDataChange{
+				ExpectedRequest: sharing.UpdateShare{
+					Updates: []sharing.SharedDataObjectUpdate{
 						{
 							Action: "ADD",
-							DataObject: SharedDataObject{
+							DataObject: &sharing.SharedDataObject{
 								Name:           "main.a",
 								DataObjectType: "TABLE",
 								Comment:        "c",
@@ -612,7 +636,7 @@ func TestCreateShareButPatchFails(t *testing.T) {
 						},
 						{
 							Action: "ADD",
-							DataObject: SharedDataObject{
+							DataObject: &sharing.SharedDataObject{
 								Name:           "main.b",
 								DataObjectType: "TABLE",
 								Comment:        "c",
@@ -659,27 +683,28 @@ func TestUpdateShareComplexDiff(t *testing.T) {
 				Method:   "GET",
 				Resource: "/api/2.1/unity-catalog/shares/abc?include_shared_data=true",
 				Response: ShareInfo{
-					Name: "abc",
-					Objects: []SharedDataObject{
-						{
-							Name:           "a",
-							DataObjectType: "TABLE",
-							Comment:        "c",
-							SharedAs:       "b",
-							AddedAt:        0,
-							AddedBy:        "",
-						},
-					},
+					sharing.ShareInfo{
+						Name: "abc",
+						Objects: []sharing.SharedDataObject{
+							{
+								Name:           "a",
+								DataObjectType: "TABLE",
+								Comment:        "c",
+								SharedAs:       "b",
+								AddedAt:        0,
+								AddedBy:        "",
+							},
+						}},
 				},
 			},
 			{
 				Method:   "PATCH",
 				Resource: "/api/2.1/unity-catalog/shares/abc",
-				ExpectedRequest: ShareUpdates{
-					Updates: []ShareDataChange{
+				ExpectedRequest: sharing.UpdateShare{
+					Updates: []sharing.SharedDataObjectUpdate{
 						{
 							Action: "ADD",
-							DataObject: SharedDataObject{
+							DataObject: &sharing.SharedDataObject{
 								Comment:        "c",
 								DataObjectType: "TABLE",
 								Name:           "b",
@@ -692,25 +717,26 @@ func TestUpdateShareComplexDiff(t *testing.T) {
 				Method:   "GET",
 				Resource: "/api/2.1/unity-catalog/shares/abc?include_shared_data=true",
 				Response: ShareInfo{
-					Name: "abc",
-					Objects: []SharedDataObject{
-						{
-							Name:           "a",
-							DataObjectType: "TABLE",
-							Comment:        "c",
-							SharedAs:       "",
-							AddedAt:        0,
-							AddedBy:        "",
-						},
-						{
-							Name:           "b",
-							DataObjectType: "TABLE",
-							Comment:        "c",
-							SharedAs:       "",
-							AddedAt:        0,
-							AddedBy:        "",
-						},
-					},
+					sharing.ShareInfo{
+						Name: "abc",
+						Objects: []sharing.SharedDataObject{
+							{
+								Name:           "a",
+								DataObjectType: "TABLE",
+								Comment:        "c",
+								SharedAs:       "",
+								AddedAt:        0,
+								AddedBy:        "",
+							},
+							{
+								Name:           "b",
+								DataObjectType: "TABLE",
+								Comment:        "c",
+								SharedAs:       "",
+								AddedAt:        0,
+								AddedBy:        "",
+							},
+						}},
 				},
 			},
 		},

--- a/sharing/resource_share_test.go
+++ b/sharing/resource_share_test.go
@@ -83,7 +83,7 @@ func TestDiffShareInfo(t *testing.T) {
 	}
 	diffAdd := []sharing.SharedDataObjectUpdate{
 		{
-			Action: ShareAdd,
+			Action: sharing.SharedDataObjectUpdateActionAdd,
 			DataObject: &sharing.SharedDataObject{
 				Name:           "main.b",
 				DataObjectType: "TABLE",
@@ -91,7 +91,7 @@ func TestDiffShareInfo(t *testing.T) {
 			},
 		},
 		{
-			Action: ShareAdd,
+			Action: sharing.SharedDataObjectUpdateActionAdd,
 			DataObject: &sharing.SharedDataObject{
 				Name:           "main.a",
 				DataObjectType: "TABLE",
@@ -101,7 +101,7 @@ func TestDiffShareInfo(t *testing.T) {
 	}
 	diffRemove := []sharing.SharedDataObjectUpdate{
 		{
-			Action: ShareRemove,
+			Action: sharing.SharedDataObjectUpdateActionRemove,
 			DataObject: &sharing.SharedDataObject{
 				Name:           "main.b",
 				DataObjectType: "TABLE",
@@ -109,7 +109,7 @@ func TestDiffShareInfo(t *testing.T) {
 			},
 		},
 		{
-			Action: ShareRemove,
+			Action: sharing.SharedDataObjectUpdateActionRemove,
 			DataObject: &sharing.SharedDataObject{
 				Name:           "main.a",
 				DataObjectType: "TABLE",
@@ -119,7 +119,7 @@ func TestDiffShareInfo(t *testing.T) {
 	}
 	diff12 := []sharing.SharedDataObjectUpdate{
 		{
-			Action: ShareRemove,
+			Action: sharing.SharedDataObjectUpdateActionRemove,
 			DataObject: &sharing.SharedDataObject{
 				Name:           "main.b",
 				DataObjectType: "TABLE",
@@ -127,7 +127,7 @@ func TestDiffShareInfo(t *testing.T) {
 			},
 		},
 		{
-			Action: ShareAdd,
+			Action: sharing.SharedDataObjectUpdateActionAdd,
 			DataObject: &sharing.SharedDataObject{
 				Name:           "main.c",
 				DataObjectType: "TABLE",
@@ -137,7 +137,7 @@ func TestDiffShareInfo(t *testing.T) {
 	}
 	diff13 := []sharing.SharedDataObjectUpdate{
 		{
-			Action: ShareRemove,
+			Action: sharing.SharedDataObjectUpdateActionRemove,
 			DataObject: &sharing.SharedDataObject{
 				Name:           "main.a",
 				DataObjectType: "TABLE",
@@ -145,7 +145,7 @@ func TestDiffShareInfo(t *testing.T) {
 			},
 		},
 		{
-			Action: ShareAdd,
+			Action: sharing.SharedDataObjectUpdateActionAdd,
 			DataObject: &sharing.SharedDataObject{
 				Name:           "main.c",
 				DataObjectType: "TABLE",
@@ -153,7 +153,7 @@ func TestDiffShareInfo(t *testing.T) {
 			},
 		},
 		{
-			Action: ShareUpdate,
+			Action: sharing.SharedDataObjectUpdateActionUpdate,
 			DataObject: &sharing.SharedDataObject{
 				Name:           "main.b",
 				DataObjectType: "TABLE",
@@ -163,7 +163,7 @@ func TestDiffShareInfo(t *testing.T) {
 	}
 	diff14 := []sharing.SharedDataObjectUpdate{
 		{
-			Action: ShareUpdate,
+			Action: sharing.SharedDataObjectUpdateActionUpdate,
 			DataObject: &sharing.SharedDataObject{
 				Name:           "main.b",
 				DataObjectType: "TABLE",
@@ -519,12 +519,13 @@ func TestUpdateShare_NoChanges(t *testing.T) {
 						Name: "abc",
 						Objects: []sharing.SharedDataObject{
 							{
-								Name:           "d",
-								DataObjectType: "TABLE",
-								Comment:        "c",
-								SharedAs:       "",
-								AddedAt:        0,
-								AddedBy:        "",
+								Name:            "d",
+								DataObjectType:  "TABLE",
+								Comment:         "c",
+								SharedAs:        "",
+								AddedAt:         0,
+								AddedBy:         "",
+								ForceSendFields: []string{"Name", "Comment", "DataObjectType"},
 							},
 						},
 					}},


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
This PR is my first attempt at migrating the Share resource from using hand-crafted API calls to the Databricks Go SDK. I’ve updated the `Read` function to use the SDK’s `Get` method. Next, I’ll work on migrating the remaining CRUD operations. I’ve run the existing tests to ensure everything is still working as expected.

Update: also included Create & Update here, which makes the Share resource go through the Go SDK for all CRUD operations.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
