### PR TITLE
[Fix] Tolerate invalid keys in `databricks_workspace_conf`

### DIFF
--- a/internal/acceptance/workspace_conf_test.go
+++ b/internal/acceptance/workspace_conf_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/databricks/databricks-sdk-go"
 	"github.com/databricks/databricks-sdk-go/service/settings"
+	"github.com/databricks/terraform-provider-databricks/workspace"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -58,7 +59,7 @@ func TestAccWorkspaceConfFullLifecycle(t *testing.T) {
 				}
 			}`,
 		// Assert on server side error returned
-		ExpectError: regexp.MustCompile(`cannot update workspace conf: Invalid keys`),
+		ExpectError: regexp.MustCompile(`cannot update workspace conf: failed to set workspace conf because some new keys are invalid: enableIpAccessLissss`),
 	}, Step{
 		// Set enableIpAccessLists to true with strange case and maxTokenLifetimeDays to verify
 		// failed deletion case
@@ -78,4 +79,50 @@ func TestAccWorkspaceConfFullLifecycle(t *testing.T) {
 			return nil
 		},
 	})
+}
+
+func TestAccWorkspaceConf_GetValidKey(t *testing.T) {
+	loadWorkspaceEnv(t)
+	ctx := context.Background()
+	w := databricks.Must(databricks.NewWorkspaceClient())
+	conf, err := workspace.SafeGetStatus(ctx, w, []string{"enableIpAccessLists"})
+	assert.NoError(t, err)
+	assert.Contains(t, conf, "enableIpAccessLists")
+}
+
+func TestAccWorkspaceConf_GetInvalidKey(t *testing.T) {
+	loadWorkspaceEnv(t)
+	ctx := context.Background()
+	w := databricks.Must(databricks.NewWorkspaceClient())
+	conf, err := workspace.SafeGetStatus(ctx, w, []string{"invalidKey", "enableIpAccessLists"})
+	assert.NoError(t, err)
+	assert.Contains(t, conf, "enableIpAccessLists")
+}
+
+func TestAccWorkspaceConf_GetOnlyInvalidKeys(t *testing.T) {
+	loadWorkspaceEnv(t)
+	ctx := context.Background()
+	w := databricks.Must(databricks.NewWorkspaceClient())
+	_, err := workspace.SafeGetStatus(ctx, w, []string{"invalidKey"})
+	assert.ErrorContains(t, err, "failed to get workspace conf because all keys are invalid: invalidKey")
+}
+
+func TestAccWorkspaceConf_SetInvalidKey(t *testing.T) {
+	loadWorkspaceEnv(t)
+	ctx := context.Background()
+	w := databricks.Must(databricks.NewWorkspaceClient())
+	err := workspace.SafeSetStatus(ctx, w, map[string]struct{}{}, map[string]string{
+		"invalidKey": "invalidValue",
+	})
+	assert.ErrorContains(t, err, "failed to set workspace conf because some new keys are invalid: invalidKey")
+}
+
+func TestAccWorkspaceConf_DeleteInvalidKey(t *testing.T) {
+	loadWorkspaceEnv(t)
+	ctx := context.Background()
+	w := databricks.Must(databricks.NewWorkspaceClient())
+	err := workspace.SafeSetStatus(ctx, w, map[string]struct{}{"invalidKey": {}}, map[string]string{
+		"invalidKey": "",
+	})
+	assert.NoError(t, err)
 }

--- a/workspace/resource_workspace_conf.go
+++ b/workspace/resource_workspace_conf.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -169,13 +170,9 @@ func SafeGetStatus(ctx context.Context, w *databricks.WorkspaceClient, keys []st
 	} else if invalidKeys != nil {
 		tflog.Warn(ctx, fmt.Sprintf("the following keys are not supported by the api: %s. Remove these keys from the configuration to avoid this warning.", strings.Join(invalidKeys, ", ")))
 		// Request again but remove invalid keys
-		invalidKeysMap := make(map[string]struct{}, len(invalidKeys))
-		for _, k := range invalidKeys {
-			invalidKeysMap[k] = struct{}{}
-		}
 		validKeys := make([]string, 0, len(keys))
 		for _, k := range keys {
-			if _, ok := invalidKeysMap[k]; !ok {
+			if !slices.Contains(invalidKeys, k) {
 				validKeys = append(validKeys, k)
 			}
 		}


### PR DESCRIPTION
## Changes
Occasionally, support for configuration keys is removed from the GetStatus/SetStatus APIs used to manage workspace configuration. When this happens, users who depended on those keys are in a bad state. The provider queries for the values for each configuration by key in the Terraform state, but those keys no longer exist.

To work around this, this PR makes `databricks_workspace_conf` resilient to keys being removed. On the read path, the provider queries for the status of all keys in state. If any key is no longer valid, it is removed from the request and the request is retried. Setting the value for invalid configuration keys is not supported. When removing an unsupported configuration key, the provider resets the key to an original state (`false` or `""`). Failures to reset invalid keys are ignored, both on the update path (removing an unsupported key from the conf) and on the delete path (removing the `databricks_workspace_conf` resource altogether).

## Tests
Integration tests verify that the new SafeGetStatus and SafeSetStatus methods work with invalid keys as expected. On the read side, they are ignored, and on the write side, they are ignored if marked for removal.

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
