### PR TITLE
[Fix] Fix Permissions Dashboard Test

### DIFF
--- a/internal/acceptance/permissions_test.go
+++ b/internal/acceptance/permissions_test.go
@@ -722,6 +722,7 @@ func TestAccPermissions_Dashboard(t *testing.T) {
 			display_name = "TF New Dashboard"
 			warehouse_id = "{env.TEST_DEFAULT_WAREHOUSE_ID}"
 			parent_path = databricks_directory.this.path
+			serialized_dashboard = "{\"pages\":[{\"name\":\"b532570b\",\"displayName\":\"New Page\"}]}"
 		}
 		`
 	WorkspaceLevel(t, Step{


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
It seems like we need to specify the `serialized_dashboard` field to be able to create the dashboard. I have raised this concern with the responsible team. But for unblocking our integration tests we can specify this for now.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->
Integration Tests Passing
- [x] `make test` run locally
- [x] covered with integration tests in `internal/acceptance`
- [x] relevant acceptance tests are passing
