### PR TITLE
[Internal] Fix irregularities in plugin framework converter function errors

### DIFF
--- a/internal/providers/pluginfw/converters/converters_test.go
+++ b/internal/providers/pluginfw/converters/converters_test.go
@@ -105,7 +105,7 @@ func TestTfSdkToGoSdkStructConversionFailure(t *testing.T) {
 	tfSdkStruct := DummyTfSdk{}
 	goSdkStruct := DummyGoSdk{}
 	actualDiagnostics := TfSdkToGoSdkStruct(context.Background(), tfSdkStruct, goSdkStruct)
-	expectedDiagnostics := diag.Diagnostics{diag.NewErrorDiagnostic("please provide a pointer for the gosdk struct, got DummyGoSdk", tfSdkToGoSdkStructConversionFailureMessage)}
+	expectedDiagnostics := diag.Diagnostics{diag.NewErrorDiagnostic(tfSdkToGoSdkStructConversionFailureMessage, "please provide a pointer for the gosdk struct, got DummyGoSdk")}
 	assert.True(t, actualDiagnostics.HasError())
 	assert.True(t, actualDiagnostics.Equal(expectedDiagnostics))
 }
@@ -114,7 +114,7 @@ func TestGoSdkToTfSdkStructConversionFailure(t *testing.T) {
 	tfSdkStruct := DummyTfSdk{}
 	goSdkStruct := DummyGoSdk{}
 	actualDiagnostics := GoSdkToTfSdkStruct(context.Background(), goSdkStruct, tfSdkStruct)
-	expectedDiagnostics := diag.Diagnostics{diag.NewErrorDiagnostic("please provide a pointer for the tfsdk struct, got DummyTfSdk", goSdkToTfSdkStructConversionFailureMessage)}
+	expectedDiagnostics := diag.Diagnostics{diag.NewErrorDiagnostic(goSdkToTfSdkStructConversionFailureMessage, "please provide a pointer for the tfsdk struct, got DummyTfSdk")}
 	assert.True(t, actualDiagnostics.HasError())
 	assert.True(t, actualDiagnostics.Equal(expectedDiagnostics))
 }

--- a/internal/providers/pluginfw/converters/converters_test.go
+++ b/internal/providers/pluginfw/converters/converters_test.go
@@ -101,7 +101,7 @@ func RunConverterTest(t *testing.T, description string, tfSdkStruct DummyTfSdk, 
 	assert.True(t, reflect.DeepEqual(convertedTfSdkStruct, tfSdkStruct), fmt.Sprintf("gosdk to tfsdk conversion - %s", description))
 }
 
