### PR TITLE
[Fix] Tolerate `databricks_permissions` resources for SQL warehouses with `/warehouses/...` IDs

### DIFF
--- a/permissions/permission_definitions.go
+++ b/permissions/permission_definitions.go
@@ -558,6 +558,11 @@ func allResourcePermissions() []resourcePermissions {
 			field:             "sql_endpoint_id",
 			objectType:        "warehouses",
 			requestObjectType: "sql/warehouses",
+			// ISSUE-4143: some older warehouse permissions have an ID that starts with "/warehouses" instead of "/sql/warehouses"
+			// Because no idRetriever is defined, any warehouse permissions resources will be created with the "/sql/warehouses" prefix.
+			idMatcher: func(id string) bool {
+				return strings.HasPrefix(id, "/sql/warehouses/") || strings.HasPrefix(id, "/warehouses/")
+			},
 			allowedPermissionLevels: map[string]permissionLevelOptions{
 				"CAN_USE":     {isManagementPermission: false},
 				"CAN_MANAGE":  {isManagementPermission: true},


### PR DESCRIPTION
## Changes
#4143 reported a regression to the `databricks_permissions` resource caused by https://github.com/databricks/terraform-provider-databricks/pull/3956. Normally, the ID for this resource when configured for a SQL warehouse is `/sql/warehouses/<ID>`. However, it seems like at some point in the past, some users may have had an ID of `/warehouses/<ID>`. It's possible that importing this resource worked like this: when calling the permissions REST API, whether using object type `sql/warehouses` or `warehouses`, the API returns permissions for the same resources:

```
15:13:01 DEBUG GET /api/2.0/permissions/sql/warehouses/<ID>
< HTTP/2.0 200 OK
< {
<   "access_control_list": [
<     {
<       "all_permissions": [
<         {
<           "inherited": false,
<           "permission_level": "IS_OWNER"
<         }
<       ],
<       "display_name": "<ME>",
<       "user_name": "<ME>"
<     },
<     {
<       "all_permissions": [
<         {
<           "inherited": true,
<           "inherited_from_object": [
<             "/sql/warehouses/"
<           ],
<           "permission_level": "CAN_MANAGE"
<         }
<       ],
<       "group_name": "admins"
<     }
<   ],
<   "object_id": "/sql/warehouses/<ID>",
<   "object_type": "warehouses"
< } pid=53287 sdk=true
...
15:12:56 DEBUG GET /api/2.0/permissions/warehouses/<ID>
< HTTP/2.0 200 OK
< {
<   "access_control_list": [
<     {
<       "all_permissions": [
<         {
<           "inherited": false,
<           "permission_level": "IS_OWNER"
<         }
<       ],
<       "display_name": "<ME>",
<       "user_name": "<ME>"
<     },
<     {
<       "all_permissions": [
<         {
<           "inherited": true,
<           "inherited_from_object": [
<             "/sql/warehouses/"
<           ],
<           "permission_level": "CAN_MANAGE"
<         }
<       ],
<       "group_name": "admins"
<     }
<   ],
<   "object_id": "/sql/warehouses/<ID>",
<   "object_type": "warehouses"
< } pid=53248 sdk=true
```

This PR modifies the SQL warehouse configuration for `databricks_permissions` to be chosen for instances with an ID of the form `/warehouses/...`.

## Tests
The additional integration test ensures that a resource can be imported with the `/warehouses/<ID>` format.