### PR TITLE
[Internal] Migrate Share Data Source to Plugin Framework

### DIFF
--- a/internal/providers/pluginfw/pluginfw.go
+++ b/internal/providers/pluginfw/pluginfw.go
@@ -21,6 +21,7 @@ import (
 	"github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/resources/notificationdestinations"
 	"github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/resources/qualitymonitor"
 	"github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/resources/registered_model"
+	"github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/resources/share"
 	"github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/resources/volume"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -56,6 +57,8 @@ func (p *DatabricksProviderPluginFramework) DataSources(ctx context.Context) []f
 		volume.DataSourceVolumes,
 		registered_model.DataSourceRegisteredModel,
 		notificationdestinations.DataSourceNotificationDestinations,
+		share.DataSourceShare,
+		share.DataSourceShares,
 	}
 }
 

--- a/internal/providers/pluginfw/resources/share/data_share.go
+++ b/internal/providers/pluginfw/resources/share/data_share.go
@@ -1,0 +1,74 @@
+package share
+
+import (
+	"context"
+
+	"github.com/databricks/databricks-sdk-go/service/sharing"
+	"github.com/databricks/terraform-provider-databricks/common"
+	pluginfwcommon "github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/common"
+	"github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/converters"
+	"github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/tfschema"
+	"github.com/databricks/terraform-provider-databricks/internal/service/sharing_tf"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+)
+
+func DataSourceShare() datasource.DataSource {
+	return &ShareDataSource{}
+}
+
+var _ datasource.DataSourceWithConfigure = &ShareDataSource{}
+
+type ShareDataSource struct {
+	Client *common.DatabricksClient
+}
+
+func (d *ShareDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = pluginfwcommon.GetDatabricksStagingName("share")
+}
+
+func (d *ShareDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	attrs, blocks := tfschema.DataSourceStructToSchemaMap(sharing_tf.ShareInfo{}, nil)
+	resp.Schema = schema.Schema{
+		Attributes: attrs,
+		Blocks:     blocks,
+	}
+}
+
+func (d *ShareDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if d.Client == nil {
+		d.Client = pluginfwcommon.ConfigureDataSource(req, resp)
+	}
+}
+
+func (d *ShareDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	w, diags := d.Client.GetWorkspaceClient()
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var config sharing_tf.ShareInfo
+	diags = req.Config.Get(ctx, &config)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	share, err := w.Shares.Get(ctx, sharing.GetShareRequest{
+		Name:              config.Name.ValueString(),
+		IncludeSharedData: true,
+	})
+	if err != nil {
+		resp.Diagnostics.AddError("Failed to fetch share", err.Error())
+		return
+	}
+
+	var shareInfoTfSdk sharing_tf.ShareInfo
+	resp.Diagnostics.Append(converters.GoSdkToTfSdkStruct(ctx, share, &shareInfoTfSdk)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, shareInfoTfSdk)...)
+}

--- a/internal/providers/pluginfw/resources/share/data_shares.go
+++ b/internal/providers/pluginfw/resources/share/data_shares.go
@@ -1,0 +1,67 @@
+package share
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/databricks/databricks-sdk-go/service/sharing"
+	"github.com/databricks/terraform-provider-databricks/common"
+	pluginfwcommon "github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/common"
+	"github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/tfschema"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+)
+
+type SharesList struct {
+	Shares []types.String `tfsdk:"shares" tf:"computed,optional,slice_set"`
+}
+
+func DataSourceShares() datasource.DataSource {
+	return &SharesDataSource{}
+}
+
+var _ datasource.DataSourceWithConfigure = &SharesDataSource{}
+
+type SharesDataSource struct {
+	Client *common.DatabricksClient
+}
+
+func (d *SharesDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = pluginfwcommon.GetDatabricksStagingName("shares")
+}
+
+func (d *SharesDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	attrs, blocks := tfschema.DataSourceStructToSchemaMap(SharesList{}, nil)
+	resp.Schema = schema.Schema{
+		Attributes: attrs,
+		Blocks:     blocks,
+	}
+}
+
+func (d *SharesDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if d.Client == nil {
+		d.Client = pluginfwcommon.ConfigureDataSource(req, resp)
+	}
+}
+
+func (d *SharesDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	w, diags := d.Client.GetWorkspaceClient()
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	shares, err := w.Shares.ListAll(ctx, sharing.ListSharesRequest{})
+	if err != nil {
+		resp.Diagnostics.AddError("Failed to fetch shares", err.Error())
+		return
+	}
+
+	shareNames := make([]types.String, len(shares))
+	for i, share := range shares {
+		shareNames[i] = types.StringValue(share.Name)
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, SharesList{Shares: shareNames})...)
+}

--- a/internal/providers/pluginfw/resources/share/data_shares_acc_test.go
+++ b/internal/providers/pluginfw/resources/share/data_shares_acc_test.go
@@ -1,9 +1,10 @@
-package acceptance
+package share_test
 
 import (
 	"strconv"
 	"testing"
 
+	"github.com/databricks/terraform-provider-databricks/internal/acceptance"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -11,15 +12,15 @@ import (
 
 func checkSharesDataSourcePopulated(t *testing.T) func(s *terraform.State) error {
 	return func(s *terraform.State) error {
-		_, ok := s.Modules[0].Resources["data.databricks_shares.this"]
-		require.True(t, ok, "data.databricks_shares.this has to be there")
+		_, ok := s.Modules[0].Resources["data.databricks_shares_pluginframework.this"]
+		require.True(t, ok, "data.databricks_shares_pluginframework.this has to be there")
 		num_shares, _ := strconv.Atoi(s.Modules[0].Outputs["shares"].Value.(string))
 		assert.GreaterOrEqual(t, num_shares, 1)
 		return nil
 	}
 }
 func TestUcAccDataSourceShares(t *testing.T) {
-	UnityWorkspaceLevel(t, Step{
+	acceptance.UnityWorkspaceLevel(t, acceptance.Step{
 		Template: `
 		resource "databricks_catalog" "sandbox" {
 			name         = "sandbox{var.RANDOM}"
@@ -85,11 +86,11 @@ func TestUcAccDataSourceShares(t *testing.T) {
 			}						
 		}
 
-		data "databricks_shares" "this" {
+		data "databricks_shares_pluginframework" "this" {
 			depends_on = [databricks_share.myshare]
 		}
 		output "shares" {
-			value = length(data.databricks_shares.this.shares)
+			value = length(data.databricks_shares_pluginframework.this.shares)
 		}
 		`,
 		Check: checkSharesDataSourcePopulated(t),


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
This PR migrates the share/shares data sources to the Plugin framework. The code was largely copied "as is" from the previous implementation of the share data source, with the necessary adaptations made for integration with the Plugin framework.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->
Note: current tests create shares using the SDKv2 resource, but fetch them using the new plugin framework data source. Once the resource migration will be merged, I will amend this.

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [x] covered with integration tests in `internal/acceptance`
- [x] relevant acceptance tests are passing
- [x] using Go SDK
