### PR TITLE
[Fix] Force send fields for settings resources

### DIFF
--- a/docs/resources/automatic_cluster_update_setting.md
+++ b/docs/resources/automatic_cluster_update_setting.md
@@ -33,17 +33,16 @@ resource "databricks_automatic_cluster_update_workspace_setting" "this" {
 
 The resource supports the following arguments:
 
-* `enabled` - (Required) The configuration details.
-* `restart_even_if_no_updates_available` - (Optional) To force clusters and other compute resources to restart during the maintenance window regardless of the availability of a new update.
-
-A `maintenance_window` block that defines the maintenance frequency with the following arguments
-
-* A `week_day_based_schedule` block with the following arguments
-  * `day_of_week` - the day of the week in uppercase, e.g. `MONDAY` or `SUNDAY`
-  * `frequency` - one of the `FIRST_OF_MONTH`, `SECOND_OF_MONTH`, `THIRD_OF_MONTH`, `FOURTH_OF_MONTH`, `FIRST_AND_THIRD_OF_MONTH`, `SECOND_AND_FOURTH_OF_MONTH`, `EVERY_WEEK`.
-  * A `window_start_time` block that defines the time of your maintenance window. The default timezone is UTC and cannot be changed.
-    * `hours`
-    * `minutes`
+- `automatic_cluster_update_workspace` (Required) block with following attributes
+  - `enabled` - (Required) The configuration details.
+  - `restart_even_if_no_updates_available` - (Optional) To force clusters and other compute resources to restart during the maintenance window regardless of the availability of a new update.
+  - `maintenance_window` block that defines the maintenance frequency with the following arguments
+    - `week_day_based_schedule` block with the following arguments
+      - `day_of_week` - the day of the week in uppercase, e.g. `MONDAY` or `SUNDAY`
+      - `frequency` - one of the `FIRST_OF_MONTH`, `SECOND_OF_MONTH`, `THIRD_OF_MONTH`, `FOURTH_OF_MONTH`, `FIRST_AND_THIRD_OF_MONTH`, `SECOND_AND_FOURTH_OF_MONTH`, `EVERY_WEEK`.
+      - `window_start_time` block that defines the time of your maintenance window. The default timezone is UTC and cannot be changed.
+        - `hours` - hour to perform update: 0-23
+        - `minutes` - minute to perform update: 0-59
 
 ## Import
 

--- a/docs/resources/compliance_security_profile_setting.md
+++ b/docs/resources/compliance_security_profile_setting.md
@@ -27,8 +27,9 @@ resource "databricks_compliance_security_profile_workspace_setting" "this" {
 
 The resource supports the following arguments:
 
-* `is_enabled` - (Required) Enable the Compliance Security Profile on the workspace
-* `compliance_standards` - (Required) Enable one or more compliance standards on the workspace, e.g. `HIPAA`, `PCI_DSS`, `FEDRAMP_MODERATE`
+- `compliance_security_profile_workspace` block with following attributes:
+  - `is_enabled` - (Required) Enable the Compliance Security Profile on the workspace
+  - `compliance_standards` - (Required) Enable one or more compliance standards on the workspace, e.g. `HIPAA`, `PCI_DSS`, `FEDRAMP_MODERATE`
 
 ## Import
 

--- a/docs/resources/enhanced_security_monitoring_setting.md
+++ b/docs/resources/enhanced_security_monitoring_setting.md
@@ -25,7 +25,8 @@ resource "databricks_enhanced_security_monitoring_workspace_setting" "this" {
 
 The resource supports the following arguments:
 
-* `is_enabled` - (Required) Enable the Enhanced Security Monitoring on the workspace
+ - `enhanced_security_monitoring_workspace` block with following attributes:
+   - `is_enabled` - (Required) Enable the Enhanced Security Monitoring on the workspace
 
 ## Import
 

--- a/settings/resource_automatic_cluster_update_setting.go
+++ b/settings/resource_automatic_cluster_update_setting.go
@@ -19,6 +19,7 @@ var automaticClusterUpdateFieldMask = strings.Join([]string{
 	"automatic_cluster_update_workspace.maintenance_window.week_day_based_schedule.window_start_time.hours",
 	"automatic_cluster_update_workspace.maintenance_window.week_day_based_schedule.window_start_time.minutes",
 }, ",")
+
 var automaticClusterUpdateSetting = workspaceSetting[settings.AutomaticClusterUpdateSetting]{
 	settingStruct: settings.AutomaticClusterUpdateSetting{},
 	customizeSchemaFunc: func(s map[string]*schema.Schema) map[string]*schema.Schema {
@@ -32,6 +33,12 @@ var automaticClusterUpdateSetting = workspaceSetting[settings.AutomaticClusterUp
 	},
 	updateFunc: func(ctx context.Context, w *databricks.WorkspaceClient, t settings.AutomaticClusterUpdateSetting) (string, error) {
 		t.SettingName = "default"
+		t.AutomaticClusterUpdateWorkspace.ForceSendFields = []string{"Enabled", "RestartEvenIfNoUpdatesAvailable"}
+		if t.AutomaticClusterUpdateWorkspace.MaintenanceWindow != nil &&
+			t.AutomaticClusterUpdateWorkspace.MaintenanceWindow.WeekDayBasedSchedule != nil &&
+			t.AutomaticClusterUpdateWorkspace.MaintenanceWindow.WeekDayBasedSchedule.WindowStartTime != nil {
+			t.AutomaticClusterUpdateWorkspace.MaintenanceWindow.WeekDayBasedSchedule.WindowStartTime.ForceSendFields = []string{"Hours", "Minutes"}
+		}
 		res, err := w.Settings.AutomaticClusterUpdate().Update(ctx, settings.UpdateAutomaticClusterUpdateSettingRequest{
 			AllowMissing: true,
 			Setting:      t,
@@ -49,7 +56,8 @@ var automaticClusterUpdateSetting = workspaceSetting[settings.AutomaticClusterUp
 				Etag:        etag,
 				SettingName: "default",
 				AutomaticClusterUpdateWorkspace: settings.ClusterAutoRestartMessage{
-					Enabled: false,
+					Enabled:         false,
+					ForceSendFields: []string{"Enabled"},
 				},
 			},
 			FieldMask: automaticClusterUpdateFieldMask,

--- a/settings/resource_automatic_cluster_update_setting.go
+++ b/settings/resource_automatic_cluster_update_setting.go
@@ -23,7 +23,16 @@ var automaticClusterUpdateFieldMask = strings.Join([]string{
 var automaticClusterUpdateSetting = workspaceSetting[settings.AutomaticClusterUpdateSetting]{
 	settingStruct: settings.AutomaticClusterUpdateSetting{},
 	customizeSchemaFunc: func(s map[string]*schema.Schema) map[string]*schema.Schema {
-		common.MustSchemaPath(s, "automatic_cluster_update_workspace", "enablement_details").Computed = true
+		common.CustomizeSchemaPath(s, "automatic_cluster_update_workspace", "enablement_details").SetReadOnly()
+		common.CustomizeSchemaPath(s, "automatic_cluster_update_workspace", "enabled").SetRequired()
+		common.CustomizeSchemaPath(s, "automatic_cluster_update_workspace", "maintenance_window",
+			"week_day_based_schedule", "window_start_time", "hours").SetRequired()
+		common.CustomizeSchemaPath(s, "automatic_cluster_update_workspace", "maintenance_window",
+			"week_day_based_schedule", "day_of_week").SetRequired()
+		common.CustomizeSchemaPath(s, "automatic_cluster_update_workspace", "maintenance_window",
+			"week_day_based_schedule", "frequency").SetRequired()
+		common.CustomizeSchemaPath(s, "automatic_cluster_update_workspace", "maintenance_window",
+			"week_day_based_schedule", "window_start_time", "minutes").SetRequired()
 		return s
 	},
 	readFunc: func(ctx context.Context, w *databricks.WorkspaceClient, etag string) (*settings.AutomaticClusterUpdateSetting, error) {

--- a/settings/resource_automatic_cluster_update_setting_test.go
+++ b/settings/resource_automatic_cluster_update_setting_test.go
@@ -23,7 +23,8 @@ func TestQueryCreateAutomaticClusterUpdateSetting(t *testing.T) {
 				Setting: settings.AutomaticClusterUpdateSetting{
 					Etag: "",
 					AutomaticClusterUpdateWorkspace: settings.ClusterAutoRestartMessage{
-						Enabled: true,
+						Enabled:         true,
+						ForceSendFields: []string{"Enabled", "RestartEvenIfNoUpdatesAvailable"},
 					},
 					SettingName: "default",
 				},
@@ -44,7 +45,8 @@ func TestQueryCreateAutomaticClusterUpdateSetting(t *testing.T) {
 				Setting: settings.AutomaticClusterUpdateSetting{
 					Etag: "etag1",
 					AutomaticClusterUpdateWorkspace: settings.ClusterAutoRestartMessage{
-						Enabled: true,
+						Enabled:         true,
+						ForceSendFields: []string{"Enabled", "RestartEvenIfNoUpdatesAvailable"},
 					},
 					SettingName: "default",
 				},
@@ -150,14 +152,16 @@ func TestQueryUpdateAutomaticClusterUpdateSetting(t *testing.T) {
 					Etag: "etag1",
 					AutomaticClusterUpdateWorkspace: settings.ClusterAutoRestartMessage{
 						Enabled:                         true,
+						ForceSendFields:                 []string{"Enabled", "RestartEvenIfNoUpdatesAvailable"},
 						RestartEvenIfNoUpdatesAvailable: true,
 						MaintenanceWindow: &settings.ClusterAutoRestartMessageMaintenanceWindow{
 							WeekDayBasedSchedule: &settings.ClusterAutoRestartMessageMaintenanceWindowWeekDayBasedSchedule{
 								DayOfWeek: "MONDAY",
 								Frequency: "EVERY_WEEK",
 								WindowStartTime: &settings.ClusterAutoRestartMessageMaintenanceWindowWindowStartTime{
-									Hours:   1,
-									Minutes: 0,
+									Hours:           1,
+									Minutes:         0,
+									ForceSendFields: []string{"Hours", "Minutes"},
 								},
 							},
 						},
@@ -238,6 +242,7 @@ func TestQueryUpdateAutomaticClusterUpdateSettingWithConflict(t *testing.T) {
 					AutomaticClusterUpdateWorkspace: settings.ClusterAutoRestartMessage{
 						Enabled:                         true,
 						RestartEvenIfNoUpdatesAvailable: true,
+						ForceSendFields:                 []string{"Enabled", "RestartEvenIfNoUpdatesAvailable"},
 					},
 					SettingName: "default",
 				},
@@ -260,6 +265,7 @@ func TestQueryUpdateAutomaticClusterUpdateSettingWithConflict(t *testing.T) {
 					AutomaticClusterUpdateWorkspace: settings.ClusterAutoRestartMessage{
 						Enabled:                         true,
 						RestartEvenIfNoUpdatesAvailable: true,
+						ForceSendFields:                 []string{"Enabled", "RestartEvenIfNoUpdatesAvailable"},
 					},
 					SettingName: "default",
 				},
@@ -312,7 +318,8 @@ func TestQueryDeleteAutomaticClusterUpdateSetting(t *testing.T) {
 					Etag:        "etag1",
 					SettingName: "default",
 					AutomaticClusterUpdateWorkspace: settings.ClusterAutoRestartMessage{
-						Enabled: false,
+						Enabled:         false,
+						ForceSendFields: []string{"Enabled"},
 					},
 				},
 			}).Return(&settings.AutomaticClusterUpdateSetting{
@@ -347,7 +354,8 @@ func TestQueryDeleteAutomaticClusterUpdateSettingWithConflict(t *testing.T) {
 					Etag:        "etag1",
 					SettingName: "default",
 					AutomaticClusterUpdateWorkspace: settings.ClusterAutoRestartMessage{
-						Enabled: false,
+						Enabled:         false,
+						ForceSendFields: []string{"Enabled"},
 					},
 				},
 			}).Return(nil, &apierr.APIError{
@@ -368,7 +376,8 @@ func TestQueryDeleteAutomaticClusterUpdateSettingWithConflict(t *testing.T) {
 					Etag:        "etag2",
 					SettingName: "default",
 					AutomaticClusterUpdateWorkspace: settings.ClusterAutoRestartMessage{
-						Enabled: false,
+						Enabled:         false,
+						ForceSendFields: []string{"Enabled"},
 					},
 				},
 			}).Return(&settings.AutomaticClusterUpdateSetting{

--- a/settings/resource_compliance_security_profile_setting.go
+++ b/settings/resource_compliance_security_profile_setting.go
@@ -6,7 +6,9 @@ import (
 
 	"github.com/databricks/databricks-sdk-go"
 	"github.com/databricks/databricks-sdk-go/service/settings"
+	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 // Enhanced Security Monitoring setting
@@ -16,6 +18,11 @@ var complianceSecurityProfileFieldMask = strings.Join([]string{
 }, ",")
 var complianceSecurityProfileSetting = workspaceSetting[settings.ComplianceSecurityProfileSetting]{
 	settingStruct: settings.ComplianceSecurityProfileSetting{},
+	customizeSchemaFunc: func(s map[string]*schema.Schema) map[string]*schema.Schema {
+		common.CustomizeSchemaPath(s, "compliance_security_profile_workspace", "compliance_standards").SetRequired()
+		common.CustomizeSchemaPath(s, "compliance_security_profile_workspace", "is_enabled").SetRequired()
+		return s
+	},
 	readFunc: func(ctx context.Context, w *databricks.WorkspaceClient, etag string) (*settings.ComplianceSecurityProfileSetting, error) {
 		return w.Settings.ComplianceSecurityProfile().Get(ctx, settings.GetComplianceSecurityProfileSettingRequest{
 			Etag: etag,
@@ -23,6 +30,7 @@ var complianceSecurityProfileSetting = workspaceSetting[settings.ComplianceSecur
 	},
 	updateFunc: func(ctx context.Context, w *databricks.WorkspaceClient, t settings.ComplianceSecurityProfileSetting) (string, error) {
 		t.SettingName = "default"
+		t.ComplianceSecurityProfileWorkspace.ForceSendFields = []string{"IsEnabled"}
 		res, err := w.Settings.ComplianceSecurityProfile().Update(ctx, settings.UpdateComplianceSecurityProfileSettingRequest{
 			AllowMissing: true,
 			Setting:      t,

--- a/settings/resource_compliance_security_profile_setting_test.go
+++ b/settings/resource_compliance_security_profile_setting_test.go
@@ -25,6 +25,7 @@ func TestQueryCreateComplianceSecurityProfileSettingWithNoneStandard(t *testing.
 					ComplianceSecurityProfileWorkspace: settings.ComplianceSecurityProfile{
 						IsEnabled:           true,
 						ComplianceStandards: []settings.ComplianceStandard{"NONE"},
+						ForceSendFields:     []string{"IsEnabled"},
 					},
 					SettingName: "default",
 				},
@@ -47,6 +48,7 @@ func TestQueryCreateComplianceSecurityProfileSettingWithNoneStandard(t *testing.
 					ComplianceSecurityProfileWorkspace: settings.ComplianceSecurityProfile{
 						IsEnabled:           true,
 						ComplianceStandards: []settings.ComplianceStandard{"NONE"},
+						ForceSendFields:     []string{"IsEnabled"},
 					},
 					SettingName: "default",
 				},
@@ -136,6 +138,7 @@ func TestQueryUpdateComplianceSecurityProfileSetting(t *testing.T) {
 					ComplianceSecurityProfileWorkspace: settings.ComplianceSecurityProfile{
 						IsEnabled:           true,
 						ComplianceStandards: []settings.ComplianceStandard{"HIPAA", "PCI_DSS"},
+						ForceSendFields:     []string{"IsEnabled"},
 					},
 					SettingName: "default",
 				},
@@ -192,6 +195,7 @@ func TestQueryUpdateComplianceSecurityProfileSettingWithConflict(t *testing.T) {
 					ComplianceSecurityProfileWorkspace: settings.ComplianceSecurityProfile{
 						IsEnabled:           true,
 						ComplianceStandards: []settings.ComplianceStandard{"HIPAA"},
+						ForceSendFields:     []string{"IsEnabled"},
 					},
 					SettingName: "default",
 				},
@@ -214,6 +218,7 @@ func TestQueryUpdateComplianceSecurityProfileSettingWithConflict(t *testing.T) {
 					ComplianceSecurityProfileWorkspace: settings.ComplianceSecurityProfile{
 						IsEnabled:           true,
 						ComplianceStandards: []settings.ComplianceStandard{"HIPAA"},
+						ForceSendFields:     []string{"IsEnabled"},
 					},
 					SettingName: "default",
 				},

--- a/settings/resource_enhanced_security_monitoring_setting.go
+++ b/settings/resource_enhanced_security_monitoring_setting.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/databricks/databricks-sdk-go"
 	"github.com/databricks/databricks-sdk-go/service/settings"
+	"github.com/databricks/terraform-provider-databricks/common"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 // Enhanced Security Monitoring setting
@@ -14,6 +16,10 @@ var enhancedSecurityMonitoringFieldMask = strings.Join([]string{
 }, ",")
 var enhancedSecurityMonitoringSetting = workspaceSetting[settings.EnhancedSecurityMonitoringSetting]{
 	settingStruct: settings.EnhancedSecurityMonitoringSetting{},
+	customizeSchemaFunc: func(s map[string]*schema.Schema) map[string]*schema.Schema {
+		common.CustomizeSchemaPath(s, "enhanced_security_monitoring_workspace", "is_enabled").SetRequired()
+		return s
+	},
 	readFunc: func(ctx context.Context, w *databricks.WorkspaceClient, etag string) (*settings.EnhancedSecurityMonitoringSetting, error) {
 		return w.Settings.EnhancedSecurityMonitoring().Get(ctx, settings.GetEnhancedSecurityMonitoringSettingRequest{
 			Etag: etag,
@@ -21,6 +27,7 @@ var enhancedSecurityMonitoringSetting = workspaceSetting[settings.EnhancedSecuri
 	},
 	updateFunc: func(ctx context.Context, w *databricks.WorkspaceClient, t settings.EnhancedSecurityMonitoringSetting) (string, error) {
 		t.SettingName = "default"
+		t.EnhancedSecurityMonitoringWorkspace.ForceSendFields = []string{"IsEnabled"}
 		res, err := w.Settings.EnhancedSecurityMonitoring().Update(ctx, settings.UpdateEnhancedSecurityMonitoringSettingRequest{
 			AllowMissing: true,
 			Setting:      t,
@@ -38,7 +45,8 @@ var enhancedSecurityMonitoringSetting = workspaceSetting[settings.EnhancedSecuri
 				Etag:        etag,
 				SettingName: "default",
 				EnhancedSecurityMonitoringWorkspace: settings.EnhancedSecurityMonitoring{
-					IsEnabled: false,
+					IsEnabled:       false,
+					ForceSendFields: []string{"IsEnabled"},
 				},
 			},
 			FieldMask: enhancedSecurityMonitoringFieldMask,

--- a/settings/resource_enhanced_security_monitoring_setting_test.go
+++ b/settings/resource_enhanced_security_monitoring_setting_test.go
@@ -23,7 +23,8 @@ func TestQueryCreateEnhancedSecurityMonitoringSetting(t *testing.T) {
 				Setting: settings.EnhancedSecurityMonitoringSetting{
 					Etag: "",
 					EnhancedSecurityMonitoringWorkspace: settings.EnhancedSecurityMonitoring{
-						IsEnabled: true,
+						IsEnabled:       true,
+						ForceSendFields: []string{"IsEnabled"},
 					},
 					SettingName: "default",
 				},
@@ -44,7 +45,8 @@ func TestQueryCreateEnhancedSecurityMonitoringSetting(t *testing.T) {
 				Setting: settings.EnhancedSecurityMonitoringSetting{
 					Etag: "etag1",
 					EnhancedSecurityMonitoringWorkspace: settings.EnhancedSecurityMonitoring{
-						IsEnabled: true,
+						IsEnabled:       true,
+						ForceSendFields: []string{"IsEnabled"},
 					},
 					SettingName: "default",
 				},
@@ -123,14 +125,16 @@ func TestQueryUpdateEnhancedSecurityMonitoringSetting(t *testing.T) {
 				Setting: settings.EnhancedSecurityMonitoringSetting{
 					Etag: "etag1",
 					EnhancedSecurityMonitoringWorkspace: settings.EnhancedSecurityMonitoring{
-						IsEnabled: true,
+						IsEnabled:       true,
+						ForceSendFields: []string{"IsEnabled"},
 					},
 					SettingName: "default",
 				},
 			}).Return(&settings.EnhancedSecurityMonitoringSetting{
 				Etag: "etag2",
 				EnhancedSecurityMonitoringWorkspace: settings.EnhancedSecurityMonitoring{
-					IsEnabled: true,
+					IsEnabled:       true,
+					ForceSendFields: []string{"IsEnabled"},
 				},
 				SettingName: "default",
 			}, nil)
@@ -173,7 +177,8 @@ func TestQueryUpdateEnhancedSecurityMonitoringSettingWithConflict(t *testing.T) 
 				Setting: settings.EnhancedSecurityMonitoringSetting{
 					Etag: "etag1",
 					EnhancedSecurityMonitoringWorkspace: settings.EnhancedSecurityMonitoring{
-						IsEnabled: true,
+						IsEnabled:       true,
+						ForceSendFields: []string{"IsEnabled"},
 					},
 					SettingName: "default",
 				},
@@ -194,7 +199,8 @@ func TestQueryUpdateEnhancedSecurityMonitoringSettingWithConflict(t *testing.T) 
 				Setting: settings.EnhancedSecurityMonitoringSetting{
 					Etag: "etag2",
 					EnhancedSecurityMonitoringWorkspace: settings.EnhancedSecurityMonitoring{
-						IsEnabled: true,
+						IsEnabled:       true,
+						ForceSendFields: []string{"IsEnabled"},
 					},
 					SettingName: "default",
 				},
@@ -244,7 +250,8 @@ func TestQueryDeleteEnhancedSecurityMonitoringSetting(t *testing.T) {
 					Etag:        "etag1",
 					SettingName: "default",
 					EnhancedSecurityMonitoringWorkspace: settings.EnhancedSecurityMonitoring{
-						IsEnabled: false,
+						IsEnabled:       false,
+						ForceSendFields: []string{"IsEnabled"},
 					},
 				},
 			}).Return(&settings.EnhancedSecurityMonitoringSetting{
@@ -279,7 +286,8 @@ func TestQueryDeleteEnhancedSecurityMonitoringSettingWithConflict(t *testing.T) 
 					Etag:        "etag1",
 					SettingName: "default",
 					EnhancedSecurityMonitoringWorkspace: settings.EnhancedSecurityMonitoring{
-						IsEnabled: false,
+						IsEnabled:       false,
+						ForceSendFields: []string{"IsEnabled"},
 					},
 				},
 			}).Return(nil, &apierr.APIError{
@@ -300,7 +308,8 @@ func TestQueryDeleteEnhancedSecurityMonitoringSettingWithConflict(t *testing.T) 
 					Etag:        "etag2",
 					SettingName: "default",
 					EnhancedSecurityMonitoringWorkspace: settings.EnhancedSecurityMonitoring{
-						IsEnabled: false,
+						IsEnabled:       false,
+						ForceSendFields: []string{"IsEnabled"},
 					},
 				},
 			}).Return(&settings.EnhancedSecurityMonitoringSetting{


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

There was a problem that `databricks_automatic_cluster_update_setting` wasn't applied because `minutes` attribute was set to 0, and it wasn't sent in the JSON payload because it's marked as `omitempty` in the API.  After analysis, it was found that there are other places where we need to send data but the corresponding fields were marked as `omitempty`.

This PR includes following changes:

- in 3 resources force sending of boolean and numeric fields with 0 values
- add customize schema for `databricksenhanced_security_monitoring_setting`, `databricks_automatic_cluster_update_setting` and `databricks_enhanced_security_monitoring_setting` as fields are declared as required in documentation/API, but not enforced in Terraform because they are marked as `omitempty`
- expand documentation to include necessary blocks

Resolves #3976

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [x] using Go SDK
