### PR TITLE
[Fix] Add `no_wait` flag to `databricks_online_table` to avoid timeouts

### DIFF
--- a/docs/resources/online_table.md
+++ b/docs/resources/online_table.md
@@ -50,6 +50,7 @@ In addition to all arguments above, the following attributes are exported:
 * `status` - object describing status of the online table:
   * `detailed_state` - The state of the online table.
   * `message` - A text description of the current state of the online table.
+* `no_wait` - optional boolean flag specifying if we shouldn't wait until table update is done.  **Note: there is a chance that table could be in failed state if something goes wrong, so use this flag carefully!**
 
 ## Import
 


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

When creating an online table from the big Delta table, waiting for full sync could take too long time, and creation timeouts. The new `no_wait` flag allows to skip wait for online table creation.

It would be useful to merge #4048 as well

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [x] using Go SDK
