### PR TITLE
[Internal] [Fix] Update external contributor test instruction workflow

### DIFF
--- a/.github/workflows/external-message.yml
+++ b/.github/workflows/external-message.yml
@@ -37,7 +37,7 @@ jobs:
           HAS_ACCESS="false"
           
           # Check user's permission level on the repository
-          USER_PERMISSION=$(gh api repos/$REPO_OWNER/$REPO_NAME/collaborators/$USER_LOGIN/permission --jq '.permission')
+          USER_PERMISSION=$(gh api repos/$REPO_OWNER/$REPO_NAME/collaborators/$USER_LOGIN/permission --jq '.permission' || echo "none")
           
           if [[ "$USER_PERMISSION" == "admin" || "$USER_PERMISSION" == "write" ]]; then
             HAS_ACCESS="true"


### PR DESCRIPTION
## Changes
Update external contributor test intructions workflow

`$(gh api repos/$REPO_OWNER/$REPO_NAME/collaborators/$USER_LOGIN/permission --jq '.permission')` exits with non-zero causing workflow to terminate prematurely (when executed for an external user without no repo permissions) https://github.com/databricks/terraform-provider-databricks/actions/runs/11615285780/job/32345486647?pr=4181

```shell
Pull request opened by: ashenm
gh: Resource not accessible by integration (HTTP 403)
Error: Process completed with exit code 1.
```

## Tests
