### PR TITLE
[Doc] Adopt official naming of Mosaic AI Vector Search

### DIFF
--- a/docs/resources/vector_search_endpoint.md
+++ b/docs/resources/vector_search_endpoint.md
@@ -1,11 +1,11 @@
 ---
-subcategory: "Vector Search"
+subcategory: "Mosaic AI Vector Search"
 ---
 # databricks_vector_search_endpoint Resource
 
 -> **Note** This resource could be only used on Unity Catalog-enabled workspace!
 
-This resource allows you to create [Vector Search Endpoint](https://docs.databricks.com/en/generative-ai/vector-search.html) in Databricks.  Vector Search is a serverless similarity search engine that allows you to store a vector representation of your data, including metadata, in a vector database.  The Vector Search Endpoint is used to create and access vector search indexes.
+This resource allows you to create [Mosaic AI Vector Search Endpoint](https://docs.databricks.com/en/generative-ai/vector-search.html) in Databricks.  Mosaic AI Vector Search is a serverless similarity search engine that allows you to store a vector representation of your data, including metadata, in a vector database.  The Mosaic AI Vector Search Endpoint is used to create and access vector search indexes.
 
 ## Example Usage
 
@@ -20,8 +20,8 @@ resource "databricks_vector_search_endpoint" "this" {
 
 The following arguments are supported (change of any parameter leads to recreation of the resource):
 
-* `name` - (Required) Name of the Vector Search Endpoint to create.
-* `endpoint_type` (Required) Type of Vector Search Endpoint.  Currently only accepting single value: `STANDARD` (See [documentation](https://docs.databricks.com/api/workspace/vectorsearchendpoints/createendpoint) for the list of currently supported values).
+* `name` - (Required) Name of the Mosaic AI Vector Search Endpoint to create.
+* `endpoint_type` (Required) Type of Mosaic AI Vector Search Endpoint.  Currently only accepting single value: `STANDARD` (See [documentation](https://docs.databricks.com/api/workspace/vectorsearchendpoints/createendpoint) for the list of currently supported values).
 
 ## Attribute Reference
 
@@ -40,7 +40,7 @@ In addition to all the arguments above, the following attributes are exported:
 
 ## Import
 
-The resource can be imported using the name of the Vector Search Endpoint
+The resource can be imported using the name of the Mosaic AI Vector Search Endpoint
 
 ```bash
 terraform import databricks_vector_search_endpoint.this <endpoint-name>

--- a/docs/resources/vector_search_index.md
+++ b/docs/resources/vector_search_index.md
@@ -1,11 +1,11 @@
 ---
-subcategory: "Vector Search"
+subcategory: "Mosaic AI Vector Search"
 ---
 # databricks_vector_search_index Resource
 
 -> **Note** This resource could be only used on Unity Catalog-enabled workspace!
 
-This resource allows you to create [Vector Search Index](https://docs.databricks.com/en/generative-ai/create-query-vector-search.html) in Databricks.  Vector Search is a serverless similarity search engine that allows you to store a vector representation of your data, including metadata, in a vector database.  The Vector Search Index provides the ability to search data in the linked Delta Table.
+This resource allows you to create [Mosaic AI Vector Search Index](https://docs.databricks.com/en/generative-ai/create-query-vector-search.html) in Databricks.  Mosaic AI Vector Search is a serverless similarity search engine that allows you to store a vector representation of your data, including metadata, in a vector database.  The Mosaic AI Vector Search Index provides the ability to search data in the linked Delta Table.
 
 ## Example Usage
 
@@ -30,10 +30,10 @@ resource "databricks_vector_search_index" "sync" {
 
 The following arguments are supported (change of any parameter leads to recreation of the resource):
 
-* `name` - (required) Three-level name of the Vector Search Index to create (`catalog.schema.index_name`).
-* `endpoint_name` - (required) The name of the Vector Search Endpoint that will be used for indexing the data.
+* `name` - (required) Three-level name of the Mosaic AI Vector Search Index to create (`catalog.schema.index_name`).
+* `endpoint_name` - (required) The name of the Mosaic AI Vector Search Endpoint that will be used for indexing the data.
 * `primary_key` - (required) The column name that will be used as a primary key.
-* `index_type` - (required) Vector Search index type. Currently supported values are:
+* `index_type` - (required) Mosaic AI Vector Search index type. Currently supported values are:
   * `DELTA_SYNC`: An index that automatically syncs with a source Delta Table, automatically and incrementally updating the index as the underlying data in the Delta Table changes.
   * `DIRECT_ACCESS`: An index that supports the direct read and write of vectors and metadata through our REST and SDK APIs. With this model, the user manages index updates.
 * `delta_sync_index_spec` - (object) Specification for Delta Sync Index. Required if `index_type` is `DELTA_SYNC`.
@@ -72,7 +72,7 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-The resource can be imported using the name of the Vector Search Index
+The resource can be imported using the name of the Mosaic AI Vector Search Index
 
 ```bash
 terraform import databricks_vector_search_index.this <index-name>


### PR DESCRIPTION
## Changes
Changed Vector Search naming to official naming "Mosaic AI Vector Search", addressing #3280.
This does not cover instances of the term for the following cases:

- [ ] resource names
- [ ] error messages
- [ ] usages of the general term, rather than the product - such as in "The **Mosaic AI Vector Search** Endpoint is used to create and access **vector search** indexes."

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
