### PR TITLE
[Doc] Resolves #3127: Remove deprecated account_id field from mws_credentials resource

### DIFF
--- a/docs/resources/dashboard.md
+++ b/docs/resources/dashboard.md
@@ -11,15 +11,15 @@ Dashboard using `serialized_dashboard` attribute:
 
 ```hcl
 data "databricks_sql_warehouse" "starter" {
-    name = "Starter Warehouse"
+  name = "Starter Warehouse"
 }
 
 resource "databricks_dashboard" "dashboard" {
-    display_name	 = "New Dashboard"
-    warehouse_id	 = data.databricks_sql_warehouse.starter.id
-    serialized_dashboard = "{\"pages\":[{\"name\":\"new_name\",\"displayName\":\"New Page\"}]}"
-    embed_credentials    = false // Optional
-    parent_path	         = "/Shared/provider-test"
+  display_name         = "New Dashboard"
+  warehouse_id         = data.databricks_sql_warehouse.starter.id
+  serialized_dashboard = "{\"pages\":[{\"name\":\"new_name\",\"displayName\":\"New Page\"}]}"
+  embed_credentials    = false // Optional
+  parent_path          = "/Shared/provider-test"
 }
 ```
 
@@ -27,15 +27,15 @@ Dashboard using `file_path` attribute:
 
 ```hcl
 data "databricks_sql_warehouse" "starter" {
-    name = "Starter Warehouse"
+  name = "Starter Warehouse"
 }
 
 resource "databricks_dashboard" "dashboard" {
-    display_name         = "New Dashboard"
-    warehouse_id         = data.databricks_sql_warehouse.starter.id
-    file_path	         = "${path.module}/dashboard.json"
-    embed_credentials    = false // Optional
-    parent_path	         = "/Shared/provider-test"
+  display_name      = "New Dashboard"
+  warehouse_id      = data.databricks_sql_warehouse.starter.id
+  file_path         = "${path.module}/dashboard.json"
+  embed_credentials = false // Optional
+  parent_path       = "/Shared/provider-test"
 }
 ```
 

--- a/docs/resources/job.md
+++ b/docs/resources/job.md
@@ -302,13 +302,13 @@ This block describes [an Environment](https://docs.databricks.com/en/compute/ser
   * `dependencies` - (list of strings) List of pip dependencies, as supported by the version of pip in this environment. Each dependency is a pip requirement file line.  See [API docs](https://docs.databricks.com/api/workspace/jobs/create#environments-spec-dependencies) for more information.
 
 ```hcl
-  environment {
-    spec {
-      dependencies = ["foo==0.0.1", "-r /Workspace/test/requirements.txt"]
-      client       = "1"
-    }
-    environment_key = "Default"
+environment {
+  spec {
+    dependencies = ["foo==0.0.1", "-r /Workspace/test/requirements.txt"]
+    client       = "1"
   }
+  environment_key = "Default"
+}
 ```
 
 #### depends_on Configuration Block

--- a/docs/resources/mws_credentials.md
+++ b/docs/resources/mws_credentials.md
@@ -37,7 +37,6 @@ resource "aws_iam_role_policy" "this" {
 
 resource "databricks_mws_credentials" "this" {
   provider         = databricks.mws
-  account_id       = var.databricks_account_id
   credentials_name = "${local.prefix}-creds"
   role_arn         = aws_iam_role.cross_account_role.arn
 }
@@ -47,7 +46,7 @@ resource "databricks_mws_credentials" "this" {
 
 The following arguments are required:
 
-* `account_id` - (Optional) Account Id that could be found in the top right corner of [Accounts Console](https://accounts.cloud.databricks.com/)
+* `account_id` - **(Deprecated)** Maintained for backwards compatibility and will be removed in a later version. It should now be specified under a provider instance where `host = "https://accounts.cloud.databricks.com"` 
 * `credentials_name` - (Required) name of credentials to register
 * `role_arn` - (Required) ARN of cross-account role
 
@@ -77,3 +76,4 @@ The following resources are used in the same context:
 * [databricks_mws_networks](mws_networks.md) to [configure VPC](https://docs.databricks.com/administration-guide/cloud-configurations/aws/customer-managed-vpc.html) & subnets for new workspaces within AWS.
 * [databricks_mws_storage_configurations](mws_storage_configurations.md) to configure root bucket new workspaces within AWS.
 * [databricks_mws_workspaces](mws_workspaces.md) to set up [AWS and GCP workspaces](https://docs.databricks.com/getting-started/overview.html#e2-architecture-1).
+

--- a/docs/resources/notification_destination.md
+++ b/docs/resources/notification_destination.md
@@ -11,62 +11,62 @@ This resource allows you to manage [Notification Destinations](https://docs.data
 
 ```hcl
 resource "databricks_notification_destination" "ndresource" {
-    display_name = "Notification Destination"
-    config {
-        email {
-            addresses = ["abc@gmail.com"]
-        }
+  display_name = "Notification Destination"
+  config {
+    email {
+      addresses = ["abc@gmail.com"]
     }
+  }
 }
 ```
 `Slack` notification destination:
 
 ```hcl
 resource "databricks_notification_destination" "ndresource" {
-    display_name = "Notification Destination"
-    config {
-        slack {
-            url     = "https://hooks.slack.com/services/..."
-        }
+  display_name = "Notification Destination"
+  config {
+    slack {
+      url = "https://hooks.slack.com/services/..."
     }
+  }
 }
 ```
 `PagerDuty` notification destination:
 
 ```hcl
 resource "databricks_notification_destination" "ndresource" {
-    display_name = "Notification Destination"
-    config {
-        pagerduty {
-            integration_key = "xxxxxx"
-        }
+  display_name = "Notification Destination"
+  config {
+    pagerduty {
+      integration_key = "xxxxxx"
     }
+  }
 }
 ```
 `Microsoft Teams` notification destination:
 
 ```hcl
 resource "databricks_notification_destination" "ndresource" {
-    display_name = "Notification Destination"
-    config {
-        microsoft_teams {
-            url = "https://outlook.office.com/webhook/..."
-        }
+  display_name = "Notification Destination"
+  config {
+    microsoft_teams {
+      url = "https://outlook.office.com/webhook/..."
     }
+  }
 }
 ```
 `Generic Webhook` notification destination:
 
 ```hcl
 resource "databricks_notification_destination" "ndresource" {
-    display_name = "Notification Destination"
-    config {
-        generic_webhook {
-            url = "https://example.com/webhook"
-            username = "username" // Optional
-            password = "password" // Optional
-        }
+  display_name = "Notification Destination"
+  config {
+    generic_webhook {
+      url      = "https://example.com/webhook"
+      username = "username" // Optional
+      password = "password" // Optional
     }
+  }
 }
 ```
 

--- a/docs/resources/permissions.md
+++ b/docs/resources/permissions.md
@@ -749,8 +749,8 @@ resource "databricks_group" "eng" {
 }
 
 resource "databricks_dashboard" "dashboard" {
-    display_name = "TF New Dashboard"
-    # ...
+  display_name = "TF New Dashboard"
+  # ...
 }
 
 


### PR DESCRIPTION
## Changes
Updated **`docs/resources/mws_credentials.md`** to reflect that `account_id` is deprecated from the `mws_credentials` resource and should be specifically added under a provider instance where `host = "https://accounts.cloud.databricks.com"`. Additionally, updated the code example to reflect this change. Ran `make fmt-docs`.

Closes [#3217](https://github.com/databricks/terraform-provider-databricks/issues/3217)  

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
