### PR TITLE
[Fix] Use cluster list API to determine pinned cluster status

### DIFF
--- a/clusters/resource_cluster.go
+++ b/clusters/resource_cluster.go
@@ -513,20 +513,23 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, c *commo
 }
 
 func setPinnedStatus(ctx context.Context, d *schema.ResourceData, clusterAPI compute.ClustersInterface) error {
-	events, err := clusterAPI.EventsAll(ctx, compute.GetEvents{
-		ClusterId:  d.Id(),
-		Limit:      1,
-		Order:      compute.GetEventsOrderDesc,
-		EventTypes: []compute.EventType{compute.EventTypePinned, compute.EventTypeUnpinned},
+	clusterDetails := clusterAPI.List(ctx, compute.ListClustersRequest{
+		FilterBy: &compute.ListClustersFilterBy{
+			IsPinned: true,
+		},
+		PageSize: 100, // pinned cluster limit - just get all of them
 	})
-	if err != nil {
-		return err
+
+	for clusterDetails.HasNext(ctx) {
+		detail, err := clusterDetails.Next(ctx)
+		if err != nil {
+			return err
+		}
+		if detail.ClusterId == d.Id() {
+			return d.Set("is_pinned", true)
+		}
 	}
-	pinnedEvent := compute.EventTypeUnpinned
-	if len(events) > 0 {
-		pinnedEvent = events[0].Type
-	}
-	return d.Set("is_pinned", pinnedEvent == compute.EventTypePinned)
+	return d.Set("is_pinned", false)
 }
 
 func resourceClusterRead(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {

--- a/clusters/resource_cluster_test.go
+++ b/clusters/resource_cluster_test.go
@@ -45,17 +45,10 @@ func TestResourceClusterCreate(t *testing.T) {
 				},
 			},
 			{
-				Method:   "POST",
-				Resource: "/api/2.1/clusters/events",
-				ExpectedRequest: compute.GetEvents{
-					ClusterId:  "abc",
-					Limit:      1,
-					Order:      compute.GetEventsOrderDesc,
-					EventTypes: []compute.EventType{compute.EventTypePinned, compute.EventTypeUnpinned},
-				},
-				Response: compute.GetEventsResponse{
-					Events:     []compute.ClusterEvent{},
-					TotalCount: 0,
+				Method:   "GET",
+				Resource: "/api/2.1/clusters/list?filter_by.is_pinned=true&page_size=100",
+				Response: compute.ListClustersResponse{
+					Clusters: []compute.ClusterDetails{},
 				},
 			},
 			{
@@ -79,6 +72,7 @@ func TestResourceClusterCreate(t *testing.T) {
 	}.Apply(t)
 	assert.NoError(t, err)
 	assert.Equal(t, "abc", d.Id())
+	assert.Equal(t, false, d.Get("is_pinned"))
 }
 
 func TestResourceClusterCreatePinned(t *testing.T) {
@@ -128,24 +122,18 @@ func TestResourceClusterCreatePinned(t *testing.T) {
 				},
 			},
 			{
-				Method:   "POST",
-				Resource: "/api/2.1/clusters/events",
-				ExpectedRequest: compute.GetEvents{
-					ClusterId:  "abc",
-					Limit:      1,
-					Order:      compute.GetEventsOrderDesc,
-					EventTypes: []compute.EventType{compute.EventTypePinned, compute.EventTypeUnpinned},
-				},
-				Response: compute.GetEventsResponse{
-					Events: []compute.ClusterEvent{
-						{
-							ClusterId: "abc",
-							Timestamp: int64(123),
-							Type:      compute.EventTypePinned,
-							Details:   &compute.EventDetails{},
-						},
-					},
-					TotalCount: 1,
+				Method:   "GET",
+				Resource: "/api/2.1/clusters/list?filter_by.is_pinned=true&page_size=100",
+				Response: compute.ListClustersResponse{
+					Clusters: []compute.ClusterDetails{{
+						ClusterId:              "abc",
+						NumWorkers:             100,
+						ClusterName:            "Shared Autoscaling",
+						SparkVersion:           "7.1-scala12",
+						NodeTypeId:             "i3.xlarge",
+						AutoterminationMinutes: 15,
+						State:                  compute.StateRunning,
+					}},
 				},
 			},
 		},
@@ -162,6 +150,7 @@ func TestResourceClusterCreatePinned(t *testing.T) {
 	}.Apply(t)
 	assert.NoError(t, err)
 	assert.Equal(t, "abc", d.Id())
+	assert.Equal(t, true, d.Get("is_pinned"))
 }
 
 func TestResourceClusterCreateErrorFollowedByDeletion(t *testing.T) {
@@ -307,17 +296,10 @@ func TestResourceClusterCreate_WithLibraries(t *testing.T) {
 				},
 			},
 			{
-				Method:   "POST",
-				Resource: "/api/2.1/clusters/events",
-				ExpectedRequest: compute.GetEvents{
-					ClusterId:  "abc",
-					Limit:      1,
-					Order:      compute.GetEventsOrderDesc,
-					EventTypes: []compute.EventType{compute.EventTypePinned, compute.EventTypeUnpinned},
-				},
-				Response: compute.GetEventsResponse{
-					Events:     []compute.ClusterEvent{},
-					TotalCount: 0,
+				Method:   "GET",
+				Resource: "/api/2.1/clusters/list?filter_by.is_pinned=true&page_size=100",
+				Response: compute.ListClustersResponse{
+					Clusters: []compute.ClusterDetails{},
 				},
 			},
 			{
@@ -506,17 +488,10 @@ func TestResourceClusterCreatePhoton(t *testing.T) {
 				},
 			},
 			{
-				Method:   "POST",
-				Resource: "/api/2.1/clusters/events",
-				ExpectedRequest: compute.GetEvents{
-					ClusterId:  "abc",
-					Limit:      1,
-					Order:      compute.GetEventsOrderDesc,
-					EventTypes: []compute.EventType{compute.EventTypePinned, compute.EventTypeUnpinned},
-				},
-				Response: compute.GetEventsResponse{
-					Events:     []compute.ClusterEvent{},
-					TotalCount: 0,
+				Method:   "GET",
+				Resource: "/api/2.1/clusters/list?filter_by.is_pinned=true&page_size=100",
+				Response: compute.ListClustersResponse{
+					Clusters: []compute.ClusterDetails{},
 				},
 			},
 			{
@@ -574,17 +549,10 @@ func TestResourceClusterCreateNoWait_WithLibraries(t *testing.T) {
 				},
 			},
 			{
-				Method:   "POST",
-				Resource: "/api/2.1/clusters/events",
-				ExpectedRequest: compute.GetEvents{
-					ClusterId:  "abc",
-					Limit:      1,
-					Order:      compute.GetEventsOrderDesc,
-					EventTypes: []compute.EventType{compute.EventTypePinned, compute.EventTypeUnpinned},
-				},
-				Response: compute.GetEventsResponse{
-					Events:     []compute.ClusterEvent{},
-					TotalCount: 0,
+				Method:   "GET",
+				Resource: "/api/2.1/clusters/list?filter_by.is_pinned=true&page_size=100",
+				Response: compute.ListClustersResponse{
+					Clusters: []compute.ClusterDetails{},
 				},
 			},
 			{
@@ -668,17 +636,10 @@ func TestResourceClusterCreateNoWait(t *testing.T) {
 				},
 			},
 			{
-				Method:   "POST",
-				Resource: "/api/2.1/clusters/events",
-				ExpectedRequest: compute.GetEvents{
-					ClusterId:  "abc",
-					Limit:      1,
-					Order:      compute.GetEventsOrderDesc,
-					EventTypes: []compute.EventType{compute.EventTypePinned, compute.EventTypeUnpinned},
-				},
-				Response: compute.GetEventsResponse{
-					Events:     []compute.ClusterEvent{},
-					TotalCount: 0,
+				Method:   "GET",
+				Resource: "/api/2.1/clusters/list?filter_by.is_pinned=true&page_size=100",
+				Response: compute.ListClustersResponse{
+					Clusters: []compute.ClusterDetails{},
 				},
 			},
 		},
@@ -745,17 +706,10 @@ func TestResourceClusterRead(t *testing.T) {
 				},
 			},
 			{
-				Method:   "POST",
-				Resource: "/api/2.1/clusters/events",
-				ExpectedRequest: compute.GetEvents{
-					ClusterId:  "abc",
-					Limit:      1,
-					Order:      compute.GetEventsOrderDesc,
-					EventTypes: []compute.EventType{compute.EventTypePinned, compute.EventTypeUnpinned},
-				},
-				Response: compute.GetEventsResponse{
-					Events:     []compute.ClusterEvent{},
-					TotalCount: 0,
+				Method:   "GET",
+				Resource: "/api/2.1/clusters/list?filter_by.is_pinned=true&page_size=100",
+				Response: compute.ListClustersResponse{
+					Clusters: []compute.ClusterDetails{},
 				},
 			},
 		},
@@ -843,17 +797,10 @@ func TestResourceClusterUpdate_ResizeForAutoscalingToNumWorkersCluster(t *testin
 				},
 			},
 			{
-				Method:   "POST",
-				Resource: "/api/2.1/clusters/events",
-				ExpectedRequest: compute.GetEvents{
-					ClusterId:  "abc",
-					Limit:      1,
-					Order:      compute.GetEventsOrderDesc,
-					EventTypes: []compute.EventType{compute.EventTypePinned, compute.EventTypeUnpinned},
-				},
-				Response: compute.GetEventsResponse{
-					Events:     []compute.ClusterEvent{},
-					TotalCount: 0,
+				Method:   "GET",
+				Resource: "/api/2.1/clusters/list?filter_by.is_pinned=true&page_size=100",
+				Response: compute.ListClustersResponse{
+					Clusters: []compute.ClusterDetails{},
 				},
 			},
 			{
@@ -907,17 +854,10 @@ func TestResourceClusterUpdate_ResizeForNumWorkersToAutoscalingCluster(t *testin
 				},
 			},
 			{
-				Method:   "POST",
-				Resource: "/api/2.1/clusters/events",
-				ExpectedRequest: compute.GetEvents{
-					ClusterId:  "abc",
-					Limit:      1,
-					Order:      compute.GetEventsOrderDesc,
-					EventTypes: []compute.EventType{compute.EventTypePinned, compute.EventTypeUnpinned},
-				},
-				Response: compute.GetEventsResponse{
-					Events:     []compute.ClusterEvent{},
-					TotalCount: 0,
+				Method:   "GET",
+				Resource: "/api/2.1/clusters/list?filter_by.is_pinned=true&page_size=100",
+				Response: compute.ListClustersResponse{
+					Clusters: []compute.ClusterDetails{},
 				},
 			},
 			{
@@ -974,17 +914,10 @@ func TestResourceClusterUpdate_EditNumWorkersWhenClusterTerminated(t *testing.T)
 				},
 			},
 			{
-				Method:   "POST",
-				Resource: "/api/2.1/clusters/events",
-				ExpectedRequest: compute.GetEvents{
-					ClusterId:  "abc",
-					Limit:      1,
-					Order:      compute.GetEventsOrderDesc,
-					EventTypes: []compute.EventType{compute.EventTypePinned, compute.EventTypeUnpinned},
-				},
-				Response: compute.GetEventsResponse{
-					Events:     []compute.ClusterEvent{},
-					TotalCount: 0,
+				Method:   "GET",
+				Resource: "/api/2.1/clusters/list?filter_by.is_pinned=true&page_size=100",
+				Response: compute.ListClustersResponse{
+					Clusters: []compute.ClusterDetails{},
 				},
 			},
 			{
@@ -1050,17 +983,10 @@ func TestResourceClusterUpdate_ResizeAutoscale(t *testing.T) {
 				},
 			},
 			{
-				Method:   "POST",
-				Resource: "/api/2.1/clusters/events",
-				ExpectedRequest: compute.GetEvents{
-					ClusterId:  "abc",
-					Limit:      1,
-					Order:      compute.GetEventsOrderDesc,
-					EventTypes: []compute.EventType{compute.EventTypePinned, compute.EventTypeUnpinned},
-				},
-				Response: compute.GetEventsResponse{
-					Events:     []compute.ClusterEvent{},
-					TotalCount: 0,
+				Method:   "GET",
+				Resource: "/api/2.1/clusters/list?filter_by.is_pinned=true&page_size=100",
+				Response: compute.ListClustersResponse{
+					Clusters: []compute.ClusterDetails{},
 				},
 			},
 		},
@@ -1109,17 +1035,10 @@ func TestResourceClusterUpdate_ResizeNumWorkers(t *testing.T) {
 				},
 			},
 			{
-				Method:   "POST",
-				Resource: "/api/2.1/clusters/events",
-				ExpectedRequest: compute.GetEvents{
-					ClusterId:  "abc",
-					Limit:      1,
-					Order:      compute.GetEventsOrderDesc,
-					EventTypes: []compute.EventType{compute.EventTypePinned, compute.EventTypeUnpinned},
-				},
-				Response: compute.GetEventsResponse{
-					Events:     []compute.ClusterEvent{},
-					TotalCount: 0,
+				Method:   "GET",
+				Resource: "/api/2.1/clusters/list?filter_by.is_pinned=true&page_size=100",
+				Response: compute.ListClustersResponse{
+					Clusters: []compute.ClusterDetails{},
 				},
 			},
 			{
@@ -1169,17 +1088,10 @@ func TestResourceClusterUpdate(t *testing.T) {
 				},
 			},
 			{
-				Method:   "POST",
-				Resource: "/api/2.1/clusters/events",
-				ExpectedRequest: compute.GetEvents{
-					ClusterId:  "abc",
-					Limit:      1,
-					Order:      compute.GetEventsOrderDesc,
-					EventTypes: []compute.EventType{compute.EventTypePinned, compute.EventTypeUnpinned},
-				},
-				Response: compute.GetEventsResponse{
-					Events:     []compute.ClusterEvent{},
-					TotalCount: 0,
+				Method:   "GET",
+				Resource: "/api/2.1/clusters/list?filter_by.is_pinned=true&page_size=100",
+				Response: compute.ListClustersResponse{
+					Clusters: []compute.ClusterDetails{},
 				},
 			},
 			{
@@ -1249,17 +1161,10 @@ func TestResourceClusterUpdate_WhileScaling(t *testing.T) {
 				},
 			},
 			{
-				Method:   "POST",
-				Resource: "/api/2.1/clusters/events",
-				ExpectedRequest: compute.GetEvents{
-					ClusterId:  "abc",
-					Limit:      1,
-					Order:      compute.GetEventsOrderDesc,
-					EventTypes: []compute.EventType{compute.EventTypePinned, compute.EventTypeUnpinned},
-				},
-				Response: compute.GetEventsResponse{
-					Events:     []compute.ClusterEvent{},
-					TotalCount: 0,
+				Method:   "GET",
+				Resource: "/api/2.1/clusters/list?filter_by.is_pinned=true&page_size=100",
+				Response: compute.ListClustersResponse{
+					Clusters: []compute.ClusterDetails{},
 				},
 			},
 			{
@@ -1345,17 +1250,10 @@ func TestResourceClusterUpdateWithPinned(t *testing.T) {
 				},
 			},
 			{
-				Method:   "POST",
-				Resource: "/api/2.1/clusters/events",
-				ExpectedRequest: compute.GetEvents{
-					ClusterId:  "abc",
-					Limit:      1,
-					Order:      compute.GetEventsOrderDesc,
-					EventTypes: []compute.EventType{compute.EventTypePinned, compute.EventTypeUnpinned},
-				},
-				Response: compute.GetEventsResponse{
-					Events:     []compute.ClusterEvent{},
-					TotalCount: 0,
+				Method:   "GET",
+				Resource: "/api/2.1/clusters/list?filter_by.is_pinned=true&page_size=100",
+				Response: compute.ListClustersResponse{
+					Clusters: []compute.ClusterDetails{},
 				},
 			},
 			{
@@ -1493,17 +1391,10 @@ func TestResourceClusterUpdate_LibrariesChangeOnTerminatedCluster(t *testing.T) 
 				},
 			},
 			{
-				Method:   "POST",
-				Resource: "/api/2.1/clusters/events",
-				ExpectedRequest: compute.GetEvents{
-					ClusterId:  "abc",
-					Limit:      1,
-					Order:      compute.GetEventsOrderDesc,
-					EventTypes: []compute.EventType{compute.EventTypePinned, compute.EventTypeUnpinned},
-				},
-				Response: compute.GetEventsResponse{
-					Events:     []compute.ClusterEvent{},
-					TotalCount: 0,
+				Method:   "GET",
+				Resource: "/api/2.1/clusters/list?filter_by.is_pinned=true&page_size=100",
+				Response: compute.ListClustersResponse{
+					Clusters: []compute.ClusterDetails{},
 				},
 			},
 			{ // start cluster before libs install
@@ -1633,17 +1524,10 @@ func TestResourceClusterUpdate_AutoAz(t *testing.T) {
 				},
 			},
 			{
-				Method:   "POST",
-				Resource: "/api/2.1/clusters/events",
-				ExpectedRequest: compute.GetEvents{
-					ClusterId:  "abc",
-					Limit:      1,
-					Order:      compute.GetEventsOrderDesc,
-					EventTypes: []compute.EventType{compute.EventTypePinned, compute.EventTypeUnpinned},
-				},
-				Response: compute.GetEventsResponse{
-					Events:     []compute.ClusterEvent{},
-					TotalCount: 0,
+				Method:   "GET",
+				Resource: "/api/2.1/clusters/list?filter_by.is_pinned=true&page_size=100",
+				Response: compute.ListClustersResponse{
+					Clusters: []compute.ClusterDetails{},
 				},
 			},
 			{
@@ -1786,17 +1670,10 @@ func TestResourceClusterCreate_SingleNode(t *testing.T) {
 				},
 			},
 			{
-				Method:   "POST",
-				Resource: "/api/2.1/clusters/events",
-				ExpectedRequest: compute.GetEvents{
-					ClusterId:  "abc",
-					Limit:      1,
-					Order:      compute.GetEventsOrderDesc,
-					EventTypes: []compute.EventType{compute.EventTypePinned, compute.EventTypeUnpinned},
-				},
-				Response: compute.GetEventsResponse{
-					Events:     []compute.ClusterEvent{},
-					TotalCount: 0,
+				Method:   "GET",
+				Resource: "/api/2.1/clusters/list?filter_by.is_pinned=true&page_size=100",
+				Response: compute.ListClustersResponse{
+					Clusters: []compute.ClusterDetails{},
 				},
 			},
 			{
@@ -1970,8 +1847,11 @@ func TestReadOnStoppedClusterWithLibrariesDoesNotFail(t *testing.T) {
 				},
 			},
 			{
-				Method:   "POST",
-				Resource: "/api/2.1/clusters/events",
+				Method:   "GET",
+				Resource: "/api/2.1/clusters/list?filter_by.is_pinned=true&page_size=100",
+				Response: compute.ListClustersResponse{
+					Clusters: []compute.ClusterDetails{},
+				},
 			},
 			{
 				Method:       "GET",
@@ -2008,8 +1888,11 @@ func TestRefreshOnRunningClusterWithFailedLibraryUninstallsIt(t *testing.T) {
 				},
 			},
 			{
-				Method:   "POST",
-				Resource: "/api/2.1/clusters/events",
+				Method:   "GET",
+				Resource: "/api/2.1/clusters/list?filter_by.is_pinned=true&page_size=100",
+				Response: compute.ListClustersResponse{
+					Clusters: []compute.ClusterDetails{},
+				},
 			},
 			{
 				Method:   "GET",
@@ -2072,17 +1955,10 @@ func TestResourceClusterUpdate_LocalSsdCount(t *testing.T) {
 				},
 			},
 			{
-				Method:   "POST",
-				Resource: "/api/2.1/clusters/events",
-				ExpectedRequest: compute.GetEvents{
-					ClusterId:  "abc",
-					Limit:      1,
-					Order:      compute.GetEventsOrderDesc,
-					EventTypes: []compute.EventType{compute.EventTypePinned, compute.EventTypeUnpinned},
-				},
-				Response: compute.GetEventsResponse{
-					Events:     []compute.ClusterEvent{},
-					TotalCount: 0,
+				Method:   "GET",
+				Resource: "/api/2.1/clusters/list?filter_by.is_pinned=true&page_size=100",
+				Response: compute.ListClustersResponse{
+					Clusters: []compute.ClusterDetails{},
 				},
 			},
 			{

--- a/clusters/resource_cluster_test.go
+++ b/clusters/resource_cluster_test.go
@@ -12,9 +12,18 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var nothingPinned = qa.HTTPFixture{
+	Method:   "GET",
+	Resource: "/api/2.1/clusters/list?filter_by.is_pinned=true&page_size=100",
+	Response: compute.ListClustersResponse{
+		Clusters: []compute.ClusterDetails{},
+	},
+}
+
 func TestResourceClusterCreate(t *testing.T) {
 	d, err := qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
+			nothingPinned,
 			{
 				Method:   "POST",
 				Resource: "/api/2.1/clusters/create",
@@ -42,13 +51,6 @@ func TestResourceClusterCreate(t *testing.T) {
 					NodeTypeId:             "i3.xlarge",
 					AutoterminationMinutes: 15,
 					State:                  compute.StateRunning,
-				},
-			},
-			{
-				Method:   "GET",
-				Resource: "/api/2.1/clusters/list?filter_by.is_pinned=true&page_size=100",
-				Response: compute.ListClustersResponse{
-					Clusters: []compute.ClusterDetails{},
 				},
 			},
 			{
@@ -267,6 +269,7 @@ func TestResourceClusterCreateErrorFollowedByDeletionError(t *testing.T) {
 func TestResourceClusterCreate_WithLibraries(t *testing.T) {
 	d, err := qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
+			nothingPinned,
 			{
 				Method:   "POST",
 				Resource: "/api/2.1/clusters/create",
@@ -293,13 +296,6 @@ func TestResourceClusterCreate_WithLibraries(t *testing.T) {
 					NodeTypeId:             "i3.xlarge",
 					AutoterminationMinutes: 15,
 					State:                  compute.StateRunning,
-				},
-			},
-			{
-				Method:   "GET",
-				Resource: "/api/2.1/clusters/list?filter_by.is_pinned=true&page_size=100",
-				Response: compute.ListClustersResponse{
-					Clusters: []compute.ClusterDetails{},
 				},
 			},
 			{
@@ -456,6 +452,7 @@ func TestResourceClusterCreate_WithLibraries(t *testing.T) {
 func TestResourceClusterCreatePhoton(t *testing.T) {
 	d, err := qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
+			nothingPinned,
 			{
 				Method:   "POST",
 				Resource: "/api/2.1/clusters/create",
@@ -489,13 +486,6 @@ func TestResourceClusterCreatePhoton(t *testing.T) {
 			},
 			{
 				Method:   "GET",
-				Resource: "/api/2.1/clusters/list?filter_by.is_pinned=true&page_size=100",
-				Response: compute.ListClustersResponse{
-					Clusters: []compute.ClusterDetails{},
-				},
-			},
-			{
-				Method:   "GET",
 				Resource: "/api/2.0/libraries/cluster-status?cluster_id=abc",
 				Response: compute.ClusterLibraryStatuses{
 					LibraryStatuses: []compute.LibraryFullStatus{},
@@ -521,6 +511,7 @@ func TestResourceClusterCreatePhoton(t *testing.T) {
 func TestResourceClusterCreateNoWait_WithLibraries(t *testing.T) {
 	d, err := qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
+			nothingPinned,
 			{
 				Method:   "POST",
 				Resource: "/api/2.1/clusters/create",
@@ -546,13 +537,6 @@ func TestResourceClusterCreateNoWait_WithLibraries(t *testing.T) {
 					NodeTypeId:             "i3.xlarge",
 					AutoterminationMinutes: 15,
 					State:                  compute.StateUnknown,
-				},
-			},
-			{
-				Method:   "GET",
-				Resource: "/api/2.1/clusters/list?filter_by.is_pinned=true&page_size=100",
-				Response: compute.ListClustersResponse{
-					Clusters: []compute.ClusterDetails{},
 				},
 			},
 			{
@@ -606,6 +590,7 @@ func TestResourceClusterCreateNoWait_WithLibraries(t *testing.T) {
 func TestResourceClusterCreateNoWait(t *testing.T) {
 	d, err := qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
+			nothingPinned,
 			{
 				Method:   "POST",
 				Resource: "/api/2.1/clusters/create",
@@ -633,13 +618,6 @@ func TestResourceClusterCreateNoWait(t *testing.T) {
 					NodeTypeId:             "i3.xlarge",
 					AutoterminationMinutes: 15,
 					State:                  compute.StateUnknown,
-				},
-			},
-			{
-				Method:   "GET",
-				Resource: "/api/2.1/clusters/list?filter_by.is_pinned=true&page_size=100",
-				Response: compute.ListClustersResponse{
-					Clusters: []compute.ClusterDetails{},
 				},
 			},
 		},
@@ -689,6 +667,7 @@ func TestResourceClusterCreate_Error(t *testing.T) {
 func TestResourceClusterRead(t *testing.T) {
 	d, err := qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
+			nothingPinned,
 			{
 				Method:   "GET",
 				Resource: "/api/2.1/clusters/get?cluster_id=abc",
@@ -703,13 +682,6 @@ func TestResourceClusterRead(t *testing.T) {
 					Autoscale: &compute.AutoScale{
 						MaxWorkers: 4,
 					},
-				},
-			},
-			{
-				Method:   "GET",
-				Resource: "/api/2.1/clusters/list?filter_by.is_pinned=true&page_size=100",
-				Response: compute.ListClustersResponse{
-					Clusters: []compute.ClusterDetails{},
 				},
 			},
 		},
@@ -779,6 +751,7 @@ func TestResourceClusterRead_Error(t *testing.T) {
 func TestResourceClusterUpdate_ResizeForAutoscalingToNumWorkersCluster(t *testing.T) {
 	qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
+			nothingPinned,
 			{
 				Method:       "GET",
 				Resource:     "/api/2.1/clusters/get?cluster_id=abc",
@@ -794,13 +767,6 @@ func TestResourceClusterUpdate_ResizeForAutoscalingToNumWorkersCluster(t *testin
 					NodeTypeId:             "i3.xlarge",
 					AutoterminationMinutes: 15,
 					State:                  compute.StateRunning,
-				},
-			},
-			{
-				Method:   "GET",
-				Resource: "/api/2.1/clusters/list?filter_by.is_pinned=true&page_size=100",
-				Response: compute.ListClustersResponse{
-					Clusters: []compute.ClusterDetails{},
 				},
 			},
 			{
@@ -839,6 +805,7 @@ func TestResourceClusterUpdate_ResizeForAutoscalingToNumWorkersCluster(t *testin
 func TestResourceClusterUpdate_ResizeForNumWorkersToAutoscalingCluster(t *testing.T) {
 	qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
+			nothingPinned,
 			{
 				Method:       "GET",
 				Resource:     "/api/2.1/clusters/get?cluster_id=abc",
@@ -851,13 +818,6 @@ func TestResourceClusterUpdate_ResizeForNumWorkersToAutoscalingCluster(t *testin
 					NodeTypeId:             "i3.xlarge",
 					AutoterminationMinutes: 15,
 					State:                  compute.StateRunning,
-				},
-			},
-			{
-				Method:   "GET",
-				Resource: "/api/2.1/clusters/list?filter_by.is_pinned=true&page_size=100",
-				Response: compute.ListClustersResponse{
-					Clusters: []compute.ClusterDetails{},
 				},
 			},
 			{
@@ -899,6 +859,7 @@ func TestResourceClusterUpdate_ResizeForNumWorkersToAutoscalingCluster(t *testin
 func TestResourceClusterUpdate_EditNumWorkersWhenClusterTerminated(t *testing.T) {
 	qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
+			nothingPinned,
 			{
 				Method:       "GET",
 				Resource:     "/api/2.1/clusters/get?cluster_id=abc",
@@ -911,13 +872,6 @@ func TestResourceClusterUpdate_EditNumWorkersWhenClusterTerminated(t *testing.T)
 					NodeTypeId:             "i3.xlarge",
 					AutoterminationMinutes: 15,
 					State:                  compute.StateTerminated,
-				},
-			},
-			{
-				Method:   "GET",
-				Resource: "/api/2.1/clusters/list?filter_by.is_pinned=true&page_size=100",
-				Response: compute.ListClustersResponse{
-					Clusters: []compute.ClusterDetails{},
 				},
 			},
 			{
@@ -956,6 +910,7 @@ func TestResourceClusterUpdate_EditNumWorkersWhenClusterTerminated(t *testing.T)
 func TestResourceClusterUpdate_ResizeAutoscale(t *testing.T) {
 	qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
+			nothingPinned,
 			{
 				Method:       "GET",
 				Resource:     "/api/2.1/clusters/get?cluster_id=abc",
@@ -980,13 +935,6 @@ func TestResourceClusterUpdate_ResizeAutoscale(t *testing.T) {
 						MinWorkers: 4,
 						MaxWorkers: 10,
 					},
-				},
-			},
-			{
-				Method:   "GET",
-				Resource: "/api/2.1/clusters/list?filter_by.is_pinned=true&page_size=100",
-				Response: compute.ListClustersResponse{
-					Clusters: []compute.ClusterDetails{},
 				},
 			},
 		},
@@ -1020,6 +968,7 @@ func TestResourceClusterUpdate_ResizeAutoscale(t *testing.T) {
 func TestResourceClusterUpdate_ResizeNumWorkers(t *testing.T) {
 	qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
+			nothingPinned,
 			{
 				Method:       "GET",
 				Resource:     "/api/2.1/clusters/get?cluster_id=abc",
@@ -1032,13 +981,6 @@ func TestResourceClusterUpdate_ResizeNumWorkers(t *testing.T) {
 					NodeTypeId:             "i3.xlarge",
 					AutoterminationMinutes: 15,
 					State:                  compute.StateRunning,
-				},
-			},
-			{
-				Method:   "GET",
-				Resource: "/api/2.1/clusters/list?filter_by.is_pinned=true&page_size=100",
-				Response: compute.ListClustersResponse{
-					Clusters: []compute.ClusterDetails{},
 				},
 			},
 			{
@@ -1073,6 +1015,7 @@ func TestResourceClusterUpdate_ResizeNumWorkers(t *testing.T) {
 func TestResourceClusterUpdate(t *testing.T) {
 	d, err := qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
+			nothingPinned,
 			{
 				Method:       "GET",
 				Resource:     "/api/2.1/clusters/get?cluster_id=abc",
@@ -1085,13 +1028,6 @@ func TestResourceClusterUpdate(t *testing.T) {
 					NodeTypeId:             "i3.xlarge",
 					AutoterminationMinutes: 15,
 					State:                  compute.StateRunning,
-				},
-			},
-			{
-				Method:   "GET",
-				Resource: "/api/2.1/clusters/list?filter_by.is_pinned=true&page_size=100",
-				Response: compute.ListClustersResponse{
-					Clusters: []compute.ClusterDetails{},
 				},
 			},
 			{
@@ -1146,6 +1082,7 @@ func TestResourceClusterUpdate(t *testing.T) {
 func TestResourceClusterUpdate_WhileScaling(t *testing.T) {
 	d, err := qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
+			nothingPinned,
 			{
 				Method:       "GET",
 				Resource:     "/api/2.1/clusters/get?cluster_id=abc",
@@ -1158,13 +1095,6 @@ func TestResourceClusterUpdate_WhileScaling(t *testing.T) {
 					NodeTypeId:             "i3.xlarge",
 					AutoterminationMinutes: 15,
 					State:                  compute.StateRunning,
-				},
-			},
-			{
-				Method:   "GET",
-				Resource: "/api/2.1/clusters/list?filter_by.is_pinned=true&page_size=100",
-				Response: compute.ListClustersResponse{
-					Clusters: []compute.ClusterDetails{},
 				},
 			},
 			{
@@ -1235,6 +1165,7 @@ func TestResourceClusterUpdate_WhileScaling(t *testing.T) {
 func TestResourceClusterUpdateWithPinned(t *testing.T) {
 	d, err := qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
+			nothingPinned,
 			{
 				Method:       "GET",
 				Resource:     "/api/2.1/clusters/get?cluster_id=abc",
@@ -1247,13 +1178,6 @@ func TestResourceClusterUpdateWithPinned(t *testing.T) {
 					NodeTypeId:             "i3.xlarge",
 					AutoterminationMinutes: 15,
 					State:                  compute.StateRunning,
-				},
-			},
-			{
-				Method:   "GET",
-				Resource: "/api/2.1/clusters/list?filter_by.is_pinned=true&page_size=100",
-				Response: compute.ListClustersResponse{
-					Clusters: []compute.ClusterDetails{},
 				},
 			},
 			{
@@ -1344,6 +1268,7 @@ func TestResourceClusterUpdate_LibrariesChangeOnTerminatedCluster(t *testing.T) 
 	}
 	d, err := qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
+			nothingPinned,
 			terminated, // 1 of ...
 			{
 				Method:   "POST",
@@ -1388,13 +1313,6 @@ func TestResourceClusterUpdate_LibrariesChangeOnTerminatedCluster(t *testing.T) 
 					SparkVersion: "7.1-scala12",
 					NodeTypeId:   "i3.xlarge",
 					State:        compute.StateTerminated,
-				},
-			},
-			{
-				Method:   "GET",
-				Resource: "/api/2.1/clusters/list?filter_by.is_pinned=true&page_size=100",
-				Response: compute.ListClustersResponse{
-					Clusters: []compute.ClusterDetails{},
 				},
 			},
 			{ // start cluster before libs install
@@ -1504,6 +1422,7 @@ func TestResourceClusterUpdate_Error(t *testing.T) {
 func TestResourceClusterUpdate_AutoAz(t *testing.T) {
 	d, err := qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
+			nothingPinned,
 			{
 				Method:       "GET",
 				Resource:     "/api/2.1/clusters/get?cluster_id=abc",
@@ -1521,13 +1440,6 @@ func TestResourceClusterUpdate_AutoAz(t *testing.T) {
 						FirstOnDemand: 1,
 						ZoneId:        "us-west-2a",
 					},
-				},
-			},
-			{
-				Method:   "GET",
-				Resource: "/api/2.1/clusters/list?filter_by.is_pinned=true&page_size=100",
-				Response: compute.ListClustersResponse{
-					Clusters: []compute.ClusterDetails{},
 				},
 			},
 			{
@@ -1646,6 +1558,7 @@ func TestResourceClusterDelete_Error(t *testing.T) {
 func TestResourceClusterCreate_SingleNode(t *testing.T) {
 	d, err := qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
+			nothingPinned,
 			{
 				Method:   "POST",
 				Resource: "/api/2.1/clusters/create",
@@ -1667,13 +1580,6 @@ func TestResourceClusterCreate_SingleNode(t *testing.T) {
 				Response: compute.ClusterDetails{
 					ClusterId: "abc",
 					State:     compute.StateRunning,
-				},
-			},
-			{
-				Method:   "GET",
-				Resource: "/api/2.1/clusters/list?filter_by.is_pinned=true&page_size=100",
-				Response: compute.ListClustersResponse{
-					Clusters: []compute.ClusterDetails{},
 				},
 			},
 			{
@@ -1839,18 +1745,12 @@ func TestReadOnStoppedClusterWithLibrariesDoesNotFail(t *testing.T) {
 	qa.ResourceFixture{
 		Resource: ResourceCluster(),
 		Fixtures: []qa.HTTPFixture{
+			nothingPinned,
 			{
 				Method:   "GET",
 				Resource: "/api/2.1/clusters/get?cluster_id=foo",
 				Response: compute.ClusterDetails{
 					State: compute.StateTerminated,
-				},
-			},
-			{
-				Method:   "GET",
-				Resource: "/api/2.1/clusters/list?filter_by.is_pinned=true&page_size=100",
-				Response: compute.ListClustersResponse{
-					Clusters: []compute.ClusterDetails{},
 				},
 			},
 			{
@@ -1889,13 +1789,6 @@ func TestRefreshOnRunningClusterWithFailedLibraryUninstallsIt(t *testing.T) {
 			},
 			{
 				Method:   "GET",
-				Resource: "/api/2.1/clusters/list?filter_by.is_pinned=true&page_size=100",
-				Response: compute.ListClustersResponse{
-					Clusters: []compute.ClusterDetails{},
-				},
-			},
-			{
-				Method:   "GET",
 				Resource: "/api/2.0/libraries/cluster-status?cluster_id=foo",
 				Response: compute.ClusterLibraryStatuses{
 					ClusterId: "foo",
@@ -1928,6 +1821,7 @@ func TestRefreshOnRunningClusterWithFailedLibraryUninstallsIt(t *testing.T) {
 					},
 				},
 			},
+			nothingPinned,
 		},
 		Read: true,
 		ID:   "foo",
@@ -1937,6 +1831,7 @@ func TestRefreshOnRunningClusterWithFailedLibraryUninstallsIt(t *testing.T) {
 func TestResourceClusterUpdate_LocalSsdCount(t *testing.T) {
 	_, err := qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
+			nothingPinned,
 			{
 				Method:       "GET",
 				Resource:     "/api/2.1/clusters/get?cluster_id=abc",
@@ -1952,13 +1847,6 @@ func TestResourceClusterUpdate_LocalSsdCount(t *testing.T) {
 					GcpAttributes: &compute.GcpAttributes{
 						LocalSsdCount: 2,
 					},
-				},
-			},
-			{
-				Method:   "GET",
-				Resource: "/api/2.1/clusters/list?filter_by.is_pinned=true&page_size=100",
-				Response: compute.ListClustersResponse{
-					Clusters: []compute.ClusterDetails{},
 				},
 			},
 			{

--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -836,9 +836,12 @@ func TestImportingClusters(t *testing.T) {
 				ReuseRequest: true,
 			},
 			{
-				Method:   "POST",
-				Resource: "/api/2.1/clusters/events",
-				Response: compute.GetEvents{},
+				Method:   "GET",
+				Resource: "/api/2.1/clusters/list?filter_by.is_pinned=true&page_size=100",
+				Response: compute.ListClustersResponse{
+					Clusters: []compute.ClusterDetails{},
+				},
+				ReuseRequest: true,
 			},
 			{
 				Method:       "GET",
@@ -869,30 +872,6 @@ func TestImportingClusters(t *testing.T) {
 				Response: getJSONObject("test-data/get-cluster-test2-response.json"),
 			},
 			{
-				Method:   "POST",
-				Resource: "/api/2.1/clusters/events",
-				ExpectedRequest: compute.GetEvents{
-					ClusterId:  "test2",
-					Order:      compute.GetEventsOrderDesc,
-					EventTypes: []compute.EventType{compute.EventTypePinned, compute.EventTypeUnpinned},
-					Limit:      1,
-				},
-				Response:     compute.EventDetails{},
-				ReuseRequest: true,
-			},
-			{
-				Method:   "POST",
-				Resource: "/api/2.1/clusters/events",
-				ExpectedRequest: compute.GetEvents{
-					ClusterId:  "test1",
-					Order:      compute.GetEventsOrderDesc,
-					EventTypes: []compute.EventType{compute.EventTypePinned, compute.EventTypeUnpinned},
-					Limit:      1,
-				},
-				Response:     compute.EventDetails{},
-				ReuseRequest: true,
-			},
-			{
 				Method:   "GET",
 				Resource: "/api/2.0/libraries/cluster-status?cluster_id=test2",
 				Response: getJSONObject("test-data/libraries-cluster-status-test2.json"),
@@ -916,17 +895,6 @@ func TestImportingClusters(t *testing.T) {
 				Method:   "GET",
 				Resource: "/api/2.1/clusters/get?cluster_id=awscluster",
 				Response: getJSONObject("test-data/get-cluster-awscluster-response.json"),
-			},
-			{
-				Method:   "POST",
-				Resource: "/api/2.1/clusters/events",
-				ExpectedRequest: compute.GetEvents{
-					ClusterId:  "awscluster",
-					Order:      compute.GetEventsOrderDesc,
-					EventTypes: []compute.EventType{compute.EventTypePinned, compute.EventTypeUnpinned},
-					Limit:      1,
-				},
-				Response: compute.EventDetails{},
 			},
 			{
 				Method:   "GET",

--- a/internal/acceptance/cluster_test.go
+++ b/internal/acceptance/cluster_test.go
@@ -51,7 +51,7 @@ func TestAccClusterResource_CreateClusterWithLibraries(t *testing.T) {
 	})
 }
 
-func singleNodeClusterTemplate(autoTerminationMinutes string) string {
+func singleNodeClusterTemplate(autoTerminationMinutes string, isPinned bool) string {
 	return fmt.Sprintf(`
 		data "databricks_spark_version" "latest" {
 		}
@@ -61,6 +61,7 @@ func singleNodeClusterTemplate(autoTerminationMinutes string) string {
 			instance_pool_id = "{env.TEST_INSTANCE_POOL_ID}"
 			num_workers = 0
 			autotermination_minutes = %s
+			is_pinned = %t
 			spark_conf = {
 				"spark.databricks.cluster.profile" = "singleNode"
 				"spark.master" = "local[*]"
@@ -69,14 +70,14 @@ func singleNodeClusterTemplate(autoTerminationMinutes string) string {
 				"ResourceClass" = "SingleNode"
 			}
 		}
-	`, autoTerminationMinutes)
+	`, autoTerminationMinutes, isPinned)
 }
 
 func TestAccClusterResource_CreateSingleNodeCluster(t *testing.T) {
 	WorkspaceLevel(t, Step{
-		Template: singleNodeClusterTemplate("10"),
+		Template: singleNodeClusterTemplate("10", false),
 	}, Step{
-		Template: singleNodeClusterTemplate("20"),
+		Template: singleNodeClusterTemplate("20", false),
 	})
 }
 
@@ -173,6 +174,19 @@ func TestAccClusterResource_WorkloadType(t *testing.T) {
 		Check: resource.ComposeAggregateTestCheckFunc(
 			resource.TestCheckResourceAttr("databricks_cluster.this", "workload_type.#", "0"),
 		),
+	})
+}
+
+func TestAccClusterResource_PinAndUnpin(t *testing.T) {
+	WorkspaceLevel(t, Step{
+		Template: singleNodeClusterTemplate("10", false),
+		Check:    resource.TestCheckResourceAttr("databricks_cluster.this", "is_pinned", "false"),
+	}, Step{
+		Template: singleNodeClusterTemplate("10", true),
+		Check:    resource.TestCheckResourceAttr("databricks_cluster.this", "is_pinned", "true"),
+	}, Step{
+		Template: singleNodeClusterTemplate("10", false),
+		Check:    resource.TestCheckResourceAttr("databricks_cluster.this", "is_pinned", "false"),
 	})
 }
 


### PR DESCRIPTION
## Changes
Modify `setPinnedStatus` to use the clusters list API internally for determining the pinning status of a cluster. The existing implementation using the cluster events API subjects the resource to drift as events expire after a period of time.

Closes #3616 

## Tests
* Coverage added to `TestResourceClusterCreate` and `TestResourceClusterCreatePinned`.
* Fixtures modified to mock the necessary API calls in all other relevant tests.
* `TestAccClusterResource_PinAndUnpin` acceptance test added

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [x] covered with integration tests in `internal/acceptance`
- [x] relevant acceptance tests are passing
- [x] using Go SDK
