### PR TITLE
[Doc] Clarify that `graviton` option of `databricks_node_type` could be used on Azure

### DIFF
--- a/docs/data-sources/node_type.md
+++ b/docs/data-sources/node_type.md
@@ -56,7 +56,7 @@ Data source allows you to pick groups by the following attributes
   * `GPU Accelerated` (AWS, Azure)
 * `photon_worker_capable` - (Optional) Pick only nodes that can run Photon workers. Defaults to _false_.
 * `photon_driver_capable` - (Optional) Pick only nodes that can run Photon driver. Defaults to _false_.
-* `graviton` - (boolean, optional)  if we should limit the search only to nodes with AWS Graviton CPUs. Default to _false_.
+* `graviton` - (boolean, optional)  if we should limit the search only to nodes with AWS Graviton or Azure Cobalt CPUs. Default to _false_.
 * `fleet` - (boolean, optional)  if we should limit the search only to [AWS fleet instance types](https://docs.databricks.com/compute/aws-fleet-instances.html). Default to _false_.
 * `is_io_cache_enabled` - (Optional) . Pick only nodes that have IO Cache. Defaults to _false_.
 * `support_port_forwarding` - (Optional) Pick only nodes that support port forwarding. Defaults to _false_.


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

When used on Azure the `databricks_node_type` will search for VMs built on Azure Cobalt CPUs.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
