### PR TITLE
[Fix] Tables with struct subcolumns which have dot in their name are redeployed on databricks_sql_table resource #3866

### DIFF
--- a/catalog/resource_sql_table.go
+++ b/catalog/resource_sql_table.go
@@ -489,7 +489,8 @@ var columnTypeAliases = map[string]string{
 }
 
 func getColumnType(columnType string) string {
-	caseInsensitiveColumnType := strings.ToLower(columnType)
+	columnTypeNoBackticks := strings.ReplaceAll(columnType, "`", "")
+	caseInsensitiveColumnType := strings.ToLower(columnTypeNoBackticks)
 	if alias, ok := columnTypeAliases[caseInsensitiveColumnType]; ok {
 		return alias
 	}


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

Backticks are removed from the column type in order for struct subfield names to be compatible with the subfield names deployed. These subfields names are part of the column type. Example struct<\`x.z\`:string> == struct\<x.z:string>

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant acceptance tests are passing
- [x] using Go SDK

tested using internal integration tests where tables were created and terraform plans were reviewed to have no changes.
