### PR TITLE
[Fix] Fixed logging for underlying Go SDK

### DIFF
--- a/internal/acceptance/init_test.go
+++ b/internal/acceptance/init_test.go
@@ -33,7 +33,7 @@ func init() {
 	rand.Seed(time.Now().UnixMicro())
 	databricks.WithProduct("tf-integration-tests", common.Version())
 	os.Setenv("TF_LOG", "DEBUG")
-	dbproviderlogger.SetLogger(context.Background())
+	dbproviderlogger.SetTfLogger(context.Background())
 }
 
 func workspaceLevel(t *testing.T, steps ...step) {

--- a/internal/acceptance/init_test.go
+++ b/internal/acceptance/init_test.go
@@ -33,7 +33,7 @@ func init() {
 	rand.Seed(time.Now().UnixMicro())
 	databricks.WithProduct("tf-integration-tests", common.Version())
 	os.Setenv("TF_LOG", "DEBUG")
-	dbproviderlogger.SetLogger()
+	dbproviderlogger.SetLogger(context.Background())
 }
 
 func workspaceLevel(t *testing.T, steps ...step) {

--- a/internal/acceptance/init_test.go
+++ b/internal/acceptance/init_test.go
@@ -33,7 +33,7 @@ func init() {
 	rand.Seed(time.Now().UnixMicro())
 	databricks.WithProduct("tf-integration-tests", common.Version())
 	os.Setenv("TF_LOG", "DEBUG")
-	dbproviderlogger.SetTfLogger(context.Background())
+	dbproviderlogger.SetTfLogger(dbproviderlogger.NewTfLogger(context.Background()))
 }
 
 func workspaceLevel(t *testing.T, steps ...step) {

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -22,44 +22,55 @@ func (tfLogger *TfLogger) Enabled(_ context.Context, _ logger.Level) bool {
 	return true
 }
 
-func (tfLogger *TfLogger) Tracef(_ context.Context, format string, v ...any) {
+func (tfLogger *TfLogger) Tracef(ctx context.Context, format string, v ...any) {
 	if tfLogger == nil {
-		tflog.Trace(loggerContext, fmt.Sprintf(format, v...), nil)
+		tflog.Trace(getLoggerValidContext(ctx), fmt.Sprintf(format, v...), nil)
 	} else {
-		tflog.SubsystemTrace(loggerContext, tfLogger.Name, fmt.Sprintf(format, v...), nil)
+		tflog.SubsystemTrace(getLoggerValidContext(ctx), tfLogger.Name, fmt.Sprintf(format, v...), nil)
 	}
 }
 
-func (tfLogger *TfLogger) Debugf(_ context.Context, format string, v ...any) {
+func (tfLogger *TfLogger) Debugf(ctx context.Context, format string, v ...any) {
 	if tfLogger == nil {
-		tflog.Debug(loggerContext, fmt.Sprintf(format, v...), nil)
+		tflog.Debug(getLoggerValidContext(ctx), fmt.Sprintf(format, v...), nil)
 	} else {
-		tflog.SubsystemDebug(loggerContext, tfLogger.Name, fmt.Sprintf(format, v...), nil)
+		tflog.SubsystemDebug(getLoggerValidContext(ctx), tfLogger.Name, fmt.Sprintf(format, v...), nil)
 	}
 }
 
-func (tfLogger *TfLogger) Infof(_ context.Context, format string, v ...any) {
+func (tfLogger *TfLogger) Infof(ctx context.Context, format string, v ...any) {
 	if tfLogger == nil {
-		tflog.Info(loggerContext, fmt.Sprintf(format, v...), nil)
+		tflog.Info(getLoggerValidContext(ctx), fmt.Sprintf(format, v...), nil)
 	} else {
-		tflog.SubsystemInfo(loggerContext, tfLogger.Name, fmt.Sprintf(format, v...), nil)
+		tflog.SubsystemInfo(getLoggerValidContext(ctx), tfLogger.Name, fmt.Sprintf(format, v...), nil)
 	}
 }
 
-func (tfLogger *TfLogger) Warnf(_ context.Context, format string, v ...any) {
+func (tfLogger *TfLogger) Warnf(ctx context.Context, format string, v ...any) {
 	if tfLogger == nil {
-		tflog.Warn(loggerContext, fmt.Sprintf(format, v...), nil)
+		tflog.Warn(getLoggerValidContext(ctx), fmt.Sprintf(format, v...), nil)
 	} else {
-		tflog.SubsystemWarn(loggerContext, tfLogger.Name, fmt.Sprintf(format, v...), nil)
+		tflog.SubsystemWarn(getLoggerValidContext(ctx), tfLogger.Name, fmt.Sprintf(format, v...), nil)
 	}
 }
 
-func (tfLogger *TfLogger) Errorf(_ context.Context, format string, v ...any) {
+func (tfLogger *TfLogger) Errorf(ctx context.Context, format string, v ...any) {
 	if tfLogger == nil {
-		tflog.Error(loggerContext, fmt.Sprintf(format, v...), nil)
+		tflog.Error(getLoggerValidContext(ctx), fmt.Sprintf(format, v...), nil)
 	} else {
-		tflog.SubsystemError(loggerContext, tfLogger.Name, fmt.Sprintf(format, v...), nil)
+		tflog.SubsystemError(getLoggerValidContext(ctx), tfLogger.Name, fmt.Sprintf(format, v...), nil)
 	}
+}
+
+// Tflogger is called through Databricks provider and also Go SDK
+// We need a way to check if the context is correctly set for logging, if not then we use the context we define in configureContextFunc
+// We can't use the logging.GetProviderRootLogger(ctx) to check as it is internal
+func getLoggerValidContext(ctx context.Context) context.Context {
+	logger := ctx.Value("provider")
+	if logger == nil {
+		return loggerContext
+	}
+	return ctx
 }
 
 func SetLogger(ctx context.Context) {

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -20,8 +20,6 @@ func SetTfLogger(ctx context.Context) {
 	logger.DefaultLogger = NewTfLogger(ctx)
 }
 
-var loggerContext context.Context
-
 // This function is always enabled because TfLogger implements the Logger interface from Go SDK and there we check
 // if the logging is enabled based on level (which default to Info).
 // This however isn't possible here since tflog isn't enabled / disabled based on log level.

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -12,6 +12,8 @@ type TfLogger struct {
 	ctx context.Context
 }
 
+// This function expects the context to have the logger key configured to hold the logger.
+// Please see: GetProviderRootLogger defined in terraform-plugin-log here: https://github.com/hashicorp/terraform-plugin-log/blob/main/internal/logging/provider.go#L14 for reference.
 func NewTfLogger(ctx context.Context) *TfLogger {
 	return &TfLogger{ctx: ctx}
 }

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -12,6 +12,8 @@ type TfLogger struct {
 	Name string
 }
 
+var loggerContext context.Context
+
 // This function is always enabled because TfLogger implements the Logger interface from Go SDK and there we check
 // if the logging is enabled based on level (which default to Info).
 // This however isn't possible here since tflog isn't enabled / disabled based on log level.
@@ -20,47 +22,48 @@ func (tfLogger *TfLogger) Enabled(_ context.Context, _ logger.Level) bool {
 	return true
 }
 
-func (tfLogger *TfLogger) Tracef(ctx context.Context, format string, v ...any) {
+func (tfLogger *TfLogger) Tracef(_ context.Context, format string, v ...any) {
 	if tfLogger == nil {
-		tflog.Trace(ctx, fmt.Sprintf(format, v...), nil)
+		tflog.Trace(loggerContext, fmt.Sprintf(format, v...), nil)
 	} else {
-		tflog.SubsystemTrace(ctx, tfLogger.Name, fmt.Sprintf(format, v...), nil)
+		tflog.SubsystemTrace(loggerContext, tfLogger.Name, fmt.Sprintf(format, v...), nil)
 	}
 }
 
-func (tfLogger *TfLogger) Debugf(ctx context.Context, format string, v ...any) {
+func (tfLogger *TfLogger) Debugf(_ context.Context, format string, v ...any) {
 	if tfLogger == nil {
-		tflog.Debug(ctx, fmt.Sprintf(format, v...), nil)
+		tflog.Debug(loggerContext, fmt.Sprintf(format, v...), nil)
 	} else {
-		tflog.SubsystemDebug(ctx, tfLogger.Name, fmt.Sprintf(format, v...), nil)
+		tflog.SubsystemDebug(loggerContext, tfLogger.Name, fmt.Sprintf(format, v...), nil)
 	}
 }
 
-func (tfLogger *TfLogger) Infof(ctx context.Context, format string, v ...any) {
+func (tfLogger *TfLogger) Infof(_ context.Context, format string, v ...any) {
 	if tfLogger == nil {
-		tflog.Info(ctx, fmt.Sprintf(format, v...), nil)
+		tflog.Info(loggerContext, fmt.Sprintf(format, v...), nil)
 	} else {
-		tflog.SubsystemInfo(ctx, tfLogger.Name, fmt.Sprintf(format, v...), nil)
+		tflog.SubsystemInfo(loggerContext, tfLogger.Name, fmt.Sprintf(format, v...), nil)
 	}
 }
 
-func (tfLogger *TfLogger) Warnf(ctx context.Context, format string, v ...any) {
+func (tfLogger *TfLogger) Warnf(_ context.Context, format string, v ...any) {
 	if tfLogger == nil {
-		tflog.Warn(ctx, fmt.Sprintf(format, v...), nil)
+		tflog.Warn(loggerContext, fmt.Sprintf(format, v...), nil)
 	} else {
-		tflog.SubsystemWarn(ctx, tfLogger.Name, fmt.Sprintf(format, v...), nil)
+		tflog.SubsystemWarn(loggerContext, tfLogger.Name, fmt.Sprintf(format, v...), nil)
 	}
 }
 
-func (tfLogger *TfLogger) Errorf(ctx context.Context, format string, v ...any) {
+func (tfLogger *TfLogger) Errorf(_ context.Context, format string, v ...any) {
 	if tfLogger == nil {
-		tflog.Error(ctx, fmt.Sprintf(format, v...), nil)
+		tflog.Error(loggerContext, fmt.Sprintf(format, v...), nil)
 	} else {
-		tflog.SubsystemError(ctx, tfLogger.Name, fmt.Sprintf(format, v...), nil)
+		tflog.SubsystemError(loggerContext, tfLogger.Name, fmt.Sprintf(format, v...), nil)
 	}
 }
 
-func SetLogger() {
+func SetLogger(ctx context.Context) {
 	var tfLogger *TfLogger
 	logger.DefaultLogger = tfLogger
+	loggerContext = ctx
 }

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -16,8 +16,8 @@ func NewTfLogger(ctx context.Context) *TfLogger {
 	return &TfLogger{ctx: ctx}
 }
 
-func SetTfLogger(ctx context.Context) {
-	logger.DefaultLogger = NewTfLogger(ctx)
+func SetTfLogger(tfLogger *TfLogger) {
+	logger.DefaultLogger = tfLogger
 }
 
 // This function is always enabled because TfLogger implements the Logger interface from Go SDK and there we check

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -9,7 +9,15 @@ import (
 )
 
 type TfLogger struct {
-	Name string
+	ctx context.Context
+}
+
+func NewTfLogger(ctx context.Context) *TfLogger {
+	return &TfLogger{ctx: ctx}
+}
+
+func SetTfLogger(ctx context.Context) {
+	logger.DefaultLogger = NewTfLogger(ctx)
 }
 
 var loggerContext context.Context
@@ -22,59 +30,22 @@ func (tfLogger *TfLogger) Enabled(_ context.Context, _ logger.Level) bool {
 	return true
 }
 
-func (tfLogger *TfLogger) Tracef(ctx context.Context, format string, v ...any) {
-	if tfLogger == nil {
-		tflog.Trace(getLoggerValidContext(ctx), fmt.Sprintf(format, v...), nil)
-	} else {
-		tflog.SubsystemTrace(getLoggerValidContext(ctx), tfLogger.Name, fmt.Sprintf(format, v...), nil)
-	}
+func (tfLogger *TfLogger) Tracef(_ context.Context, format string, v ...any) {
+	tflog.Trace(tfLogger.ctx, fmt.Sprintf(format, v...), nil)
 }
 
-func (tfLogger *TfLogger) Debugf(ctx context.Context, format string, v ...any) {
-	if tfLogger == nil {
-		tflog.Debug(getLoggerValidContext(ctx), fmt.Sprintf(format, v...), nil)
-	} else {
-		tflog.SubsystemDebug(getLoggerValidContext(ctx), tfLogger.Name, fmt.Sprintf(format, v...), nil)
-	}
+func (tfLogger *TfLogger) Debugf(_ context.Context, format string, v ...any) {
+	tflog.Debug(tfLogger.ctx, fmt.Sprintf(format, v...), nil)
 }
 
-func (tfLogger *TfLogger) Infof(ctx context.Context, format string, v ...any) {
-	if tfLogger == nil {
-		tflog.Info(getLoggerValidContext(ctx), fmt.Sprintf(format, v...), nil)
-	} else {
-		tflog.SubsystemInfo(getLoggerValidContext(ctx), tfLogger.Name, fmt.Sprintf(format, v...), nil)
-	}
+func (tfLogger *TfLogger) Infof(_ context.Context, format string, v ...any) {
+	tflog.Info(tfLogger.ctx, fmt.Sprintf(format, v...), nil)
 }
 
-func (tfLogger *TfLogger) Warnf(ctx context.Context, format string, v ...any) {
-	if tfLogger == nil {
-		tflog.Warn(getLoggerValidContext(ctx), fmt.Sprintf(format, v...), nil)
-	} else {
-		tflog.SubsystemWarn(getLoggerValidContext(ctx), tfLogger.Name, fmt.Sprintf(format, v...), nil)
-	}
+func (tfLogger *TfLogger) Warnf(_ context.Context, format string, v ...any) {
+	tflog.Warn(tfLogger.ctx, fmt.Sprintf(format, v...), nil)
 }
 
-func (tfLogger *TfLogger) Errorf(ctx context.Context, format string, v ...any) {
-	if tfLogger == nil {
-		tflog.Error(getLoggerValidContext(ctx), fmt.Sprintf(format, v...), nil)
-	} else {
-		tflog.SubsystemError(getLoggerValidContext(ctx), tfLogger.Name, fmt.Sprintf(format, v...), nil)
-	}
-}
-
-// Tflogger is called through Databricks provider and also Go SDK
-// We need a way to check if the context is correctly set for logging, if not then we use the context we define in configureContextFunc
-// We can't use the logging.GetProviderRootLogger(ctx) to check as it is internal
-func getLoggerValidContext(ctx context.Context) context.Context {
-	logger := ctx.Value("provider")
-	if logger == nil {
-		return loggerContext
-	}
-	return ctx
-}
-
-func SetLogger(ctx context.Context) {
-	var tfLogger *TfLogger
-	logger.DefaultLogger = tfLogger
-	loggerContext = ctx
+func (tfLogger *TfLogger) Errorf(_ context.Context, format string, v ...any) {
+	tflog.Error(tfLogger.ctx, fmt.Sprintf(format, v...), nil)
 }

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -14,6 +14,6 @@ func TestTfLogger_Enabled(t *testing.T) {
 }
 
 func TestSetLogger(t *testing.T) {
-	SetLogger(context.Background())
+	SetTfLogger(context.Background())
 	assert.IsType(t, &TfLogger{}, goLogger.DefaultLogger)
 }

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -14,6 +14,6 @@ func TestTfLogger_Enabled(t *testing.T) {
 }
 
 func TestSetLogger(t *testing.T) {
-	SetTfLogger(context.Background())
+	SetTfLogger(NewTfLogger(context.Background()))
 	assert.IsType(t, &TfLogger{}, goLogger.DefaultLogger)
 }

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -14,6 +14,6 @@ func TestTfLogger_Enabled(t *testing.T) {
 }
 
 func TestSetLogger(t *testing.T) {
-	SetLogger()
+	SetLogger(context.Background())
 	assert.IsType(t, &TfLogger{}, goLogger.DefaultLogger)
 }

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -224,7 +224,7 @@ func DatabricksProvider() *schema.Provider {
 		if p.TerraformVersion != "" {
 			useragent.WithUserAgentExtra("terraform", p.TerraformVersion)
 		}
-		logger.SetTfLogger(ctx)
+		logger.SetTfLogger(logger.NewTfLogger(ctx))
 		return ConfigureDatabricksClient(ctx, d)
 	}
 	common.AddContextToAllResources(p, "databricks")

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -27,7 +27,7 @@ import (
 	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/databricks/terraform-provider-databricks/dashboards"
 	"github.com/databricks/terraform-provider-databricks/jobs"
-	tflogger "github.com/databricks/terraform-provider-databricks/logger"
+	"github.com/databricks/terraform-provider-databricks/logger"
 	"github.com/databricks/terraform-provider-databricks/mlflow"
 	"github.com/databricks/terraform-provider-databricks/mws"
 	"github.com/databricks/terraform-provider-databricks/permissions"
@@ -224,7 +224,7 @@ func DatabricksProvider() *schema.Provider {
 		if p.TerraformVersion != "" {
 			useragent.WithUserAgentExtra("terraform", p.TerraformVersion)
 		}
-		tflogger.SetLogger(ctx)
+		logger.SetTfLogger(ctx)
 		return ConfigureDatabricksClient(ctx, d)
 	}
 	common.AddContextToAllResources(p, "databricks")

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -224,7 +224,7 @@ func DatabricksProvider() *schema.Provider {
 		if p.TerraformVersion != "" {
 			useragent.WithUserAgentExtra("terraform", p.TerraformVersion)
 		}
-		tflogger.SetLogger()
+		tflogger.SetLogger(ctx)
 		return ConfigureDatabricksClient(ctx, d)
 	}
 	common.AddContextToAllResources(p, "databricks")


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
Go SDK doesn't contain valid context for terraform logger, due to this we get a nil logger from context: https://github.com/hashicorp/terraform-plugin-log/blob/main/tflog/provider.go#L40. 

We always use the context from terraform and ignore the one from Go SDK. 

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->
`TF_LOG=TRACE terraform apply` won't print: https://github.com/databricks/databricks-sdk-go/blob/main/config/auth_default.go#L54 on main, prints it after change. Also tested manually for some debug statements.  

Ran integration tests and see debug logs.
- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
