### PR TITLE
[Feature] Add computed attribute `table_serving_url` to `databricks_online_table`

### DIFF
--- a/catalog/resource_online_table.go
+++ b/catalog/resource_online_table.go
@@ -59,6 +59,7 @@ func ResourceOnlineTable() common.Resource {
 			common.CustomizeSchemaPath(m, "spec", "source_table_full_name").SetCustomSuppressDiff(common.EqualFoldDiffSuppress)
 			common.CustomizeSchemaPath(m, "name").SetRequired().SetForceNew()
 			common.CustomizeSchemaPath(m, "status").SetReadOnly()
+			common.CustomizeSchemaPath(m, "table_serving_url").SetReadOnly()
 			common.CustomizeSchemaPath(m, "spec", "pipeline_id").SetReadOnly()
 
 			runTypes := []string{"spec.0.run_triggered", "spec.0.run_continuously"}

--- a/docs/resources/online_table.md
+++ b/docs/resources/online_table.md
@@ -50,6 +50,7 @@ In addition to all arguments above, the following attributes are exported:
 * `status` - object describing status of the online table:
   * `detailed_state` - The state of the online table.
   * `message` - A text description of the current state of the online table.
+* `table_serving_url` - Data serving REST API URL for this table.
 
 ## Import
 


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

New attribute was added, but it wasn't marked as `computed` in the TF resource definition


## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [x] using Go SDK
