### PR TITLE
[Internal] Add integration tests for volumes and quality monitor plugin framework

### DIFF
--- a/internal/acceptance/data_volumes_test.go
+++ b/internal/acceptance/data_volumes_test.go
@@ -58,3 +58,51 @@ func TestUcAccDataSourceVolumes(t *testing.T) {
 		Check: checkDataSourceVolumesPopulated(t),
 	})
 }
+
+func checkDataSourceVolumesPluginFrameworkPopulated(t *testing.T) func(s *terraform.State) error {
+	return func(s *terraform.State) error {
+		_, ok := s.Modules[0].Resources["data.databricks_volumes_pluginframework.this"]
+		require.True(t, ok, "data.databricks_volumes_pluginframework.this has to be there")
+		num_volumes, _ := strconv.Atoi(s.Modules[0].Outputs["volumes"].Value.(string))
+		assert.GreaterOrEqual(t, num_volumes, 1)
+		return nil
+	}
+}
+
+func TestUcAccDataSourceVolumesPluginFramework(t *testing.T) {
+	unityWorkspaceLevel(t, step{
+		Template: `
+		resource "databricks_catalog" "sandbox" {
+			name         = "sandbox{var.RANDOM}"
+			comment      = "this catalog is managed by terraform"
+			properties = {
+				purpose = "testing"
+			}
+		}
+		
+		resource "databricks_schema" "things" {
+			catalog_name = databricks_catalog.sandbox.id
+			name         = "things{var.RANDOM}"
+			comment      = "this database is managed by terraform"
+			properties = {
+				kind = "various"
+			}
+		}
+		resource "databricks_volume" "this" {
+			name         = "volume_data_source_test"
+			catalog_name = databricks_catalog.sandbox.name
+			schema_name  = databricks_schema.things.name
+			volume_type  = "MANAGED"      
+		}
+		data "databricks_volumes_pluginframework" "this" {
+			catalog_name = databricks_catalog.sandbox.name
+			schema_name = databricks_schema.things.name
+			depends_on = [ databricks_volume.this ] 
+		}
+		output "volumes" {
+			value = length(data.databricks_volumes_pluginframework.this.ids)
+		}
+		`,
+		Check: checkDataSourceVolumesPluginFrameworkPopulated(t),
+	})
+}

