### PR TITLE
[Fix] force send `read_only` in `databricks_storage_credential` when it's changed

### DIFF
--- a/catalog/resource_storage_credential.go
+++ b/catalog/resource_storage_credential.go
@@ -196,6 +196,9 @@ func ResourceStorageCredential() common.Resource {
 					return nil
 				}
 
+				if d.HasChange("read_only") {
+					update.ForceSendFields = append(update.ForceSendFields, "ReadOnly")
+				}
 				update.Owner = ""
 				_, err := acc.StorageCredentials.Update(ctx, catalog.AccountsUpdateStorageCredential{
 					CredentialInfo:        &update,
@@ -240,6 +243,9 @@ func ResourceStorageCredential() common.Resource {
 					return nil
 				}
 
+				if d.HasChange("read_only") {
+					update.ForceSendFields = append(update.ForceSendFields, "ReadOnly")
+				}
 				update.Owner = ""
 				_, err = w.StorageCredentials.Update(ctx, update)
 				if err != nil {

--- a/catalog/resource_storage_credential_test.go
+++ b/catalog/resource_storage_credential_test.go
@@ -432,6 +432,54 @@ func TestUpdateStorageCredentials(t *testing.T) {
 	}.ApplyNoError(t)
 }
 
+func TestUpdateStorageCredentialsFromReadOnly(t *testing.T) {
+	qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "PATCH",
+				Resource: "/api/2.1/unity-catalog/storage-credentials/a",
+				ExpectedRequest: catalog.UpdateStorageCredential{
+					AwsIamRole: &catalog.AwsIamRoleRequest{
+						RoleArn: "CHANGED",
+					},
+					Comment:         "c",
+					ReadOnly:        false,
+					ForceSendFields: []string{"ReadOnly"},
+				},
+			},
+			{
+				Method:   "GET",
+				Resource: "/api/2.1/unity-catalog/storage-credentials/a?",
+				Response: catalog.StorageCredentialInfo{
+					Name: "a",
+					AwsIamRole: &catalog.AwsIamRoleResponse{
+						RoleArn: "CHANGED",
+					},
+					MetastoreId: "d",
+					Comment:     "c",
+					ReadOnly:    false,
+				},
+			},
+		},
+		Resource: ResourceStorageCredential(),
+		Update:   true,
+		ID:       "a",
+		InstanceState: map[string]string{
+			"name":      "a",
+			"comment":   "c",
+			"read_only": "true",
+		},
+		HCL: `
+		name = "a"
+		aws_iam_role {
+			role_arn = "CHANGED"
+		}
+		comment = "c"
+		read_only = false
+		`,
+	}.ApplyNoError(t)
+}
+
 func TestUpdateStorageCredentialsWithOwnerOnly(t *testing.T) {
 	qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

It's similar to #4067 - the `read_only = false` wasn't sent for storage credentials as well

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
