### PR TITLE
[Fix] Mark unity_catalog_provisioning_state as ReadOnly

### DIFF
--- a/catalog/resource_online_table.go
+++ b/catalog/resource_online_table.go
@@ -59,6 +59,7 @@ func ResourceOnlineTable() common.Resource {
 			common.CustomizeSchemaPath(m, "spec", "source_table_full_name").SetCustomSuppressDiff(common.EqualFoldDiffSuppress)
 			common.CustomizeSchemaPath(m, "name").SetRequired().SetForceNew()
 			common.CustomizeSchemaPath(m, "status").SetReadOnly()
+			common.CustomizeSchemaPath(m, "unity_catalog_provisioning_state").SetReadOnly()
 			common.CustomizeSchemaPath(m, "table_serving_url").SetReadOnly()
 			common.CustomizeSchemaPath(m, "spec", "pipeline_id").SetReadOnly()
 

--- a/docs/resources/online_table.md
+++ b/docs/resources/online_table.md
@@ -49,6 +49,7 @@ In addition to all arguments above, the following attributes are exported:
   * `detailed_state` - The state of the online table.
   * `message` - A text description of the current state of the online table.
 * `table_serving_url` - Data serving REST API URL for this table.
+* `unity_catalog_provisioning_state` - The provisioning state of the online table entity in Unity Catalog. This is distinct from the state of the data synchronization pipeline (i.e. the table may be in "ACTIVE" but the pipeline may be in "PROVISIONING" as it runs asynchronously).
 
 ## Import
 


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
In a recent update to the GoSDK, a new field called `unity_catalog_provisioning_state` was added. This field changes values based on server decisions, so it's supposed to be marked as computed. This pull request sorts out that issue.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