--- a/internal/acceptance/quality_monitor_test.go
+++ b/internal/acceptance/quality_monitor_test.go
@@ -149,3 +149,107 @@ func TestUcAccUpdateQualityMonitor(t *testing.T) {
 		`,
 	})
 }
+
+func TestUcAccQualityMonitorPluginFramework(t *testing.T) {
+	if os.Getenv("GOOGLE_CREDENTIALS") != "" {
+		t.Skipf("databricks_quality_monitor resource is not available on GCP")
+	}
+	unityWorkspaceLevel(t, step{
+		Template: commonPartQualityMonitoring + `
+
+			resource "databricks_quality_monitor_pluginframework" "testMonitorInference" {
+				table_name = databricks_sql_table.myInferenceTable.id
+				assets_dir = "/Shared/provider-test/databricks_quality_monitoring/${databricks_sql_table.myInferenceTable.name}"
+				output_schema_name = databricks_schema.things.id
+				inference_log = {
+				  granularities = ["1 day"]
+				  timestamp_col = "timestamp"
+				  prediction_col = "prediction"
+				  model_id_col = "model_id"
+				  problem_type = "PROBLEM_TYPE_REGRESSION"
+				} 
+			}
+
+			resource "databricks_sql_table" "myTimeseries" {
+				catalog_name = databricks_catalog.sandbox.id
+				schema_name = databricks_schema.things.name
+				name = "bar{var.STICKY_RANDOM}_timeseries"
+				table_type = "MANAGED"
+				data_source_format = "DELTA"
+
+				column {
+					name = "timestamp"
+					type = "int"
+				}
+			}
+
+			resource "databricks_quality_monitor_pluginframework" "testMonitorTimeseries" {
+				table_name = databricks_sql_table.myTimeseries.id
+				assets_dir = "/Shared/provider-test/databricks_quality_monitoring/${databricks_sql_table.myTimeseries.name}"
+				output_schema_name = databricks_schema.things.id
+				time_series = {
+				  granularities = ["1 day"]
+				  timestamp_col = "timestamp"
+				} 
+			}
+
+			resource "databricks_sql_table" "mySnapshot" {
+				catalog_name = databricks_catalog.sandbox.id
+				schema_name = databricks_schema.things.name
+				name = "bar{var.STICKY_RANDOM}_snapshot"
+				table_type = "MANAGED"
+				data_source_format = "DELTA"
+
+				column {
+					name = "timestamp"
+					type = "int"
+				}
+			}
+
+			resource "databricks_quality_monitor_pluginframework" "testMonitorSnapshot" {
+				table_name = databricks_sql_table.mySnapshot.id
+				assets_dir = "/Shared/provider-test/databricks_quality_monitoring/${databricks_sql_table.myTimeseries.name}"
+				output_schema_name = databricks_schema.things.id
+				snapshot = {
+				} 
+			}
+		`,
+	})
+}
+
+func TestUcAccUpdateQualityMonitorPluginFramework(t *testing.T) {
+	if os.Getenv("GOOGLE_CREDENTIALS") != "" {
+		t.Skipf("databricks_quality_monitor resource is not available on GCP")
+	}
+	unityWorkspaceLevel(t, step{
+		Template: commonPartQualityMonitoring + `
+			resource "databricks_quality_monitor_pluginframework" "testMonitorInference" {
+				table_name = databricks_sql_table.myInferenceTable.id
+				assets_dir = "/Shared/provider-test/databricks_quality_monitoring/${databricks_sql_table.myInferenceTable.name}"
+				output_schema_name = databricks_schema.things.id
+				inference_log = {
+				  granularities = ["1 day"]
+				  timestamp_col = "timestamp"
+				  prediction_col = "prediction"
+				  model_id_col = "model_id"
+				  problem_type = "PROBLEM_TYPE_REGRESSION"
+				}
+			}
+		`,
+	}, step{
+		Template: commonPartQualityMonitoring + `
+		resource "databricks_quality_monitor_pluginframework" "testMonitorInference" {
+			table_name = databricks_sql_table.myInferenceTable.id
+			assets_dir = "/Shared/provider-test/databricks_quality_monitoring/${databricks_sql_table.myInferenceTable.name}"
+			output_schema_name = databricks_schema.things.id
+			inference_log = {
+				granularities = ["1 hour"]
+				timestamp_col = "timestamp"
+				prediction_col = "prediction"
+				model_id_col = "model_id"
+				problem_type = "PROBLEM_TYPE_REGRESSION"
+			}
+		}
+		`,
+	})
+}

--- a/internal/providers/pluginfw/common/common.go
+++ b/internal/providers/pluginfw/common/common.go
@@ -12,6 +12,9 @@ import (
 // It returns the DatabricksClient if it can be successfully fetched from the ProviderData in the request;
 // otherwise, the error is appended to the diagnostics of the response.
 func ConfigureDataSource(req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) *common.DatabricksClient {
+	if req.ProviderData == nil {
+		return nil
+	}
 	client, ok := req.ProviderData.(*common.DatabricksClient)
 	if !ok {
 		resp.Diagnostics.AddError(

--- a/internal/providers/pluginfw/common/common.go
+++ b/internal/providers/pluginfw/common/common.go
@@ -12,6 +12,7 @@ import (
 // It returns the DatabricksClient if it can be successfully fetched from the ProviderData in the request;
 // otherwise, the error is appended to the diagnostics of the response.
 func ConfigureDataSource(req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) *common.DatabricksClient {
+	// Nil case for acceptance tests.
 	if req.ProviderData == nil {
 		return nil
 	}
@@ -30,6 +31,10 @@ func ConfigureDataSource(req datasource.ConfigureRequest, resp *datasource.Confi
 // It returns the DatabricksClient if it can be successfully fetched from the ProviderData in the request;
 // otherwise, the error is appended to the diagnostics of the response.
 func ConfigureResource(req resource.ConfigureRequest, resp *resource.ConfigureResponse) *common.DatabricksClient {
+	// Nil case for acceptance tests.
+	if req.ProviderData == nil {
+		return nil
+	}
 	client, ok := req.ProviderData.(*common.DatabricksClient)
 	if !ok {
 		resp.Diagnostics.AddError(

--- a/internal/providers/pluginfw/resources/qualitymonitor/resource_quality_monitor.go
+++ b/internal/providers/pluginfw/resources/qualitymonitor/resource_quality_monitor.go
@@ -71,7 +71,6 @@ func (r *QualityMonitorResource) Schema(ctx context.Context, req resource.Schema
 		Attributes: tfschema.ResourceStructToSchemaMap(MonitorInfoExtended{}, func(c tfschema.CustomizableSchema) tfschema.CustomizableSchema {
 			c.SetRequired("assets_dir")
 			c.SetRequired("output_schema_name")
-			c.SetRequired("table_name")
 			c.SetReadOnly("monitor_version")
 			c.SetReadOnly("drift_metrics_table_name")
 			c.SetReadOnly("profile_metrics_table_name")
@@ -84,7 +83,7 @@ func (r *QualityMonitorResource) Schema(ctx context.Context, req resource.Schema
 }
 
 func (d *QualityMonitorResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
-	if d.Client == nil {
+	if d.Client == nil && req.ProviderData != nil {
 		d.Client = pluginfwcommon.ConfigureResource(req, resp)
 	}
 }

--- a/internal/providers/pluginfw/resources/qualitymonitor/resource_quality_monitor.go
+++ b/internal/providers/pluginfw/resources/qualitymonitor/resource_quality_monitor.go
@@ -107,7 +107,7 @@ func (r *QualityMonitorResource) Create(ctx context.Context, req resource.Create
 	}
 	monitor, err := w.QualityMonitors.Create(ctx, createMonitorGoSDK)
 	if err != nil {
-		resp.Diagnostics.AddError("failed to get created monitor", err.Error())
+		resp.Diagnostics.AddError("failed to create monitor", err.Error())
 		return
 	}
 	resp.Diagnostics.Append(waitForMonitor(ctx, w, monitor)...)

--- a/internal/providers/pluginfw/resources/volume/data_volumes.go
+++ b/internal/providers/pluginfw/resources/volume/data_volumes.go
@@ -28,7 +28,7 @@ type VolumesDataSource struct {
 type VolumesList struct {
 	CatalogName types.String   `tfsdk:"catalog_name"`
 	SchemaName  types.String   `tfsdk:"schema_name"`
-	Ids         []types.String `tfsdk:"ids" tf:"computed,optional"`
+	Ids         []types.String `tfsdk:"ids" tf:"optional"`
 }
 
 func (d *VolumesDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
@@ -37,7 +37,10 @@ func (d *VolumesDataSource) Metadata(ctx context.Context, req datasource.Metadat
 
 func (d *VolumesDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		Attributes: tfschema.DataSourceStructToSchemaMap(VolumesList{}, nil),
+		Attributes: tfschema.DataSourceStructToSchemaMap(VolumesList{}, func(c tfschema.CustomizableSchema) tfschema.CustomizableSchema {
+			c.SetComputed("ids")
+			return c
+		}),
 	}
 }
 


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
- Add integration tests for resource and data source introduced [here](https://github.com/databricks/terraform-provider-databricks/pull/3958)
- Small updates to `ConfigureDataSource` function to handle nil case
- In `data_volumes`, we don't support `computed` tf tag yet, so we need to do that in customizable schema

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [x] covered with integration tests in `internal/acceptance`
- [x] relevant acceptance tests are passing
- [x] using Go SDK
