### PR TITLE
[Internal] Upgrade `staticcheck` to v0.5.1 to get Go 1.23 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ fmt-docs:
 
 lint: vendor
 	@echo "✓ Linting source code with https://staticcheck.io/ ..."
-	@go run honnef.co/go/tools/cmd/staticcheck@v0.4.0 ./...
+	@go run honnef.co/go/tools/cmd/staticcheck@v0.5.1 ./...
 
 test: lint
 	@echo "✓ Running tests ..."

--- a/clusters/resource_cluster.go
+++ b/clusters/resource_cluster.go
@@ -143,7 +143,7 @@ func Validate(cluster any) error {
 	if profile == "singleNode" && strings.HasPrefix(master, "local") && resourceClass == "SingleNode" {
 		return nil
 	}
-	return fmt.Errorf(numWorkerErr)
+	return errors.New(numWorkerErr)
 }
 
 // This method is a duplicate of ModifyRequestOnInstancePool() in clusters/clusters_api.go that uses Go SDK.

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"time"
@@ -184,11 +185,11 @@ func (a CommandsAPI) waitForContextReady(contextID, clusterID string) error {
 			return resource.NonRetryableError(err)
 		}
 		if status == "Error" {
-			return resource.NonRetryableError(fmt.Errorf(status))
+			return resource.NonRetryableError(errors.New(status))
 		}
 		if status == "Running" {
 			return nil
 		}
-		return resource.RetryableError(fmt.Errorf(status))
+		return resource.RetryableError(errors.New(status))
 	})
 }

--- a/common/commands.go
+++ b/common/commands.go
@@ -2,7 +2,7 @@ package common
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"html"
 	"regexp"
 	"strings"
@@ -88,7 +88,7 @@ func (cr *CommandResults) Err() error {
 	if !cr.Failed() {
 		return nil
 	}
-	return fmt.Errorf(cr.Error())
+	return errors.New(cr.Error())
 }
 
 // Error returns error in a bit more friendly way

--- a/pipelines/resource_pipeline.go
+++ b/pipelines/resource_pipeline.go
@@ -2,6 +2,7 @@ package pipelines
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"regexp"
@@ -96,7 +97,7 @@ func Delete(w *databricks.WorkspaceClient, ctx context.Context, id string, timeo
 			}
 			message := fmt.Sprintf("Pipeline %s is in state %s, not yet deleted", id, i.State)
 			log.Printf("[DEBUG] %s", message)
-			return retry.RetryableError(fmt.Errorf(message))
+			return retry.RetryableError(errors.New(message))
 		})
 }
 
@@ -120,7 +121,7 @@ func waitForState(w *databricks.WorkspaceClient, ctx context.Context, id string,
 			}
 			message := fmt.Sprintf("Pipeline %s is in state %s, not yet in state %s", id, state, desiredState)
 			log.Printf("[DEBUG] %s", message)
-			return retry.RetryableError(fmt.Errorf(message))
+			return retry.RetryableError(errors.New(message))
 		})
 }
 

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -466,7 +467,7 @@ func configureProviderAndReturnClient(t *testing.T, tt providerFixture) (*common
 		for _, d := range diags {
 			issues = append(issues, d.Summary)
 		}
-		return nil, fmt.Errorf(strings.Join(issues, ", "))
+		return nil, errors.New(strings.Join(issues, ", "))
 	}
 	client := p.Meta().(*common.DatabricksClient)
 	r, err := http.NewRequest("GET", "", nil)

--- a/qa/testing.go
+++ b/qa/testing.go
@@ -335,7 +335,7 @@ func (f ResourceFixture) Apply(t *testing.T) (*schema.ResourceData, error) {
 		// this is a bit strange, but we'll fix it later
 		diags := execute(ctx, resourceData, client)
 		if diags != nil {
-			return resourceData, fmt.Errorf(diagsToString(diags))
+			return resourceData, errors.New(diagsToString(diags))
 		}
 	}
 	if resourceData.Id() == "" && !f.Removed {

--- a/scim/resource_user_test.go
+++ b/scim/resource_user_test.go
@@ -2,6 +2,7 @@ package scim
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -639,7 +640,7 @@ func TestCreateForceOverwriteCannotListUsers(t *testing.T) {
 		d := ResourceUser().ToResource().TestResourceData()
 		d.Set("force", true)
 		err := createForceOverridesManuallyAddedUser(
-			fmt.Errorf(userExistsErrorMessage("me@example.com", false)),
+			errors.New(userExistsErrorMessage("me@example.com", false)),
 			d, NewUsersAPI(ctx, client), User{
 				UserName: "me@example.com",
 			})
@@ -660,7 +661,7 @@ func TestCreateForceOverwriteCannotListAccUsers(t *testing.T) {
 		d := ResourceUser().ToResource().TestResourceData()
 		d.Set("force", true)
 		err := createForceOverridesManuallyAddedUser(
-			fmt.Errorf(userExistsErrorMessage("me@example.com", true)),
+			errors.New(userExistsErrorMessage("me@example.com", true)),
 			d, NewUsersAPI(ctx, client), User{
 				UserName: "me@example.com",
 			})
@@ -701,7 +702,7 @@ func TestCreateForceOverwriteFindsAndSetsID(t *testing.T) {
 		d.Set("force", true)
 		d.Set("user_name", "me@example.com")
 		err := createForceOverridesManuallyAddedUser(
-			fmt.Errorf(userExistsErrorMessage("Me@Example.Com", false)),
+			errors.New(userExistsErrorMessage("Me@Example.Com", false)),
 			d, NewUsersAPI(ctx, client), User{
 				UserName: "me@example.com",
 			})
@@ -743,7 +744,7 @@ func TestCreateForceOverwriteFindsAndSetsAccID(t *testing.T) {
 		d.Set("force", true)
 		d.Set("user_name", "me@example.com")
 		err := createForceOverridesManuallyAddedUser(
-			fmt.Errorf(userExistsErrorMessage("me@example.com", true)),
+			errors.New(userExistsErrorMessage("me@example.com", true)),
 			d, NewUsersAPI(ctx, client), User{
 				UserName: "me@example.com",
 			})


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

The old version (v0.4.0) is crashing when used with Go 1.23, so I was need to bump the version and fix new findings (use of `fmt.Errorf` instead of direct creation of errors from string).


## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
