### PR TITLE
[Fix] Modify error code when library cluster status is not found during read

### DIFF
--- a/clusters/resource_library_test.go
+++ b/clusters/resource_library_test.go
@@ -59,6 +59,26 @@ func TestLibraryCreate(t *testing.T) {
 	}.ApplyNoError(t)
 }
 
+func TestLibraryRead_ClusterDoesNotExist(t *testing.T) {
+	qa.ResourceFixture{
+		Resource: ResourceLibrary(),
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "GET",
+				Resource: "/api/2.0/libraries/cluster-status?cluster_id=abc",
+				Response: map[string]string{
+					"error_code": "INVALID_PARAMETER_VALUE",
+					"message":    "Cluster abc does not exist",
+				},
+				Status: 400,
+			},
+		},
+		Read:    true,
+		Removed: true,
+		ID:      "abc/whl:foo.whl",
+	}.ApplyNoError(t)
+}
+
 func TestLibraryDelete(t *testing.T) {
 	qa.ResourceFixture{
 		Resource: ResourceLibrary(),

--- a/libraries/libraries_api_sdk.go
+++ b/libraries/libraries_api_sdk.go
@@ -26,6 +26,7 @@ func WaitForLibrariesInstalledSdk(ctx context.Context, w *databricks.WorkspaceCl
 			}
 			if apiErr.StatusCode != 404 && strings.Contains(apiErr.Message,
 				fmt.Sprintf("Cluster %s does not exist", wait.ClusterID)) {
+				apiErr.ErrorCode = "NOT_FOUND"
 				apiErr.StatusCode = 404
 			}
 			return resource.NonRetryableError(apiErr)


### PR DESCRIPTION
## Changes
Set the API error code within `libraries.WaitForLibrariesInstalledSdk` to `NOT_FOUND` when the cluster status is not found.

The error code takes precedence over the status code in the [databricks-go-sdk](https://github.com/databricks/databricks-sdk-go/blob/590d59704619647b958eec09f8faf9fa952ddd86/apierr/unwrap.go#L35-L42) when error checking is performed to determine whether a resource should be [automatically removed from state](https://github.com/databricks/terraform-provider-databricks/blob/a4b02256e80cc6b8a33160d63aca9363d20ed4ea/common/resource.go#L133-L137) during a failed read. Only overriding the status code for a 400 Bad Request response from the `libraries/cluster-status` API otherwise has no effect due to this detail.

Fixes #3984 

## Tests
Unit test added

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
