### PR TITLE
Migrate databricks cluster resource and data source to plugin framework

### DIFF
--- a/internal/providers/pluginfw/resources/cluster/data_cluster.go
+++ b/internal/providers/pluginfw/resources/cluster/data_cluster.go
@@ -1,0 +1,87 @@
+package cluster
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/databricks/databricks-sdk-go/service/compute"
+	"github.com/databricks/terraform-provider-databricks/common"
+	pluginfwcommon "github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/common"
+	"github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/tfschema"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func DataSourceCluster() datasource.DataSource {
+	return &ClusterDataSource{}
+}
+
+var _ datasource.DataSourceWithConfigure = &ClusterDataSource{}
+
+type ClusterDataSource struct {
+	Client *common.DatabricksClient
+}
+
+type ClusterInfo struct {
+	Id          types.String            `json:"id,omitempty" tf:"computed"`
+	ClusterId   types.String            `json:"cluster_id,omitempty" tf:"computed"`
+	Name        types.String            `json:"cluster_name,omitempty" tf:"computed"`
+	ClusterInfo *compute.ClusterDetails `json:"cluster_info,omitempty" tf:"computed"`
+}
+
+func (d *ClusterDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = "databricks_cluster_pluginframework"
+}
+
+func (d *ClusterDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: tfschema.DataSourceStructToSchemaMap(ClusterInfo{}, nil),
+	}
+}
+
+func (d *ClusterDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if d.Client == nil {
+		d.Client = pluginfwcommon.ConfigureDataSource(req, resp)
+	}
+}
+
+func (d *ClusterDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	w, diags := d.Client.GetWorkspaceClient()
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var clusterInfo ClusterInfo
+	diags = req.Config.Get(ctx, &clusterInfo)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if clusterInfo.Name.ValueString() != "" {
+		clusters, err := w.Clusters.ListAll(ctx, compute.ListClustersRequest{})
+		if err != nil {
+			resp.Diagnostics.AddError("failed to list clusters", err.Error())
+			return
+		}
+		namedClusters := []compute.ClusterDetails{}
+		for _, clst := range clusters {
+			cluster := clst
+			if cluster.ClusterName == clusterInfo.Name.ValueString() {
+				namedClusters = append(namedClusters, cluster)
+			}
+		}
+		if len(namedClusters) == 0 {
+			resp.Diagnostics.AddError(fmt.Sprintf("there is no cluster with name '%s'", clusterInfo.Name.ValueString()), "")
+			return
+		}
+		if len(namedClusters) > 1 {
+			resp.Diagnostics.AddError(fmt.Sprintf("there is more than one cluster with name '%s'", clusterInfo.Name.ValueString()), "")
+			return
+		}
+		clusterInfo.ClusterInfo = &namedClusters[0]
+		resp.State.Set(ctx, clusterInfo)
+	}
+}

--- a/internal/providers/pluginfw/resources/cluster/data_clusters.go
+++ b/internal/providers/pluginfw/resources/cluster/data_clusters.go
@@ -1,0 +1,79 @@
+package cluster
+
+import (
+	"context"
+	"strings"
+
+	"github.com/databricks/databricks-sdk-go/service/compute"
+	"github.com/databricks/terraform-provider-databricks/common"
+	pluginfwcommon "github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/common"
+	"github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/tfschema"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+)
+
+func DataSourceClusters() datasource.DataSource {
+	return &ClustersDataSource{}
+}
+
+var _ datasource.DataSourceWithConfigure = &ClustersDataSource{}
+
+type ClustersDataSource struct {
+	Client *common.DatabricksClient
+}
+
+type ClustersInfo struct {
+	Id                  string   `json:"id,omitempty" tf:"computed"`
+	Ids                 []string `json:"ids,omitempty" tf:"computed,slice_set"`
+	ClusterNameContains string   `json:"cluster_name_contains,omitempty"`
+}
+
+func (d *ClustersDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = "databricks_clusters_pluginframework"
+}
+
+func (d *ClustersDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: tfschema.DataSourceStructToSchemaMap(ClustersInfo{}, nil),
+	}
+}
+
+func (d *ClustersDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if d.Client == nil {
+		d.Client = pluginfwcommon.ConfigureDataSource(req, resp)
+	}
+}
+
+func (d *ClustersDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	w, diags := d.Client.GetWorkspaceClient()
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var clustersInfo ClustersInfo
+	diags = req.Config.Get(ctx, &clustersInfo)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	clusters, err := w.Clusters.ListAll(ctx, compute.ListClustersRequest{})
+	if err != nil {
+		resp.Diagnostics.AddError("failed to list clusters", err.Error())
+		return
+	}
+
+	ids := make([]string, 0, len(clusters))
+	name_contains := strings.ToLower(clustersInfo.ClusterNameContains)
+	for _, v := range clusters {
+		match_name := strings.Contains(strings.ToLower(v.ClusterName), name_contains)
+		if name_contains != "" && !match_name {
+			continue
+		}
+		ids = append(ids, v.ClusterId)
+	}
+	clustersInfo.Ids = ids
+	clustersInfo.Id = "_"
+	resp.State.Set(ctx, clustersInfo)
+}

--- a/internal/providers/pluginfw/resources/cluster/resource_cluster.go
+++ b/internal/providers/pluginfw/resources/cluster/resource_cluster.go
@@ -1,0 +1,1 @@
+package cluster


### PR DESCRIPTION
##### Changes
<!-- Summary of your changes that are easy to understand -->
Migrate the following to plugin framework
- databricks cluster resource
- databricks cluster data source
- databricks clusers data source

Note: These resources will be suffixed with `_pluginframework` and will be made default in another PR. 
## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->
- Integration tests
- Unit tests
- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
