### PR TITLE
[Fix] force send `read_only` in `databricks_external_location` when it's changed

### DIFF
--- a/catalog/resource_external_location.go
+++ b/catalog/resource_external_location.go
@@ -116,6 +116,9 @@ func ResourceExternalLocation() common.Resource {
 			if !d.HasChangeExcept("owner") {
 				return nil
 			}
+			if d.HasChange("read_only") {
+				updateExternalLocationRequest.ForceSendFields = append(updateExternalLocationRequest.ForceSendFields, "ReadOnly")
+			}
 
 			updateExternalLocationRequest.Owner = ""
 			_, err = w.ExternalLocations.Update(ctx, updateExternalLocationRequest)

--- a/catalog/resource_external_location_test.go
+++ b/catalog/resource_external_location_test.go
@@ -293,6 +293,7 @@ func TestUpdateExternalLocation(t *testing.T) {
 					Url:            "s3://foo/bar",
 					CredentialName: "bcd",
 					Comment:        "def",
+					ReadOnly:       false,
 				},
 			},
 			{
@@ -320,6 +321,52 @@ func TestUpdateExternalLocation(t *testing.T) {
 		url = "s3://foo/bar"
 		credential_name = "bcd"
 		comment = "def"
+		`,
+	}.ApplyNoError(t)
+}
+
+func TestUpdateExternalLocation_FromReadOnly(t *testing.T) {
+	qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "PATCH",
+				Resource: "/api/2.1/unity-catalog/external-locations/abc",
+				ExpectedRequest: catalog.UpdateExternalLocation{
+					Url:             "s3://foo/bar",
+					CredentialName:  "bcd",
+					Comment:         "def",
+					ReadOnly:        false,
+					ForceSendFields: []string{"ReadOnly"},
+				},
+			},
+			{
+				Method:   "GET",
+				Resource: "/api/2.1/unity-catalog/external-locations/abc?",
+				Response: catalog.ExternalLocationInfo{
+					Name:           "abc",
+					Url:            "s3://foo/bar",
+					CredentialName: "bcd",
+					Comment:        "def",
+					ReadOnly:       false,
+				},
+			},
+		},
+		Resource: ResourceExternalLocation(),
+		Update:   true,
+		ID:       "abc",
+		InstanceState: map[string]string{
+			"name":            "abc",
+			"url":             "s3://foo/bar",
+			"credential_name": "abc",
+			"comment":         "def",
+			"read_only":       "true",
+		},
+		HCL: `
+		name = "abc"
+		url = "s3://foo/bar"
+		credential_name = "bcd"
+		comment = "def"
+		read_only = false
 		`,
 	}.ApplyNoError(t)
 }


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

See linked issue for details

Resolves #4037, Resolves #4004

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
