### PR TITLE
[Exporter] Ignore `databricks_artifact_allowlist` with zero `artifact_matcher` blocks

### DIFF
--- a/exporter/importables.go
+++ b/exporter/importables.go
@@ -2518,6 +2518,14 @@ var resourcesMap map[string]importable = map[string]importable{
 			}
 			return nil
 		},
+		Ignore: func(ic *importContext, r *resource) bool {
+			numBlocks := r.Data.Get("artifact_matcher.#").(int)
+			if numBlocks == 0 {
+				log.Printf("[WARN] Ignoring artifcat allowlist with ID %s", r.ID)
+				ic.addIgnoredResource(fmt.Sprintf("databricks_artifact_allowlist. id=%s", r.ID))
+			}
+			return numBlocks == 0
+		},
 		Depends: []reference{
 			{Path: "artifact_matcher.artifact", Resource: "databricks_volume", Match: "volume_path",
 				IsValidApproximation: isMatchingAllowListArtifact},

--- a/exporter/importables_test.go
+++ b/exporter/importables_test.go
@@ -1474,6 +1474,34 @@ func TestListUcAllowListSuccess(t *testing.T) {
 	err := resourcesMap["databricks_artifact_allowlist"].List(ic)
 	assert.NoError(t, err)
 	assert.Equal(t, len(ic.testEmits), 3)
+	// Test ignore function
+	d := tfcatalog.ResourceArtifactAllowlist().ToResource().TestResourceData()
+	d.MarkNewResource()
+	d.Set("id", "abc")
+	res := ic.Importables["databricks_artifact_allowlist"].Ignore(ic, &resource{
+		ID:   "abc",
+		Data: d,
+	})
+	assert.True(t, res)
+	assert.Contains(t, ic.ignoredResources, "databricks_artifact_allowlist. id=abc")
+	// Test ignore function, with blocks
+	err = common.StructToData(
+		tfcatalog.ArtifactAllowlistInfo{
+			ArtifactType: "INIT_SCRIPT",
+			ArtifactMatchers: []catalog.ArtifactMatcher{
+				{
+					Artifact:  "/Volumes/inits",
+					MatchType: "PREFIX_MATCH",
+				},
+			},
+		},
+		tfcatalog.ResourceArtifactAllowlist().Schema, d)
+	assert.NoError(t, err)
+	res = ic.Importables["databricks_artifact_allowlist"].Ignore(ic, &resource{
+		ID:   "abc",
+		Data: d,
+	})
+	assert.False(t, res)
 }
 
 func TestEmitSqlParent(t *testing.T) {


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

Don't generate `databricks_artifact_allowlist` when no `artifact_matcher` blocks are defined

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
