### PR TITLE
[Internal] Support import in acceptance test + adding import state for quality monitor

### DIFF
--- a/internal/acceptance/init.go
+++ b/internal/acceptance/init.go
@@ -75,6 +75,8 @@ type Step struct {
 	PreventDiskCleanup        bool
 	PreventPostDestroyRefresh bool
 	ImportState               bool
+	ImportStateId             string
+	ImportStateIdFunc         func(*terraform.State) (string, error)
 	ImportStateVerify         bool
 	ProtoV6ProviderFactories  map[string]func() (tfprotov6.ProviderServer, error)
 	// Necessary for ImportState
@@ -196,7 +198,10 @@ func run(t *testing.T, steps []Step) {
 			PreventDiskCleanup:        s.PreventDiskCleanup,
 			PreventPostDestroyRefresh: s.PreventPostDestroyRefresh,
 			ImportState:               s.ImportState,
+			ImportStateId:             s.ImportStateId,
+			ImportStateIdFunc:         s.ImportStateIdFunc,
 			ImportStateVerify:         s.ImportStateVerify,
+			ResourceName:              s.ResourceName,
 			ExpectError:               s.ExpectError,
 			ProtoV6ProviderFactories:  providerFactoryForStep,
 			Check: func(state *terraform.State) error {

--- a/internal/acceptance/init.go
+++ b/internal/acceptance/init.go
@@ -77,6 +77,8 @@ type Step struct {
 	ImportState               bool
 	ImportStateVerify         bool
 	ProtoV6ProviderFactories  map[string]func() (tfprotov6.ProviderServer, error)
+	// Necessary for ImportState
+	ResourceName string
 }
 
 func createUuid() string {

--- a/internal/acceptance/init.go
+++ b/internal/acceptance/init.go
@@ -74,11 +74,14 @@ type Step struct {
 	PlanOnly                  bool
 	PreventDiskCleanup        bool
 	PreventPostDestroyRefresh bool
-	ImportState               bool
-	ImportStateId             string
-	ImportStateIdFunc         func(*terraform.State) (string, error)
-	ImportStateVerify         bool
-	ProtoV6ProviderFactories  map[string]func() (tfprotov6.ProviderServer, error)
+
+	// If true, will test the functionality of ImportState by importing the resource with ResourceName (must be set) and the ID of that resource.
+	// ID can be supplied with either ImportStateId or ImportStateIdFunc.
+	ImportState              bool
+	ImportStateId            string
+	ImportStateIdFunc        func(*terraform.State) (string, error)
+	ImportStateVerify        bool
+	ProtoV6ProviderFactories map[string]func() (tfprotov6.ProviderServer, error)
 	// Necessary for ImportState
 	ResourceName string
 }

--- a/internal/providers/pluginfw/resources/qualitymonitor/resource_quality_monitor.go
+++ b/internal/providers/pluginfw/resources/qualitymonitor/resource_quality_monitor.go
@@ -88,6 +88,10 @@ func (d *QualityMonitorResource) Configure(ctx context.Context, req resource.Con
 	}
 }
 
+func (d *QualityMonitorResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("table_name"), req, resp)
+}
+
 func (r *QualityMonitorResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	w, diags := r.Client.GetWorkspaceClient()
 	resp.Diagnostics.Append(diags...)

--- a/internal/providers/pluginfw/resources/qualitymonitor/resource_quality_monitor_test.go
+++ b/internal/providers/pluginfw/resources/qualitymonitor/resource_quality_monitor_test.go
@@ -1,12 +1,10 @@
 package qualitymonitor_test
 
 import (
-	"fmt"
 	"os"
 	"testing"
 
 	"github.com/databricks/terraform-provider-databricks/internal/acceptance"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 var commonPartQualityMonitoring = `resource "databricks_catalog" "sandbox" {
@@ -158,8 +156,9 @@ func TestUcAccQualityMonitorImportPluginFramework(t *testing.T) {
 	if os.Getenv("GOOGLE_CREDENTIALS") != "" {
 		t.Skipf("databricks_quality_monitor resource is not available on GCP")
 	}
-	acceptance.UnityWorkspaceLevel(t, acceptance.Step{
-		Template: commonPartQualityMonitoring + `
+	acceptance.UnityWorkspaceLevel(t,
+		acceptance.Step{
+			Template: commonPartQualityMonitoring + `
 
 			resource "databricks_quality_monitor_pluginframework" "testMonitorInference" {
 				table_name = databricks_sql_table.myInferenceTable.id
@@ -173,23 +172,14 @@ func TestUcAccQualityMonitorImportPluginFramework(t *testing.T) {
 				  problem_type = "PROBLEM_TYPE_REGRESSION"
 				} 
 			}
-
-			output "table_name" {
-				value = databricks_quality_monitor_pluginframework.testMonitorInference.table_name
-			}
 		`,
-	},
+		},
 		acceptance.Step{
-			ImportState:  true,
-			ResourceName: "databricks_quality_monitor_pluginframework.testMonitorInference",
-			ImportStateIdFunc: func(s *terraform.State) (string, error) {
-				// Fetch the output value of 'table_name' from the state
-				rs, ok := s.RootModule().Outputs["table_name"]
-				if !ok || rs.Value == "" {
-					return "", fmt.Errorf("table_name output not found in the first step")
-				}
-				return rs.Value.(string), nil
-			},
+			ImportState:                          true,
+			ResourceName:                         "databricks_quality_monitor_pluginframework.testMonitorInference",
+			ImportStateIdFunc:                    acceptance.BuildImportStateIdFunc("databricks_quality_monitor_pluginframework.testMonitorInference", "table_name"),
+			ImportStateVerify:                    true,
+			ImportStateVerifyIdentifierAttribute: "table_name",
 		},
 	)
 }

--- a/internal/providers/pluginfw/resources/qualitymonitor/resource_quality_monitor_test.go
+++ b/internal/providers/pluginfw/resources/qualitymonitor/resource_quality_monitor_test.go
@@ -1,10 +1,12 @@
 package qualitymonitor_test
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
 	"github.com/databricks/terraform-provider-databricks/internal/acceptance"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 var commonPartQualityMonitoring = `resource "databricks_catalog" "sandbox" {
@@ -171,6 +173,23 @@ func TestUcAccQualityMonitorImportPluginFramework(t *testing.T) {
 				  problem_type = "PROBLEM_TYPE_REGRESSION"
 				} 
 			}
+
+			output "table_name" {
+				value = databricks_quality_monitor_pluginframework.testMonitorInference.table_name
+			}
 		`,
-	})
+	},
+		acceptance.Step{
+			ImportState:  true,
+			ResourceName: "databricks_quality_monitor_pluginframework.testMonitorInference",
+			ImportStateIdFunc: func(s *terraform.State) (string, error) {
+				// Fetch the output value of 'table_name' from the state
+				rs, ok := s.RootModule().Outputs["table_name"]
+				if !ok || rs.Value == "" {
+					return "", fmt.Errorf("table_name output not found in the first step")
+				}
+				return rs.Value.(string), nil
+			},
+		},
+	)
 }