-func TestSdkToGoSdkStructConversionFailure(t *testing.T) {
+func TestTfSdkToGoSdkStructConversionFailure(t *testing.T) {
 	tfSdkStruct := DummyTfSdk{}
 	goSdkStruct := DummyGoSdk{}
 	actualDiagnostics := TfSdkToGoSdkStruct(context.Background(), tfSdkStruct, goSdkStruct)

--- a/internal/providers/pluginfw/converters/converters_test.go
+++ b/internal/providers/pluginfw/converters/converters_test.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/stretchr/testify/assert"
 )
@@ -98,6 +99,24 @@ func RunConverterTest(t *testing.T, description string, tfSdkStruct DummyTfSdk, 
 	convertedTfSdkStruct := DummyTfSdk{}
 	assert.True(t, !GoSdkToTfSdkStruct(context.Background(), goSdkStruct, &convertedTfSdkStruct).HasError())
 	assert.True(t, reflect.DeepEqual(convertedTfSdkStruct, tfSdkStruct), fmt.Sprintf("gosdk to tfsdk conversion - %s", description))
+}
+
+func TestTfSdkToGoSdkStructConversionFailure(t *testing.T) {
+	tfSdkStruct := DummyTfSdk{}
+	goSdkStruct := DummyGoSdk{}
+	actualDiagnostics := TfSdkToGoSdkStruct(context.Background(), tfSdkStruct, goSdkStruct)
+	expectedDiagnostics := diag.Diagnostics{diag.NewErrorDiagnostic("please provide a pointer for the gosdk struct, got DummyGoSdk", tfSdkToGoSdkStructConversionFailureMessage)}
+	assert.True(t, actualDiagnostics.HasError())
+	assert.True(t, actualDiagnostics.Equal(expectedDiagnostics))
+}
+
+func TestGoSdkToTfSdkStructConversionFailure(t *testing.T) {
+	tfSdkStruct := DummyTfSdk{}
+	goSdkStruct := DummyGoSdk{}
+	actualDiagnostics := GoSdkToTfSdkStruct(context.Background(), goSdkStruct, tfSdkStruct)
+	expectedDiagnostics := diag.Diagnostics{diag.NewErrorDiagnostic("please provide a pointer for the tfsdk struct, got DummyTfSdk", goSdkToTfSdkStructConversionFailureMessage)}
+	assert.True(t, actualDiagnostics.HasError())
+	assert.True(t, actualDiagnostics.Equal(expectedDiagnostics))
 }
 
 var tests = []struct {

--- a/internal/providers/pluginfw/converters/converters_test.go
+++ b/internal/providers/pluginfw/converters/converters_test.go
@@ -101,7 +101,7 @@ func RunConverterTest(t *testing.T, description string, tfSdkStruct DummyTfSdk, 
 	assert.True(t, reflect.DeepEqual(convertedTfSdkStruct, tfSdkStruct), fmt.Sprintf("gosdk to tfsdk conversion - %s", description))
 }
 
-func TestTfSdkToGoSdkStructConversionFailure(t *testing.T) {
+func TestSdkToGoSdkStructConversionFailure(t *testing.T) {
 	tfSdkStruct := DummyTfSdk{}
 	goSdkStruct := DummyGoSdk{}
 	actualDiagnostics := TfSdkToGoSdkStruct(context.Background(), tfSdkStruct, goSdkStruct)

--- a/internal/providers/pluginfw/converters/go_to_tf.go
+++ b/internal/providers/pluginfw/converters/go_to_tf.go
@@ -41,12 +41,12 @@ func GoSdkToTfSdkStruct(ctx context.Context, gosdk interface{}, tfsdk interface{
 	}
 
 	if destVal.Kind() != reflect.Ptr {
-		return diag.Diagnostics{diag.NewErrorDiagnostic(fmt.Sprintf("please provide a pointer for the tfsdk struct, got %s", destVal.Type().Name()), goSdkToTfSdkStructConversionFailureMessage)}
+		return diag.Diagnostics{diag.NewErrorDiagnostic(goSdkToTfSdkStructConversionFailureMessage, fmt.Sprintf("please provide a pointer for the tfsdk struct, got %s", destVal.Type().Name()))}
 	}
 	destVal = destVal.Elem()
 
 	if srcVal.Kind() != reflect.Struct || destVal.Kind() != reflect.Struct {
-		return diag.Diagnostics{diag.NewErrorDiagnostic(fmt.Sprintf("input should be structs %s, %s", srcVal.Type().Name(), destVal.Type().Name()), goSdkToTfSdkStructConversionFailureMessage)}
+		return diag.Diagnostics{diag.NewErrorDiagnostic(goSdkToTfSdkStructConversionFailureMessage, fmt.Sprintf("input should be structs %s, %s", srcVal.Type().Name(), destVal.Type().Name()))}
 	}
 
 	var forceSendFieldVal []string
@@ -76,7 +76,7 @@ func GoSdkToTfSdkStruct(ctx context.Context, gosdk interface{}, tfsdk interface{
 
 		err := goSdkToTfSdkSingleField(ctx, srcField, destField, fieldInForceSendFields(srcFieldName, forceSendFieldVal))
 		if err != nil {
-			return diag.Diagnostics{diag.NewErrorDiagnostic(err.Error(), goSdkToTfSdkFieldConversionFailureMessage)}
+			return diag.Diagnostics{diag.NewErrorDiagnostic(goSdkToTfSdkFieldConversionFailureMessage, err.Error())}
 		}
 	}
 	return nil

--- a/internal/providers/pluginfw/converters/go_to_tf.go
+++ b/internal/providers/pluginfw/converters/go_to_tf.go
@@ -13,8 +13,8 @@ import (
 	"github.com/databricks/terraform-provider-databricks/internal/tfreflect"
 )
 
-var goSdkToTfSdkStructConversionFailureMessage = "gosdk to tfsdk struct conversion failure"
-var goSdkToTfSdkFieldConversionFailureMessage = "gosdk to tfsdk field conversion failure"
+const goSdkToTfSdkStructConversionFailureMessage = "gosdk to tfsdk struct conversion failure"
+const goSdkToTfSdkFieldConversionFailureMessage = "gosdk to tfsdk field conversion failure"
 
 // GoSdkToTfSdkStruct converts a gosdk struct into a tfsdk struct, with the folowing rules.
 //

--- a/internal/providers/pluginfw/converters/go_to_tf.go
+++ b/internal/providers/pluginfw/converters/go_to_tf.go
@@ -41,7 +41,7 @@ func GoSdkToTfSdkStruct(ctx context.Context, gosdk interface{}, tfsdk interface{
 	}
 
 	if destVal.Kind() != reflect.Ptr {
-		return diag.Diagnostics{diag.NewErrorDiagnostic("please provide a pointer for the tfsdk struct", goSdkToTfSdkStructConversionFailureMessage)}
+		return diag.Diagnostics{diag.NewErrorDiagnostic(fmt.Sprintf("please provide a pointer for the tfsdk struct, got %s", destVal.Type().Name()), goSdkToTfSdkStructConversionFailureMessage)}
 	}
 	destVal = destVal.Elem()
 

--- a/internal/providers/pluginfw/converters/go_to_tf.go
+++ b/internal/providers/pluginfw/converters/go_to_tf.go
@@ -13,6 +13,9 @@ import (
 	"github.com/databricks/terraform-provider-databricks/internal/tfreflect"
 )
 
+var goSdkToTfSdkStructConversionFailureMessage = "gosdk to tfsdk struct conversion failure"
+var goSdkToTfSdkFieldConversionFailureMessage = "gosdk to tfsdk field conversion failure"
+
 // GoSdkToTfSdkStruct converts a gosdk struct into a tfsdk struct, with the folowing rules.
 //
 //	string -> types.String
@@ -38,12 +41,12 @@ func GoSdkToTfSdkStruct(ctx context.Context, gosdk interface{}, tfsdk interface{
 	}
 
 	if destVal.Kind() != reflect.Ptr {
-		return diag.Diagnostics{diag.NewErrorDiagnostic("please provide a pointer for the tfsdk struct", "tfsdk to gosdk struct conversion failure")}
+		return diag.Diagnostics{diag.NewErrorDiagnostic("please provide a pointer for the tfsdk struct", goSdkToTfSdkStructConversionFailureMessage)}
 	}
 	destVal = destVal.Elem()
 
 	if srcVal.Kind() != reflect.Struct || destVal.Kind() != reflect.Struct {
-		return diag.Diagnostics{diag.NewErrorDiagnostic(fmt.Sprintf("input should be structs %s, %s", srcVal.Type().Name(), destVal.Type().Name()), "tfsdk to gosdk struct conversion failure")}
+		return diag.Diagnostics{diag.NewErrorDiagnostic(fmt.Sprintf("input should be structs %s, %s", srcVal.Type().Name(), destVal.Type().Name()), goSdkToTfSdkStructConversionFailureMessage)}
 	}
 
 	var forceSendFieldVal []string
@@ -73,7 +76,7 @@ func GoSdkToTfSdkStruct(ctx context.Context, gosdk interface{}, tfsdk interface{
 
 		err := goSdkToTfSdkSingleField(ctx, srcField, destField, fieldInForceSendFields(srcFieldName, forceSendFieldVal))
 		if err != nil {
-			return diag.Diagnostics{diag.NewErrorDiagnostic(err.Error(), "gosdk to tfsdk field conversion failure")}
+			return diag.Diagnostics{diag.NewErrorDiagnostic(err.Error(), goSdkToTfSdkFieldConversionFailureMessage)}
 		}
 	}
 	return nil
@@ -101,7 +104,7 @@ func goSdkToTfSdkSingleField(ctx context.Context, srcField reflect.Value, destFi
 
 		// Recursively populate the nested struct.
 		if GoSdkToTfSdkStruct(ctx, srcFieldValue, destField.Interface()).HasError() {
-			panic(fmt.Sprintf("Error converting gosdk to tfsdk struct. %s", common.TerraformBugErrorMessage))
+			panic(fmt.Sprintf("%s. %s", goSdkToTfSdkStructConversionFailureMessage, common.TerraformBugErrorMessage))
 		}
 	case reflect.Bool:
 		boolVal := srcFieldValue.(bool)
@@ -150,7 +153,7 @@ func goSdkToTfSdkSingleField(ctx context.Context, srcField reflect.Value, destFi
 		}
 		// resolve the nested struct by recursively calling the function
 		if GoSdkToTfSdkStruct(ctx, srcFieldValue, destField.Addr().Interface()).HasError() {
-			panic(fmt.Sprintf("Error converting gosdk to tfsdk struct. %s", common.TerraformBugErrorMessage))
+			panic(fmt.Sprintf("%s. %s", goSdkToTfSdkStructConversionFailureMessage, common.TerraformBugErrorMessage))
 		}
 	case reflect.Slice:
 		if srcField.IsNil() {

--- a/internal/providers/pluginfw/converters/tf_to_go.go
+++ b/internal/providers/pluginfw/converters/tf_to_go.go
@@ -40,12 +40,12 @@ func TfSdkToGoSdkStruct(ctx context.Context, tfsdk interface{}, gosdk interface{
 	}
 
 	if destVal.Kind() != reflect.Ptr {
-		return diag.Diagnostics{diag.NewErrorDiagnostic(fmt.Sprintf("please provide a pointer for the gosdk struct, got %s", destVal.Type().Name()), tfSdkToGoSdkStructConversionFailureMessage)}
+		return diag.Diagnostics{diag.NewErrorDiagnostic(tfSdkToGoSdkStructConversionFailureMessage, fmt.Sprintf("please provide a pointer for the gosdk struct, got %s", destVal.Type().Name()))}
 	}
 	destVal = destVal.Elem()
 
 	if srcVal.Kind() != reflect.Struct {
-		return diag.Diagnostics{diag.NewErrorDiagnostic(fmt.Sprintf("input should be structs, got %s,", srcVal.Type().Name()), tfSdkToGoSdkStructConversionFailureMessage)}
+		return diag.Diagnostics{diag.NewErrorDiagnostic(tfSdkToGoSdkStructConversionFailureMessage, fmt.Sprintf("input should be structs, got %s,", srcVal.Type().Name()))}
 	}
 
 	forceSendFieldsField := destVal.FieldByName("ForceSendFields")
@@ -64,7 +64,7 @@ func TfSdkToGoSdkStruct(ctx context.Context, tfsdk interface{}, gosdk interface{
 
 		err := tfSdkToGoSdkSingleField(ctx, srcField, destField, srcFieldName, &forceSendFieldsField)
 		if err != nil {
-			return diag.Diagnostics{diag.NewErrorDiagnostic(err.Error(), tfSdkToGoSdkFieldConversionFailureMessage)}
+			return diag.Diagnostics{diag.NewErrorDiagnostic(tfSdkToGoSdkFieldConversionFailureMessage, err.Error())}
 		}
 	}
 

--- a/internal/providers/pluginfw/converters/tf_to_go.go
+++ b/internal/providers/pluginfw/converters/tf_to_go.go
@@ -14,8 +14,8 @@ import (
 	"github.com/databricks/terraform-provider-databricks/internal/tfreflect"
 )
 
-var tfSdkToGoSdkStructConversionFailureMessage = "tfsdk to gosdk struct conversion failure"
-var tfSdkToGoSdkFieldConversionFailureMessage = "tfsdk to gosdk field conversion failure"
+const tfSdkToGoSdkStructConversionFailureMessage = "tfsdk to gosdk struct conversion failure"
+const tfSdkToGoSdkFieldConversionFailureMessage = "tfsdk to gosdk field conversion failure"
 
 // TfSdkToGoSdkStruct converts a tfsdk struct into a gosdk struct, with the folowing rules.
 //


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
I noticed few irregularities in converter functions while working on clusters plugin framework migration, creating a PR to address those: 
1. Typo in error message -- in `GoSdkToTfSdkStruct` we say: `tfsdk to gosdk struct conversion failure`. It should be `gosdk to tfsdk struct conversion failure`
2.  In `GoSdkToTfSdkStruct ` we don't specify destination value type but we do it in `TfSdkToGoSdkStruct`. 
3. Abstract the error message out to reduce redundancy 
4. Standardise similar types of error messages to be same so it's easier to maintain. 

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->
Added unit tests. 

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
