### PR TITLE
Add datasource `databricks_users`

### DIFF
--- a/docs/data-sources/users.md
+++ b/docs/data-sources/users.md
@@ -1,0 +1,63 @@
+---
+subcategory: "Security"
+---
+
+# databricks_users Data Source
+
+->**Note** This is an account-level data source.
+
+-> **Note** If you have a fully automated setup with workspaces created by [databricks_mws_workspaces](../resources/mws_workspaces.md) or [azurerm_databricks_workspace](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/databricks_workspace), please make sure to add [depends_on attribute](../guides/troubleshooting.md#data-resources-and-authentication-is-not-configured-errors) in order to prevent _default auth: cannot configure default credentials_ errors.
+
+Retrieves information about multiple [databricks_user](../resources/user.md) resources.
+
+## Example Usage
+
+Adding a subset of users to a group
+
+```hcl
+data "databricks_users" "company_users" {
+  user_name_contains = "@domain.org"
+}
+
+resource "databricks_group" "data_users_group" {
+  display_name = "Data Users"
+}
+
+resource "databricks_group_member" "add_users_to_group" {
+  for_each = { for user in data.databricks_users.company_users.users : user.id => user }
+  group_id  = databricks_group.data_users_group.id
+  member_id = each.value.id
+}
+```
+
+## Argument Reference
+
+This data source allows you to filter the list of users using the following optional arguments: 
+
+- `display_name_contains` - (Optional) A substring to filter users by their display name. Only users whose display names contain this substring will be included in the results.
+- `user_name_contains` - (Optional) A substring to filter users by their username. Only users whose usernames contain this substring will be included in the results.
+
+->**Note** You can specify **exactly one** of `display_name_contains` or `user_name_contains`. If neither is specified, all users will be returned.
+
+## Attribute Reference
+
+This data source exposes the following attributes:
+
+- `users` - A list of users matching the specified criteria. Each user has the following attributes:
+    - `id` - The ID of the user.
+    - `user_name` - The username of the user.
+    - `display_name` - The display name of the user. 
+
+## Related Resources
+
+The following resources are used in the same context:
+
+- [**databricks_user**](../resources/user.md): Resource to manage individual users in Databricks.
+
+- [**databricks_group**](../resources/group.md): Resource to manage groups in Databricks.
+
+- [**databricks_group_member**](../resources/group_member.md): Resource to manage group memberships by adding users to groups.
+
+- [**databricks_permissions**](../resources/permissions.md): Resource to manage access control in the Databricks workspace.
+
+- [**databricks_current_user**](current_user.md): Data source to retrieve information about the user or service principal that is calling the Databricks REST API.

--- a/internal/acceptance/data_users_test.go
+++ b/internal/acceptance/data_users_test.go
@@ -1,0 +1,67 @@
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+func TestAccDataSourceDataUsers_DisplayNameContains(t *testing.T) {
+	accountLevel(t, step{
+		Template: `
+		data "databricks_data_users" "this" {
+			display_name_contains = "testuser"
+		}`,
+		Check: func(s *terraform.State) error {
+			r, ok := s.RootModule().Resources["data.databricks_data_users.this"]
+			if !ok {
+				return fmt.Errorf("data not found in state")
+			}
+			ids := r.Primary.Attributes["users.#"]
+			if ids == "" {
+				return fmt.Errorf("users is empty: %v", r.Primary.Attributes)
+			}
+			return nil
+		},
+	})
+}
+
+func TestAccDataSourceDataUsers_UserNameContains(t *testing.T) {
+	accountLevel(t, step{
+		Template: `
+		data "databricks_data_users" "this" {
+			user_name_contains = "example.com"
+		}`,
+		Check: func(s *terraform.State) error {
+			r, ok := s.RootModule().Resources["data.databricks_data_users.this"]
+			if !ok {
+				return fmt.Errorf("data not found in state")
+			}
+			usersCount := r.Primary.Attributes["users.#"]
+			if usersCount == "" || usersCount == "0" {
+				return fmt.Errorf("users list is empty: %v", r.Primary.Attributes)
+			}
+			return nil
+		},
+	})
+}
+
+func TestAccDataSourceDataUsers_NoFilters(t *testing.T) {
+	accountLevel(t, step{
+		Template: `
+		data "databricks_data_users" "this" {
+		}`,
+		Check: func(s *terraform.State) error {
+			r, ok := s.RootModule().Resources["data.databricks_data_users.this"]
+			if !ok {
+				return fmt.Errorf("data not found in state")
+			}
+			usersCount := r.Primary.Attributes["users.#"]
+			if usersCount == "" || usersCount == "0" {
+				return fmt.Errorf("users list is empty: %v", r.Primary.Attributes)
+			}
+			return nil
+		},
+	})
+}

--- a/scim/data_users.go
+++ b/scim/data_users.go
@@ -1,0 +1,52 @@
+package scim
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/databricks/databricks-sdk-go"
+	"github.com/databricks/databricks-sdk-go/service/iam"
+	"github.com/databricks/terraform-provider-databricks/common"
+)
+
+func DataSourceDataUsers() common.Resource {
+
+	type DataUsers struct {
+		Id                  string                   `json:"id,omitempty" tf:"computed"`
+		DisplayNameContains string                   `json:"display_name_contains,omitempty" tf:"computed"`
+		Users               []map[string]interface{} `json:"users,omitempty" tf:"computed"`
+	}
+
+	return common.AccountData(func(ctx context.Context, data *DataUsers, acc *databricks.AccountClient) error {
+		listRequest := iam.ListAccountUsersRequest{}
+
+		if data.DisplayNameContains != "" {
+			listRequest.Filter = fmt.Sprintf("displayName co \"%s\"", data.DisplayNameContains)
+		}
+
+		userList, err := acc.Users.ListAll(ctx, listRequest)
+
+		if err != nil {
+			return err
+		}
+
+		if len(userList) == 0 {
+			return fmt.Errorf("cannot find users with display name containing %s", data.DisplayNameContains)
+		}
+
+		var users []map[string]interface{}
+
+		for _, u := range userList {
+			user := map[string]interface{}{
+				"id":           u.Id,
+				"user_name":    u.UserName,
+				"display_name": u.DisplayName,
+			}
+			users = append(users, user)
+		}
+
+		data.Users = users
+
+		return nil
+	})
+}

