### PR TITLE
[Doc] Small Grammar Corrections in Docs

### DIFF
--- a/docs/data-sources/aws_crossaccount_policy.md
+++ b/docs/data-sources/aws_crossaccount_policy.md
@@ -3,7 +3,7 @@ subcategory: "Deployment"
 ---
 # databricks_aws_crossaccount_policy Data Source
 
--> **Note** This data source could be only used with account-level provider!
+-> **Note** This data source can only be used with an account-level provider!
 
 This data source constructs necessary AWS cross-account policy for you, which is based on [official documentation](https://docs.databricks.com/administration-guide/account-api/iam-role.html#language-Your%C2%A0VPC,%C2%A0default).
 

--- a/docs/data-sources/catalog.md
+++ b/docs/data-sources/catalog.md
@@ -3,7 +3,7 @@ subcategory: "Unity Catalog"
 ---
 # databricks_catalog Data Source
 
--> **Note** This data source could be only used with workspace-level provider!
+-> **Note** This data source can only be used with a workspace-level provider!
 
 -> **Note** If you have a fully automated setup with workspaces created by [databricks_mws_workspaces](../resources/mws_workspaces.md) or [azurerm_databricks_workspace](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/databricks_workspace), please make sure to add [depends_on attribute](../guides/troubleshooting.md#data-resources-and-authentication-is-not-configured-errors) in order to prevent _default auth: cannot configure default credentials_ errors.
 

--- a/docs/data-sources/catalogs.md
+++ b/docs/data-sources/catalogs.md
@@ -3,7 +3,7 @@ subcategory: "Unity Catalog"
 ---
 # databricks_catalogs Data Source
 
--> **Note** This data source could be only used with workspace-level provider!
+-> **Note** This data source can only be used with a workspace-level provider!
 
 -> **Note** If you have a fully automated setup with workspaces created by [databricks_mws_workspaces](../resources/mws_workspaces.md) or [azurerm_databricks_workspace](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/databricks_workspace), please make sure to add [depends_on attribute](../guides/troubleshooting.md#data-resources-and-authentication-is-not-configured-errors) in order to prevent _default auth: cannot configure default credentials_ errors.
 

--- a/docs/data-sources/external_location.md
+++ b/docs/data-sources/external_location.md
@@ -3,7 +3,7 @@ subcategory: "Unity Catalog"
 ---
 # databricks_external_location Data Source
 
--> **Note** This data source could be only used with workspace-level provider!
+-> **Note** This data source can only be used with a workspace-level provider!
 
 Retrieves details about a [databricks_external_location](../resources/external_location.md) that were created by Terraform or manually.
 

--- a/docs/data-sources/external_locations.md
+++ b/docs/data-sources/external_locations.md
@@ -3,7 +3,7 @@ subcategory: "Unity Catalog"
 ---
 # databricks_external_locations Data Source
 
--> **Note** This data source could be only used with workspace-level provider!
+-> **Note** This data source can only be used with a workspace-level provider!
 
 Retrieves a list of [databricks_external_location](./external_location.md) objects, that were created by Terraform or manually, so that special handling could be applied.
 

--- a/docs/data-sources/metastore.md
+++ b/docs/data-sources/metastore.md
@@ -3,7 +3,7 @@ subcategory: "Unity Catalog"
 ---
 # databricks_metastore Data Source
 
--> **Note** This data source could be only used with account-level provider!
+-> **Note** This data source can only be used with an account-level provider!
 
 Retrieves information about metastore for a given id of [databricks_metastore](../resources/metastore.md) object, that was created by Terraform or manually, so that special handling could be applied.
 

--- a/docs/data-sources/metastores.md
+++ b/docs/data-sources/metastores.md
@@ -3,7 +3,7 @@ subcategory: "Unity Catalog"
 ---
 # databricks_metastores Data Source
 
--> **Note** This data source could be only used with account-level provider!
+-> **Note** This data source can only be used with an account-level provider!
 
 Retrieves a mapping of name to id of [databricks_metastore](../resources/metastore.md) objects, that were created by Terraform or manually, so that special handling could be applied.
 

--- a/docs/data-sources/schemas.md
+++ b/docs/data-sources/schemas.md
@@ -3,7 +3,7 @@ subcategory: "Unity Catalog"
 ---
 # databricks_schemas Data Source
 
--> **Note** This data source could be only used with workspace-level provider!
+-> **Note** This data source can only be used with a workspace-level provider!
 
 -> **Note** If you have a fully automated setup with workspaces created by [databricks_mws_workspaces](../resources/mws_workspaces.md) or [azurerm_databricks_workspace](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/databricks_workspace), please make sure to add [depends_on attribute](../guides/troubleshooting.md#data-resources-and-authentication-is-not-configured-errors) in order to prevent _default auth: cannot configure default credentials_ errors.
 

--- a/docs/data-sources/storage_credential.md
+++ b/docs/data-sources/storage_credential.md
@@ -3,7 +3,7 @@ subcategory: "Unity Catalog"
 ---
 # databricks_storage_credential Data Source
 
--> **Note** This data source could be only used with workspace-level provider!
+-> **Note** This data source can only be used with a workspace-level provider!
 
 Retrieves details about a [databricks_storage_credential](../resources/storage_credential.md) that were created by Terraform or manually.
 

--- a/docs/data-sources/storage_credentials.md
+++ b/docs/data-sources/storage_credentials.md
@@ -3,7 +3,7 @@ subcategory: "Unity Catalog"
 ---
 # databricks_storage_credentials Data Source
 
--> **Note** This data source could be only used with workspace-level provider!
+-> **Note** This data source can only be used with a workspace-level provider!
 
 Retrieves a list of [databricks_storage_credential](./storage_credential.md) objects, that were created by Terraform or manually, so that special handling could be applied.
 

--- a/docs/data-sources/table.md
+++ b/docs/data-sources/table.md
@@ -3,7 +3,7 @@ subcategory: "Unity Catalog"
 ---
 # databricks_table Data Source
 
--> **Note** This data source could be only used with workspace-level provider!
+-> **Note** This data source can only be used with a workspace-level provider!
 
 -> **Note** If you have a fully automated setup with workspaces created by [databricks_mws_workspaces](../resources/mws_workspaces.md) or [azurerm_databricks_workspace](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/databricks_workspace), please make sure to add [depends_on attribute](../guides/troubleshooting.md#data-resources-and-authentication-is-not-configured-errors) in order to prevent _default auth: cannot configure default credentials_ errors.
 

--- a/docs/data-sources/tables.md
+++ b/docs/data-sources/tables.md
@@ -3,7 +3,7 @@ subcategory: "Unity Catalog"
 ---
 # databricks_tables Data Source
 
--> **Note** This data source could be only used with workspace-level provider!
+-> **Note** This data source can only be used with a workspace-level provider!
 
 -> **Note** If you have a fully automated setup with workspaces created by [databricks_mws_workspaces](../resources/mws_workspaces.md) or [azurerm_databricks_workspace](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/databricks_workspace), please make sure to add [depends_on attribute](../guides/troubleshooting.md#data-resources-and-authentication-is-not-configured-errors) in order to prevent _default auth: cannot configure default credentials_ errors.
 

--- a/docs/data-sources/volumes.md
+++ b/docs/data-sources/volumes.md
@@ -3,7 +3,7 @@ subcategory: "Unity Catalog"
 ---
 # databricks_volumes Data Source
 
--> **Note** This data source could be only used with workspace-level provider!
+-> **Note** This data source can only be used with a workspace-level provider!
 
 Retrieves a list of [databricks_volume](../resources/volume.md) ids (full names), that were created by Terraform or manually.
 

--- a/docs/resources/access_control_rule_set.md
+++ b/docs/resources/access_control_rule_set.md
@@ -4,7 +4,7 @@ subcategory: "Security"
 
 # databricks_access_control_rule_set Resource
 
--> **Note** This resource could be used with account or workspace-level provider.
+-> **Note** This resource can be used with an account or workspace-level provider.
 
 This resource allows you to manage access rules on Databricks account level resources. For convenience we allow accessing this resource through the Databricks account and workspace.
 

--- a/docs/resources/artifact_allowlist.md
+++ b/docs/resources/artifact_allowlist.md
@@ -6,7 +6,7 @@ subcategory: "Unity Catalog"
 -> **Note**
   It is required to define all allowlist for an artifact type in a single resource, otherwise Terraform cannot guarantee config drift prevention.
 
--> **Note** This resource could be only used with workspace-level provider!
+-> **Note** This resource can only be used with a workspace-level provider!
 
 In Databricks Runtime 13.3 and above, you can add libraries and init scripts to the allowlist in UC so that users can leverage these artifacts on compute configured with shared access mode.
 

--- a/docs/resources/automatic_cluster_update_setting.md
+++ b/docs/resources/automatic_cluster_update_setting.md
@@ -4,7 +4,7 @@ subcategory: "Settings"
 
 # databricks_automatic_cluster_update_workspace_setting Resource
 
--> **Note** This resource could be only used with workspace-level provider!
+-> **Note** This resource can only be used with a workspace-level provider!
 
 The `databricks_automatic_cluster_update_workspace_setting` resource allows you to control whether automatic cluster update is enabled for the current workspace. By default, it is turned off. Enabling this feature on a workspace requires that you add the Enhanced Security and Compliance add-on.
 

--- a/docs/resources/catalog.md
+++ b/docs/resources/catalog.md
@@ -3,7 +3,7 @@ subcategory: "Unity Catalog"
 ---
 # databricks_catalog Resource
 
--> **Note** This resource could be only used with workspace-level provider!
+-> **Note** This resource can only be used with a workspace-level provider!
 
 Within a metastore, Unity Catalog provides a 3-level namespace for organizing data: Catalogs, Databases (also called Schemas), and Tables / Views.
 

--- a/docs/resources/compliance_security_profile_setting.md
+++ b/docs/resources/compliance_security_profile_setting.md
@@ -4,7 +4,7 @@ subcategory: "Settings"
 
 # databricks_compliance_security_profile_workspace_setting Resource
 
--> **Note** This resource could be only used with workspace-level provider!
+-> **Note** This resource can only be used with a workspace-level provider!
 
 -> **Note** This setting can NOT be disabled once it is enabled.
 

--- a/docs/resources/connection.md
+++ b/docs/resources/connection.md
@@ -3,7 +3,7 @@ subcategory: "Unity Catalog"
 ---
 # databricks_connection (Resource)
 
--> **Note** This resource could be only used with workspace-level provider!
+-> **Note** This resource can only be used with a workspace-level provider!
 
 Lakehouse Federation is the query federation platform for Databricks. Databricks uses Unity Catalog to manage query federation. To make a dataset available for read-only querying using Lakehouse Federation, you create the following:
 

--- a/docs/resources/default_namespace_setting.md
+++ b/docs/resources/default_namespace_setting.md
@@ -4,7 +4,7 @@ subcategory: "Settings"
 
 # databricks_default_namespace_setting Resource
 
--> **Note** This resource could be only used with workspace-level provider!
+-> **Note** This resource can only be used with a workspace-level provider!
 
 The `databricks_default_namespace_setting` resource allows you to operate the setting configuration for the default namespace in the Databricks workspace.
 Setting the default catalog for the workspace determines the catalog that is used when queries do not reference

--- a/docs/resources/enhanced_security_monitoring_setting.md
+++ b/docs/resources/enhanced_security_monitoring_setting.md
@@ -4,7 +4,7 @@ subcategory: "Settings"
 
 # databricks_enhanced_security_monitoring_workspace_setting Resource
 
--> **Note** This resource could be only used with workspace-level provider!
+-> **Note** This resource can only be used with a workspace-level provider!
 
 The `databricks_enhanced_security_monitoring_workspace_setting` resource allows you to control whether enhanced security monitoring 
 is enabled for the current workspace. If the compliance security profile is enabled, this is automatically enabled. By default, 

--- a/docs/resources/external_location.md
+++ b/docs/resources/external_location.md
@@ -3,7 +3,7 @@ subcategory: "Unity Catalog"
 ---
 # databricks_external_location Resource
 
--> **Note** This resource could be only used with workspace-level provider!
+-> **Note** This resource can only be used with a workspace-level provider!
 
 To work with external tables, Unity Catalog introduces two new objects to access and work with external cloud storage:
 

--- a/docs/resources/metastore.md
+++ b/docs/resources/metastore.md
@@ -3,7 +3,7 @@ subcategory: "Unity Catalog"
 ---
 # databricks_metastore Resource
 
--> **Note** This resource could be used with account or workspace-level provider.
+-> **Note** This resource can be used with an account or workspace-level provider.
 
 A metastore is the top-level container of objects in Unity Catalog. It stores data assets (tables and views) and the permissions that govern access to them. Databricks account admins can create metastores and assign them to Databricks workspaces in order to control which workloads use each metastore.
 

--- a/docs/resources/metastore_assignment.md
+++ b/docs/resources/metastore_assignment.md
@@ -3,7 +3,7 @@ subcategory: "Unity Catalog"
 ---
 # databricks_metastore_assignment (Resource)
 
--> **Note** This resource could be used with account or workspace-level provider.
+-> **Note** This resource can be used with an account or workspace-level provider.
 
 A single [databricks_metastore](metastore.md) can be shared across Databricks workspaces, and each linked workspace has a consistent view of the data and a single set of access policies. You can only create a single metastore for each region in which your organization operates.
 

--- a/docs/resources/metastore_data_access.md
+++ b/docs/resources/metastore_data_access.md
@@ -3,7 +3,7 @@ subcategory: "Unity Catalog"
 ---
 # databricks_metastore_data_access (Resource)
 
--> **Note** This resource could be used with account or workspace-level provider.
+-> **Note** This resource can be used with an account or workspace-level provider.
 
 Optionally, each [databricks_metastore](metastore.md) can have a default [databricks_storage_credential](storage_credential.md) defined as `databricks_metastore_data_access`. This will be used by Unity Catalog to access data in the root storage location if defined.
 

--- a/docs/resources/online_table.md
+++ b/docs/resources/online_table.md
@@ -4,7 +4,7 @@ subcategory: "Unity Catalog"
 # databricks_online_table (Resource)
 
 
--> **Note** This resource could be only used on Unity Catalog-enabled workspace!
+-> **Note** This resource can only be used on Unity Catalog-enabled workspace!
 
 This resource allows you to create [Online Table](https://docs.databricks.com/en/machine-learning/feature-store/online-tables.html) in Databricks.  An online table is a read-only copy of a Delta Table that is stored in row-oriented format optimized for online access. Online tables are fully serverless tables that auto-scale throughput capacity with the request load and provide low latency and high throughput access to data of any scale. Online tables are designed to work with Databricks Model Serving, Feature Serving, and retrieval-augmented generation (RAG) applications where they are used for fast data lookups.
 

--- a/docs/resources/online_table.md
+++ b/docs/resources/online_table.md
@@ -4,7 +4,7 @@ subcategory: "Unity Catalog"
 # databricks_online_table (Resource)
 
 
--> **Note** This resource can only be used on Unity Catalog-enabled workspace!
+-> **Note** This resource can only be used on a Unity Catalog-enabled workspace!
 
 This resource allows you to create [Online Table](https://docs.databricks.com/en/machine-learning/feature-store/online-tables.html) in Databricks.  An online table is a read-only copy of a Delta Table that is stored in row-oriented format optimized for online access. Online tables are fully serverless tables that auto-scale throughput capacity with the request load and provide low latency and high throughput access to data of any scale. Online tables are designed to work with Databricks Model Serving, Feature Serving, and retrieval-augmented generation (RAG) applications where they are used for fast data lookups.
 

--- a/docs/resources/provider.md
+++ b/docs/resources/provider.md
@@ -3,7 +3,7 @@ subcategory: "Delta Sharing"
 ---
 # databricks_provider Resource
 
--> **Note** This resource could be only used with workspace-level provider!
+-> **Note** This resource can only be used with a workspace-level provider!
 
 In Delta Sharing, a provider is an entity that shares data with a recipient. Within a metastore, Unity Catalog provides the ability to create a provider which contains a list of shares that have been shared with you.
 

--- a/docs/resources/recipient.md
+++ b/docs/resources/recipient.md
@@ -3,7 +3,7 @@ subcategory: "Delta Sharing"
 ---
 # databricks_recipient Resource
 
--> **Note** This resource could be only used with workspace-level provider!
+-> **Note** This resource can only be used with a workspace-level provider!
 
 In Delta Sharing, a recipient is an entity that receives shares from a provider. In Unity Catalog, a share is a securable object that represents an organization and associates it with a credential or secure sharing identifier that allows that organization to access one or more shares.
 

--- a/docs/resources/registered_model.md
+++ b/docs/resources/registered_model.md
@@ -3,7 +3,7 @@ subcategory: "Unity Catalog"
 ---
 # databricks_registered_model Resource
 
--> **Note** This resource could be only used with workspace-level provider!
+-> **Note** This resource can only be used with a workspace-level provider!
 
 This resource allows you to create [Models in Unity Catalog](https://docs.databricks.com/en/mlflow/models-in-uc.html) in Databricks.
 

--- a/docs/resources/restrict_workspace_admins_setting.md
+++ b/docs/resources/restrict_workspace_admins_setting.md
@@ -4,7 +4,7 @@ subcategory: "Settings"
 
 # databricks_restrict_workspace_admins_setting Resource
 
--> **Note** This resource could be only used with workspace-level provider!
+-> **Note** This resource can only be used with a workspace-level provider!
 
 The `databricks_restrict_workspace_admins_setting` resource lets you control the capabilities of workspace admins.
 

--- a/docs/resources/schema.md
+++ b/docs/resources/schema.md
@@ -3,7 +3,7 @@ subcategory: "Unity Catalog"
 ---
 # databricks_schema Resource
 
--> **Note** This resource could be only used with workspace-level provider!
+-> **Note** This resource can only be used with a workspace-level provider!
 
 Within a metastore, Unity Catalog provides a 3-level namespace for organizing data: Catalogs, Databases (also called Schemas), and Tables / Views.
 

--- a/docs/resources/share.md
+++ b/docs/resources/share.md
@@ -3,7 +3,7 @@ subcategory: "Delta Sharing"
 ---
 # databricks_share Resource
 
--> **Note** This resource could be only used with workspace-level provider!
+-> **Note** This resource can only be used with a workspace-level provider!
 
 In Delta Sharing, a share is a read-only collection of tables and table partitions that a provider wants to share with one or more recipients. If your recipient uses a Unity Catalog-enabled Databricks workspace, you can also include notebook files, views (including dynamic views that restrict access at the row and column level), Unity Catalog volumes, and Unity Catalog models in a share.
 

--- a/docs/resources/storage_credential.md
+++ b/docs/resources/storage_credential.md
@@ -3,7 +3,7 @@ subcategory: "Unity Catalog"
 ---
 # databricks_storage_credential Resource
 
--> **Note** This resource could be used with account or workspace-level provider.
+-> **Note** This resource can be used with an account or workspace-level provider.
 
 To work with external tables, Unity Catalog introduces two new objects to access and work with external cloud storage:
 

--- a/docs/resources/system_schema.md
+++ b/docs/resources/system_schema.md
@@ -5,7 +5,7 @@ subcategory: "Unity Catalog"
 
 -> **Public Preview** This feature is in [Public Preview](https://docs.databricks.com/release-notes/release-types.html).
 
--> **Note** This resource could be only used with workspace-level provider!
+-> **Note** This resource can only be used with a workspace-level provider!
 
 Manages system tables enablement. System tables are a Databricks-hosted analytical store of your account’s operational data. System tables can be used for historical observability across your account. System tables must be enabled by an account admin.
 

--- a/docs/resources/vector_search_endpoint.md
+++ b/docs/resources/vector_search_endpoint.md
@@ -3,7 +3,7 @@ subcategory: "Mosaic AI Vector Search"
 ---
 # databricks_vector_search_endpoint Resource
 
--> **Note** This resource could be only used on Unity Catalog-enabled workspace!
+-> **Note** This resource can only be used on Unity Catalog-enabled workspace!
 
 This resource allows you to create [Mosaic AI Vector Search Endpoint](https://docs.databricks.com/en/generative-ai/vector-search.html) in Databricks.  Mosaic AI Vector Search is a serverless similarity search engine that allows you to store a vector representation of your data, including metadata, in a vector database.  The Mosaic AI Vector Search Endpoint is used to create and access vector search indexes.
 

--- a/docs/resources/vector_search_endpoint.md
+++ b/docs/resources/vector_search_endpoint.md
@@ -3,7 +3,7 @@ subcategory: "Mosaic AI Vector Search"
 ---
 # databricks_vector_search_endpoint Resource
 
--> **Note** This resource can only be used on Unity Catalog-enabled workspace!
+-> **Note** This resource can only be used on a Unity Catalog-enabled workspace!
 
 This resource allows you to create [Mosaic AI Vector Search Endpoint](https://docs.databricks.com/en/generative-ai/vector-search.html) in Databricks.  Mosaic AI Vector Search is a serverless similarity search engine that allows you to store a vector representation of your data, including metadata, in a vector database.  The Mosaic AI Vector Search Endpoint is used to create and access vector search indexes.
 

--- a/docs/resources/vector_search_index.md
+++ b/docs/resources/vector_search_index.md
@@ -3,7 +3,7 @@ subcategory: "Mosaic AI Vector Search"
 ---
 # databricks_vector_search_index Resource
 
--> **Note** This resource could be only used on Unity Catalog-enabled workspace!
+-> **Note** This resource can only be used on Unity Catalog-enabled workspace!
 
 This resource allows you to create [Mosaic AI Vector Search Index](https://docs.databricks.com/en/generative-ai/create-query-vector-search.html) in Databricks.  Mosaic AI Vector Search is a serverless similarity search engine that allows you to store a vector representation of your data, including metadata, in a vector database.  The Mosaic AI Vector Search Index provides the ability to search data in the linked Delta Table.
 

--- a/docs/resources/vector_search_index.md
+++ b/docs/resources/vector_search_index.md
@@ -3,7 +3,7 @@ subcategory: "Mosaic AI Vector Search"
 ---
 # databricks_vector_search_index Resource
 
--> **Note** This resource can only be used on Unity Catalog-enabled workspace!
+-> **Note** This resource can only be used on a Unity Catalog-enabled workspace!
 
 This resource allows you to create [Mosaic AI Vector Search Index](https://docs.databricks.com/en/generative-ai/create-query-vector-search.html) in Databricks.  Mosaic AI Vector Search is a serverless similarity search engine that allows you to store a vector representation of your data, including metadata, in a vector database.  The Mosaic AI Vector Search Index provides the ability to search data in the linked Delta Table.
 

--- a/docs/resources/volume.md
+++ b/docs/resources/volume.md
@@ -5,7 +5,7 @@ subcategory: "Unity Catalog"
 
 -> **Public Preview** This feature is in [Public Preview](https://docs.databricks.com/release-notes/release-types.html).
 
--> **Note** This resource could be only used with workspace-level provider!
+-> **Note** This resource can only be used with a workspace-level provider!
 
 Volumes are Unity Catalog objects representing a logical volume of storage in a cloud object storage location. Volumes provide capabilities for accessing, storing, governing, and organizing files. While tables provide governance over tabular datasets, volumes add governance over non-tabular datasets. You can use volumes to store and access files in any format, including structured, semi-structured, and unstructured data.
 

--- a/docs/resources/workspace_binding.md
+++ b/docs/resources/workspace_binding.md
@@ -3,7 +3,7 @@ subcategory: "Unity Catalog"
 ---
 # databricks_workspace_binding Resource
 
--> **Note** This resource could be only used with workspace-level provider!
+-> **Note** This resource can only be used with a workspace-level provider!
 
 If you use workspaces to isolate user data access, you may want to limit access to catalog, external locations or storage credentials from specific workspaces in your account, also known as workspace binding
 


### PR DESCRIPTION
## Changes
Hey team,

This PR fixes a bunch of small nits in the documentation around verb tense (specifically 'could' vs 'can') and adds indefinite articles ('a'/'an') before singular resource references. This brings it more in line with other documentation, and fixes grammatical errors.


## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
