### PR TITLE
[Internal] Allow vector search tests to fail

### DIFF
--- a/test-config.yaml
+++ b/test-config.yaml
@@ -15,3 +15,6 @@ ignored_tests:
     - package: github.com/databricks/terraform-provider-databricks/internal/acceptance
       test_name: TestUcAccAssignGroupToWorkspace
       comment: Failures due to read-after-write inconsistency. Tracked in https://databricks.atlassian.net/browse/ES-1100061
+    - package: github.com/databricks/terraform-provider-databricks/internal/acceptance
+      test_name: TestUcAccVectorSearchEndpoint
+      comment: Failure due to read-after-create inconsistency. https://databricks.atlassian.net/browse/ES-1243690


### PR DESCRIPTION
## Changes
Vector Search endpoints has a regression with get after create. I've filed a ticket, linked in the comment of the test config, to ignore test failures for this test in the meantime.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
