### PR TITLE
[Internal] Make test utils public and move integration test for quality monitor

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -333,7 +333,7 @@ func TestExampleResourceCreate(t *testing.T) {
 
 ```go
 func TestAccSecretAclResource(t *testing.T) {
- workspaceLevel(t, step{
+ WorkspaceLevel(t, Step{
   Template: `
   resource "databricks_group" "ds" {
    display_name = "data-scientists-{var.RANDOM}"

--- a/internal/acceptance/acceptance_test.go
+++ b/internal/acceptance/acceptance_test.go
@@ -50,7 +50,7 @@ func TestRunningRealTerraformWithFixtureBackend(t *testing.T) {
 			t.Setenv("DATABRICKS_HOST", client.Config.Host)
 			t.Setenv("DATABRICKS_TOKEN", client.Config.Token)
 
-			workspaceLevel(t, step{
+			WorkspaceLevel(t, Step{
 				Template: `resource "databricks_token" "this" {
 					lifetime_seconds = 6000
 					comment = "Testing token"

--- a/internal/acceptance/account_rule_set_test.go
+++ b/internal/acceptance/account_rule_set_test.go
@@ -32,7 +32,7 @@ func getServicePrincipalResource(t *testing.T) string {
 func TestMwsAccAccountServicePrincipalRuleSetsFullLifeCycle(t *testing.T) {
 	loadAccountEnv(t)
 	spResource := getServicePrincipalResource(t)
-	accountLevel(t, step{
+	AccountLevel(t, Step{
 		Template: spResource + `
 		resource "databricks_group" "this" {
 			display_name = "Group {var.RANDOM}"
@@ -69,7 +69,7 @@ func TestMwsAccAccountServicePrincipalRuleSetsFullLifeCycle(t *testing.T) {
 
 func TestMwsAccAccountGroupRuleSetsFullLifeCycle(t *testing.T) {
 	username := qa.RandomEmail()
-	accountLevel(t, step{
+	AccountLevel(t, Step{
 		Template: `
 		resource "databricks_user" "this" {
 			user_name = "` + username + `"

--- a/internal/acceptance/artifact_allowlist_test.go
+++ b/internal/acceptance/artifact_allowlist_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestUcAccArtifactAllowlistResourceFullLifecycle(t *testing.T) {
-	unityWorkspaceLevel(t, step{
+	UnityWorkspaceLevel(t, Step{
 		Template: `
 		resource "databricks_artifact_allowlist" "init" {
 			artifact_type = "INIT_SCRIPT"

--- a/internal/acceptance/catalog_test.go
+++ b/internal/acceptance/catalog_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestUcAccCatalog(t *testing.T) {
 	loadUcwsEnv(t)
-	unityWorkspaceLevel(t, step{
+	UnityWorkspaceLevel(t, Step{
 		Template: fmt.Sprintf(`
 		resource "databricks_catalog" "sandbox" {
 			name         = "sandbox{var.RANDOM}"
@@ -21,7 +21,7 @@ func TestUcAccCatalog(t *testing.T) {
 }
 
 func TestUcAccCatalogIsolated(t *testing.T) {
-	unityWorkspaceLevel(t, step{
+	UnityWorkspaceLevel(t, Step{
 		Template: `
 		resource "databricks_catalog" "sandbox" {
 			name           = "sandbox{var.STICKY_RANDOM}"
@@ -30,7 +30,7 @@ func TestUcAccCatalogIsolated(t *testing.T) {
 				purpose = "testing"
 			}
 		}`,
-	}, step{
+	}, Step{
 		Template: `
 		resource "databricks_catalog" "sandbox" {
 			name           = "sandbox{var.STICKY_RANDOM}"
@@ -40,7 +40,7 @@ func TestUcAccCatalogIsolated(t *testing.T) {
 				purpose = "testing"
 			}
 		}`,
-	}, step{
+	}, Step{
 		Template: `
 		resource "databricks_catalog" "sandbox" {
 			name           = "sandbox{var.STICKY_RANDOM}"
@@ -55,7 +55,7 @@ func TestUcAccCatalogIsolated(t *testing.T) {
 
 func TestUcAccCatalogUpdate(t *testing.T) {
 	loadUcwsEnv(t)
-	unityWorkspaceLevel(t, step{
+	UnityWorkspaceLevel(t, Step{
 		Template: fmt.Sprintf(`
 		resource "databricks_catalog" "sandbox" {
 			name           = "sandbox{var.STICKY_RANDOM}"
@@ -65,7 +65,7 @@ func TestUcAccCatalogUpdate(t *testing.T) {
 			}
 			%s
 		}`, getPredictiveOptimizationSetting(t, true)),
-	}, step{
+	}, Step{
 		Template: fmt.Sprintf(`
 		resource "databricks_catalog" "sandbox" {
 			name           = "sandbox{var.STICKY_RANDOM}"
@@ -76,7 +76,7 @@ func TestUcAccCatalogUpdate(t *testing.T) {
 			%s
 			owner = "account users"
 		}`, getPredictiveOptimizationSetting(t, true)),
-	}, step{
+	}, Step{
 		Template: fmt.Sprintf(`
 		resource "databricks_catalog" "sandbox" {
 			name           = "sandbox{var.STICKY_RANDOM}"
@@ -87,7 +87,7 @@ func TestUcAccCatalogUpdate(t *testing.T) {
 			%s
 			owner = "{env.TEST_DATA_ENG_GROUP}"
 		}`, getPredictiveOptimizationSetting(t, true)),
-	}, step{
+	}, Step{
 		Template: fmt.Sprintf(`
 		resource "databricks_catalog" "sandbox" {
 			name           = "sandbox{var.STICKY_RANDOM}"

--- a/internal/acceptance/cluster_policy_test.go
+++ b/internal/acceptance/cluster_policy_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestAccClusterPolicyResourceFullLifecycle(t *testing.T) {
-	workspaceLevel(t, step{
+	WorkspaceLevel(t, Step{
 		Template: `resource "databricks_cluster_policy" "external_metastore" {
 			name = "Terraform policy {var.RANDOM}"
 			definition = jsonencode({
@@ -15,7 +15,7 @@ func TestAccClusterPolicyResourceFullLifecycle(t *testing.T) {
 				}
 			})
 		}`,
-	}, step{
+	}, Step{
 		// renaming to a new random name
 		Template: `resource "databricks_cluster_policy" "external_metastore" {
 			name = "Terraform policy {var.RANDOM}"
@@ -30,7 +30,7 @@ func TestAccClusterPolicyResourceFullLifecycle(t *testing.T) {
 }
 
 func TestAccClusterPolicyResourceOverrideBuiltIn(t *testing.T) {
-	workspaceLevel(t, step{
+	WorkspaceLevel(t, Step{
 		Template: `resource "databricks_cluster_policy" "personal_vm" {
 			name = "Personal Compute"
 			policy_family_id = "personal-vm"
@@ -46,7 +46,7 @@ func TestAccClusterPolicyResourceOverrideBuiltIn(t *testing.T) {
 }
 
 func TestAccClusterPolicyResourceOverrideNew(t *testing.T) {
-	workspaceLevel(t, step{
+	WorkspaceLevel(t, Step{
 		Template: `resource "databricks_cluster_policy" "policyoverrideempty" {
 			policy_family_id = "personal-vm"
 			name             = "Policy Override {var.RANDOM}"

--- a/internal/acceptance/cluster_test.go
+++ b/internal/acceptance/cluster_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestAccClusterResource_CreateClusterWithLibraries(t *testing.T) {
-	workspaceLevel(t, step{
+	WorkspaceLevel(t, Step{
 		Template: `data "databricks_spark_version" "latest" {
 		}
 		resource "databricks_cluster" "this" {
@@ -73,9 +73,9 @@ func singleNodeClusterTemplate(autoTerminationMinutes string) string {
 }
 
 func TestAccClusterResource_CreateSingleNodeCluster(t *testing.T) {
-	workspaceLevel(t, step{
+	WorkspaceLevel(t, Step{
 		Template: singleNodeClusterTemplate("10"),
-	}, step{
+	}, Step{
 		Template: singleNodeClusterTemplate("20"),
 	})
 }
@@ -103,16 +103,16 @@ func awsClusterTemplate(availability string) string {
 func TestAccClusterResource_CreateAndUpdateAwsAttributes(t *testing.T) {
 	loadWorkspaceEnv(t)
 	if isAws(t) {
-		workspaceLevel(t, step{
+		WorkspaceLevel(t, Step{
 			Template: awsClusterTemplate("SPOT"),
-		}, step{
+		}, Step{
 			Template: awsClusterTemplate("SPOT_WITH_FALLBACK"),
 		})
 	}
 }
 
 func TestAccClusterResource_CreateAndNoWait(t *testing.T) {
-	workspaceLevel(t, step{
+	WorkspaceLevel(t, Step{
 		Template: `data "databricks_spark_version" "latest" {
 		}
 		resource "databricks_cluster" "this" {
@@ -133,9 +133,9 @@ func TestAccClusterResource_CreateAndNoWait(t *testing.T) {
 }
 
 func TestAccClusterResource_WorkloadType(t *testing.T) {
-	workspaceLevel(t, step{
+	WorkspaceLevel(t, Step{
 		Template: testAccClusterResourceWorkloadTypeTemplate(""),
-	}, step{
+	}, Step{
 		Template: testAccClusterResourceWorkloadTypeTemplate(`
 		workload_type {
 		    clients {
@@ -147,7 +147,7 @@ func TestAccClusterResource_WorkloadType(t *testing.T) {
 			resource.TestCheckResourceAttr("databricks_cluster.this", "workload_type.0.clients.0.jobs", "true"),
 			resource.TestCheckResourceAttr("databricks_cluster.this", "workload_type.0.clients.0.notebooks", "true"),
 		),
-	}, step{
+	}, Step{
 		Template: testAccClusterResourceWorkloadTypeTemplate(`
 		workload_type {
 		    clients {
@@ -159,7 +159,7 @@ func TestAccClusterResource_WorkloadType(t *testing.T) {
 			resource.TestCheckResourceAttr("databricks_cluster.this", "workload_type.0.clients.0.jobs", "false"),
 			resource.TestCheckResourceAttr("databricks_cluster.this", "workload_type.0.clients.0.notebooks", "false"),
 		),
-	}, step{
+	}, Step{
 		Template: testAccClusterResourceWorkloadTypeTemplate(`
 		workload_type {
 		    clients { }
@@ -168,7 +168,7 @@ func TestAccClusterResource_WorkloadType(t *testing.T) {
 			resource.TestCheckResourceAttr("databricks_cluster.this", "workload_type.0.clients.0.jobs", "true"),
 			resource.TestCheckResourceAttr("databricks_cluster.this", "workload_type.0.clients.0.notebooks", "true"),
 		),
-	}, step{
+	}, Step{
 		Template: testAccClusterResourceWorkloadTypeTemplate(``),
 		Check: resource.ComposeAggregateTestCheckFunc(
 			resource.TestCheckResourceAttr("databricks_cluster.this", "workload_type.#", "0"),

--- a/internal/acceptance/connection_test.go
+++ b/internal/acceptance/connection_test.go
@@ -49,19 +49,19 @@ func connectionTemplateWithoutOwner() string {
 	`
 }
 func TestUcAccConnectionsResourceFullLifecycle(t *testing.T) {
-	unityWorkspaceLevel(t, step{
+	UnityWorkspaceLevel(t, Step{
 		Template: connectionTemplateWithOwner("test.mysql.database.azure.com", "account users"),
-	}, step{
+	}, Step{
 		Template: connectionTemplateWithOwner("test.mysql.database.aws.com", "account users"),
-	}, step{
+	}, Step{
 		Template: connectionTemplateWithOwner("test.mysql.database.azure.com", "{env.TEST_METASTORE_ADMIN_GROUP_NAME}"),
 	})
 }
 
 func TestUcAccConnectionsWithoutOwnerResourceFullLifecycle(t *testing.T) {
-	unityWorkspaceLevel(t, step{
+	UnityWorkspaceLevel(t, Step{
 		Template: connectionTemplateWithoutOwner(),
-	}, step{
+	}, Step{
 		Template: connectionTemplateWithoutOwner(),
 	})
 }

--- a/internal/acceptance/dashboard_test.go
+++ b/internal/acceptance/dashboard_test.go
@@ -89,7 +89,7 @@ func (t *templateStruct) SetAttributes(mapper map[string]string) templateStruct 
 func TestAccBasicDashboard(t *testing.T) {
 	var template templateStruct
 	displayName := fmt.Sprintf("Test Dashboard - %s", qa.RandomName())
-	workspaceLevel(t, step{
+	WorkspaceLevel(t, Step{
 		Template: makeTemplate(template.SetAttributes(map[string]string{
 			"display_name":         displayName,
 			"warehouse_id":         "{env.TEST_DEFAULT_WAREHOUSE_ID}",
@@ -119,7 +119,7 @@ func TestAccBasicDashboard(t *testing.T) {
 func TestAccDashboardWithSerializedJSON(t *testing.T) {
 	var template templateStruct
 	displayName := fmt.Sprintf("Test Dashboard - %s", qa.RandomName())
-	workspaceLevel(t, step{
+	WorkspaceLevel(t, Step{
 		Template: makeTemplate(template.SetAttributes(map[string]string{
 			"display_name":         displayName,
 			"warehouse_id":         "{env.TEST_DEFAULT_WAREHOUSE_ID}",
@@ -142,7 +142,7 @@ func TestAccDashboardWithSerializedJSON(t *testing.T) {
 			require.NoError(t, err)
 			return nil
 		}),
-	}, step{
+	}, Step{
 		Template: makeTemplate(template.SetAttributes(map[string]string{
 			"serialized_dashboard": `{\"pages\":[{\"name\":\"new_name\",\"displayName\":\"New Page Modified\"}]}`,
 			"embed_credentials":    "true",
@@ -174,7 +174,7 @@ func TestAccDashboardWithFilePath(t *testing.T) {
 	fileName := tmpDir + "/Dashboard.json"
 	var template templateStruct
 	displayName := fmt.Sprintf("Test Dashboard - %s", qa.RandomName())
-	workspaceLevel(t, step{
+	WorkspaceLevel(t, Step{
 		PreConfig: func() {
 			os.Mkdir(tmpDir, 0755)
 			os.WriteFile(fileName, []byte("{\"pages\":[{\"name\":\"new_name\",\"displayName\":\"New Page\"}]}"), 0644)
@@ -200,7 +200,7 @@ func TestAccDashboardWithFilePath(t *testing.T) {
 			require.NoError(t, err)
 			return nil
 		}),
-	}, step{
+	}, Step{
 		PreConfig: func() {
 			os.WriteFile(fileName, []byte("{\"pages\":[{\"name\":\"new_name\",\"displayName\":\"New Page Modified\"}]}"), 0644)
 		},
@@ -231,7 +231,7 @@ func TestAccDashboardWithNoChange(t *testing.T) {
 	initial_update_time := ""
 	var template templateStruct
 	displayName := fmt.Sprintf("Test Dashboard - %s", qa.RandomName())
-	workspaceLevel(t, step{
+	WorkspaceLevel(t, Step{
 		Template: makeTemplate(template.SetAttributes(map[string]string{
 			"display_name":         displayName,
 			"warehouse_id":         "{env.TEST_DEFAULT_WAREHOUSE_ID}",
@@ -254,7 +254,7 @@ func TestAccDashboardWithNoChange(t *testing.T) {
 			initial_update_time = dashboard.UpdateTime
 			return nil
 		}),
-	}, step{
+	}, Step{
 		Template: makeTemplate(template),
 		Check: resourceCheck("databricks_dashboard.d1", func(ctx context.Context, client *common.DatabricksClient, id string) error {
 			w, err := client.WorkspaceClient()
@@ -284,7 +284,7 @@ func TestAccDashboardWithRemoteChange(t *testing.T) {
 	etag := ""
 	var template templateStruct
 	displayName := fmt.Sprintf("Test Dashboard - %s", qa.RandomName())
-	workspaceLevel(t, step{
+	WorkspaceLevel(t, Step{
 		Template: makeTemplate(template.SetAttributes(map[string]string{
 			"display_name":         displayName,
 			"warehouse_id":         "{env.TEST_DEFAULT_WAREHOUSE_ID}",
@@ -310,7 +310,7 @@ func TestAccDashboardWithRemoteChange(t *testing.T) {
 			etag = dashboard.Etag
 			return nil
 		}),
-	}, step{
+	}, Step{
 		PreConfig: func() {
 			w, err := databricks.NewWorkspaceClient(&databricks.Config{})
 			require.NoError(t, err)
@@ -355,7 +355,7 @@ func TestAccDashboardTestAll(t *testing.T) {
 	fileName := tmpDir + "/Dashboard.json"
 	var template templateStruct
 	displayName := fmt.Sprintf("Test Dashboard - %s", qa.RandomName())
-	workspaceLevel(t, step{
+	WorkspaceLevel(t, Step{
 		PreConfig: func() {
 			os.Mkdir(tmpDir, 0755)
 			os.WriteFile(fileName, []byte("{\"pages\":[{\"name\":\"new_name\",\"displayName\":\"New Page in file\"}]}"), 0644)
@@ -388,7 +388,7 @@ func TestAccDashboardTestAll(t *testing.T) {
 			require.Equal(t, publish_dash.EmbedCredentials, false)
 			return nil
 		}),
-	}, step{
+	}, Step{
 		PreConfig: func() {
 			os.WriteFile(fileName, []byte("{\"pages\":[{\"name\":\"new_name\",\"displayName\":\"New Page Modified\"}]}"), 0644)
 		},
@@ -414,7 +414,7 @@ func TestAccDashboardTestAll(t *testing.T) {
 			assert.NotEqual(t, "", dashboard.SerializedDashboard)
 			return nil
 		}),
-	}, step{
+	}, Step{
 		PreConfig: func() {
 			w, err := databricks.NewWorkspaceClient(&databricks.Config{})
 			require.NoError(t, err)
@@ -444,7 +444,7 @@ func TestAccDashboardTestAll(t *testing.T) {
 			require.NoError(t, err)
 			return nil
 		}),
-	}, step{
+	}, Step{
 		Template: makeTemplate(template.SetAttributes(map[string]string{
 			"embed_credentials": "true",
 			"parent_path":       "/Shared/Teams",
@@ -466,7 +466,7 @@ func TestAccDashboardTestAll(t *testing.T) {
 			assert.NotEqual(t, "", dashboard.SerializedDashboard)
 			return nil
 		}),
-	}, step{
+	}, Step{
 		PreConfig: func() {
 			os.WriteFile(fileName, []byte("{\"pages\":[{\"name\":\"new_name\",\"displayName\":\"New Page Modified again\"}]}"), 0644)
 		},

--- a/internal/acceptance/data_aws_crossaccount_policy_test.go
+++ b/internal/acceptance/data_aws_crossaccount_policy_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestMwsAccDataSourceAwsCrossaccountPolicy(t *testing.T) {
 	GetEnvOrSkipTest(t, "TEST_ROOT_BUCKET") // marker for AWS test env
-	accountLevel(t, step{
+	AccountLevel(t, Step{
 		Template: `
 		data "databricks_aws_crossaccount_policy" "this" {
 		}`,

--- a/internal/acceptance/data_catalog_test.go
+++ b/internal/acceptance/data_catalog_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestUcAccDataSourceCatalog(t *testing.T) {
-	unityWorkspaceLevel(t, step{
+	UnityWorkspaceLevel(t, Step{
 		Template: `
 		resource "databricks_catalog" "sandbox" {
 			name         = "sandbox{var.RANDOM}"

--- a/internal/acceptance/data_cluster_test.go
+++ b/internal/acceptance/data_cluster_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestAccDataSourceCluster(t *testing.T) {
-	workspaceLevel(t, step{
+	WorkspaceLevel(t, Step{
 		Template: `
 		data "databricks_cluster" "this" {
 			cluster_id = "{env.TEST_DEFAULT_CLUSTER_ID}"

--- a/internal/acceptance/data_clusters_test.go
+++ b/internal/acceptance/data_clusters_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestAccDataSourceClustersNoFilter(t *testing.T) {
-	workspaceLevel(t, step{
+	WorkspaceLevel(t, Step{
 		Template: `
 		data "databricks_clusters" "this" {
 		} `,
@@ -13,7 +13,7 @@ func TestAccDataSourceClustersNoFilter(t *testing.T) {
 }
 
 func TestAccDataSourceClustersWithFilter(t *testing.T) {
-	workspaceLevel(t, step{
+	WorkspaceLevel(t, Step{
 		Template: `
 		data "databricks_clusters" "this" {
 			cluster_name_contains = "Default"

--- a/internal/acceptance/data_current_config_test.go
+++ b/internal/acceptance/data_current_config_test.go
@@ -24,17 +24,17 @@ func checkCurrentConfig(t *testing.T, cloudType string, isAccount string) func(s
 func TestAccDataCurrentConfig(t *testing.T) {
 	loadWorkspaceEnv(t)
 	if isAws(t) {
-		workspaceLevel(t, step{
+		WorkspaceLevel(t, Step{
 			Template: `data "databricks_current_config" "this" {}`,
 			Check:    checkCurrentConfig(t, "aws", "false"),
 		})
 	} else if isAzure(t) {
-		workspaceLevel(t, step{
+		WorkspaceLevel(t, Step{
 			Template: `data "databricks_current_config" "this" {}`,
 			Check:    checkCurrentConfig(t, "azure", "false"),
 		})
 	} else if isGcp(t) {
-		workspaceLevel(t, step{
+		WorkspaceLevel(t, Step{
 			Template: `data "databricks_current_config" "this" {}`,
 			Check:    checkCurrentConfig(t, "gcp", "false"),
 		})
@@ -44,17 +44,17 @@ func TestAccDataCurrentConfig(t *testing.T) {
 func TestMwsAccDataCurrentConfig(t *testing.T) {
 	loadAccountEnv(t)
 	if isAws(t) {
-		accountLevel(t, step{
+		AccountLevel(t, Step{
 			Template: `data "databricks_current_config" "this" {}`,
 			Check:    checkCurrentConfig(t, "aws", "true"),
 		})
 	} else if isAzure(t) {
-		accountLevel(t, step{
+		AccountLevel(t, Step{
 			Template: `data "databricks_current_config" "this" {}`,
 			Check:    checkCurrentConfig(t, "azure", "true"),
 		})
 	} else if isGcp(t) {
-		accountLevel(t, step{
+		AccountLevel(t, Step{
 			Template: `data "databricks_current_config" "this" {}`,
 			Check:    checkCurrentConfig(t, "gcp", "true"),
 		})

--- a/internal/acceptance/data_current_metastore_test.go
+++ b/internal/acceptance/data_current_metastore_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestUcAccDataSourceCurrentMetastore(t *testing.T) {
-	workspaceLevel(t, step{
+	WorkspaceLevel(t, Step{
 		Template: `
 		data "databricks_current_metastore" "this" {
 		}`,

--- a/internal/acceptance/data_external_locations_test.go
+++ b/internal/acceptance/data_external_locations_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestUcAccDataSourceExternalLocations(t *testing.T) {
-	unityWorkspaceLevel(t, step{
+	UnityWorkspaceLevel(t, Step{
 		Template: `
 		data "databricks_external_locations" "this" {
 		}`,

--- a/internal/acceptance/data_group_test.go
+++ b/internal/acceptance/data_group_test.go
@@ -59,7 +59,7 @@ func checkGroupDataSourcePopulated(t *testing.T) func(s *terraform.State) error 
 
 func TestMwsAccGroupDataSplitMembers(t *testing.T) {
 	GetEnvOrSkipTest(t, "ARM_CLIENT_ID")
-	accountLevel(t, step{
+	AccountLevel(t, Step{
 		Template: groupDataSourceTemplate,
 		Check:    checkGroupDataSourcePopulated(t),
 	})
@@ -67,7 +67,7 @@ func TestMwsAccGroupDataSplitMembers(t *testing.T) {
 
 func TestAccGroupDataSplitMembers(t *testing.T) {
 	GetEnvOrSkipTest(t, "ARM_CLIENT_ID")
-	workspaceLevel(t, step{
+	WorkspaceLevel(t, Step{
 		Template: groupDataSourceTemplate,
 		Check:    checkGroupDataSourcePopulated(t),
 	})

--- a/internal/acceptance/data_instance_profiles_test.go
+++ b/internal/acceptance/data_instance_profiles_test.go
@@ -6,7 +6,7 @@ import (
 
 func TestAccDataSourceInstanceProfiles(t *testing.T) {
 	GetEnvOrSkipTest(t, "TEST_EC2_INSTANCE_PROFILE")
-	workspaceLevel(t, step{
+	WorkspaceLevel(t, Step{
 		Template: `
 		data "databricks_instance_profiles" "this" {
 		}

--- a/internal/acceptance/data_job_test.go
+++ b/internal/acceptance/data_job_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestAccDataSourceJob(t *testing.T) {
-	workspaceLevel(t, step{
+	WorkspaceLevel(t, Step{
 		Template: `
 		data "databricks_current_user" "me" {}
 		data "databricks_spark_version" "latest" {}

--- a/internal/acceptance/data_metastore_test.go
+++ b/internal/acceptance/data_metastore_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestUcAccDataSourceMetastore(t *testing.T) {
-	accountLevel(t, step{
+	AccountLevel(t, Step{
 		Template: `
 		data "databricks_metastore" "this" {
 			metastore_id = "{env.TEST_METASTORE_ID}"

--- a/internal/acceptance/data_metastores_test.go
+++ b/internal/acceptance/data_metastores_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestUcAccDataSourceMetastores(t *testing.T) {
-	accountLevel(t, step{
+	AccountLevel(t, Step{
 		Template: `
 		data "databricks_metastores" "this" {
 		}`,

--- a/internal/acceptance/data_mlflow_experiment_test.go
+++ b/internal/acceptance/data_mlflow_experiment_test.go
@@ -8,8 +8,8 @@ import (
 )
 
 func TestAccDataSourceMlflowExperiment(t *testing.T) {
-	workspaceLevel(t,
-		step{
+	WorkspaceLevel(t,
+		Step{
 			Template: `
 				data "databricks_current_user" "me" {}
 
@@ -19,7 +19,7 @@ func TestAccDataSourceMlflowExperiment(t *testing.T) {
 				  description       = "My MLflow experiment description"
 				}`,
 		},
-		step{
+		Step{
 			Template: `
 				data "databricks_current_user" "me" {}
 
@@ -51,7 +51,7 @@ func TestAccDataSourceMlflowExperiment(t *testing.T) {
 				return nil
 			},
 		},
-		step{
+		Step{
 			Template: `
 				data "databricks_current_user" "me" {}
 

--- a/internal/acceptance/data_mlflow_model_test.go
+++ b/internal/acceptance/data_mlflow_model_test.go
@@ -8,8 +8,8 @@ import (
 )
 
 func TestAccDataMlflowModel(t *testing.T) {
-	workspaceLevel(t,
-		step{
+	WorkspaceLevel(t,
+		Step{
 			Template: `
 			resource "databricks_mlflow_model" "this" {
 			  name = "model-{var.RANDOM}"
@@ -26,7 +26,7 @@ func TestAccDataMlflowModel(t *testing.T) {
 			  }
 			}`,
 		},
-		step{
+		Step{
 			Template: `
 			resource "databricks_mlflow_model" "this" {
 			  name = "model-{var.RANDOM}"

--- a/internal/acceptance/data_mws_credentials_test.go
+++ b/internal/acceptance/data_mws_credentials_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestAccDataSourceMwsCredentials(t *testing.T) {
-	accountLevel(t, step{
+	AccountLevel(t, Step{
 		Template: `
 		data "databricks_mws_credentials" "this" {
 		}`,

--- a/internal/acceptance/data_mws_workspaces_test.go
+++ b/internal/acceptance/data_mws_workspaces_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestAccDataSourceMwsWorkspaces(t *testing.T) {
-	accountLevel(t, step{
+	AccountLevel(t, Step{
 		Template: `
 		data "databricks_mws_workspaces" "this" {
 		}`,

--- a/internal/acceptance/data_pipelines_test.go
+++ b/internal/acceptance/data_pipelines_test.go
@@ -48,7 +48,7 @@ var (
 )
 
 func TestAccDataSourcePipelines(t *testing.T) {
-	workspaceLevel(t, step{
+	WorkspaceLevel(t, Step{
 		Template: `
 		locals {
 			name = "pipeline-ds-acceptance-{var.RANDOM}"

--- a/internal/acceptance/data_schema_test.go
+++ b/internal/acceptance/data_schema_test.go
@@ -15,7 +15,7 @@ func checkDataSourceSchema(t *testing.T) func(s *terraform.State) error {
 	}
 }
 func TestUcAccDataSourceSchema(t *testing.T) {
-	unityWorkspaceLevel(t, step{
+	UnityWorkspaceLevel(t, Step{
 		Template: `
 		resource "databricks_catalog" "sandbox" {
 			name         = "sandbox{var.RANDOM}"

--- a/internal/acceptance/data_schemas_test.go
+++ b/internal/acceptance/data_schemas_test.go
@@ -20,7 +20,7 @@ func checkSchemasDataSourcePopulated(t *testing.T) func(s *terraform.State) erro
 	}
 }
 func TestUcAccDataSourceSchemas(t *testing.T) {
-	unityWorkspaceLevel(t, step{
+	UnityWorkspaceLevel(t, Step{
 		Template: `
 		resource "databricks_catalog" "sandbox" {
 			name         = "sandbox{var.RANDOM}"

--- a/internal/acceptance/data_service_principals_test.go
+++ b/internal/acceptance/data_service_principals_test.go
@@ -28,21 +28,21 @@ data databricks_service_principals "this" {
 
 func TestAccDataSourceSPNsOnAWS(t *testing.T) {
 	GetEnvOrSkipTest(t, "TEST_EC2_INSTANCE_PROFILE")
-	workspaceLevel(t, step{
+	WorkspaceLevel(t, Step{
 		Template: spns,
 	})
 }
 
 func TestAccDataSourceSPNsOnGCP(t *testing.T) {
 	GetEnvOrSkipTest(t, "GOOGLE_CREDENTIALS")
-	workspaceLevel(t, step{
+	WorkspaceLevel(t, Step{
 		Template: spns,
 	})
 }
 
 func TestAccDataSourceSPNsOnAzure(t *testing.T) {
 	GetEnvOrSkipTest(t, "ARM_CLIENT_ID")
-	workspaceLevel(t, step{
+	WorkspaceLevel(t, Step{
 		Template: azureSpns,
 	})
 }

--- a/internal/acceptance/data_shares_test.go
+++ b/internal/acceptance/data_shares_test.go
@@ -19,7 +19,7 @@ func checkSharesDataSourcePopulated(t *testing.T) func(s *terraform.State) error
 	}
 }
 func TestUcAccDataSourceShares(t *testing.T) {
-	unityWorkspaceLevel(t, step{
+	UnityWorkspaceLevel(t, Step{
 		Template: `
 		resource "databricks_catalog" "sandbox" {
 			name         = "sandbox{var.RANDOM}"

--- a/internal/acceptance/data_sql_warehouse_test.go
+++ b/internal/acceptance/data_sql_warehouse_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestAccDataSourceWarehouse(t *testing.T) {
-	workspaceLevel(t, step{
+	WorkspaceLevel(t, Step{
 		Template: `
 		data "databricks_sql_warehouse" "this" {
 			id = "{env.TEST_DEFAULT_WAREHOUSE_ID}"

--- a/internal/acceptance/data_storage_credential_test.go
+++ b/internal/acceptance/data_storage_credential_test.go
@@ -20,7 +20,7 @@ func checkStorageCredentialDataSourcePopulated(t *testing.T) func(s *terraform.S
 	}
 }
 func TestUcAccDataSourceStorageCredential(t *testing.T) {
-	unityWorkspaceLevel(t, step{
+	UnityWorkspaceLevel(t, Step{
 		Template: `
 		resource "databricks_storage_credential" "external" {
 			name = "cred-{var.RANDOM}"

--- a/internal/acceptance/data_storage_credentials_test.go
+++ b/internal/acceptance/data_storage_credentials_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestUcAccDataSourceStorageCredentials(t *testing.T) {
-	unityWorkspaceLevel(t, step{
+	UnityWorkspaceLevel(t, Step{
 		Template: `
 		data "databricks_storage_credentials" "this" {
 		}`,

--- a/internal/acceptance/data_table_test.go
+++ b/internal/acceptance/data_table_test.go
@@ -15,7 +15,7 @@ func checkTableDataSourcePopulated(t *testing.T) func(s *terraform.State) error 
 	}
 }
 func TestUcAccDataSourceTable(t *testing.T) {
-	unityWorkspaceLevel(t, step{
+	UnityWorkspaceLevel(t, Step{
 		Template: `
 		resource "databricks_catalog" "sandbox" {
 			name         = "sandbox{var.RANDOM}"

--- a/internal/acceptance/data_tables_test.go
+++ b/internal/acceptance/data_tables_test.go
@@ -25,7 +25,7 @@ func checkTablesDataSourcePopulated(t *testing.T) func(s *terraform.State) error
 	}
 }
 func TestUcAccDataSourceTables(t *testing.T) {
-	unityWorkspaceLevel(t, step{
+	UnityWorkspaceLevel(t, Step{
 		Template: `
 		resource "databricks_catalog" "sandbox" {
 			name         = "sandbox{var.RANDOM}"

--- a/internal/acceptance/data_user_test.go
+++ b/internal/acceptance/data_user_test.go
@@ -26,14 +26,14 @@ func checkUserDataSourcePopulated(t *testing.T) func(s *terraform.State) error {
 }
 
 func TestMwsAccUserData(t *testing.T) {
-	accountLevel(t, step{
+	AccountLevel(t, Step{
 		Template: userDataSourceTemplate,
 		Check:    checkUserDataSourcePopulated(t),
 	})
 }
 
 func TestAccUserData(t *testing.T) {
-	workspaceLevel(t, step{
+	WorkspaceLevel(t, Step{
 		Template: userDataSourceTemplate,
 		Check:    checkUserDataSourcePopulated(t),
 	})

--- a/internal/acceptance/data_volume_test.go
+++ b/internal/acceptance/data_volume_test.go
@@ -15,7 +15,7 @@ func checkDataSourceVolume(t *testing.T) func(s *terraform.State) error {
 	}
 }
 func TestUcAccDataSourceVolume(t *testing.T) {
-	unityWorkspaceLevel(t, step{
+	UnityWorkspaceLevel(t, Step{
 		Template: `
 		resource "databricks_catalog" "sandbox" {
 			name         = "sandbox{var.RANDOM}"

--- a/internal/acceptance/data_volumes_test.go
+++ b/internal/acceptance/data_volumes_test.go
@@ -19,7 +19,7 @@ func checkDataSourceVolumesPopulated(t *testing.T) func(s *terraform.State) erro
 	}
 }
 func TestUcAccDataSourceVolumes(t *testing.T) {
-	unityWorkspaceLevel(t, step{
+	UnityWorkspaceLevel(t, Step{
 		Template: `
 		resource "databricks_catalog" "sandbox" {
 			name         = "sandbox{var.RANDOM}"
@@ -70,7 +70,7 @@ func checkDataSourceVolumesPluginFrameworkPopulated(t *testing.T) func(s *terraf
 }
 
 func TestUcAccDataSourceVolumesPluginFramework(t *testing.T) {
-	unityWorkspaceLevel(t, step{
+	UnityWorkspaceLevel(t, Step{
 		Template: `
 		resource "databricks_catalog" "sandbox" {
 			name         = "sandbox{var.RANDOM}"

--- a/internal/acceptance/dbfs_file_test.go
+++ b/internal/acceptance/dbfs_file_test.go
@@ -5,12 +5,12 @@ import (
 )
 
 func TestAccDatabricksDBFSFile_CreateViaContent(t *testing.T) {
-	workspaceLevel(t, step{
+	WorkspaceLevel(t, Step{
 		Template: `resource "databricks_dbfs_file" "this" {
 			content_base64 = base64encode("{var.RANDOM}")
 			path = "/tmp/tf-test/{var.RANDOM}.bin"
 		}`,
-	}, step{
+	}, Step{
 		Template: `resource "databricks_dbfs_file" "this" {
 			content_base64 = base64encode("{var.RANDOM}-changed")
 			path = "/tmp/tf-test/{var.RANDOM}.bin"
@@ -19,7 +19,7 @@ func TestAccDatabricksDBFSFile_CreateViaContent(t *testing.T) {
 }
 
 func TestAccDatabricksDBFSFile_CreateViaSource(t *testing.T) {
-	workspaceLevel(t, step{
+	WorkspaceLevel(t, Step{
 		Template: `resource "databricks_dbfs_file" "file_1" {
 			source = "{var.CWD}/../../storage/testdata/tf-test-python.py"
 			path = "/tmp/tf-test/file-source-{var.RANDOM}"

--- a/internal/acceptance/default_namespace_test.go
+++ b/internal/acceptance/default_namespace_test.go
@@ -21,7 +21,7 @@ func TestAccDefaultNamespaceSetting(t *testing.T) {
 		}
 	}
 	`
-	workspaceLevel(t, step{
+	WorkspaceLevel(t, Step{
 		Template: template,
 		Check: resourceCheckWithState("databricks_default_namespace_setting.this",
 			func(ctx context.Context, client *common.DatabricksClient, state *terraform.InstanceState) error {
@@ -39,7 +39,7 @@ func TestAccDefaultNamespaceSetting(t *testing.T) {
 				return nil
 			}),
 	},
-		step{
+		Step{
 			Template: template,
 			Destroy:  true,
 			Check: resourceCheck("databricks_default_namespace_setting.this", func(ctx context.Context, client *common.DatabricksClient, id string) error {

--- a/internal/acceptance/directory_test.go
+++ b/internal/acceptance/directory_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestAccDirectoryResource(t *testing.T) {
-	workspaceLevel(t, step{
+	WorkspaceLevel(t, Step{
 		Template: `resource "databricks_directory" "this" {
 			path = "/Shared/provider-test/dir_{var.RANDOM}"
 		}

--- a/internal/acceptance/entitlements_test.go
+++ b/internal/acceptance/entitlements_test.go
@@ -21,13 +21,13 @@ func (e entitlement) String() string {
 	return fmt.Sprintf("%s = %t", e.name, e.value)
 }
 
-func entitlementsStepBuilder(t *testing.T, r entitlementResource) func(entitlements []entitlement) step {
-	return func(entitlements []entitlement) step {
+func entitlementsStepBuilder(t *testing.T, r entitlementResource) func(entitlements []entitlement) Step {
+	return func(entitlements []entitlement) Step {
 		entitlementsBuf := strings.Builder{}
 		for _, entitlement := range entitlements {
 			entitlementsBuf.WriteString(fmt.Sprintf("%s\n", entitlement.String()))
 		}
-		return step{
+		return Step{
 			Template: fmt.Sprintf(`
 			%s
 			resource "databricks_entitlements" "entitlements_users" {
@@ -56,10 +56,10 @@ func entitlementsStepBuilder(t *testing.T, r entitlementResource) func(entitleme
 	}
 }
 
-func makeEntitlementsSteps(t *testing.T, r entitlementResource, entitlementsSteps [][]entitlement) []step {
+func makeEntitlementsSteps(t *testing.T, r entitlementResource, entitlementsSteps [][]entitlement) []Step {
 	r.setDisplayName(RandomName("entitlements-"))
 	makeEntitlementsStep := entitlementsStepBuilder(t, r)
-	steps := make([]step, len(entitlementsSteps))
+	steps := make([]Step, len(entitlementsSteps))
 	for i, entitlements := range entitlementsSteps {
 		steps[i] = makeEntitlementsStep(entitlements)
 	}
@@ -114,7 +114,7 @@ func TestAccEntitlementsAddToEmpty(t *testing.T) {
 				{"databricks_sql_access", true},
 			},
 		})
-		workspaceLevel(t, steps...)
+		WorkspaceLevel(t, steps...)
 	})
 }
 
@@ -135,7 +135,7 @@ func TestAccEntitlementsSetExplicitlyToFalse(t *testing.T) {
 				{"databricks_sql_access", false},
 			},
 		})
-		workspaceLevel(t, steps...)
+		WorkspaceLevel(t, steps...)
 	})
 }
 
@@ -150,7 +150,7 @@ func TestAccEntitlementsRemoveExisting(t *testing.T) {
 			},
 			{},
 		})
-		workspaceLevel(t, steps...)
+		WorkspaceLevel(t, steps...)
 	})
 }
 
@@ -164,6 +164,6 @@ func TestAccEntitlementsSomeTrueSomeFalse(t *testing.T) {
 				{"databricks_sql_access", true},
 			},
 		})
-		workspaceLevel(t, steps...)
+		WorkspaceLevel(t, steps...)
 	})
 }

--- a/internal/acceptance/external_location_test.go
+++ b/internal/acceptance/external_location_test.go
@@ -44,7 +44,7 @@ func storageCredentialTemplateWithOwner(comment, owner string) string {
 }
 
 func TestUcAccExternalLocation(t *testing.T) {
-	unityWorkspaceLevel(t, step{
+	UnityWorkspaceLevel(t, Step{
 		Template: `
 		resource "databricks_storage_credential" "external" {
 			name = "cred-{var.RANDOM}"
@@ -64,7 +64,7 @@ func TestUcAccExternalLocation(t *testing.T) {
 }
 
 func TestUcAccExternalLocationForceDestroy(t *testing.T) {
-	unityWorkspaceLevel(t, step{
+	UnityWorkspaceLevel(t, Step{
 		Template: `
 		resource "databricks_storage_credential" "external" {
 			name = "cred-{var.RANDOM}"
@@ -85,19 +85,19 @@ func TestUcAccExternalLocationForceDestroy(t *testing.T) {
 }
 
 func TestUcAccExternalLocationUpdate(t *testing.T) {
-	unityWorkspaceLevel(t, step{
+	UnityWorkspaceLevel(t, Step{
 		Template: storageCredentialTemplateWithOwner("Managed by TF", "account users") +
 			externalLocationTemplateWithOwner("Managed by TF", "account users") +
 			grantsTemplateForExternalLocation,
-	}, step{
+	}, Step{
 		Template: storageCredentialTemplateWithOwner("Managed by TF -- Updated Comment", "account users") +
 			externalLocationTemplateWithOwner("Managed by TF -- Updated Comment", "account users") +
 			grantsTemplateForExternalLocation,
-	}, step{
+	}, Step{
 		Template: storageCredentialTemplateWithOwner("Managed by TF -- Updated Comment", "{env.TEST_DATA_ENG_GROUP}") +
 			externalLocationTemplateWithOwner("Managed by TF -- Updated Comment", "{env.TEST_DATA_ENG_GROUP}") +
 			grantsTemplateForExternalLocation,
-	}, step{
+	}, Step{
 		Template: storageCredentialTemplateWithOwner("Managed by TF -- Updated Comment 2", "{env.TEST_METASTORE_ADMIN_GROUP_NAME}") +
 			externalLocationTemplateWithOwner("Managed by TF -- Updated Comment 2", "{env.TEST_METASTORE_ADMIN_GROUP_NAME}") +
 			grantsTemplateForExternalLocation,

--- a/internal/acceptance/file_test.go
+++ b/internal/acceptance/file_test.go
@@ -18,7 +18,7 @@ import (
 
 func TestUcAccFileDontUpdateIfNoChange(t *testing.T) {
 	createdTime := ""
-	unityWorkspaceLevel(t, step{
+	UnityWorkspaceLevel(t, Step{
 		Template: `
 		resource "databricks_schema" "this" {
 			name 		 = "schema-{var.STICKY_RANDOM}"
@@ -50,7 +50,7 @@ func TestUcAccFileDontUpdateIfNoChange(t *testing.T) {
 			createdTime = m.LastModified
 			return nil
 		}),
-	}, step{
+	}, Step{
 		Template: `
 		resource "databricks_schema" "this" {
 			name 		 = "schema-{var.STICKY_RANDOM}"
@@ -86,7 +86,7 @@ func TestUcAccFileDontUpdateIfNoChange(t *testing.T) {
 
 func TestUcAccFileUpdateOnLocalContentChange(t *testing.T) {
 	createdTime := ""
-	unityWorkspaceLevel(t, step{
+	UnityWorkspaceLevel(t, Step{
 		Template: `
 		resource "databricks_schema" "this" {
 			name 		 = "schema-{var.STICKY_RANDOM}"
@@ -118,7 +118,7 @@ func TestUcAccFileUpdateOnLocalContentChange(t *testing.T) {
 			createdTime = m.LastModified
 			return nil
 		}),
-	}, step{
+	}, Step{
 		Template: `
 		resource "databricks_schema" "this" {
 			name 		 = "schema-{var.STICKY_RANDOM}"
@@ -174,7 +174,7 @@ func TestUcAccFileUpdateOnLocalFileChange(t *testing.T) {
 		source = "%s"
 		path = "/Volumes/${databricks_volume.this.catalog_name}/${databricks_volume.this.schema_name}/${databricks_volume.this.name}/abcde"
 	}`, fileName)
-	unityWorkspaceLevel(t, step{
+	UnityWorkspaceLevel(t, Step{
 		PreConfig: func() {
 			os.Mkdir(tmpDir, 0755)
 			os.WriteFile(fileName, []byte("abc\n"), 0644)
@@ -193,7 +193,7 @@ func TestUcAccFileUpdateOnLocalFileChange(t *testing.T) {
 			createdTime = m.LastModified
 			return nil
 		}),
-	}, step{
+	}, Step{
 		PreConfig: func() {
 			os.WriteFile(fileName, []byte("def\n"), 0644)
 		},
@@ -235,7 +235,7 @@ func TestUcAccFileNoUpdateIfFileDoesNotChange(t *testing.T) {
 		source = "%s"
 		path = "/Volumes/${databricks_volume.this.catalog_name}/${databricks_volume.this.schema_name}/${databricks_volume.this.name}/abcde"
 	}`, fileName)
-	unityWorkspaceLevel(t, step{
+	UnityWorkspaceLevel(t, Step{
 		PreConfig: func() {
 			os.Mkdir(tmpDir, 0755)
 			os.WriteFile(fileName, []byte("abc\n"), 0644)
@@ -254,7 +254,7 @@ func TestUcAccFileNoUpdateIfFileDoesNotChange(t *testing.T) {
 			createdTime = m.LastModified
 			return nil
 		}),
-	}, step{
+	}, Step{
 		Template: template,
 		Check: resourceCheck("databricks_file.this", func(ctx context.Context, client *common.DatabricksClient, id string) error {
 			w, err := client.WorkspaceClient()
@@ -273,7 +273,7 @@ func TestUcAccFileNoUpdateIfFileDoesNotChange(t *testing.T) {
 
 func TestUcAccFileUpdateServerChange(t *testing.T) {
 	createdTime := ""
-	unityWorkspaceLevel(t, step{
+	UnityWorkspaceLevel(t, Step{
 		Template: `
 		resource "databricks_schema" "this" {
 			name 		 = "schema-{var.STICKY_RANDOM}"
@@ -314,7 +314,7 @@ func TestUcAccFileUpdateServerChange(t *testing.T) {
 			return nil
 		}),
 	},
-		step{
+		Step{
 			Template: `
 		resource "databricks_schema" "this" {
 			name 		 = "schema-{var.STICKY_RANDOM}"
@@ -356,7 +356,7 @@ func TestUcAccFileUpdateServerChange(t *testing.T) {
 }
 
 func TestUcAccFileFullLifeCycle(t *testing.T) {
-	unityWorkspaceLevel(t, step{
+	UnityWorkspaceLevel(t, Step{
 		Template: `
 		resource "databricks_schema" "this" {
 			name 		 = "schema-{var.STICKY_RANDOM}"
@@ -375,7 +375,7 @@ func TestUcAccFileFullLifeCycle(t *testing.T) {
 			source = "{var.CWD}/../../storage/testdata/tf-test-python.py"
 			path = "/Volumes/${databricks_volume.this.catalog_name}/${databricks_volume.this.schema_name}/${databricks_volume.this.name}/abcde"
 		}`,
-	}, step{
+	}, Step{
 		Template: `
 		resource "databricks_schema" "this" {
 			name 		 = "schema-{var.STICKY_RANDOM}"
@@ -398,7 +398,7 @@ func TestUcAccFileFullLifeCycle(t *testing.T) {
 }
 
 func TestUcAccFileBase64FullLifeCycle(t *testing.T) {
-	unityWorkspaceLevel(t, step{
+	UnityWorkspaceLevel(t, Step{
 		Template: `
 		resource "databricks_schema" "this" {
 			name 		 = "schema-{var.STICKY_RANDOM}"
@@ -417,7 +417,7 @@ func TestUcAccFileBase64FullLifeCycle(t *testing.T) {
 			content_base64 = "YWJjCg=="
 			path = "/Volumes/${databricks_volume.this.catalog_name}/${databricks_volume.this.schema_name}/${databricks_volume.this.name}/abcde"
 		}`,
-	}, step{
+	}, Step{
 		Template: `
 		resource "databricks_schema" "this" {
 			name 		 = "schema-{var.STICKY_RANDOM}"

--- a/internal/acceptance/git_credential_test.go
+++ b/internal/acceptance/git_credential_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestAccGitCredentials(t *testing.T) {
-	workspaceLevel(t, step{
+	WorkspaceLevel(t, Step{
 		Template: `resource "databricks_git_credential" "this" {
 			git_username = "test"
 			git_provider = "gitHub"

--- a/internal/acceptance/global_init_script_test.go
+++ b/internal/acceptance/global_init_script_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestAccGlobalInitScriptResource_Create(t *testing.T) {
-	workspaceLevel(t, step{
+	WorkspaceLevel(t, Step{
 		Template: `
 		resource "databricks_global_init_script" "this" {
 			name = "init-{var.RANDOM}"

--- a/internal/acceptance/grant_test.go
+++ b/internal/acceptance/grant_test.go
@@ -99,11 +99,11 @@ resource "databricks_grant" "some" {
 }`
 
 func TestUcAccGrant(t *testing.T) {
-	unityWorkspaceLevel(t, step{
+	UnityWorkspaceLevel(t, Step{
 		Template: strings.ReplaceAll(grantTemplate, "%s", "{env.TEST_DATA_ENG_GROUP}"),
-	}, step{
+	}, Step{
 		Template: strings.ReplaceAll(grantTemplate, "%s", "{env.TEST_DATA_SCI_GROUP}"),
-	}, step{
+	}, Step{
 		Template: strings.ReplaceAll(strings.ReplaceAll(grantTemplate, "ALL_PRIVILEGES", "ALL PRIVILEGES"), "%s", "{env.TEST_DATA_ENG_GROUP}"),
 	})
 }
@@ -127,11 +127,11 @@ func grantTemplateForNamePermissionChange(suffix string, permission string) stri
 }
 
 func TestUcAccGrantForIdChange(t *testing.T) {
-	unityWorkspaceLevel(t, step{
+	UnityWorkspaceLevel(t, Step{
 		Template: grantTemplateForNamePermissionChange("-old", "ALL_PRIVILEGES"),
-	}, step{
+	}, Step{
 		Template: grantTemplateForNamePermissionChange("-new", "ALL_PRIVILEGES"),
-	}, step{
+	}, Step{
 		Template:    grantTemplateForNamePermissionChange("-fail", "abc"),
 		ExpectError: regexp.MustCompile(`cannot create grant: Privilege ABC is not applicable to this entity`),
 	})

--- a/internal/acceptance/grants_test.go
+++ b/internal/acceptance/grants_test.go
@@ -105,11 +105,11 @@ resource "databricks_grants" "some" {
 }`
 
 func TestUcAccGrants(t *testing.T) {
-	unityWorkspaceLevel(t, step{
+	UnityWorkspaceLevel(t, Step{
 		Template: strings.ReplaceAll(grantsTemplate, "%s", "{env.TEST_DATA_ENG_GROUP}"),
-	}, step{
+	}, Step{
 		Template: strings.ReplaceAll(grantsTemplate, "%s", "{env.TEST_DATA_SCI_GROUP}"),
-	}, step{
+	}, Step{
 		Template: strings.ReplaceAll(strings.ReplaceAll(grantsTemplate, "ALL_PRIVILEGES", "ALL PRIVILEGES"), "%s", "{env.TEST_DATA_ENG_GROUP}"),
 	})
 }
@@ -135,11 +135,11 @@ func grantsTemplateForNamePermissionChange(suffix string, permission string) str
 }
 
 func TestUcAccGrantsForIdChange(t *testing.T) {
-	unityWorkspaceLevel(t, step{
+	UnityWorkspaceLevel(t, Step{
 		Template: grantsTemplateForNamePermissionChange("-old", "ALL_PRIVILEGES"),
-	}, step{
+	}, Step{
 		Template: grantsTemplateForNamePermissionChange("-new", "ALL_PRIVILEGES"),
-	}, step{
+	}, Step{
 		Template:    grantsTemplateForNamePermissionChange("-fail", "abc"),
 		ExpectError: regexp.MustCompile(`Error: cannot create grants: Privilege ABC is not applicable to this entity`),
 	})

--- a/internal/acceptance/group_member_test.go
+++ b/internal/acceptance/group_member_test.go
@@ -29,7 +29,7 @@ resource "databricks_group_member" "rs" {
 }`
 
 func TestMwsAccGroupMemberResource(t *testing.T) {
-	accountLevel(t, step{
+	AccountLevel(t, Step{
 		Template: groupMemberTest,
 		Check: resourceCheck("databricks_group.root",
 			func(ctx context.Context, client *common.DatabricksClient, id string) error {
@@ -44,7 +44,7 @@ func TestMwsAccGroupMemberResource(t *testing.T) {
 }
 
 func TestAccGroupMemberResource(t *testing.T) {
-	workspaceLevel(t, step{
+	WorkspaceLevel(t, Step{
 		Template: groupMemberTest,
 		Check: resourceCheck("databricks_group.root",
 			func(ctx context.Context, client *common.DatabricksClient, id string) error {

--- a/internal/acceptance/group_role_test.go
+++ b/internal/acceptance/group_role_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestAccGroupRole(t *testing.T) {
-	workspaceLevel(t, step{
+	WorkspaceLevel(t, Step{
 		Template: `
 		resource "databricks_group" "this" {
 			display_name = "tf-{var.RANDOM}"

--- a/internal/acceptance/group_test.go
+++ b/internal/acceptance/group_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestMwsAccGroupsExternalIdAndScimProvisioning(t *testing.T) {
 	name := qa.RandomName("tfgroup")
-	accountLevel(t, step{
+	AccountLevel(t, Step{
 		Template: `resource "databricks_group" "this" {
 			display_name = "` + name + `"
 		}`,
@@ -33,7 +33,7 @@ func TestMwsAccGroupsExternalIdAndScimProvisioning(t *testing.T) {
 				return groupsAPI.UpdateNameAndEntitlements(
 					id, group.DisplayName, qa.RandomName("ext-id"), group.Entitlements)
 			}),
-	}, step{
+	}, Step{
 		Template: `resource "databricks_group" "this" {
 			display_name = "` + name + `"
 		}`,
@@ -43,7 +43,7 @@ func TestMwsAccGroupsExternalIdAndScimProvisioning(t *testing.T) {
 // https://github.com/databricks/terraform-provider-databricks/issues/1099
 func TestAccGroupsExternalIdAndScimProvisioning(t *testing.T) {
 	name := qa.RandomName("tfgroup")
-	workspaceLevel(t, step{
+	WorkspaceLevel(t, Step{
 		Template: `resource "databricks_group" "this" {
 			display_name = "` + name + `"
 			allow_cluster_create = true
@@ -63,7 +63,7 @@ func TestAccGroupsExternalIdAndScimProvisioning(t *testing.T) {
 						id, group.DisplayName, qa.RandomName("ext-id"), group.Entitlements)
 				}),
 		),
-	}, step{
+	}, Step{
 		Template: `resource "databricks_group" "this" {
 			display_name = "` + name + `"
 			allow_cluster_create = true
@@ -74,7 +74,7 @@ func TestAccGroupsExternalIdAndScimProvisioning(t *testing.T) {
 func TestMwsAccGroupsUpdateDisplayName(t *testing.T) {
 	nameInit := qa.RandomName("tfgroup")
 	nameUpdate := qa.RandomName("tfgroup")
-	accountLevel(t, step{
+	AccountLevel(t, Step{
 		Template: `resource "databricks_group" "this" {
 			display_name = "` + nameInit + `"
 		}`,
@@ -91,7 +91,7 @@ func TestMwsAccGroupsUpdateDisplayName(t *testing.T) {
 					return nil
 				}),
 		),
-	}, step{
+	}, Step{
 		Template: `resource "databricks_group" "this" {
 			display_name = "` + nameUpdate + `"
 		}`,
@@ -113,7 +113,7 @@ func TestMwsAccGroupsUpdateDisplayName(t *testing.T) {
 func TestAccGroupsUpdateDisplayName(t *testing.T) {
 	nameInit := qa.RandomName("tfgroup")
 	nameUpdate := qa.RandomName("tfgroup")
-	workspaceLevel(t, step{
+	WorkspaceLevel(t, Step{
 		Template: `resource "databricks_group" "this" {
 			display_name = "` + nameInit + `"
 		}`,
@@ -130,7 +130,7 @@ func TestAccGroupsUpdateDisplayName(t *testing.T) {
 					return nil
 				}),
 		),
-	}, step{
+	}, Step{
 		Template: `resource "databricks_group" "this" {
 			display_name = "` + nameUpdate + `"
 		}`,

--- a/internal/acceptance/init.go
+++ b/internal/acceptance/init.go
@@ -36,28 +36,28 @@ func init() {
 	dbproviderlogger.SetTfLogger(dbproviderlogger.NewTfLogger(context.Background()))
 }
 
-func workspaceLevel(t *testing.T, steps ...step) {
+func WorkspaceLevel(t *testing.T, steps ...Step) {
 	loadWorkspaceEnv(t)
 	run(t, steps)
 }
 
-func accountLevel(t *testing.T, steps ...step) {
+func AccountLevel(t *testing.T, steps ...Step) {
 	loadAccountEnv(t)
 	run(t, steps)
 }
 
-func unityWorkspaceLevel(t *testing.T, steps ...step) {
+func UnityWorkspaceLevel(t *testing.T, steps ...Step) {
 	loadUcwsEnv(t)
 	run(t, steps)
 }
 
-func unityAccountLevel(t *testing.T, steps ...step) {
+func UnityAccountLevel(t *testing.T, steps ...Step) {
 	loadUcacctEnv(t)
 	run(t, steps)
 }
 
 // A step in a terraform acceptance test
-type step struct {
+type Step struct {
 	// Terraform HCL for resources to materialize in this test step.
 	Template string
 
@@ -132,7 +132,7 @@ func environmentTemplate(t *testing.T, template string, otherVars ...map[string]
 
 // Test wrapper over terraform testing framework. Multiple steps share the same
 // terraform state context.
-func run(t *testing.T, steps []step) {
+func run(t *testing.T, steps []Step) {
 	cloudEnv := os.Getenv("CLOUD_ENV")
 	if cloudEnv == "" {
 		t.Skip("Acceptance tests skipped unless env 'CLOUD_ENV' is set")

--- a/internal/acceptance/instance_profile_test.go
+++ b/internal/acceptance/instance_profile_test.go
@@ -7,9 +7,9 @@ import (
 // "databricks_instance_profile" is a singleton. To avoid multiple tests using this resource
 // from interfering with each other, we run them in sequence as steps of a single test.
 func TestAccInstanceProfileIntegrationSuite(t *testing.T) {
-	workspaceLevel(t,
+	WorkspaceLevel(t,
 		// Assign instance profile to group
-		step{
+		Step{
 			Template: `
 		resource "databricks_instance_profile" "this" {
 			instance_profile_arn = "{env.DUMMY_EC2_INSTANCE_PROFILE}"
@@ -22,7 +22,7 @@ func TestAccInstanceProfileIntegrationSuite(t *testing.T) {
 			instance_profile_id = databricks_instance_profile.this.id
 		}`},
 		// Assign instance profile to mount
-		step{
+		Step{
 			Template: `
 			resource "databricks_instance_profile" "this" {
 				instance_profile_arn = "{env.DUMMY_EC2_INSTANCE_PROFILE}"
@@ -37,7 +37,7 @@ func TestAccInstanceProfileIntegrationSuite(t *testing.T) {
 			}`,
 		},
 		// ServicePrincipal resource on Aws with role
-		step{
+		Step{
 			Template: `
 			resource "databricks_service_principal" "this" {
 				display_name = "SPN {var.RANDOM}"

--- a/internal/acceptance/ip_access_list_test.go
+++ b/internal/acceptance/ip_access_list_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestAccIPACLListsResourceFullLifecycle(t *testing.T) {
-	workspaceLevel(t, step{
+	WorkspaceLevel(t, Step{
 		Template: `
 		resource "databricks_ip_access_list" "this" {
 			label = "tf-{var.RANDOM}"
@@ -15,7 +15,7 @@ func TestAccIPACLListsResourceFullLifecycle(t *testing.T) {
 				"10.0.10.0/24"
 			]
 		}`,
-	}, step{
+	}, Step{
 		Template: `
 		resource "databricks_ip_access_list" "this" {
 			label = "tf-{var.RANDOM}"

--- a/internal/acceptance/job_test.go
+++ b/internal/acceptance/job_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestAccJobTasks(t *testing.T) {
-	workspaceLevel(t, step{
+	WorkspaceLevel(t, Step{
 		Template: `
 		data "databricks_current_user" "me" {}
 		data "databricks_spark_version" "latest" {}
@@ -120,7 +120,7 @@ func TestAccJobTasks(t *testing.T) {
 
 func TestAccForEachTask(t *testing.T) {
 	t.Skip("Skipping this test because feature not enabled in Prod")
-	workspaceLevel(t, step{
+	WorkspaceLevel(t, Step{
 		Template: `
 		data "databricks_current_user" "me" {}
 		data "databricks_spark_version" "latest" {}
@@ -282,19 +282,19 @@ func TestAccJobControlRunState(t *testing.T) {
 	}
 	randomName1 := RandomName("notebook-")
 	randomName2 := RandomName("updated-notebook-")
-	workspaceLevel(t, step{
+	WorkspaceLevel(t, Step{
 		// A new continuous job with empty block should be started automatically
 		Template: getJobTemplate(randomName1, ``),
 		Check:    resourceCheck("databricks_job.this", waitForRunToStart),
-	}, step{
+	}, Step{
 		// Updating the notebook should cancel the existing run
 		Template: getJobTemplate(randomName2, ``),
 		Check:    resourceCheck("databricks_job.this", waitForRunToStart),
-	}, step{
+	}, Step{
 		// Marking the job as paused should cancel existing run and not start a new one
 		Template: getJobTemplate(randomName2, `pause_status = "PAUSED"`),
 		Check:    resourceCheck("databricks_job.this", waitForAllRunsToEnd),
-	}, step{
+	}, Step{
 		// No pause status should be the equivalent of unpaused
 		Template: getJobTemplate(randomName2, `pause_status = "UNPAUSED"`),
 		Check:    resourceCheck("databricks_job.this", waitForRunToStart),
@@ -346,7 +346,7 @@ func runAsTemplate(runAs string) string {
 }
 
 func TestAccJobRunAsUser(t *testing.T) {
-	workspaceLevel(t, step{
+	WorkspaceLevel(t, Step{
 		Template: `
 		resource "databricks_user" "this" {
 			user_name = "` + qa.RandomEmail() + `"
@@ -358,7 +358,7 @@ func TestAccJobRunAsUser(t *testing.T) {
 func TestUcAccJobRunAsServicePrincipal(t *testing.T) {
 	loadUcwsEnv(t)
 	spId := GetEnvOrSkipTest(t, "ACCOUNT_LEVEL_SERVICE_PRINCIPAL_ID")
-	unityWorkspaceLevel(t, step{
+	UnityWorkspaceLevel(t, Step{
 		Template: runAsTemplate(`service_principal_name = "` + spId + `"`),
 	})
 }
@@ -378,18 +378,18 @@ func TestUcAccJobRunAsMutations(t *testing.T) {
 	// Note: the attribute must match the type of principal that the test is run as.
 	ctx := context.Background()
 	attribute := getRunAsAttribute(t, ctx)
-	unityWorkspaceLevel(
+	UnityWorkspaceLevel(
 		t,
 		// Provision job with service principal `run_as`
-		step{
+		Step{
 			Template: runAsTemplate(`service_principal_name = "` + spId + `"`),
 		},
 		// Update job to a user `run_as`
-		step{
+		Step{
 			Template: runAsTemplate(attribute + ` = data.databricks_current_user.me.user_name`),
 		},
 		// Update job back to a service principal `run_as`
-		step{
+		Step{
 			Template: runAsTemplate(`service_principal_name = "` + spId + `"`),
 		},
 	)
@@ -397,7 +397,7 @@ func TestUcAccJobRunAsMutations(t *testing.T) {
 
 func TestAccRemoveWebhooks(t *testing.T) {
 	skipf(t)("There is no API to create notification destinations. Once available, add here and enable this test.")
-	workspaceLevel(t, step{
+	WorkspaceLevel(t, Step{
 		Template: `
 		resource databricks_job test {
 			webhook_notifications {
@@ -407,7 +407,7 @@ func TestAccRemoveWebhooks(t *testing.T) {
 			}
 		}
 		`,
-	}, step{
+	}, Step{
 		Template: `
 		resource databricks_job test {}
 		`,
@@ -415,7 +415,7 @@ func TestAccRemoveWebhooks(t *testing.T) {
 }
 
 func TestAccPeriodicTrigger(t *testing.T) {
-	workspaceLevel(t, step{
+	WorkspaceLevel(t, Step{
 		Template: `
 		resource "databricks_job" "this" {
 			name = "{var.RANDOM}"

--- a/internal/acceptance/metastore_assignment_test.go
+++ b/internal/acceptance/metastore_assignment_test.go
@@ -15,7 +15,7 @@ func lockForTest(t *testing.T) func() {
 }
 
 func TestUcAccMetastoreAssignment(t *testing.T) {
-	unityWorkspaceLevel(t, step{
+	UnityWorkspaceLevel(t, Step{
 		PreConfig: lockForTest(t),
 		Template: `resource "databricks_metastore_assignment" "this" {
 			metastore_id = "{env.TEST_METASTORE_ID}"
@@ -25,13 +25,13 @@ func TestUcAccMetastoreAssignment(t *testing.T) {
 }
 
 func TestUcAccAccountMetastoreAssignment(t *testing.T) {
-	unityAccountLevel(t, step{
+	UnityAccountLevel(t, Step{
 		PreConfig: lockForTest(t),
 		Template: `resource "databricks_metastore_assignment" "this" {
 			metastore_id = "{env.TEST_METASTORE_ID}"
 			workspace_id = {env.DUMMY_WORKSPACE_ID}
 		}`,
-	}, step{
+	}, Step{
 		Template: `resource "databricks_metastore_assignment" "this" {
 			metastore_id = "{env.TEST_METASTORE_ID}"
 			workspace_id = {env.DUMMY2_WORKSPACE_ID}

--- a/internal/acceptance/metastore_data_access_test.go
+++ b/internal/acceptance/metastore_data_access_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestUcAccAccountMetastoreDataAccessOnAws(t *testing.T) {
-	unityAccountLevel(t, step{
+	UnityAccountLevel(t, Step{
 		Template: `
 		resource "databricks_metastore" "this" {
 			name          = "primary-{var.RANDOM}"
@@ -24,7 +24,7 @@ func TestUcAccAccountMetastoreDataAccessOnAws(t *testing.T) {
 }
 
 func TestUcAccMetastoreDataAccessOnAws(t *testing.T) {
-	unityWorkspaceLevel(t, step{
+	UnityWorkspaceLevel(t, Step{
 		Template: `
 		resource "databricks_metastore_data_access" "this" {
 			metastore_id = "{env.TEST_METASTORE_ID}"

--- a/internal/acceptance/metastore_test.go
+++ b/internal/acceptance/metastore_test.go
@@ -87,7 +87,7 @@ func getTemplateFromExtraAttributes(t *testing.T, extraAttributes map[string]any
 
 func runMetastoreTest(t *testing.T, extraAttributes map[string]any) {
 	template := getTemplateFromExtraAttributes(t, extraAttributes)
-	unityAccountLevel(t, step{
+	UnityAccountLevel(t, Step{
 		Template: fmt.Sprintf(`resource "databricks_metastore" "this" {
 			name = "{var.RANDOM}"
 			force_destroy = true
@@ -98,21 +98,21 @@ func runMetastoreTest(t *testing.T, extraAttributes map[string]any) {
 
 func runMetastoreTestWithOwnerUpdates(t *testing.T, extraAttributes map[string]any) {
 	template := getTemplateFromExtraAttributes(t, extraAttributes)
-	unityAccountLevel(t, step{
+	UnityAccountLevel(t, Step{
 		Template: fmt.Sprintf(`resource "databricks_metastore" "this" {
 			name = "{var.STICKY_RANDOM}"
 			force_destroy = true
 			owner = "account users"
 			%s
 		}`, template),
-	}, step{
+	}, Step{
 		Template: fmt.Sprintf(`resource "databricks_metastore" "this" {
 			name = "{var.STICKY_RANDOM}"
 			force_destroy = true
 			owner = "{env.TEST_DATA_ENG_GROUP}"
 			%s
 		}`, template),
-	}, step{
+	}, Step{
 		Template: fmt.Sprintf(`resource "databricks_metastore" "this" {
 			name = "{var.STICKY_RANDOM}-updated"
 			force_destroy = true

--- a/internal/acceptance/mlflow_experiment_test.go
+++ b/internal/acceptance/mlflow_experiment_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestAccMLflowExperiment(t *testing.T) {
-	workspaceLevel(t, step{
+	WorkspaceLevel(t, Step{
 		Template: `
 		resource "databricks_mlflow_experiment" "e1" {
 			name = "/Shared/tf-{var.RANDOM}"

--- a/internal/acceptance/mlflow_model_test.go
+++ b/internal/acceptance/mlflow_model_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestAccMLflowModel(t *testing.T) {
-	workspaceLevel(t, step{
+	WorkspaceLevel(t, Step{
 		Template: `
 		resource "databricks_mlflow_model" "m1" {
 			name = "tf-{var.RANDOM}"

--- a/internal/acceptance/model_serving_test.go
+++ b/internal/acceptance/model_serving_test.go
@@ -15,7 +15,7 @@ func TestAccModelServing(t *testing.T) {
 
 	name := fmt.Sprintf("terraform-test-model-serving-%s",
 		acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum))
-	workspaceLevel(t, step{
+	WorkspaceLevel(t, Step{
 		Template: fmt.Sprintf(`
 			resource "databricks_model_serving" "endpoint" {
 				name = "%s"
@@ -57,7 +57,7 @@ func TestAccModelServing(t *testing.T) {
 			}
 		`, name),
 	},
-		step{
+		Step{
 			Template: fmt.Sprintf(`
 			resource "databricks_model_serving" "endpoint" {
 				name = "%s"
@@ -90,7 +90,7 @@ func TestUcAccModelServingProvisionedThroughput(t *testing.T) {
 
 	name := fmt.Sprintf("terraform-test-model-serving-pt-%s",
 		acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum))
-	unityWorkspaceLevel(t, step{
+	UnityWorkspaceLevel(t, Step{
 		Template: fmt.Sprintf(`
 			resource "databricks_model_serving" "endpoint" {
 				name = "%s"
@@ -111,7 +111,7 @@ func TestUcAccModelServingProvisionedThroughput(t *testing.T) {
 				}
 			}
 		`, name),
-	}, step{
+	}, Step{
 		Template: fmt.Sprintf(`
 			resource "databricks_model_serving" "endpoint" {
 				name = "%s"
@@ -132,7 +132,7 @@ func TestUcAccModelServingProvisionedThroughput(t *testing.T) {
 				}
 			}
 		`, name),
-	}, step{
+	}, Step{
 		Template: fmt.Sprintf(`
 			resource "databricks_model_serving" "endpoint" {
 				name = "%s"
@@ -167,7 +167,7 @@ func TestAccModelServingExternalModel(t *testing.T) {
 		acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum))
 	scope_name := fmt.Sprintf("terraform-test-secret-scope-%s",
 		acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum))
-	workspaceLevel(t, step{
+	WorkspaceLevel(t, Step{
 		Template: fmt.Sprintf(`
 			resource "databricks_secret_scope" "scope" {
 				name = "%s"
@@ -203,7 +203,7 @@ func TestAccModelServingExternalModel(t *testing.T) {
 			}
 		`, scope_name, name),
 	},
-		step{
+		Step{
 			Template: fmt.Sprintf(`
 			resource "databricks_secret_scope" "scope" {
 				name = "%s"

--- a/internal/acceptance/mounts_test.go
+++ b/internal/acceptance/mounts_test.go
@@ -38,8 +38,8 @@ resource "databricks_mount" "my_mount" {
 }`
 
 func TestAccCreateDatabricksMount(t *testing.T) {
-	workspaceLevel(t,
-		step{
+	WorkspaceLevel(t,
+		Step{
 			Template: mountHcl,
 		})
 }
@@ -48,9 +48,9 @@ func TestAccCreateDatabricksMountIsFineOnClusterRecreate(t *testing.T) {
 	clusterId1 := ""
 	clusterId2 := ""
 
-	workspaceLevel(t,
+	WorkspaceLevel(t,
 		// Step 1 creates the cluster and mount.
-		step{
+		Step{
 			Template: mountHcl,
 			Check: func(s *terraform.State) error {
 				resources := s.RootModule().Resources
@@ -72,7 +72,7 @@ func TestAccCreateDatabricksMountIsFineOnClusterRecreate(t *testing.T) {
 		},
 		// Step 2: Manually delete the cluster, and then reapply the config. The mount
 		// will be recreated in this case.
-		step{
+		Step{
 			PreConfig: func() {
 				w, err := databricks.NewWorkspaceClient(&databricks.Config{})
 				require.NoError(t, err)

--- a/internal/acceptance/mws_credentials_test.go
+++ b/internal/acceptance/mws_credentials_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestMwsAccCredentials(t *testing.T) {
-	accountLevel(t, step{
+	AccountLevel(t, Step{
 		Template: `resource "databricks_mws_credentials" "this" {
 			account_id       = "{env.DATABRICKS_ACCOUNT_ID}"
 			credentials_name = "creds-test-{var.RANDOM}"

--- a/internal/acceptance/mws_customer_managed_keys_test.go
+++ b/internal/acceptance/mws_customer_managed_keys_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestMwsAccAwsCustomerManagedKeys(t *testing.T) {
-	accountLevel(t, step{
+	AccountLevel(t, Step{
 		Template: `resource "databricks_mws_customer_managed_keys" "this" {
 			account_id   = "{env.DATABRICKS_ACCOUNT_ID}"
 			aws_key_info {
@@ -18,7 +18,7 @@ func TestMwsAccAwsCustomerManagedKeys(t *testing.T) {
 }
 
 func TestMwsAccGcpCustomerManagedKeysForStorage(t *testing.T) {
-	accountLevel(t, step{
+	AccountLevel(t, Step{
 		Template: `resource "databricks_mws_customer_managed_keys" "this" {
 				account_id   = "{env.DATABRICKS_ACCOUNT_ID}"
 				gcp_key_info {

--- a/internal/acceptance/mws_log_delivery_test.go
+++ b/internal/acceptance/mws_log_delivery_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestMwsAccLogDelivery(t *testing.T) {
-	accountLevel(t, step{
+	AccountLevel(t, Step{
 		Template: `resource "databricks_mws_credentials" "ld" {
 			account_id       = "{env.DATABRICKS_ACCOUNT_ID}"
 			credentials_name = "tf-acceptance-logdelivery-{var.RANDOM}"

--- a/internal/acceptance/mws_network_connectivity_config_test.go
+++ b/internal/acceptance/mws_network_connectivity_config_test.go
@@ -6,7 +6,7 @@ import (
 
 func TestMwsAccNetworkConnectivityConfig(t *testing.T) {
 	if isAzure(t) {
-		accountLevel(t, step{
+		AccountLevel(t, Step{
 			Template: `
 			resource "databricks_mws_network_connectivity_config" "this" {
 				name = "tf-{var.RANDOM}"
@@ -19,7 +19,7 @@ func TestMwsAccNetworkConnectivityConfig(t *testing.T) {
 				group_id = "blob"
 			}
 			`,
-		}, step{
+		}, Step{
 			Template: `
 			resource "databricks_mws_network_connectivity_config" "this" {
 				name = "tf-{var.RANDOM}"
@@ -35,7 +35,7 @@ func TestMwsAccNetworkConnectivityConfig(t *testing.T) {
 		})
 	}
 	if isAws(t) {
-		accountLevel(t, step{
+		AccountLevel(t, Step{
 			Template: `
 			resource "databricks_mws_network_connectivity_config" "this" {
 				account_id = "{env.DATABRICKS_ACCOUNT_ID}"
@@ -43,7 +43,7 @@ func TestMwsAccNetworkConnectivityConfig(t *testing.T) {
 				region = "{env.AWS_REGION}"
 			}
 			`,
-		}, step{
+		}, Step{
 			Template: `
 			resource "databricks_mws_network_connectivity_config" "this" {
 				account_id = "{env.DATABRICKS_ACCOUNT_ID}"

--- a/internal/acceptance/mws_networks_test.go
+++ b/internal/acceptance/mws_networks_test.go
@@ -6,7 +6,7 @@ import (
 
 func TestMwsAccNetworks(t *testing.T) {
 	GetEnvOrSkipTest(t, "TEST_ROOT_BUCKET") // marker for AWS test env
-	accountLevel(t, step{
+	AccountLevel(t, Step{
 		Template: `
 		resource "databricks_mws_networks" "my_network" {
 			account_id   = "{env.DATABRICKS_ACCOUNT_ID}"
@@ -24,7 +24,7 @@ func TestMwsAccNetworks(t *testing.T) {
 }
 
 func TestMwsAccGcpPscNetworks(t *testing.T) {
-	accountLevel(t, step{
+	AccountLevel(t, Step{
 		Template: `
 		resource "databricks_mws_networks" "my_network" {
 			account_id   = "{env.DATABRICKS_ACCOUNT_ID}"

--- a/internal/acceptance/mws_permissionassignments_test.go
+++ b/internal/acceptance/mws_permissionassignments_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestUcAccAssignGroupToWorkspace(t *testing.T) {
-	unityAccountLevel(t, step{
+	UnityAccountLevel(t, Step{
 		Template: `
 		resource "databricks_group" "this" {
 			display_name = "TF {var.RANDOM}"
@@ -15,7 +15,7 @@ func TestUcAccAssignGroupToWorkspace(t *testing.T) {
 			principal_id = databricks_group.this.id
 			permissions  = ["USER"]
 		}`,
-	}, step{
+	}, Step{
 		Template: `
 		resource "databricks_group" "this" {
 			display_name = "TF {var.RANDOM}"
@@ -25,7 +25,7 @@ func TestUcAccAssignGroupToWorkspace(t *testing.T) {
 			principal_id = databricks_group.this.id
 			permissions  = ["ADMIN"]
 		}`,
-	}, step{
+	}, Step{
 		Template: `
 		resource "databricks_group" "this" {
 			display_name = "TF {var.RANDOM}"
@@ -39,7 +39,7 @@ func TestUcAccAssignGroupToWorkspace(t *testing.T) {
 }
 
 func TestAccAssignSpnToWorkspace(t *testing.T) {
-	unityAccountLevel(t, step{
+	UnityAccountLevel(t, Step{
 		Template: `
 		resource "databricks_service_principal" "this" {
 			display_name = "TF {var.RANDOM}"

--- a/internal/acceptance/mws_private_access_settings_test.go
+++ b/internal/acceptance/mws_private_access_settings_test.go
@@ -6,7 +6,7 @@ import (
 
 func TestMwsAccPrivateAccessSettings(t *testing.T) {
 	t.SkipNow()
-	accountLevel(t, step{
+	AccountLevel(t, Step{
 		Template: `
 		resource "databricks_mws_private_access_settings" "this" {
 			account_id = "{env.DATABRICKS_ACCOUNT_ID}"
@@ -19,7 +19,7 @@ func TestMwsAccPrivateAccessSettings(t *testing.T) {
 
 func TestMwsGcpAccPrivateAccessSettings(t *testing.T) {
 	t.Skipf("skipping until feature is disabled")
-	accountLevel(t, step{
+	AccountLevel(t, Step{
 		Template: `
 		resource "databricks_mws_private_access_settings" "this" {
 			account_id = "{env.DATABRICKS_ACCOUNT_ID}"

--- a/internal/acceptance/mws_storage_configurations_test.go
+++ b/internal/acceptance/mws_storage_configurations_test.go
@@ -6,7 +6,7 @@ import (
 
 func TestMwsAccStorageConfigurations(t *testing.T) {
 	GetEnvOrSkipTest(t, "TEST_ROOT_BUCKET") // marker for AWS test env
-	accountLevel(t, step{
+	AccountLevel(t, Step{
 		Template: `
 		resource "databricks_mws_storage_configurations" "this" {
 			account_id                 = "{env.DATABRICKS_ACCOUNT_ID}"

--- a/internal/acceptance/mws_vpc_endpoint_test.go
+++ b/internal/acceptance/mws_vpc_endpoint_test.go
@@ -6,7 +6,7 @@ import (
 
 func TestMwsAccVpcEndpoint(t *testing.T) {
 	t.SkipNow()
-	accountLevel(t, step{
+	AccountLevel(t, Step{
 		Template: `
 		resource "databricks_mws_vpc_endpoint" "this" {
 			account_id = "{env.DATABRICKS_ACCOUNT_ID}"
@@ -19,7 +19,7 @@ func TestMwsAccVpcEndpoint(t *testing.T) {
 }
 
 func TestMwsAccVpcEndpoint_GCP(t *testing.T) {
-	accountLevel(t, step{
+	AccountLevel(t, Step{
 		Template: `
 		resource "databricks_mws_vpc_endpoint" "this" {
 			account_id = "{env.DATABRICKS_ACCOUNT_ID}"

--- a/internal/acceptance/mws_workspaces_test.go
+++ b/internal/acceptance/mws_workspaces_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func TestMwsAccWorkspaces(t *testing.T) {
-	accountLevel(t, step{
+	AccountLevel(t, Step{
 		Template: `
 		resource "databricks_mws_credentials" "this" {
 			account_id       = "{env.DATABRICKS_ACCOUNT_ID}"
@@ -76,7 +76,7 @@ func TestMwsAccWorkspaces(t *testing.T) {
 }
 
 func TestMwsAccWorkspacesTokenUpdate(t *testing.T) {
-	accountLevel(t, step{
+	AccountLevel(t, Step{
 		Template: `
 		resource "databricks_mws_credentials" "this" {
 			account_id       = "{env.DATABRICKS_ACCOUNT_ID}"
@@ -136,7 +136,7 @@ func TestMwsAccWorkspacesTokenUpdate(t *testing.T) {
 				return nil
 			}),
 	},
-		step{
+		Step{
 			Template: `
 		resource "databricks_mws_credentials" "this" {
 			account_id       = "{env.DATABRICKS_ACCOUNT_ID}"
@@ -199,7 +199,7 @@ func TestMwsAccWorkspacesTokenUpdate(t *testing.T) {
 }
 
 func TestMwsAccGcpWorkspaces(t *testing.T) {
-	accountLevel(t, step{
+	AccountLevel(t, Step{
 		Template: `
 		resource "databricks_mws_workspaces" "this" {
 			account_id      = "{env.DATABRICKS_ACCOUNT_ID}"
@@ -218,7 +218,7 @@ func TestMwsAccGcpWorkspaces(t *testing.T) {
 func TestMwsAccGcpByovpcWorkspaces(t *testing.T) {
 	t.Skip()
 	// FIXME: flaky with `Secondary IP range (pods, svc) is already in use by another GKE cluster`
-	accountLevel(t, step{
+	AccountLevel(t, Step{
 		Template: `
 		resource "databricks_mws_networks" "this" {
 			account_id   = "{env.DATABRICKS_ACCOUNT_ID}"
@@ -255,7 +255,7 @@ func TestMwsAccGcpByovpcWorkspaces(t *testing.T) {
 }
 
 func TestMwsAccGcpPscWorkspaces(t *testing.T) {
-	accountLevel(t, step{
+	AccountLevel(t, Step{
 		Template: `
 		resource "databricks_mws_networks" "this" {
 			account_id   = "{env.DATABRICKS_ACCOUNT_ID}"
@@ -374,7 +374,7 @@ func TestMwsAccAwsChangeToServicePrincipal(t *testing.T) {
 			return providers.GetProviderServer(context.Background(), providers.WithSdkV2Provider(pr))
 		},
 	}
-	accountLevel(t, step{
+	AccountLevel(t, Step{
 		Template: workspaceTemplate(`token { comment = "Test {var.STICKY_RANDOM}" }`) + servicePrincipal,
 		Check: func(s *terraform.State) error {
 			spId := s.RootModule().Resources["databricks_service_principal.this"].Primary.ID
@@ -412,20 +412,20 @@ func TestMwsAccAwsChangeToServicePrincipal(t *testing.T) {
 			}
 			return nil
 		},
-	}, step{
+	}, Step{
 		// Tolerate existing token
 		Template:                 workspaceTemplate(`token { comment = "Test {var.STICKY_RANDOM}" }`) + servicePrincipal,
 		ProtoV6ProviderFactories: providerFactory,
-	}, step{
+	}, Step{
 		// Allow the token to be removed
 		Template:                 workspaceTemplate(``) + servicePrincipal,
 		ProtoV6ProviderFactories: providerFactory,
-	}, step{
+	}, Step{
 		// Fail when adding the token back
 		Template:                 workspaceTemplate(`token { comment = "Test {var.STICKY_RANDOM}" }`) + servicePrincipal,
 		ProtoV6ProviderFactories: providerFactory,
 		ExpectError:              regexp.MustCompile(`cannot create token: the principal used by Databricks \(client ID .*\) is not authorized to create a token in this workspace`),
-	}, step{
+	}, Step{
 		// Use the original provider for a final step to clean up the newly created service principal
 		Template: workspaceTemplate(``) + servicePrincipal,
 	})

--- a/internal/acceptance/notebook_test.go
+++ b/internal/acceptance/notebook_test.go
@@ -5,12 +5,12 @@ import (
 )
 
 func TestAccNotebookResourceScalability(t *testing.T) {
-	workspaceLevel(t, step{
+	WorkspaceLevel(t, Step{
 		Template: `resource "databricks_notebook" "this" {
 			source = "{var.CWD}/../../storage/testdata/tf-test-python.py"
 			path = "/Shared/provider-test/xx_{var.RANDOM}"
 		}`,
-	}, step{
+	}, Step{
 		Template: `resource "databricks_notebook" "this" {
 			source = "{var.CWD}/../../storage/testdata/tf-test-python.py"
 			path = "/Shared/provider-test/xx_{var.RANDOM}_renamed"

--- a/internal/acceptance/notification_destination_test.go
+++ b/internal/acceptance/notification_destination_test.go
@@ -33,7 +33,7 @@ func checkND(t *testing.T, display_name string, config_type settings.Destination
 
 func TestAccNDEmail(t *testing.T) {
 	display_name := "Email Notification Destination - " + qa.RandomName()
-	workspaceLevel(t, step{
+	WorkspaceLevel(t, Step{
 		Template: `
 		resource "databricks_notification_destination" "this" {
 			display_name = "` + display_name + `"
@@ -44,7 +44,7 @@ func TestAccNDEmail(t *testing.T) {
 			}
 		}
 		`,
-	}, step{
+	}, Step{
 		Template: `
 		resource "databricks_notification_destination" "this" {
 			display_name = "` + display_name + `"
@@ -61,7 +61,7 @@ func TestAccNDEmail(t *testing.T) {
 
 func TestAccNDSlack(t *testing.T) {
 	display_name := "Notification Destination - " + qa.RandomName()
-	workspaceLevel(t, step{
+	WorkspaceLevel(t, Step{
 		Template: `
 		resource "databricks_notification_destination" "this" {
 			display_name = "` + display_name + `"
@@ -73,7 +73,7 @@ func TestAccNDSlack(t *testing.T) {
 		}
 		`,
 		Check: checkND(t, display_name, settings.DestinationTypeSlack),
-	}, step{
+	}, Step{
 		Template: `
 		resource "databricks_notification_destination" "this" {
 			display_name = "` + display_name + `"
@@ -90,7 +90,7 @@ func TestAccNDSlack(t *testing.T) {
 
 func TestAccNDMicrosoftTeams(t *testing.T) {
 	display_name := "Notification Destination - " + qa.RandomName()
-	workspaceLevel(t, step{
+	WorkspaceLevel(t, Step{
 		Template: `
 		resource "databricks_notification_destination" "this" {
 			display_name = "` + display_name + `"
@@ -101,7 +101,7 @@ func TestAccNDMicrosoftTeams(t *testing.T) {
 			}
 		}
 		`,
-	}, step{
+	}, Step{
 		Template: `
 		resource "databricks_notification_destination" "this" {
 			display_name = "` + display_name + `"
@@ -118,7 +118,7 @@ func TestAccNDMicrosoftTeams(t *testing.T) {
 
 func TestAccNDPagerduty(t *testing.T) {
 	display_name := "Notification Destination - " + qa.RandomName()
-	workspaceLevel(t, step{
+	WorkspaceLevel(t, Step{
 		Template: `
 		resource "databricks_notification_destination" "this" {
 			display_name = "` + display_name + `"
@@ -129,7 +129,7 @@ func TestAccNDPagerduty(t *testing.T) {
 			}
 		}
 		`,
-	}, step{
+	}, Step{
 		Template: `
 		resource "databricks_notification_destination" "this" {
 			display_name = "` + display_name + `"
@@ -146,7 +146,7 @@ func TestAccNDPagerduty(t *testing.T) {
 
 func TestAccNDGenericWebhook(t *testing.T) {
 	display_name := "Notification Destination - " + qa.RandomName()
-	workspaceLevel(t, step{
+	WorkspaceLevel(t, Step{
 		Template: `
 		resource "databricks_notification_destination" "this" {
 			display_name = "` + display_name + `"
@@ -158,7 +158,7 @@ func TestAccNDGenericWebhook(t *testing.T) {
 			}
 		}
 		`,
-	}, step{
+	}, Step{
 		Template: `
 		resource "databricks_notification_destination" "this" {
 			display_name = "` + display_name + `"
@@ -176,7 +176,7 @@ func TestAccNDGenericWebhook(t *testing.T) {
 
 func TestAccConfigTypeChange(t *testing.T) {
 	display_name := "Notification Destination - " + qa.RandomName()
-	workspaceLevel(t, step{
+	WorkspaceLevel(t, Step{
 		Template: `
 		resource "databricks_notification_destination" "this" {
 			display_name = "` + display_name + `"
@@ -188,7 +188,7 @@ func TestAccConfigTypeChange(t *testing.T) {
 		}
 		`,
 		Check: checkND(t, display_name, settings.DestinationTypeSlack),
-	}, step{
+	}, Step{
 		Template: `
 		resource "databricks_notification_destination" "this" {
 			display_name = "` + display_name + `"

--- a/internal/acceptance/obo_token_test.go
+++ b/internal/acceptance/obo_token_test.go
@@ -7,7 +7,7 @@ import (
 func TestAccAwsOboTokenResource(t *testing.T) {
 	// running this test temporarily on the UC WS level
 	// until infrastructure gets AWS specific markers
-	unityWorkspaceLevel(t, step{
+	UnityWorkspaceLevel(t, Step{
 		Template: `
 		// dummy: {env.TEST_GLOBAL_METASTORE_ID}
 		resource "databricks_service_principal" "this" {

--- a/internal/acceptance/online_table_test.go
+++ b/internal/acceptance/online_table_test.go
@@ -82,5 +82,5 @@ func TestUcAccOnlineTable(t *testing.T) {
 	if os.Getenv("GOOGLE_CREDENTIALS") != "" {
 		t.Skipf("databricks_online_table resource is not available on GCP")
 	}
-	unityWorkspaceLevel(t, step{Template: onlineTableHcl})
+	UnityWorkspaceLevel(t, Step{Template: onlineTableHcl})
 }

--- a/internal/acceptance/permissions_test.go
+++ b/internal/acceptance/permissions_test.go
@@ -19,7 +19,7 @@ import (
 
 func TestAccDatabricksPermissionsResourceFullLifecycle(t *testing.T) {
 	randomName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
-	workspaceLevel(t, step{
+	WorkspaceLevel(t, Step{
 		Template: fmt.Sprintf(`
 		resource "databricks_notebook" "this" {
 			content_base64 = base64encode("# Databricks notebook source\nprint(1)")
@@ -49,7 +49,7 @@ func TestAccDatabricksPermissionsResourceFullLifecycle(t *testing.T) {
 					return nil
 				}),
 		),
-	}, step{
+	}, Step{
 		Template: fmt.Sprintf(`
 		resource "databricks_notebook" "this" {
 			content_base64 = base64encode("# Databricks notebook source\nprint(1)")
@@ -87,7 +87,7 @@ func TestAccDatabricksPermissionsResourceFullLifecycle(t *testing.T) {
 
 func TestAccDatabricksReposPermissionsResourceFullLifecycle(t *testing.T) {
 	randomName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
-	workspaceLevel(t, step{
+	WorkspaceLevel(t, Step{
 		Template: fmt.Sprintf(`
 		resource "databricks_repo" "this" {
 			url = "https://github.com/databrickslabs/tempo.git"
@@ -199,8 +199,8 @@ func TestAccDatabricksPermissionsForSqlWarehouses(t *testing.T) {
 		}
 	}`, randomName)
 
-	workspaceLevel(t,
-		step{
+	WorkspaceLevel(t,
+		Step{
 			Template: config1,
 			Check: resource.ComposeTestCheckFunc(
 				checkObjectType,
@@ -211,7 +211,7 @@ func TestAccDatabricksPermissionsForSqlWarehouses(t *testing.T) {
 				},
 			),
 		},
-		step{
+		Step{
 			Template: config2,
 			Check: func(s *terraform.State) error {
 				id := getPermissionId(s)

--- a/internal/acceptance/pipeline_test.go
+++ b/internal/acceptance/pipeline_test.go
@@ -50,7 +50,7 @@ var (
 )
 
 func TestAccPipelineResource_CreatePipeline(t *testing.T) {
-	workspaceLevel(t, step{
+	WorkspaceLevel(t, Step{
 		Template: `
 		locals {
 			name = "pipeline-acceptance-{var.RANDOM}"
@@ -95,7 +95,7 @@ func TestAccPipelineResource_CreatePipeline(t *testing.T) {
 }
 
 func TestAccAwsPipelineResource_CreatePipeline(t *testing.T) {
-	workspaceLevel(t, step{
+	WorkspaceLevel(t, Step{
 		Template: `
 		locals {
 			name = "pipeline-acceptance-aws-{var.STICKY_RANDOM}"
@@ -135,7 +135,7 @@ func TestAccAwsPipelineResource_CreatePipeline(t *testing.T) {
 			continuous = false
 		}
 		` + dltNotebookResource,
-	}, step{
+	}, Step{
 		Template: `
 		locals {
 			name = "pipeline-acceptance-aws-{var.STICKY_RANDOM}"
@@ -179,7 +179,7 @@ func TestAccAwsPipelineResource_CreatePipeline(t *testing.T) {
 }
 
 func TestAccPipelineResource_CreatePipelineWithoutWorkers(t *testing.T) {
-	workspaceLevel(t, step{
+	WorkspaceLevel(t, Step{
 		Template: `
 		locals {
 			name = "pipeline-acceptance-{var.RANDOM}"
@@ -232,7 +232,7 @@ func TestAccPipelineResource_CreatePipelineWithoutWorkers(t *testing.T) {
 
 func TestAccPipelineResourcLastModified(t *testing.T) {
 	var lastModified int64
-	workspaceLevel(t, step{
+	WorkspaceLevel(t, Step{
 		Template: `
 		locals {
 			name = "pipeline-acceptance-{var.STICKY_RANDOM}"
@@ -284,7 +284,7 @@ func TestAccPipelineResourcLastModified(t *testing.T) {
 			lastModified = pipeline.LastModified
 			return nil
 		}),
-	}, step{
+	}, Step{
 		Template: `
 		locals {
 			name = "pipeline-acceptance-{var.STICKY_RANDOM}"

--- a/internal/acceptance/provider_test.go
+++ b/internal/acceptance/provider_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestUcAccCreateProviderDb2Open(t *testing.T) {
-	unityWorkspaceLevel(t, step{
+	UnityWorkspaceLevel(t, Step{
 		Template: `
 		resource "databricks_provider" "this" {
 			name = "terraform-test-provider"

--- a/internal/acceptance/recipient_test.go
+++ b/internal/acceptance/recipient_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestUcAccCreateRecipientDb2Open(t *testing.T) {
-	unityWorkspaceLevel(t, step{
+	UnityWorkspaceLevel(t, Step{
 		Template: `
 		resource "databricks_recipient" "db2open" {
 			name = "{var.RANDOM}-terraform-db2open-recipient"
@@ -22,7 +22,7 @@ func TestUcAccCreateRecipientDb2Open(t *testing.T) {
 }
 
 func TestUcAccCreateRecipientDb2DbAws(t *testing.T) {
-	unityWorkspaceLevel(t, step{
+	UnityWorkspaceLevel(t, Step{
 		Template: `
 		resource "databricks_metastore" "recipient_metastore" {
 			name = "{var.RANDOM}-terraform-recipient-metastore"
@@ -46,13 +46,13 @@ func TestUcAccCreateRecipientDb2DbAws(t *testing.T) {
 }
 
 func TestUcAccUpdateRecipientDb2Open(t *testing.T) {
-	unityWorkspaceLevel(t, step{
+	UnityWorkspaceLevel(t, Step{
 		Template: recipientTemplateWithOwner("made by terraform", "account users"),
-	}, step{
+	}, Step{
 		Template: recipientTemplateWithOwner("made by terraform -- updated comment", "account users"),
-	}, step{
+	}, Step{
 		Template: recipientTemplateWithOwner("made by terraform -- updated comment", "{env.TEST_DATA_ENG_GROUP}"),
-	}, step{
+	}, Step{
 		Template: recipientTemplateWithOwner("made by terraform -- updated comment 2", "{env.TEST_METASTORE_ADMIN_GROUP_NAME}"),
 	})
 }

--- a/internal/acceptance/registered_model_test.go
+++ b/internal/acceptance/registered_model_test.go
@@ -5,8 +5,8 @@ import (
 )
 
 func TestUcAccRegisteredModel(t *testing.T) {
-	unityWorkspaceLevel(t,
-		step{
+	UnityWorkspaceLevel(t,
+		Step{
 			Template: `
 			resource "databricks_registered_model" "model" {
 				name = "terraform-test-registered-model-{var.STICKY_RANDOM}"
@@ -24,7 +24,7 @@ func TestUcAccRegisteredModel(t *testing.T) {
 			}
 		`,
 		},
-		step{
+		Step{
 			Template: `
 			resource "databricks_registered_model" "model" {
 				name = "terraform-test-registered-model-{var.STICKY_RANDOM}"
@@ -34,7 +34,7 @@ func TestUcAccRegisteredModel(t *testing.T) {
 			}
 		`,
 		},
-		step{
+		Step{
 			Template: `
 			resource "databricks_registered_model" "model" {
 				name = "terraform-test-registered-model-update-{var.STICKY_RANDOM}"

--- a/internal/acceptance/restrict_workspace_admins_test.go
+++ b/internal/acceptance/restrict_workspace_admins_test.go
@@ -21,7 +21,7 @@ func TestAccRestrictWorkspaceAdminsSetting(t *testing.T) {
 		}
 	}
 	`
-	unityWorkspaceLevel(t, step{
+	UnityWorkspaceLevel(t, Step{
 		Template: template,
 		Check: resourceCheckWithState("databricks_restrict_workspace_admins_setting.this",
 			func(ctx context.Context, client *common.DatabricksClient, state *terraform.InstanceState) error {
@@ -39,7 +39,7 @@ func TestAccRestrictWorkspaceAdminsSetting(t *testing.T) {
 				return nil
 			}),
 	},
-		step{
+		Step{
 			Template: template,
 			Destroy:  true,
 			Check: resourceCheck("databricks_restrict_workspace_admins_setting.this",

--- a/internal/acceptance/schema_test.go
+++ b/internal/acceptance/schema_test.go
@@ -16,7 +16,7 @@ const catalogTemplate = `
 `
 
 func TestUcAccSchema(t *testing.T) {
-	unityWorkspaceLevel(t, step{
+	UnityWorkspaceLevel(t, Step{
 		Template: catalogTemplate + `
 		data "databricks_catalogs" "all" {
 			depends_on = [databricks_catalog.sandbox]
@@ -102,13 +102,13 @@ func getPredictiveOptimizationSetting(t *testing.T, enabled bool) string {
 
 func TestUcAccSchemaUpdate(t *testing.T) {
 	loadUcwsEnv(t)
-	unityWorkspaceLevel(t, step{
+	UnityWorkspaceLevel(t, Step{
 		Template: catalogTemplate + schemaTemplateWithOwner(t, "this database is managed by terraform", "account users"),
-	}, step{
+	}, Step{
 		Template: catalogTemplate + schemaTemplateWithOwner(t, "this database is managed by terraform -- updated comment", "account users"),
-	}, step{
+	}, Step{
 		Template: catalogTemplate + schemaTemplateWithOwner(t, "this database is managed by terraform -- updated comment", "{env.TEST_DATA_ENG_GROUP}"),
-	}, step{
+	}, Step{
 		Template: catalogTemplate + schemaTemplateWithOwner(t, "this database is managed by terraform -- updated comment 2", "{env.TEST_METASTORE_ADMIN_GROUP_NAME}"),
 	})
 }

--- a/internal/acceptance/secret_acl_test.go
+++ b/internal/acceptance/secret_acl_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestAccSecretAclResource(t *testing.T) {
-	workspaceLevel(t, step{
+	WorkspaceLevel(t, Step{
 		Template: `
 		resource "databricks_group" "ds" {
 			display_name = "data-scientists-{var.RANDOM}"
@@ -52,7 +52,7 @@ func TestAccSecretAclResource(t *testing.T) {
 }
 
 func TestAccSecretAclResourceDefaultPrincipal(t *testing.T) {
-	workspaceLevel(t, step{
+	WorkspaceLevel(t, Step{
 		Template: `
 		resource "databricks_secret_scope" "app" {
 			name = "app-{var.RANDOM}"

--- a/internal/acceptance/secret_scope_test.go
+++ b/internal/acceptance/secret_scope_test.go
@@ -18,7 +18,7 @@ import (
 
 func TestAccSecretScopeResource(t *testing.T) {
 	scope := qa.RandomName("tf-")
-	workspaceLevel(t, step{
+	WorkspaceLevel(t, Step{
 		Template: fmt.Sprintf(`
 		resource "databricks_secret_scope" "my_scope" {
 			name = "%s"
@@ -45,7 +45,7 @@ func TestAccSecretScopeResource(t *testing.T) {
 				}),
 		),
 		ExpectNonEmptyPlan: true,
-	}, step{
+	}, Step{
 		Template: fmt.Sprintf(`
 		resource "databricks_secret_scope" "my_scope" {
 			name = "%s"
@@ -63,7 +63,7 @@ func TestAccSecretScopeResourceAkvWithSp(t *testing.T) {
 		t.Skipf("service principal isn't defined")
 	}
 
-	workspaceLevel(t, step{
+	WorkspaceLevel(t, Step{
 		Template: `
 		resource "databricks_secret_scope" "my_scope" {
 			name = "tf-{var.RANDOM}"

--- a/internal/acceptance/secret_test.go
+++ b/internal/acceptance/secret_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestAccSecretResource(t *testing.T) {
-	workspaceLevel(t, step{
+	WorkspaceLevel(t, Step{
 		Template: `
 		resource "databricks_secret_scope" "this" {
 			name = "tf-scope-{var.RANDOM}"

--- a/internal/acceptance/service_principal_test.go
+++ b/internal/acceptance/service_principal_test.go
@@ -33,13 +33,13 @@ func TestAccServicePrincipalHomeDeleteSuccess(t *testing.T) {
 		force_delete_home_dir = true
 	}`
 	var spId string
-	workspaceLevel(t, step{
+	WorkspaceLevel(t, Step{
 		Template: template,
 		Check: func(s *terraform.State) error {
 			spId = s.RootModule().Resources["databricks_service_principal.a"].Primary.Attributes["application_id"]
 			return nil
 		},
-	}, step{
+	}, Step{
 		Template: template,
 		Destroy:  true,
 		Check: func(s *terraform.State) error {
@@ -69,13 +69,13 @@ func TestAccServicePrinicpalHomeDeleteNotDeleted(t *testing.T) {
 		force_delete_home_dir = false 
 	}`
 	var appId string
-	workspaceLevel(t, step{
+	WorkspaceLevel(t, Step{
 		Template: template,
 		Check: func(s *terraform.State) error {
 			appId = s.RootModule().Resources["databricks_service_principal.a"].Primary.Attributes["application_id"]
 			return provisionHomeFolder(context.Background(), s, "databricks_service_principal.a", appId)
 		},
-	}, step{
+	}, Step{
 		Template: template,
 		Destroy:  true,
 		Check: func(s *terraform.State) error {
@@ -93,9 +93,9 @@ func TestAccServicePrinicpalHomeDeleteNotDeleted(t *testing.T) {
 func TestMwsAccServicePrincipalResourceOnAzure(t *testing.T) {
 	GetEnvOrSkipTest(t, "ARM_CLIENT_ID")
 	azureSpnRenamed := strings.ReplaceAll(azureSpn, `"SPN `, `"SPN Renamed `)
-	accountLevel(t, step{
+	AccountLevel(t, Step{
 		Template: azureSpn,
-	}, step{
+	}, Step{
 		Template: azureSpnRenamed,
 	})
 }
@@ -103,9 +103,9 @@ func TestMwsAccServicePrincipalResourceOnAzure(t *testing.T) {
 func TestAccServicePrincipalResourceOnAzure(t *testing.T) {
 	GetEnvOrSkipTest(t, "ARM_CLIENT_ID")
 	azureSpnRenamed := strings.ReplaceAll(azureSpn, `"SPN `, `"SPN Renamed `)
-	workspaceLevel(t, step{
+	WorkspaceLevel(t, Step{
 		Template: azureSpn,
-	}, step{
+	}, Step{
 		Template: azureSpnRenamed,
 	})
 }
@@ -113,9 +113,9 @@ func TestAccServicePrincipalResourceOnAzure(t *testing.T) {
 func TestMwsAccServicePrincipalResourceOnAws(t *testing.T) {
 	GetEnvOrSkipTest(t, "TEST_ROOT_BUCKET")
 	awsSpnRenamed := strings.ReplaceAll(awsSpn, `"SPN `, `"SPN Renamed `)
-	accountLevel(t, step{
+	AccountLevel(t, Step{
 		Template: awsSpn,
-	}, step{
+	}, Step{
 		Template: awsSpnRenamed,
 	})
 }
@@ -123,9 +123,9 @@ func TestMwsAccServicePrincipalResourceOnAws(t *testing.T) {
 func TestAccServicePrincipalResourceOnAws(t *testing.T) {
 	GetEnvOrSkipTest(t, "TEST_EC2_INSTANCE_PROFILE")
 	awsSpnRenamed := strings.ReplaceAll(awsSpn, `"SPN `, `"SPN Renamed `)
-	workspaceLevel(t, step{
+	WorkspaceLevel(t, Step{
 		Template: awsSpn,
-	}, step{
+	}, Step{
 		Template: awsSpnRenamed,
 	})
 }

--- a/internal/acceptance/share_test.go
+++ b/internal/acceptance/share_test.go
@@ -71,7 +71,7 @@ const preTestTemplateUpdate = `
 `
 
 func TestUcAccCreateShare(t *testing.T) {
-	unityWorkspaceLevel(t, step{
+	UnityWorkspaceLevel(t, Step{
 		Template: preTestTemplate + `		
 		resource "databricks_share" "myshare" {
 			name  = "{var.STICKY_RANDOM}-terraform-delta-share"
@@ -125,13 +125,13 @@ func shareTemplateWithOwner(comment string, owner string) string {
 }
 
 func TestUcAccUpdateShare(t *testing.T) {
-	unityWorkspaceLevel(t, step{
+	UnityWorkspaceLevel(t, Step{
 		Template: preTestTemplate + preTestTemplateUpdate + shareTemplateWithOwner("c", "account users"),
-	}, step{
+	}, Step{
 		Template: preTestTemplate + preTestTemplateUpdate + shareTemplateWithOwner("e", "account users"),
-	}, step{
+	}, Step{
 		Template: preTestTemplate + preTestTemplateUpdate + shareTemplateWithOwner("e", "{env.TEST_DATA_ENG_GROUP}"),
-	}, step{
+	}, Step{
 		Template: preTestTemplate + preTestTemplateUpdate + shareTemplateWithOwner("f", "{env.TEST_METASTORE_ADMIN_GROUP_NAME}"),
 	})
 }

--- a/internal/acceptance/sql_alert_test.go
+++ b/internal/acceptance/sql_alert_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestAccAlert(t *testing.T) {
-	workspaceLevel(t, step{
+	WorkspaceLevel(t, Step{
 		Template: `
 		resource "databricks_sql_query" "this" {
 			data_source_id = "{env.TEST_DEFAULT_WAREHOUSE_DATASOURCE_ID}"
@@ -31,7 +31,7 @@ func TestAccAlert(t *testing.T) {
 				muted = false
 			}
 		}`,
-	}, step{
+	}, Step{
 		Template: `
 		resource "databricks_sql_query" "this" {
 			data_source_id = "{env.TEST_DEFAULT_WAREHOUSE_DATASOURCE_ID}"

--- a/internal/acceptance/sql_dashboard_test.go
+++ b/internal/acceptance/sql_dashboard_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestAccDashboard(t *testing.T) {
-	workspaceLevel(t, step{
+	WorkspaceLevel(t, Step{
 		Template: `
 		resource "databricks_sql_dashboard" "d1" {
 			name = "tf-{var.RANDOM}-dashboard"

--- a/internal/acceptance/sql_endpoint_test.go
+++ b/internal/acceptance/sql_endpoint_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestAccSQLEndpoint(t *testing.T) {
-	workspaceLevel(t, step{
+	WorkspaceLevel(t, Step{
 		Template: `
 		resource "databricks_sql_endpoint" "this" {
 			name = "tf-{var.RANDOM}"
@@ -25,7 +25,7 @@ func TestAccSQLEndpoint(t *testing.T) {
 				}
 			}
 		}`,
-	}, step{
+	}, Step{
 		Template: `
 		resource "databricks_sql_endpoint" "that" {
 			name = "tf-{var.RANDOM}"

--- a/internal/acceptance/sql_global_config_test.go
+++ b/internal/acceptance/sql_global_config_test.go
@@ -38,7 +38,7 @@ resource "databricks_sql_global_config" "this" {
 
 func TestAccSQLGlobalConfig(t *testing.T) {
 	loadWorkspaceEnv(t)
-	workspaceLevel(t, step{
+	WorkspaceLevel(t, Step{
 		PreConfig: func() {
 			ctx := context.Background()
 			_, err := lock.Acquire(ctx, getSqlGlobalConfigLockable(t), lock.InTest(t))
@@ -64,7 +64,7 @@ func TestAccSQLGlobalConfigServerless(t *testing.T) {
 		}
 	}
 
-	workspaceLevel(t, step{
+	WorkspaceLevel(t, Step{
 		PreConfig: func() {
 			ctx := context.Background()
 			_, err := lock.Acquire(ctx, getSqlGlobalConfigLockable(t), lock.InTest(t))
@@ -72,10 +72,10 @@ func TestAccSQLGlobalConfigServerless(t *testing.T) {
 		},
 		Template: makeSqlGlobalConfig("enable_serverless_compute = true"),
 		Check:    checkServerlessEnabled(true),
-	}, step{
+	}, Step{
 		Template: makeSqlGlobalConfig(""),
 		Check:    checkServerlessEnabled(true),
-	}, step{
+	}, Step{
 		Template: makeSqlGlobalConfig("enable_serverless_compute = false"),
 		Check:    checkServerlessEnabled(false),
 	})

--- a/internal/acceptance/sql_permissions_test.go
+++ b/internal/acceptance/sql_permissions_test.go
@@ -36,7 +36,7 @@ func TestAccTableACL(t *testing.T) {
 		require.NoError(t, err)
 		require.False(t, cr.Failed(), cr.Error())
 	})
-	workspaceLevel(t, step{
+	WorkspaceLevel(t, Step{
 		Template: `
 		resource "databricks_sql_permissions" "this" {
 			table = "` + tableName + `"

--- a/internal/acceptance/sql_query_test.go
+++ b/internal/acceptance/sql_query_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestAccQuery(t *testing.T) {
-	workspaceLevel(t, step{
+	WorkspaceLevel(t, Step{
 		Template: `
 		resource "databricks_sql_query" "q1" {
 			data_source_id = "{env.TEST_DEFAULT_WAREHOUSE_DATASOURCE_ID}"

--- a/internal/acceptance/sql_table_test.go
+++ b/internal/acceptance/sql_table_test.go
@@ -14,7 +14,7 @@ func TestUcAccResourceSqlTable_Managed(t *testing.T) {
 	if os.Getenv("GOOGLE_CREDENTIALS") != "" {
 		skipf(t)("databricks_sql_table resource not available on GCP")
 	}
-	unityWorkspaceLevel(t, step{
+	UnityWorkspaceLevel(t, Step{
 		Template: `
 		resource "databricks_schema" "this" {
 			name         = "{var.STICKY_RANDOM}"
@@ -42,7 +42,7 @@ func TestUcAccResourceSqlTable_Managed(t *testing.T) {
 			comment = "this table is managed by terraform"
 			owner = "account users"
 		}`,
-	}, step{
+	}, Step{
 		Template: `
 		resource "databricks_schema" "this" {
 			name         = "{var.STICKY_RANDOM}"
@@ -73,7 +73,7 @@ func TestUcAccResourceSqlTable_Managed(t *testing.T) {
 }
 
 func TestUcAccResourceSqlTable_External(t *testing.T) {
-	unityWorkspaceLevel(t, step{
+	UnityWorkspaceLevel(t, Step{
 		Template: `
 		resource "databricks_storage_credential" "external" {
 			name = "cred-{var.RANDOM}"
@@ -113,7 +113,7 @@ func TestUcAccResourceSqlTable_View(t *testing.T) {
 	if os.Getenv("GOOGLE_CREDENTIALS") != "" {
 		skipf(t)("databricks_sql_table resource not available on GCP")
 	}
-	unityWorkspaceLevel(t, step{
+	UnityWorkspaceLevel(t, Step{
 		Template: `
 		resource "databricks_schema" "this" {
 			name         = "{var.STICKY_RANDOM}"
@@ -164,7 +164,7 @@ func TestUcAccResourceSqlTable_WarehousePartition(t *testing.T) {
 	if os.Getenv("GOOGLE_CREDENTIALS") != "" {
 		skipf(t)("databricks_sql_table resource not available on GCP")
 	}
-	unityWorkspaceLevel(t, step{
+	UnityWorkspaceLevel(t, Step{
 		Template: `
 		resource "databricks_sql_endpoint" "this" {
 			name = "tf-{var.RANDOM}"
@@ -215,7 +215,7 @@ func TestUcAccResourceSqlTable_Liquid(t *testing.T) {
 	if os.Getenv("GOOGLE_CREDENTIALS") != "" {
 		skipf(t)("databricks_sql_table resource not available on GCP")
 	}
-	unityWorkspaceLevel(t, step{
+	UnityWorkspaceLevel(t, Step{
 		Template: `
 		resource "databricks_schema" "this" {
 			name         = "{var.STICKY_RANDOM}"
@@ -246,7 +246,7 @@ func TestUcAccResourceSqlTable_Liquid(t *testing.T) {
 			cluster_keys = ["id"]
 			comment = "this table is managed by terraform"
 		}`,
-	}, step{
+	}, Step{
 		Template: `
 		resource "databricks_schema" "this" {
 			name         = "{var.STICKY_RANDOM}"
@@ -320,9 +320,9 @@ func TestUcAccResourceSqlTable_RenameColumn(t *testing.T) {
 		skipf(t)("databricks_sql_table resource not available on GCP")
 	}
 	tableName := RandomName()
-	unityWorkspaceLevel(t, step{
+	UnityWorkspaceLevel(t, Step{
 		Template: constructManagedSqlTableTemplate(tableName, []catalog.SqlColumnInfo{{Name: "name", Type: "string", Nullable: true, Comment: "comment"}}),
-	}, step{
+	}, Step{
 		Template: constructManagedSqlTableTemplate(tableName, []catalog.SqlColumnInfo{{Name: "new_name", Type: "string", Nullable: true, Comment: "comment"}}),
 	})
 }
@@ -346,7 +346,7 @@ func TestUcAccResourceSqlTable_ColumnTypeSuppressDiff(t *testing.T) {
 	}
 	tableName := RandomName()
 	columnName := RandomName()
-	unityWorkspaceLevel(t, step{
+	UnityWorkspaceLevel(t, Step{
 		Template: constructManagedSqlTableTemplateWithColumnTypeUpdates(tableName, columnName, "0", []string{
 			"integer",
 			"long",
@@ -357,7 +357,7 @@ func TestUcAccResourceSqlTable_ColumnTypeSuppressDiff(t *testing.T) {
 			"dec",
 			"numeric",
 		}),
-	}, step{
+	}, Step{
 		Template: constructManagedSqlTableTemplateWithColumnTypeUpdates(tableName, columnName, "1", []string{
 			"INTEGER",
 			"LONG",
@@ -368,7 +368,7 @@ func TestUcAccResourceSqlTable_ColumnTypeSuppressDiff(t *testing.T) {
 			"DEC",
 			"NUMERIC",
 		}),
-	}, step{
+	}, Step{
 		Template: constructManagedSqlTableTemplateWithColumnTypeUpdates(tableName, columnName, "2", []string{
 			"int",
 			"bigint",
@@ -387,9 +387,9 @@ func TestUcAccResourceSqlTable_AddColumnComment(t *testing.T) {
 		skipf(t)("databricks_sql_table resource not available on GCP")
 	}
 	tableName := RandomName()
-	unityWorkspaceLevel(t, step{
+	UnityWorkspaceLevel(t, Step{
 		Template: constructManagedSqlTableTemplate(tableName, []catalog.SqlColumnInfo{{Name: "name", Type: "string", Nullable: true, Comment: "comment"}}),
-	}, step{
+	}, Step{
 		Template: constructManagedSqlTableTemplate(tableName, []catalog.SqlColumnInfo{{Name: "name", Type: "string", Nullable: true, Comment: "new comment"}}),
 	})
 }
@@ -399,9 +399,9 @@ func TestUcAccResourceSqlTable_DropColumnNullable(t *testing.T) {
 		skipf(t)("databricks_sql_table resource not available on GCP")
 	}
 	tableName := RandomName()
-	unityWorkspaceLevel(t, step{
+	UnityWorkspaceLevel(t, Step{
 		Template: constructManagedSqlTableTemplate(tableName, []catalog.SqlColumnInfo{{Name: "name", Type: "string", Nullable: true, Comment: "comment"}}),
-	}, step{
+	}, Step{
 		Template: constructManagedSqlTableTemplate(tableName, []catalog.SqlColumnInfo{{Name: "name", Type: "string", Nullable: false, Comment: "comment"}}),
 	})
 }
@@ -411,9 +411,9 @@ func TestUcAccResourceSqlTable_MultipleColumnUpdates(t *testing.T) {
 		skipf(t)("databricks_sql_table resource not available on GCP")
 	}
 	tableName := RandomName()
-	unityWorkspaceLevel(t, step{
+	UnityWorkspaceLevel(t, Step{
 		Template: constructManagedSqlTableTemplate(tableName, []catalog.SqlColumnInfo{{Name: "name", Type: "string", Nullable: true, Comment: "comment"}}),
-	}, step{
+	}, Step{
 		Template: constructManagedSqlTableTemplate(tableName, []catalog.SqlColumnInfo{{Name: "name", Type: "string", Nullable: false, Comment: "new comment"}}),
 	})
 }
@@ -424,9 +424,9 @@ func TestUcAccResourceSqlTable_ChangeColumnTypeThrows(t *testing.T) {
 	}
 	tableName := RandomName()
 
-	unityWorkspaceLevel(t, step{
+	UnityWorkspaceLevel(t, Step{
 		Template: constructManagedSqlTableTemplate(tableName, []catalog.SqlColumnInfo{{Name: "name", Type: "string", Nullable: true, Comment: "comment"}}),
-	}, step{
+	}, Step{
 		Template:    constructManagedSqlTableTemplate(tableName, []catalog.SqlColumnInfo{{Name: "name", Type: "int", Nullable: true, Comment: "comment"}}),
 		ExpectError: typeUpdateErrorRegex,
 	})
@@ -437,12 +437,12 @@ func TestUcAccResourceSqlTable_DropColumn(t *testing.T) {
 		skipf(t)("databricks_sql_table resource not available on GCP")
 	}
 	tableName := RandomName()
-	unityWorkspaceLevel(t, step{
+	UnityWorkspaceLevel(t, Step{
 		Template: constructManagedSqlTableTemplate(tableName, []catalog.SqlColumnInfo{
 			{Name: "name", Type: "string", Nullable: true, Comment: "comment"},
 			{Name: "nametwo", Type: "string", Nullable: true, Comment: "comment"},
 		}),
-	}, step{
+	}, Step{
 		Template: constructManagedSqlTableTemplate(tableName, []catalog.SqlColumnInfo{{Name: "name", Type: "string", Nullable: true, Comment: "comment"}}),
 	})
 }
@@ -452,13 +452,13 @@ func TestUcAccResourceSqlTable_DropMultipleColumns(t *testing.T) {
 		skipf(t)("databricks_sql_table resource not available on GCP")
 	}
 	tableName := RandomName()
-	unityWorkspaceLevel(t, step{
+	UnityWorkspaceLevel(t, Step{
 		Template: constructManagedSqlTableTemplate(tableName, []catalog.SqlColumnInfo{
 			{Name: "name", Type: "string", Nullable: true, Comment: "comment"},
 			{Name: "nametwo", Type: "string", Nullable: true, Comment: "comment"},
 			{Name: "namethree", Type: "string", Nullable: true, Comment: "comment"},
 		}),
-	}, step{
+	}, Step{
 		Template: constructManagedSqlTableTemplate(tableName, []catalog.SqlColumnInfo{{Name: "name", Type: "string", Nullable: true, Comment: "comment"}}),
 	})
 }
@@ -468,9 +468,9 @@ func TestUcAccResourceSqlTable_AddColumn(t *testing.T) {
 		skipf(t)("databricks_sql_table resource not available on GCP")
 	}
 	tableName := RandomName()
-	unityWorkspaceLevel(t, step{
+	UnityWorkspaceLevel(t, Step{
 		Template: constructManagedSqlTableTemplate(tableName, []catalog.SqlColumnInfo{{Name: "name", Type: "string", Nullable: true, Comment: "comment"}}),
-	}, step{
+	}, Step{
 		Template: constructManagedSqlTableTemplate(tableName, []catalog.SqlColumnInfo{
 			{Name: "name", Type: "string", Nullable: true, Comment: "comment"},
 			{Name: "nametwo", Type: "string", Nullable: true, Comment: "comment"},
@@ -483,9 +483,9 @@ func TestUcAccResourceSqlTable_AddMultipleColumns(t *testing.T) {
 		skipf(t)("databricks_sql_table resource not available on GCP")
 	}
 	tableName := RandomName()
-	unityWorkspaceLevel(t, step{
+	UnityWorkspaceLevel(t, Step{
 		Template: constructManagedSqlTableTemplate(tableName, []catalog.SqlColumnInfo{{Name: "name", Type: "string", Nullable: true, Comment: "comment"}}),
-	}, step{
+	}, Step{
 		Template: constructManagedSqlTableTemplate(tableName, []catalog.SqlColumnInfo{
 			{Name: "name", Type: "string", Nullable: true, Comment: "comment"},
 			{Name: "nametwo", Type: "string", Nullable: true, Comment: "comment"},
@@ -500,9 +500,9 @@ func TestUcAccResourceSqlTable_AddColumnAndUpdateThrows(t *testing.T) {
 	}
 
 	tableName := RandomName()
-	unityWorkspaceLevel(t, step{
+	UnityWorkspaceLevel(t, Step{
 		Template: constructManagedSqlTableTemplate(tableName, []catalog.SqlColumnInfo{{Name: "name", Type: "string", Nullable: true, Comment: "comment"}}),
-	}, step{
+	}, Step{
 		Template: constructManagedSqlTableTemplate(tableName, []catalog.SqlColumnInfo{
 			{Name: "name", Type: "string", Nullable: false, Comment: "new comment"},
 			{Name: "nametwo", Type: "string", Nullable: true, Comment: "comment"},
@@ -517,12 +517,12 @@ func TestUcAccResourceSqlTable_DropColumnAndUpdateThrows(t *testing.T) {
 	}
 
 	tableName := RandomName()
-	unityWorkspaceLevel(t, step{
+	UnityWorkspaceLevel(t, Step{
 		Template: constructManagedSqlTableTemplate(tableName, []catalog.SqlColumnInfo{
 			{Name: "name", Type: "string", Nullable: true, Comment: "comment"},
 			{Name: "nametwo", Type: "string", Nullable: true, Comment: "comment"},
 		}),
-	}, step{
+	}, Step{
 		Template:    constructManagedSqlTableTemplate(tableName, []catalog.SqlColumnInfo{{Name: "name", Type: "string", Nullable: false, Comment: "new comment"}}),
 		ExpectError: inlineAndMembershipChangeErrorRegex,
 	})

--- a/internal/acceptance/storage_credential_test.go
+++ b/internal/acceptance/storage_credential_test.go
@@ -7,7 +7,7 @@ import (
 func TestUcAccStorageCredential(t *testing.T) {
 	loadUcwsEnv(t)
 	if isAws(t) {
-		unityWorkspaceLevel(t, step{
+		UnityWorkspaceLevel(t, Step{
 			Template: `
 				resource "databricks_storage_credential" "external" {
 					name = "cred-{var.RANDOM}"
@@ -29,7 +29,7 @@ func TestUcAccStorageCredential(t *testing.T) {
 				}`,
 		})
 	} else if isGcp(t) {
-		unityWorkspaceLevel(t, step{
+		UnityWorkspaceLevel(t, Step{
 			Template: `
 				resource "databricks_storage_credential" "external" {
 					name = "cred-{var.RANDOM}"
@@ -42,7 +42,7 @@ func TestUcAccStorageCredential(t *testing.T) {
 }
 
 func TestAccStorageCredentialOwner(t *testing.T) {
-	unityAccountLevel(t, step{
+	UnityAccountLevel(t, Step{
 		Template: `
 			resource "databricks_service_principal" "test_acc_storage_credential_owner" {
 				display_name = "test_acc_storage_credential_owner {var.RANDOM}"

--- a/internal/acceptance/system_schema_test.go
+++ b/internal/acceptance/system_schema_test.go
@@ -9,7 +9,7 @@ func TestUcAccResourceSystemSchema(t *testing.T) {
 	if os.Getenv("GOOGLE_CREDENTIALS") != "" {
 		t.Skipf("databricks_system_schema resource not available on GCP")
 	}
-	unityWorkspaceLevel(t, step{
+	UnityWorkspaceLevel(t, Step{
 		Template: `
 		resource "databricks_system_schema" "this" {
 			schema = "access"

--- a/internal/acceptance/token_test.go
+++ b/internal/acceptance/token_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestAccTokenResource(t *testing.T) {
-	workspaceLevel(t, step{
+	WorkspaceLevel(t, Step{
 		Template: `resource "databricks_token" "this" {
 			lifetime_seconds = 6000
 			comment = "Testing token"

--- a/internal/acceptance/user_role_test.go
+++ b/internal/acceptance/user_role_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestAccUserRole(t *testing.T) {
-	workspaceLevel(t, step{
+	WorkspaceLevel(t, Step{
 		Template: `
 		resource "databricks_user" "this" {
 			user_name = "{var.RANDOM}@example.com"

--- a/internal/acceptance/user_test.go
+++ b/internal/acceptance/user_test.go
@@ -20,7 +20,7 @@ import (
 // https://github.com/databricks/terraform-provider-databricks/issues/1097
 func TestAccForceUserImport(t *testing.T) {
 	username := qa.RandomEmail()
-	workspaceLevel(t, step{
+	WorkspaceLevel(t, Step{
 		Template: `data "databricks_current_user" "me" {}`,
 		Check: func(s *terraform.State) error {
 			w, err := databricks.NewWorkspaceClient()
@@ -40,7 +40,7 @@ func TestAccForceUserImport(t *testing.T) {
 			}
 			return nil
 		},
-	}, step{
+	}, Step{
 		Template: `resource "databricks_user" "this" {
 			user_name = "` + username + `"
 			force     = true
@@ -50,13 +50,13 @@ func TestAccForceUserImport(t *testing.T) {
 
 func TestAccUserHomeDeleteHasNoEffectInAccount(t *testing.T) {
 	username := qa.RandomEmail()
-	accountLevel(t, step{
+	AccountLevel(t, Step{
 		Template: `
 		resource "databricks_user" "first" {
 			user_name = "` + username + `"
 			force_delete_home_dir = true
 		}`,
-	}, step{
+	}, Step{
 		Template: `
 		resource "databricks_user" "second" {
 			user_name = "{var.RANDOM}@example.com"
@@ -71,9 +71,9 @@ func TestAccUserHomeDelete(t *testing.T) {
 		user_name = "` + username + `"
 		force_delete_home_dir = true
 	}`
-	workspaceLevel(t, step{
+	WorkspaceLevel(t, Step{
 		Template: template,
-	}, step{
+	}, Step{
 		Template: template,
 		Destroy:  true,
 		Check: func(s *terraform.State) error {
@@ -115,12 +115,12 @@ func TestAccUserHomeDeleteNotDeleted(t *testing.T) {
 	resource "databricks_user" "a" {
 		user_name = "` + username + `"
 	}`
-	workspaceLevel(t, step{
+	WorkspaceLevel(t, Step{
 		Template: template,
 		Check: func(s *terraform.State) error {
 			return provisionHomeFolder(context.Background(), s, "databricks_user.a", username)
 		},
-	}, step{
+	}, Step{
 		Template: template,
 		Destroy:  true,
 		Check: func(s *terraform.State) error {
@@ -154,7 +154,7 @@ func TestAccUserResource(t *testing.T) {
 		allow_instance_pool_create = true
 	}
 	`
-	workspaceLevel(t, step{
+	WorkspaceLevel(t, Step{
 		Template: differentUsers,
 		Check: resource.ComposeTestCheckFunc(
 			resource.TestCheckResourceAttr("databricks_user.first", "allow_cluster_create", "false"),
@@ -164,7 +164,7 @@ func TestAccUserResource(t *testing.T) {
 			resource.TestCheckResourceAttr("databricks_user.third", "allow_cluster_create", "false"),
 			resource.TestCheckResourceAttr("databricks_user.third", "allow_instance_pool_create", "true"),
 		),
-	}, step{
+	}, Step{
 		Template: differentUsers,
 	})
 }
@@ -174,12 +174,12 @@ func TestAccUserResourceCaseInsensitive(t *testing.T) {
 	csUser := `resource "databricks_user" "first" {
 		user_name = "` + username + `"
 		}`
-	workspaceLevel(t, step{
+	WorkspaceLevel(t, Step{
 		Template: csUser,
 		Check: resource.ComposeTestCheckFunc(
 			resource.TestCheckResourceAttr("databricks_user.first", "user_name", strings.ToLower(username)),
 		),
-	}, step{
+	}, Step{
 		Template: csUser,
 	})
 }

--- a/internal/acceptance/vector_search_test.go
+++ b/internal/acceptance/vector_search_test.go
@@ -15,7 +15,7 @@ func TestUcAccVectorSearchEndpoint(t *testing.T) {
 
 	name := fmt.Sprintf("terraform-test-vector-search-%[1]s",
 		acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum))
-	unityWorkspaceLevel(t, step{
+	UnityWorkspaceLevel(t, Step{
 		Template: fmt.Sprintf(`
 			resource "databricks_vector_search_endpoint" "this" {
 				name          = "%s"

--- a/internal/acceptance/volume_test.go
+++ b/internal/acceptance/volume_test.go
@@ -26,7 +26,7 @@ resource "databricks_external_location" "some" {
 }`
 
 func TestUcAccVolumesResourceWithoutInitialOwnerAWSFullLifecycle(t *testing.T) {
-	unityWorkspaceLevel(t, step{
+	UnityWorkspaceLevel(t, Step{
 		Template: prefixTestTemplate + `
 		resource "databricks_volume" "this" {
 			name = "name-abc"
@@ -36,7 +36,7 @@ func TestUcAccVolumesResourceWithoutInitialOwnerAWSFullLifecycle(t *testing.T) {
 			volume_type = "EXTERNAL"
 			storage_location   = databricks_external_location.some.url
 		}`,
-	}, step{
+	}, Step{
 		Template: prefixTestTemplate + `
 		resource "databricks_volume" "this" {
 			name = "name-abc"
@@ -46,7 +46,7 @@ func TestUcAccVolumesResourceWithoutInitialOwnerAWSFullLifecycle(t *testing.T) {
 			volume_type = "EXTERNAL"
 			storage_location   = databricks_external_location.some.url
 		}`,
-	}, step{
+	}, Step{
 		Template: prefixTestTemplate + `
 		resource "databricks_volume" "this" {
 			name = "name-abc"
@@ -57,7 +57,7 @@ func TestUcAccVolumesResourceWithoutInitialOwnerAWSFullLifecycle(t *testing.T) {
 			volume_type = "EXTERNAL"
 			storage_location   = databricks_external_location.some.url
 		}`,
-	}, step{
+	}, Step{
 		Template: prefixTestTemplate + `
 		resource "databricks_volume" "this" {
 			name = "name-def"
@@ -72,7 +72,7 @@ func TestUcAccVolumesResourceWithoutInitialOwnerAWSFullLifecycle(t *testing.T) {
 }
 
 func TestUcAccVolumesResourceWithInitialOwnerAWSFullLifecycle(t *testing.T) {
-	unityWorkspaceLevel(t, step{
+	UnityWorkspaceLevel(t, Step{
 		Template: prefixTestTemplate + `
 		resource "databricks_volume" "this" {
 			name = "name-abc"
@@ -83,7 +83,7 @@ func TestUcAccVolumesResourceWithInitialOwnerAWSFullLifecycle(t *testing.T) {
 			volume_type = "EXTERNAL"
 			storage_location   = databricks_external_location.some.url
 		}`,
-	}, step{
+	}, Step{
 		Template: prefixTestTemplate + `
 		resource "databricks_volume" "this" {
 			name = "name-abc"
@@ -94,7 +94,7 @@ func TestUcAccVolumesResourceWithInitialOwnerAWSFullLifecycle(t *testing.T) {
 			volume_type = "EXTERNAL"
 			storage_location   = databricks_external_location.some.url
 		}`,
-	}, step{
+	}, Step{
 		Template: prefixTestTemplate + `
 		resource "databricks_volume" "this" {
 			name = "name-def"

--- a/internal/acceptance/workspace_binding_test.go
+++ b/internal/acceptance/workspace_binding_test.go
@@ -65,7 +65,7 @@ func workspaceBindingTemplateWithWorkspaceId(workspaceId string) string {
 }
 
 func TestUcAccWorkspaceBindingToOtherWorkspace(t *testing.T) {
-	unityWorkspaceLevel(t, step{
+	UnityWorkspaceLevel(t, Step{
 		Template: workspaceBindingTemplateWithWorkspaceId("{env.DUMMY_WORKSPACE_ID}"),
 	})
 }

--- a/internal/acceptance/workspace_conf_test.go
+++ b/internal/acceptance/workspace_conf_test.go
@@ -24,7 +24,7 @@ func assertEnableIpAccessList(t *testing.T, expected string) {
 }
 
 func TestAccWorkspaceConfFullLifecycle(t *testing.T) {
-	workspaceLevel(t, step{
+	WorkspaceLevel(t, Step{
 		Template: `resource "databricks_workspace_conf" "this" {
 			custom_config = {
 				"enableIpAccessLists": true
@@ -34,7 +34,7 @@ func TestAccWorkspaceConfFullLifecycle(t *testing.T) {
 			assertEnableIpAccessList(t, "true")
 			return nil
 		},
-	}, step{
+	}, Step{
 		// Set enableIpAccessLists to false
 		Template: `resource "databricks_workspace_conf" "this" {
 				custom_config = {
@@ -50,7 +50,7 @@ func TestAccWorkspaceConfFullLifecycle(t *testing.T) {
 			assert.Equal(t, "false", conf.Primary.Attributes["custom_config.enableIpAccessLists"])
 			return nil
 		},
-	}, step{
+	}, Step{
 		// Set invalid configuration
 		Template: `resource "databricks_workspace_conf" "this" {
 				custom_config = {
@@ -59,7 +59,7 @@ func TestAccWorkspaceConfFullLifecycle(t *testing.T) {
 			}`,
 		// Assert on server side error returned
 		ExpectError: regexp.MustCompile(`cannot update workspace conf: Invalid keys`),
-	}, step{
+	}, Step{
 		// Set enableIpAccessLists to true with strange case and maxTokenLifetimeDays to verify
 		// failed deletion case
 		Template: `resource "databricks_workspace_conf" "this" {

--- a/internal/acceptance/workspace_file_test.go
+++ b/internal/acceptance/workspace_file_test.go
@@ -5,12 +5,12 @@ import (
 )
 
 func TestAccWorkspaceFile(t *testing.T) {
-	workspaceLevel(t, step{
+	WorkspaceLevel(t, Step{
 		Template: `resource "databricks_workspace_file" "this" {
 			source = "{var.CWD}/../../storage/testdata/tf-test-python.py"
 			path = "/Shared/provider-test/xx_{var.RANDOM}"
 		}`,
-	}, step{
+	}, Step{
 		Template: `resource "databricks_workspace_file" "this" {
 			source = "{var.CWD}/../../storage/testdata/tf-test-python.py"
 			path = "/Shared/provider-test/xx_{var.RANDOM}_renamed"
@@ -19,7 +19,7 @@ func TestAccWorkspaceFile(t *testing.T) {
 }
 
 func TestAccWorkspaceFileEmptyFile(t *testing.T) {
-	workspaceLevel(t, step{
+	WorkspaceLevel(t, Step{
 		Template: `resource "databricks_workspace_file" "empty" {
 			source = "{var.CWD}/../../workspace/acceptance/testdata/empty_file"
 			path = "/Shared/provider-test/empty_{var.RANDOM}"
@@ -28,12 +28,12 @@ func TestAccWorkspaceFileEmptyFile(t *testing.T) {
 }
 
 func TestAccWorkspaceFileBase64(t *testing.T) {
-	workspaceLevel(t, step{
+	WorkspaceLevel(t, Step{
 		Template: `resource "databricks_workspace_file" "this2" {
 			content_base64 = "YWJjCg=="
 			path = "/Shared/provider-test/xx2_{var.RANDOM}"
 		}`,
-	}, step{
+	}, Step{
 		Template: `resource "databricks_workspace_file" "this2" {
 			content_base64 = "YWJjCg=="
 			path = "/Shared/provider-test/xx2_{var.RANDOM}_renamed"

--- a/internal/providers/pluginfw/resources/qualitymonitor/resource_quality_monitor_test.go
+++ b/internal/providers/pluginfw/resources/qualitymonitor/resource_quality_monitor_test.go
@@ -1,8 +1,10 @@
-package acceptance
+package qualitymonitor_test
 
 import (
 	"os"
 	"testing"
+
+	"github.com/databricks/terraform-provider-databricks/internal/acceptance"
 )
 
 var commonPartQualityMonitoring = `resource "databricks_catalog" "sandbox" {
@@ -46,18 +48,18 @@ resource "databricks_sql_table" "myInferenceTable" {
 
 `
 
-func TestUcAccQualityMonitor(t *testing.T) {
+func TestUcAccQualityMonitorPluginFramework(t *testing.T) {
 	if os.Getenv("GOOGLE_CREDENTIALS") != "" {
 		t.Skipf("databricks_quality_monitor resource is not available on GCP")
 	}
-	UnityWorkspaceLevel(t, Step{
+	acceptance.UnityWorkspaceLevel(t, acceptance.Step{
 		Template: commonPartQualityMonitoring + `
 
-			resource "databricks_quality_monitor" "testMonitorInference" {
+			resource "databricks_quality_monitor_pluginframework" "testMonitorInference" {
 				table_name = databricks_sql_table.myInferenceTable.id
 				assets_dir = "/Shared/provider-test/databricks_quality_monitoring/${databricks_sql_table.myInferenceTable.name}"
 				output_schema_name = databricks_schema.things.id
-				inference_log  {
+				inference_log = {
 				  granularities = ["1 day"]
 				  timestamp_col = "timestamp"
 				  prediction_col = "prediction"
@@ -79,11 +81,11 @@ func TestUcAccQualityMonitor(t *testing.T) {
 				}
 			}
 
-			resource "databricks_quality_monitor" "testMonitorTimeseries" {
+			resource "databricks_quality_monitor_pluginframework" "testMonitorTimeseries" {
 				table_name = databricks_sql_table.myTimeseries.id
 				assets_dir = "/Shared/provider-test/databricks_quality_monitoring/${databricks_sql_table.myTimeseries.name}"
 				output_schema_name = databricks_schema.things.id
-				time_series  {
+				time_series = {
 				  granularities = ["1 day"]
 				  timestamp_col = "timestamp"
 				} 
@@ -102,49 +104,49 @@ func TestUcAccQualityMonitor(t *testing.T) {
 				}
 			}
 
-			resource "databricks_quality_monitor" "testMonitorSnapshot" {
+			resource "databricks_quality_monitor_pluginframework" "testMonitorSnapshot" {
 				table_name = databricks_sql_table.mySnapshot.id
 				assets_dir = "/Shared/provider-test/databricks_quality_monitoring/${databricks_sql_table.myTimeseries.name}"
 				output_schema_name = databricks_schema.things.id
-				snapshot  {
+				snapshot = {
 				} 
 			}
 		`,
 	})
 }
 
-func TestUcAccUpdateQualityMonitor(t *testing.T) {
+func TestUcAccUpdateQualityMonitorPluginFramework(t *testing.T) {
 	if os.Getenv("GOOGLE_CREDENTIALS") != "" {
 		t.Skipf("databricks_quality_monitor resource is not available on GCP")
 	}
-	UnityWorkspaceLevel(t, Step{
+	acceptance.UnityWorkspaceLevel(t, acceptance.Step{
 		Template: commonPartQualityMonitoring + `
-			resource "databricks_quality_monitor" "testMonitorInference" {
+			resource "databricks_quality_monitor_pluginframework" "testMonitorInference" {
 				table_name = databricks_sql_table.myInferenceTable.id
 				assets_dir = "/Shared/provider-test/databricks_quality_monitoring/${databricks_sql_table.myInferenceTable.name}"
 				output_schema_name = databricks_schema.things.id
-				inference_log  {
+				inference_log = {
 				  granularities = ["1 day"]
 				  timestamp_col = "timestamp"
 				  prediction_col = "prediction"
 				  model_id_col = "model_id"
 				  problem_type = "PROBLEM_TYPE_REGRESSION"
-				} 
+				}
 			}
 		`,
-	}, Step{
+	}, acceptance.Step{
 		Template: commonPartQualityMonitoring + `
-		resource "databricks_quality_monitor" "testMonitorInference" {
+		resource "databricks_quality_monitor_pluginframework" "testMonitorInference" {
 			table_name = databricks_sql_table.myInferenceTable.id
 			assets_dir = "/Shared/provider-test/databricks_quality_monitoring/${databricks_sql_table.myInferenceTable.name}"
 			output_schema_name = databricks_schema.things.id
-			inference_log  {
-			  granularities = ["1 hour"]
-			  timestamp_col = "timestamp"
-			  prediction_col = "prediction"
-			  model_id_col = "model_id"
-			  problem_type = "PROBLEM_TYPE_REGRESSION"
-			} 
+			inference_log = {
+				granularities = ["1 hour"]
+				timestamp_col = "timestamp"
+				prediction_col = "prediction"
+				model_id_col = "model_id"
+				problem_type = "PROBLEM_TYPE_REGRESSION"
+			}
 		}
 		`,
 	})

--- a/internal/tfreflect/reflect_utils.go
+++ b/internal/tfreflect/reflect_utils.go
@@ -1,6 +1,8 @@
 package tfreflect
 
-import "reflect"
+import (
+	"reflect"
+)
 
 type Field struct {
 	StructField reflect.StructField


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
- Make `Step`, `WorkspaceLevel`, `AccountLevel`, `UnityWorkspaceLevel`, `UnityAccountLevel` public 
- Rename `init_test.go` to `init.go` because variables exported from files ending with `_test` cannot be imported
- Moved integration test for quality monitor next to the resource definition

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [x] covered with integration tests in `internal/acceptance`
- [x] relevant acceptance tests are passing
- [x] using Go SDK
