### PR TITLE
[Doc] Correct code example for the databricks_aws_unity_catalog_policy data…

### DIFF
--- a/docs/data-sources/aws_unity_catalog_policy.md
+++ b/docs/data-sources/aws_unity_catalog_policy.md
@@ -30,7 +30,7 @@ resource "aws_iam_policy" "unity_metastore" {
 
 resource "aws_iam_role" "metastore_data_access" {
   name                = "${var.prefix}-uc-access"
-  assume_role_policy  = data.aws_iam_policy_document.this.json
+  assume_role_policy  = data.databricks_aws_unity_catalog_assume_role_policy.this.json
   managed_policy_arns = [aws_iam_policy.unity_metastore.arn]
 }
 ```


### PR DESCRIPTION
## Changes
The code example for the `databricks_aws_unity_catalog_policy` data resource contains an errant reference on line 33.  It should reference the trust policy generated by the Databricks provider created earlier in the code example.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
