### PR TITLE
[Exporter] Add `List` operation for `users` service

### DIFF
--- a/docs/guides/experimental-exporter.md
+++ b/docs/guides/experimental-exporter.md
@@ -148,7 +148,7 @@ Services are just logical groups of resources used for filtering and organizatio
 * `uc-system-schemas` - **listing** exports [databricks_system_schema](../resources/system_schema.md) resources for the UC metastore of the current workspace.
 * `uc-tables` - **listing** (*we can't list directly, only via dependencies to top-level object*) [databricks_sql_table](../resources/sql_table.md) resource.
 * `uc-volumes` - **listing** (*we can't list directly, only via dependencies to top-level object*) [databricks_volume](../resources/volume.md)
-* `users` - [databricks_user](../resources/user.md) and [databricks_service_principal](../resources/service_principal.md) are written to their own file, simply because of their amount. If you use SCIM provisioning, migrating workspaces is the only use case for importing `users` service.
+* `users` - **listing** [databricks_user](../resources/user.md) and [databricks_service_principal](../resources/service_principal.md) are written to their own file, simply because of their amount. If you use SCIM provisioning, migrating workspaces is the only use case for importing `users` service.
 * `vector-search` - **listing** exports [databricks_vector_search_endpoint](../resources/vector_search_endpoint.md) and [databricks_vector_search_index](../resources/vector_search_index.md)
 * `workspace` - **listing** [databricks_workspace_conf](../resources/workspace_conf.md) and [databricks_global_init_script](../resources/global_init_script.md)
 * `wsfiles` - **listing** [databricks_workspace_file](../resources/workspace_file.md).

--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -439,9 +439,24 @@ var emptyLakeviewList = qa.HTTPFixture{
 }
 
 var emptyDestinationNotficationsList = qa.HTTPFixture{
-	Method:   "GET",
-	Resource: "/api/2.0/notification-destinations?",
-	Response: settings.ListNotificationDestinationsResponse{},
+	Method:       "GET",
+	Resource:     "/api/2.0/notification-destinations?",
+	Response:     settings.ListNotificationDestinationsResponse{},
+	ReuseRequest: true,
+}
+
+var emptyUsersList = qa.HTTPFixture{
+	Method:       "GET",
+	Resource:     "/api/2.0/preview/scim/v2/Users?attributes=id%2CuserName&count=100&startIndex=1",
+	Response:     map[string]any{},
+	ReuseRequest: true,
+}
+
+var emptySpnsList = qa.HTTPFixture{
+	Method:       "GET",
+	Resource:     "/api/2.0/preview/scim/v2/ServicePrincipals?attributes=id%2CuserName&count=100&startIndex=1",
+	Response:     map[string]any{},
+	ReuseRequest: true,
 }
 
 func TestImportingUsersGroupsSecretScopes(t *testing.T) {
@@ -739,6 +754,8 @@ func TestImportingNoResourcesError(t *testing.T) {
 					Groups: []scim.ComplexValue{},
 				},
 			},
+			emptyUsersList,
+			emptySpnsList,
 			noCurrentMetastoreAttached,
 			emptyLakeviewList,
 			emptyDestinationNotficationsList,


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

Now we can list users and service principals directly, not only as groups dependency.


## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
