### PR TITLE
[Internal] Bump Go SDK to v0.45.0

### DIFF
--- a/clusters/resource_cluster_test.go
+++ b/clusters/resource_cluster_test.go
@@ -513,7 +513,7 @@ func TestResourceClusterRead(t *testing.T) {
 }
 
 func TestResourceClusterRead_NotFound(t *testing.T) {
-	qa.ResourceFixture{
+	_, err := qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   "GET",
@@ -531,7 +531,8 @@ func TestResourceClusterRead_NotFound(t *testing.T) {
 		Read:     true,
 		Removed:  true,
 		ID:       "abc",
-	}.ApplyNoError(t)
+	}.Apply(t)
+	qa.AssertErrorStartsWith(t, err, "Cluster abc does not exist")
 }
 
 func TestResourceClusterRead_Error(t *testing.T) {

--- a/common/client_test.go
+++ b/common/client_test.go
@@ -314,7 +314,7 @@ func TestGetJWTProperty_Authenticate_Fail(t *testing.T) {
 	_, err := client.GetAzureJwtProperty("tid")
 	require.Error(t, err)
 	assert.True(t, strings.HasPrefix(err.Error(),
-		"default auth: azure-cli: cannot get access token: This is just a failing script"))
+		"default auth: azure-cli: cannot get account info"))
 }
 
 type mockInternalUserService struct {

--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,12 @@ module github.com/databricks/terraform-provider-databricks
 go 1.22
 
 require (
-	github.com/databricks/databricks-sdk-go v0.44.0
+	github.com/databricks/databricks-sdk-go v0.45.0
 	github.com/golang-jwt/jwt/v4 v4.5.0
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/hcl v1.0.0
 	github.com/hashicorp/hcl/v2 v2.21.0
+	github.com/hashicorp/terraform-plugin-framework v1.11.0
 	github.com/hashicorp/terraform-plugin-go v0.23.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/hashicorp/terraform-plugin-mux v0.16.0
@@ -49,7 +50,6 @@ require (
 	github.com/hashicorp/logutils v1.0.0 // indirect
 	github.com/hashicorp/terraform-exec v0.21.0 // indirect
 	github.com/hashicorp/terraform-json v0.22.1 // indirect
-	github.com/hashicorp/terraform-plugin-framework v1.11.0 // indirect
 	github.com/hashicorp/terraform-registry-address v0.2.3 // indirect
 	github.com/hashicorp/terraform-svchost v0.1.1 // indirect
 	github.com/hashicorp/yamux v0.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -26,8 +26,8 @@ github.com/cloudflare/circl v1.3.7/go.mod h1:sRTcRWXGLrKw6yIGJ+l7amYJFfAXbZG0kBS
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cyphar/filepath-securejoin v0.2.4 h1:Ugdm7cg7i6ZK6x3xDF1oEu1nfkyfH53EtKeQYTC3kyg=
 github.com/cyphar/filepath-securejoin v0.2.4/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxGGx79pTxQpKOJNYHHl4=
-github.com/databricks/databricks-sdk-go v0.44.0 h1:9/FZACv4EFQIOYxfwYVKnY7v46xio9FKCw9tpKB2O/s=
-github.com/databricks/databricks-sdk-go v0.44.0/go.mod h1:ds+zbv5mlQG7nFEU5ojLtgN/u0/9YzZmKQES/CfedzU=
+github.com/databricks/databricks-sdk-go v0.45.0 h1:wdx5Wm/ESrahdHeq62WrjLeGjV4r722LLanD8ahI0Mo=
+github.com/databricks/databricks-sdk-go v0.45.0/go.mod h1:ds+zbv5mlQG7nFEU5ojLtgN/u0/9YzZmKQES/CfedzU=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -329,7 +329,7 @@ func TestConfig_AzureCliHost_Fail(t *testing.T) {
 			"HOME": p,
 			"FAIL": "yes",
 		},
-		assertError: "default auth: azure-cli: cannot get access token: This is just a failing script.",
+		assertError: "default auth: azure-cli: cannot get account info",
 	}.apply(t)
 }
 


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
Bumps the Go SDK to latest version and fix some tests related to changes in:
- https://github.com/databricks/databricks-sdk-go/pull/1014
- https://github.com/databricks/databricks-sdk-go/pull/1021

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->
Unit tests, nightly will run over release PR.
- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
