### PR TITLE
[Fix] Provide more prescriptive error when users fail to create a single node cluster

### DIFF
--- a/clusters/clusters_api.go
+++ b/clusters/clusters_api.go
@@ -447,7 +447,7 @@ func (cluster Cluster) Validate() error {
 	if profile == "singleNode" && strings.HasPrefix(master, "local") && resourceClass == "SingleNode" {
 		return nil
 	}
-	return fmt.Errorf("NumWorkers could be 0 only for SingleNode clusters. See https://docs.databricks.com/clusters/single-node.html for more details")
+	return errors.New(numWorkerErr)
 }
 
 // TODO: Remove this once all the resources using clusters are migrated to Go SDK.

--- a/clusters/resource_cluster.go
+++ b/clusters/resource_cluster.go
@@ -38,6 +38,10 @@ cluster please include the following configuration in your cluster configuration
     "ResourceClass" = "SingleNode"
   }
 
+Please note that the Databricks terraform provider cannot detect if the above configuration
+is defined in a policy used by the cluster. Please define this in the cluster configuration
+itself to create a single node cluster.
+
 For more details please see:
   1. https://registry.terraform.io/providers/databricks/databricks/latest/docs/resources/cluster#fixed-size-or-autoscaling-cluster
   2. https://docs.databricks.com/clusters/single-node.html 

--- a/clusters/resource_cluster.go
+++ b/clusters/resource_cluster.go
@@ -44,8 +44,8 @@ itself to create a single node cluster.
 
 For more details please see:
   1. https://registry.terraform.io/providers/databricks/databricks/latest/docs/resources/cluster#fixed-size-or-autoscaling-cluster
-  2. https://docs.databricks.com/clusters/single-node.html 
-`
+  2. https://docs.databricks.com/clusters/single-node.html`
+
 	unsupportedExceptCreateEditClusterSpecErr = "unsupported type %T, must be one of %scompute.CreateCluster, %scompute.ClusterSpec or %scompute.EditCluster. Please report this issue to the GitHub repo"
 )
 

--- a/clusters/resource_cluster.go
+++ b/clusters/resource_cluster.go
@@ -38,7 +38,7 @@ cluster please include the following configuration in your cluster configuration
     "ResourceClass" = "SingleNode"
   }
 
-Please note that the Databricks terraform provider cannot detect if the above configuration
+Please note that the Databricks Terraform provider cannot detect if the above configuration
 is defined in a policy used by the cluster. Please define this in the cluster configuration
 itself to create a single node cluster.
 

--- a/clusters/resource_cluster.go
+++ b/clusters/resource_cluster.go
@@ -26,7 +26,7 @@ var clusterSchema = resourceClusterSchema()
 var clusterSchemaVersion = 4
 
 const (
-	numWorkerErr = `NumWorkers could be 0 only for SingleNode clusters. To create a single node
+	numWorkerErr = `num_workers may be 0 only for single-node clusters. To create a single node
 cluster please include the following configuration in your cluster configuration:
 
   spark_conf = {

--- a/clusters/resource_cluster.go
+++ b/clusters/resource_cluster.go
@@ -26,7 +26,22 @@ var clusterSchema = resourceClusterSchema()
 var clusterSchemaVersion = 4
 
 const (
-	numWorkerErr                              = "NumWorkers could be 0 only for SingleNode clusters. See https://docs.databricks.com/clusters/single-node.html for more details"
+	numWorkerErr = `NumWorkers could be 0 only for SingleNode clusters. To create a single node
+cluster please include the following configuration in your cluster configuration:
+
+  spark_conf = {
+    "spark.databricks.cluster.profile" : "singleNode"
+    "spark.master" : "local[*]"
+  }
+
+  custom_tags = {
+    "ResourceClass" = "SingleNode"
+  }
+
+For more details please see:
+  1. https://registry.terraform.io/providers/databricks/databricks/latest/docs/resources/cluster#fixed-size-or-autoscaling-cluster
+  2. https://docs.databricks.com/clusters/single-node.html 
+`
 	unsupportedExceptCreateEditClusterSpecErr = "unsupported type %T, must be one of %scompute.CreateCluster, %scompute.ClusterSpec or %scompute.EditCluster. Please report this issue to the GitHub repo"
 )
 

--- a/clusters/resource_cluster_test.go
+++ b/clusters/resource_cluster_test.go
@@ -1860,7 +1860,6 @@ func TestResourceClusterCreate_SingleNodeFail(t *testing.T) {
 			"is_pinned":               false,
 		},
 	}.Apply(t)
-	assert.Error(t, err)
 	assert.EqualError(t, err, numWorkerErr)
 }
 

--- a/clusters/resource_cluster_test.go
+++ b/clusters/resource_cluster_test.go
@@ -1861,7 +1861,7 @@ func TestResourceClusterCreate_SingleNodeFail(t *testing.T) {
 		},
 	}.Apply(t)
 	assert.Error(t, err)
-	require.Equal(t, true, strings.Contains(err.Error(), "NumWorkers could be 0 only for SingleNode clusters"))
+	assert.EqualError(t, err, numWorkerErr)
 }
 
 func TestResourceClusterCreate_NegativeNumWorkers(t *testing.T) {
@@ -1900,8 +1900,7 @@ func TestResourceClusterUpdate_FailNumWorkersZero(t *testing.T) {
 			"num_workers":             0,
 		},
 	}.Apply(t)
