### PR TITLE
[Fix] Permanently delete `ERROR` and `TERMINATED` state clusters if their creation fails

### DIFF
--- a/clusters/resource_cluster.go
+++ b/clusters/resource_cluster.go
@@ -472,6 +472,8 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, c *commo
 
 	clusterInfo, err := clusterWaiter.GetWithTimeout(timeout)
 	if err != nil {
+		// In case of error or terminated state, WaitGetClusterRunning return an error and we cleanup the cluster before returning
+		resourceClusterDelete(ctx, d, c)
 		return err
 	}
 

--- a/clusters/resource_cluster.go
+++ b/clusters/resource_cluster.go
@@ -473,7 +473,10 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, c *commo
 	clusterInfo, err := clusterWaiter.GetWithTimeout(timeout)
 	if err != nil {
 		// In case of "ERROR" or "TERMINATED" state, WaitGetClusterRunning returns an error and we should delete the cluster before returning
-		resourceClusterDelete(ctx, d, c)
+		deleteError := resourceClusterDelete(ctx, d, c)
+		if deleteError != nil {
+			return fmt.Errorf("failed to create cluster: %v and failed to delete it during cleanup: %v", err, deleteError)
+		}
 		return err
 	}
 

--- a/clusters/resource_cluster.go
+++ b/clusters/resource_cluster.go
@@ -472,7 +472,7 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, c *commo
 
 	clusterInfo, err := clusterWaiter.GetWithTimeout(timeout)
 	if err != nil {
-		// In case of error or terminated state, WaitGetClusterRunning return an error and we cleanup the cluster before returning
+		// In case of "ERROR" or "TERMINATED" state, WaitGetClusterRunning returns an error and we should delete the cluster before returning
 		resourceClusterDelete(ctx, d, c)
 		return err
 	}


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
If we get error or terminated cluster (after getting WaitGetClusterRunning in Create) then we permanently delete them. 

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->
Unit tests
- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
