### PR TITLE
[Fix] Make subscriptions optional for SqlAlertTask

### DIFF
--- a/docs/resources/job.md
+++ b/docs/resources/job.md
@@ -231,7 +231,7 @@ One of the `query`, `dashboard` or `alert` needs to be provided.
   * `pause_subscriptions` - (Optional) flag that specifies if subscriptions are paused or not.
 * `alert` - (Optional) block consisting of following fields:
   * `alert_id` - (Required) (String) identifier of the Databricks SQL Alert.
-  * `subscriptions` - (Required) a list of subscription blocks consisting out of one of the required fields: `user_name` for user emails or `destination_id` - for Alert destination's identifier.
+  * `subscriptions` - (Optional) a list of subscription blocks consisting out of one of the required fields: `user_name` for user emails or `destination_id` - for Alert destination's identifier.
   * `pause_subscriptions` - (Optional) flag that specifies if subscriptions are paused or not.
 * `file` - (Optional) block consisting of single string fields:
   * `source` - (Optional) The source of the project. Possible values are `WORKSPACE` and `GIT`.

--- a/jobs/resource_job.go
+++ b/jobs/resource_job.go
@@ -83,7 +83,7 @@ type SqlDashboardTask struct {
 
 type SqlAlertTask struct {
 	AlertID            string            `json:"alert_id"`
-	Subscriptions      []SqlSubscription `json:"subscriptions"`
+	Subscriptions      []SqlSubscription `json:"subscriptions,omitempty"`
 	PauseSubscriptions bool              `json:"pause_subscriptions,omitempty"`
 }
 
@@ -623,9 +623,6 @@ func (JobSettingsResource) CustomizeSchema(s *common.CustomizableSchema) *common
 
 	s.SchemaPath("task", "python_wheel_task", "package_name").SetOptional()
 	s.SchemaPath("task", "for_each_task", "task", "python_wheel_task", "package_name").SetOptional()
-
-	s.SchemaPath("task", "sql_task", "alert", "subscriptions").SetRequired()
-	s.SchemaPath("task", "for_each_task", "task", "sql_task", "alert", "subscriptions").SetRequired()
 
 	s.SchemaPath("task", "new_cluster", "cluster_id").SetOptional()
 	s.SchemaPath("task", "for_each_task", "task", "new_cluster", "cluster_id").SetOptional()


### PR DESCRIPTION
## Changes
Make subscriptions optional for SqlAlertTask since it is optional in our API.

## Tests
- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