--- a/internal/providers/pluginfw/resources/qualitymonitor/resource_quality_monitor_test.go
+++ b/internal/providers/pluginfw/resources/qualitymonitor/resource_quality_monitor_test.go
@@ -151,3 +151,26 @@ func TestUcAccUpdateQualityMonitorPluginFramework(t *testing.T) {
 		`,
 	})
 }
+
+func TestUcAccQualityMonitorImportPluginFramework(t *testing.T) {
+	if os.Getenv("GOOGLE_CREDENTIALS") != "" {
+		t.Skipf("databricks_quality_monitor resource is not available on GCP")
+	}
+	acceptance.UnityWorkspaceLevel(t, acceptance.Step{
+		Template: commonPartQualityMonitoring + `
+
+			resource "databricks_quality_monitor_pluginframework" "testMonitorInference" {
+				table_name = databricks_sql_table.myInferenceTable.id
+				assets_dir = "/Shared/provider-test/databricks_quality_monitoring/${databricks_sql_table.myInferenceTable.name}"
+				output_schema_name = databricks_schema.things.id
+				inference_log = {
+				  granularities = ["1 day"]
+				  timestamp_col = "timestamp"
+				  prediction_col = "prediction"
+				  model_id_col = "model_id"
+				  problem_type = "PROBLEM_TYPE_REGRESSION"
+				} 
+			}
+		`,
+	})
+}


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
- Add `ImportState` method for `quality monitor` resource
- Make acceptance test infrastructure able to test importing behavior
- Add integration test for import state for quality monitor

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [x] covered with integration tests in `internal/acceptance`
- [x] relevant acceptance tests are passing
- [x] using Go SDK
