### PR TITLE
[Fix] Do not validate single node clusters if a policy is configured

### DIFF
--- a/clusters/clusters_api.go
+++ b/clusters/clusters_api.go
@@ -435,22 +435,6 @@ type Cluster struct {
 }
 
 // TODO: Remove this once all the resources using clusters are migrated to Go SDK.
-// They would then be using Validate(cluster compute.CreateCluster) defined in resource_cluster.go that is a duplicate of this method but uses Go SDK.
-func (cluster Cluster) Validate() error {
-	// TODO: rewrite with CustomizeDiff
-	if cluster.NumWorkers > 0 || cluster.Autoscale != nil {
-		return nil
-	}
-	profile := cluster.SparkConf["spark.databricks.cluster.profile"]
-	master := cluster.SparkConf["spark.master"]
-	resourceClass := cluster.CustomTags["ResourceClass"]
-	if profile == "singleNode" && strings.HasPrefix(master, "local") && resourceClass == "SingleNode" {
-		return nil
-	}
-	return errors.New(numWorkerErr)
-}
-
-// TODO: Remove this once all the resources using clusters are migrated to Go SDK.
 // They would then be using ModifyRequestOnInstancePool(cluster *compute.CreateCluster) defined in resource_cluster.go that is a duplicate of this method but uses Go SDK.
 // ModifyRequestOnInstancePool helps remove all request fields that should not be submitted when instance pool is selected.
 func (cluster *Cluster) ModifyRequestOnInstancePool() {

--- a/jobs/jobs_api_go_sdk.go
+++ b/jobs/jobs_api_go_sdk.go
@@ -157,7 +157,7 @@ func (c controlRunStateLifecycleManagerGoSdk) OnUpdate(ctx context.Context) erro
 }
 
 func updateAndValidateJobClusterSpec(clusterSpec *compute.ClusterSpec, d *schema.ResourceData) error {
-	err := clusters.Validate(*clusterSpec)
+	err := clusters.ValidateIfSingleNode(*clusterSpec)
 	if err != nil {
 		return err
 	}

--- a/jobs/resource_job.go
+++ b/jobs/resource_job.go
@@ -1072,12 +1072,12 @@ func ResourceJob() common.Resource {
 				if task.NewCluster == nil {
 					continue
 				}
-				if err := clusters.Validate(*task.NewCluster); err != nil {
+				if err := clusters.ValidateIfSingleNode(*task.NewCluster); err != nil {
 					return fmt.Errorf("task %s invalid: %w", task.TaskKey, err)
 				}
 			}
 			if js.NewCluster != nil {
-				if err := clusters.Validate(*js.NewCluster); err != nil {
+				if err := clusters.ValidateIfSingleNode(*js.NewCluster); err != nil {
 					return fmt.Errorf("invalid job cluster: %w", err)
 				}
 			}


### PR DESCRIPTION
## Changes
Addresses another problem reported in https://github.com/databricks/cli/issues/1546, where customers were not able to configure and use cluster policies for single node clusters.

## Tests
Unit tests, and manually verified that cluster is successfully created without spark_conf even when `num_workers` is 0.