### PR TITLE
[Fix] Fix databricks_cluster_pluginframework data source

### DIFF
--- a/internal/providers/pluginfw/resources/cluster/data_cluster.go
+++ b/internal/providers/pluginfw/resources/cluster/data_cluster.go
@@ -32,9 +32,9 @@ type ClusterDataSource struct {
 }
 
 type ClusterInfo struct {
-	ClusterId   types.String               `tfsdk:"cluster_id" tf:"optional,computed"`
-	Name        types.String               `tfsdk:"cluster_name" tf:"optional,computed"`
-	ClusterInfo *compute_tf.ClusterDetails `tfsdk:"cluster_info" tf:"optional,computed"`
+	ClusterId   types.String                `tfsdk:"cluster_id" tf:"optional,computed"`
+	Name        types.String                `tfsdk:"cluster_name" tf:"optional,computed"`
+	ClusterInfo []compute_tf.ClusterDetails `tfsdk:"cluster_info" tf:"optional,computed"`
 }
 
 func (d *ClusterDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
@@ -109,7 +109,7 @@ func (d *ClusterDataSource) Read(ctx context.Context, req datasource.ReadRequest
 		if resp.Diagnostics.HasError() {
 			return
 		}
-		clusterInfo.ClusterInfo = &namedClusters[0]
+		clusterInfo.ClusterInfo = namedClusters[0:1]
 	} else if clusterId != "" {
 		cluster, err := w.Clusters.GetByClusterId(ctx, clusterId)
 		if err != nil {
@@ -124,12 +124,12 @@ func (d *ClusterDataSource) Read(ctx context.Context, req datasource.ReadRequest
 		if resp.Diagnostics.HasError() {
 			return
 		}
-		clusterInfo.ClusterInfo = &clusterDetails
+		clusterInfo.ClusterInfo = []compute_tf.ClusterDetails{clusterDetails}
 	} else {
 		resp.Diagnostics.AddError("you need to specify either `cluster_name` or `cluster_id`", "")
 		return
 	}
-	clusterInfo.ClusterId = clusterInfo.ClusterInfo.ClusterId
-	clusterInfo.Name = clusterInfo.ClusterInfo.ClusterName
+	clusterInfo.ClusterId = clusterInfo.ClusterInfo[0].ClusterId
+	clusterInfo.Name = clusterInfo.ClusterInfo[0].ClusterName
 	resp.Diagnostics.Append(resp.State.Set(ctx, clusterInfo)...)
 }


### PR DESCRIPTION
## Changes
After https://github.com/databricks/terraform-provider-databricks/commit/bac842d603465ddbf3582e2dab2d9189c17e3113 , the autogenerated structures used for interacting with state/config/plan always use Lists for nested structures, even if there is only ever at most one, for compatibility with older versions of the TF provider. The cluster data source on the plugin framework is handwritten and also needs to be converted to use lists instead of a pointer as well.

## Tests
Ran the `TestAccDataSourceClusterByID` and `TestAccDataSourceClusterByName` integration tests, which now pass.

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