-	assert.Error(t, err)
-	require.Equal(t, true, strings.Contains(err.Error(), "NumWorkers could be 0 only for SingleNode clusters"))
+	assert.EqualError(t, err, numWorkerErr)
 }
 
 func TestModifyClusterRequestAws(t *testing.T) {

--- a/jobs/resource_job_test.go
+++ b/jobs/resource_job_test.go
@@ -2066,7 +2066,11 @@ cluster please include the following configuration in your cluster configuration
 
   custom_tags = {
     "ResourceClass" = "SingleNode"
-  }`)
+  }
+
+Please note that the Databricks terraform provider cannot detect if the above configuration
+is defined in a policy used by the cluster. Please define this in the cluster configuration
+itself to create a single node cluster.`)
 }
 
 func TestResourceJobRead(t *testing.T) {
@@ -2965,7 +2969,11 @@ cluster please include the following configuration in your cluster configuration
 
   custom_tags = {
     "ResourceClass" = "SingleNode"
-  }`)
+  }
+
+Please note that the Databricks terraform provider cannot detect if the above configuration
+is defined in a policy used by the cluster. Please define this in the cluster configuration
+itself to create a single node cluster.`)
 }
 
 func TestJobsAPIList(t *testing.T) {

--- a/jobs/resource_job_test.go
+++ b/jobs/resource_job_test.go
@@ -2056,7 +2056,7 @@ func TestResourceJobCreateSingleNode_Fail(t *testing.T) {
 			jar = "dbfs://ff/gg/hh.jar"
 		}`,
 	}.Apply(t)
-	assert.ErrorContains(t, err, `NumWorkers could be 0 only for SingleNode clusters. To create a single node
+	assert.ErrorContains(t, err, `num_workers may be 0 only for single-node clusters. To create a single node
 cluster please include the following configuration in your cluster configuration:
 
   spark_conf = {
@@ -2959,7 +2959,7 @@ func TestResourceJobUpdate_FailNumWorkersZero(t *testing.T) {
 			parameters = ["--cleanup", "full"]
 		}`,
 	}.Apply(t)
-	assert.ErrorContains(t, err, `NumWorkers could be 0 only for SingleNode clusters. To create a single node
+	assert.ErrorContains(t, err, `num_workers may be 0 only for single-node clusters. To create a single node
 cluster please include the following configuration in your cluster configuration:
 
   spark_conf = {

--- a/jobs/resource_job_test.go
+++ b/jobs/resource_job_test.go
@@ -2068,7 +2068,7 @@ cluster please include the following configuration in your cluster configuration
     "ResourceClass" = "SingleNode"
   }
 
-Please note that the Databricks terraform provider cannot detect if the above configuration
+Please note that the Databricks Terraform provider cannot detect if the above configuration
 is defined in a policy used by the cluster. Please define this in the cluster configuration
 itself to create a single node cluster.`)
 }
@@ -2971,7 +2971,7 @@ cluster please include the following configuration in your cluster configuration
     "ResourceClass" = "SingleNode"
   }
 
-Please note that the Databricks terraform provider cannot detect if the above configuration
+Please note that the Databricks Terraform provider cannot detect if the above configuration
 is defined in a policy used by the cluster. Please define this in the cluster configuration
 itself to create a single node cluster.`)
 }

--- a/jobs/resource_job_test.go
+++ b/jobs/resource_job_test.go
@@ -2056,8 +2056,17 @@ func TestResourceJobCreateSingleNode_Fail(t *testing.T) {
 			jar = "dbfs://ff/gg/hh.jar"
 		}`,
 	}.Apply(t)
-	assert.Error(t, err)
-	require.Equal(t, true, strings.Contains(err.Error(), "NumWorkers could be 0 only for SingleNode clusters"))
+	assert.ErrorContains(t, err, `NumWorkers could be 0 only for SingleNode clusters. To create a single node
+cluster please include the following configuration in your cluster configuration:
+
+  spark_conf = {
+    "spark.databricks.cluster.profile" : "singleNode"
+    "spark.master" : "local[*]"
+  }
+
+  custom_tags = {
+    "ResourceClass" = "SingleNode"
+  }`)
 }
 
 func TestResourceJobRead(t *testing.T) {
@@ -2946,8 +2955,17 @@ func TestResourceJobUpdate_FailNumWorkersZero(t *testing.T) {
 			parameters = ["--cleanup", "full"]
 		}`,
 	}.Apply(t)
-	assert.Error(t, err)
-	require.Equal(t, true, strings.Contains(err.Error(), "NumWorkers could be 0 only for SingleNode clusters"))
+	assert.ErrorContains(t, err, `NumWorkers could be 0 only for SingleNode clusters. To create a single node
+cluster please include the following configuration in your cluster configuration:
+
+  spark_conf = {
+    "spark.databricks.cluster.profile" : "singleNode"
+    "spark.master" : "local[*]"
+  }
+
+  custom_tags = {
+    "ResourceClass" = "SingleNode"
+  }`)
 }
 
 func TestJobsAPIList(t *testing.T) {


### PR DESCRIPTION
## Changes
A better error message is warranted because many DABs customers have reportedly run into this. Original issue: https://github.com/databricks/cli/issues/1546

## Tests
Unit test
