### PR TITLE
[Fix] Fix `TestAccClusterResource_WorkloadType`

### DIFF
--- a/internal/acceptance/cluster_test.go
+++ b/internal/acceptance/cluster_test.go
@@ -171,8 +171,7 @@ func TestAccClusterResource_WorkloadType(t *testing.T) {
 	}, step{
 		Template: testAccClusterResourceWorkloadTypeTemplate(``),
 		Check: resource.ComposeAggregateTestCheckFunc(
-			resource.TestCheckResourceAttr("databricks_cluster.this", "workload_type.0.clients.0.jobs", "true"),
-			resource.TestCheckResourceAttr("databricks_cluster.this", "workload_type.0.clients.0.notebooks", "true"),
+			resource.TestCheckResourceAttr("databricks_cluster.this", "workload_type.#", "0"),
 		),
 	})
 }


### PR DESCRIPTION
## Changes
`TestAccClusterResource_WorkloadType` merged with a small bug that caused it to fail deterministically, asserting that the workload_type had a clients block in state even when it wasn't specified in the config, which is not expected. This PR changes the assertion on state to verify that the block is not present in state when removed from the config.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
