### PR TITLE
[Internal] Move volumes test next to plugin framework data source

### DIFF
--- a/internal/providers/pluginfw/resources/volume/data_volumes_test.go
+++ b/internal/providers/pluginfw/resources/volume/data_volumes_test.go
@@ -1,25 +1,27 @@
-package acceptance
+package volume_test
 
 import (
 	"strconv"
 	"testing"
 
+	"github.com/databricks/terraform-provider-databricks/internal/acceptance"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func checkDataSourceVolumesPopulated(t *testing.T) func(s *terraform.State) error {
+func checkDataSourceVolumesPluginFrameworkPopulated(t *testing.T) func(s *terraform.State) error {
 	return func(s *terraform.State) error {
-		_, ok := s.Modules[0].Resources["data.databricks_volumes.this"]
-		require.True(t, ok, "data.databricks_volumes.this has to be there")
+		_, ok := s.Modules[0].Resources["data.databricks_volumes_pluginframework.this"]
+		require.True(t, ok, "data.databricks_volumes_pluginframework.this has to be there")
 		num_volumes, _ := strconv.Atoi(s.Modules[0].Outputs["volumes"].Value.(string))
 		assert.GreaterOrEqual(t, num_volumes, 1)
 		return nil
 	}
 }
-func TestUcAccDataSourceVolumes(t *testing.T) {
-	UnityWorkspaceLevel(t, Step{
+
+func TestUcAccDataSourceVolumesPluginFramework(t *testing.T) {
+	acceptance.UnityWorkspaceLevel(t, acceptance.Step{
 		Template: `
 		resource "databricks_catalog" "sandbox" {
 			name         = "sandbox{var.RANDOM}"
@@ -37,24 +39,21 @@ func TestUcAccDataSourceVolumes(t *testing.T) {
 				kind = "various"
 			}
 		}
-
 		resource "databricks_volume" "this" {
 			name         = "volume_data_source_test"
 			catalog_name = databricks_catalog.sandbox.name
 			schema_name  = databricks_schema.things.name
 			volume_type  = "MANAGED"      
 		}
-
-		data "databricks_volumes" "this" {
+		data "databricks_volumes_pluginframework" "this" {
 			catalog_name = databricks_catalog.sandbox.name
 			schema_name = databricks_schema.things.name
 			depends_on = [ databricks_volume.this ] 
 		}
-
 		output "volumes" {
-			value = length(data.databricks_volumes.this.ids)
+			value = length(data.databricks_volumes_pluginframework.this.ids)
 		}
 		`,
-		Check: checkDataSourceVolumesPopulated(t),
+		Check: checkDataSourceVolumesPluginFrameworkPopulated(t),
 	})
 }


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
- Moving the test file to be next to the data source definition

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [x] covered with integration tests in `internal/acceptance`
- [x] relevant acceptance tests are passing
- [x] using Go SDK
