### PR TITLE
Suppress equal fold diff for DLT pipeline resource

### DIFF
--- a/pipelines/resource_pipeline.go
+++ b/pipelines/resource_pipeline.go
@@ -230,6 +230,11 @@ func (Pipeline) CustomizeSchema(s *common.CustomizableSchema) *common.Customizab
 	s.SchemaPath("edition").SetCustomSuppressDiff(common.EqualFoldDiffSuppress)
 	s.SchemaPath("storage").SetCustomSuppressDiff(suppressStorageDiff)
 
+	// As of 6th Nov 2024, the DLT API only normalizes the catalog name when creating
+	// a pipeline. So we only ignore the equal fold diff for the catalog name and not other
+	// UC resources like target or ingestion_definition.connection_name.
+	s.SchemaPath("catalog").SetCustomSuppressDiff(common.EqualFoldDiffSuppress)
+
 	// Deprecated fields
 	s.SchemaPath("cluster", "init_scripts", "dbfs").SetDeprecated(clusters.DbfsDeprecationWarning)
 	s.SchemaPath("library", "whl").SetDeprecated("The 'whl' field is deprecated")


### PR DESCRIPTION
## Changes
Fixes https://github.com/databricks/cli/issues/1763. During creation the `catalog` name for a DLT pipeline is normalized to small case causing a persistent drift.

## Tests
Manually with the following configuration:
```
resource "databricks_pipeline" "this" {
  name = "testing caps"
  catalog = "MaiN"
  library {
    notebook {
      path = "/a/b/c"
    }
  }
}
```

Before:
There'd be a persistent drift where terraform would try to convert "MaiN" -> "main"

After:
No diff detected.