--- a/scim/data_users_test.go
+++ b/scim/data_users_test.go
@@ -1,6 +1,7 @@
 package scim
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/databricks/databricks-sdk-go/experimental/mocks"
@@ -9,7 +10,7 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
-func TestDataSourceDataUsers(t *testing.T) {
+func TestDataSourceDataUsers_DisplayNameContains(t *testing.T) {
 	qa.ResourceFixture{
 		MockAccountClientFunc: func(m *mocks.MockAccountClient) {
 			e := m.GetMockAccountUsersAPI()
@@ -49,12 +50,139 @@ func TestDataSourceDataUsers(t *testing.T) {
 	})
 }
 
-func TestCatalogsData_Error(t *testing.T) {
+func TestDataSourceDataUsers_UserNameContains(t *testing.T) {
 	qa.ResourceFixture{
-		Fixtures:    qa.HTTPFailures,
+		MockAccountClientFunc: func(m *mocks.MockAccountClient) {
+			e := m.GetMockAccountUsersAPI()
+			e.On("ListAll",
+				mock.Anything,
+				mock.MatchedBy(func(req iam.ListAccountUsersRequest) bool {
+					return req.Filter == `userName co "testuser"` &&
+						req.Attributes == "id,userName,displayName"
+				})).Return([]iam.User{
+				{
+					Id:          "123",
+					UserName:    "testuser@example.com",
+					DisplayName: "testuser",
+				},
+				{
+					Id:          "456",
+					UserName:    "testuser2@example.com",
+					DisplayName: "testuser2",
+				},
+			}, nil)
+		},
 		Resource:    DataSourceDataUsers(),
 		Read:        true,
 		NonWritable: true,
 		ID:          "_",
-	}.ExpectError(t, "i'm a teapot")
+		HCL: `
+		user_name_contains = "testuser"
+		`,
+	}.ApplyAndExpectData(t, map[string]any{
+		"users.#":              2,
+		"users.0.id":           "123",
+		"users.0.user_name":    "testuser@example.com",
+		"users.0.display_name": "testuser",
+		"users.1.id":           "456",
+		"users.1.user_name":    "testuser2@example.com",
+		"users.1.display_name": "testuser2",
+	})
+}
+
+func TestDataSourceDataUsers_BothFiltersSpecified(t *testing.T) {
+	qa.ResourceFixture{
+		Resource:    DataSourceDataUsers(),
+		Read:        true,
+		NonWritable: true,
+		ID:          "_",
+		HCL: `
+        display_name_contains = "user"
+        user_name_contains    = "example.com"
+        `,
+	}.ExpectError(t, "exactly one of display_name_contains or user_name_contains should be specified, not both")
+}
+
+func TestDataSourceDataUsersNoUsers(t *testing.T) {
+	qa.ResourceFixture{
+		MockAccountClientFunc: func(m *mocks.MockAccountClient) {
+			e := m.GetMockAccountUsersAPI()
+			e.On("ListAll",
+				mock.Anything,
+				mock.MatchedBy(func(req iam.ListAccountUsersRequest) bool {
+					return req.Filter == `displayName co "testuser"` &&
+						req.Attributes == "id,userName,displayName"
+				})).Return([]iam.User{}, nil)
+		},
+		Resource:    DataSourceDataUsers(),
+		Read:        true,
+		NonWritable: true,
+		ID:          "_",
+		HCL: `
+		display_name_contains = "testuser"
+		`,
+	}.ExpectError(t, "cannot find users with display name containing testuser")
+}
+
+func TestDataSourceDataUsersNoFilter(t *testing.T) {
+	qa.ResourceFixture{
+		MockAccountClientFunc: func(m *mocks.MockAccountClient) {
+			e := m.GetMockAccountUsersAPI()
+			e.On("ListAll",
+				mock.Anything,
+				mock.MatchedBy(func(req iam.ListAccountUsersRequest) bool {
+					return req.Attributes == "id,userName,displayName"
+				})).Return([]iam.User{
+				{
+					Id:          "123",
+					UserName:    "testuser@example.com",
+					DisplayName: "testuser",
+				},
+				{
+					Id:          "456",
+					UserName:    "testuser2@example.com",
+					DisplayName: "testuser2",
+				},
+				{
+					Id:          "789",
+					UserName:    "testuser3@example.com",
+					DisplayName: "testuser3",
+				},
+			}, nil)
+		},
+		Resource:    DataSourceDataUsers(),
+		Read:        true,
+		NonWritable: true,
+		ID:          "_",
+	}.ApplyAndExpectData(t, map[string]any{
+		"users.#":              3,
+		"users.0.id":           "123",
+		"users.0.user_name":    "testuser@example.com",
+		"users.0.display_name": "testuser",
+		"users.1.id":           "456",
+		"users.1.user_name":    "testuser2@example.com",
+		"users.1.display_name": "testuser2",
+		"users.2.id":           "789",
+		"users.2.user_name":    "testuser3@example.com",
+		"users.2.display_name": "testuser3",
+	})
+}
+
+func TestDataSourceDataUsers_APIError(t *testing.T) {
+	qa.ResourceFixture{
+		MockAccountClientFunc: func(m *mocks.MockAccountClient) {
+			usersAPI := m.GetMockAccountUsersAPI()
+			usersAPI.On("ListAll",
+				mock.Anything,
+				mock.Anything,
+			).Return(nil, fmt.Errorf("api error"))
+		},
+		Resource:    DataSourceDataUsers(),
+		Read:        true,
+		NonWritable: true,
+		ID:          "_",
+		HCL: `
+		display_name_contains = "testuser"
+		`,
+	}.ExpectError(t, "api error")
 }

--- a/scim/data_users_test.go
+++ b/scim/data_users_test.go
@@ -3,19 +3,50 @@ package scim
 import (
 	"testing"
 
+	"github.com/databricks/databricks-sdk-go/experimental/mocks"
+	"github.com/databricks/databricks-sdk-go/service/iam"
 	"github.com/databricks/terraform-provider-databricks/qa"
+	"github.com/stretchr/testify/mock"
 )
 
 func TestDataSourceDataUsers(t *testing.T) {
 	qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			// TODO: run this test to get fixtures
+		MockAccountClientFunc: func(m *mocks.MockAccountClient) {
+			e := m.GetMockAccountUsersAPI()
+			e.On("ListAll",
+				mock.Anything,
+				mock.MatchedBy(func(req iam.ListAccountUsersRequest) bool {
+					return req.Filter == `displayName co "testuser"` &&
+						req.Attributes == "id,userName,displayName"
+				})).Return([]iam.User{
+				{
+					Id:          "123",
+					UserName:    "testuser@example.com",
+					DisplayName: "testuser",
+				},
+				{
+					Id:          "456",
+					UserName:    "testuser2@example.com",
+					DisplayName: "testuser2",
+				},
+			}, nil)
 		},
 		Resource:    DataSourceDataUsers(),
 		Read:        true,
 		NonWritable: true,
 		ID:          "_",
-	}.ApplyNoError(t)
+		HCL: `
+		display_name_contains = "testuser"
+		`,
+	}.ApplyAndExpectData(t, map[string]any{
+		"users.#":              2,
+		"users.0.id":           "123",
+		"users.0.user_name":    "testuser@example.com",
+		"users.0.display_name": "testuser",
+		"users.1.id":           "456",
+		"users.1.user_name":    "testuser2@example.com",
+		"users.1.display_name": "testuser2",
+	})
 }
 
 func TestCatalogsData_Error(t *testing.T) {

--- a/scim/data_users_test.go
+++ b/scim/data_users_test.go
@@ -1,0 +1,29 @@
+package scim
+
+import (
+	"testing"
+
+	"github.com/databricks/terraform-provider-databricks/qa"
+)
+
+func TestDataSourceDataUsers(t *testing.T) {
+	qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			// TODO: run this test to get fixtures
+		},
+		Resource:    DataSourceDataUsers(),
+		Read:        true,
+		NonWritable: true,
+		ID:          "_",
+	}.ApplyNoError(t)
+}
+
+func TestCatalogsData_Error(t *testing.T) {
+	qa.ResourceFixture{
+		Fixtures:    qa.HTTPFailures,
+		Resource:    DataSourceDataUsers(),
+		Read:        true,
+		NonWritable: true,
+		ID:          "_",
+	}.ExpectError(t, "i'm a teapot")
+}


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
Added `databricks_users` data source as requested in #3468 to retrieve multiple users from the account-level API with optional filtering by `display_name_contains` or `user_name_contains`, enabling bulk user management operations. 

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [x] covered with integration tests in `internal/acceptance`
- [x] relevant acceptance tests are passing
- [x] using Go SDK
