### PR TITLE
Remove single-node validation from interactive clusters

### DIFF
--- a/clusters/resource_cluster.go
+++ b/clusters/resource_cluster.go
@@ -26,26 +26,6 @@ var clusterSchema = resourceClusterSchema()
 var clusterSchemaVersion = 4
 
 const (
-	numWorkerErr = `num_workers may be 0 only for single-node clusters. To create a single node
-cluster please include the following configuration in your cluster configuration:
-
-  spark_conf = {
-    "spark.databricks.cluster.profile" : "singleNode"
-    "spark.master" : "local[*]"
-  }
-
-  custom_tags = {
-    "ResourceClass" = "SingleNode"
-  }
-
-Please note that the Databricks Terraform provider cannot detect if the above configuration
-is defined in a policy used by the cluster. Please define this in the cluster configuration
-itself to create a single node cluster.
-
-For more details please see:
-  1. https://registry.terraform.io/providers/databricks/databricks/latest/docs/resources/cluster#fixed-size-or-autoscaling-cluster
-  2. https://docs.databricks.com/clusters/single-node.html`
-
 	unsupportedExceptCreateEditClusterSpecErr = "unsupported type %T, must be one of %scompute.CreateCluster, %scompute.ClusterSpec or %scompute.EditCluster. Please report this issue to the GitHub repo"
 )
 
@@ -128,39 +108,6 @@ func ZoneDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
 		return true
 	}
 	return false
-}
-
-func Validate(cluster any) error {
-	var profile, master, resourceClass string
-	switch c := cluster.(type) {
-	case compute.CreateCluster:
-		if c.NumWorkers > 0 || c.Autoscale != nil {
-			return nil
-		}
-		profile = c.SparkConf["spark.databricks.cluster.profile"]
-		master = c.SparkConf["spark.master"]
-		resourceClass = c.CustomTags["ResourceClass"]
-	case compute.EditCluster:
-		if c.NumWorkers > 0 || c.Autoscale != nil {
-			return nil
-		}
-		profile = c.SparkConf["spark.databricks.cluster.profile"]
-		master = c.SparkConf["spark.master"]
-		resourceClass = c.CustomTags["ResourceClass"]
-	case compute.ClusterSpec:
-		if c.NumWorkers > 0 || c.Autoscale != nil {
-			return nil
-		}
-		profile = c.SparkConf["spark.databricks.cluster.profile"]
-		master = c.SparkConf["spark.master"]
-		resourceClass = c.CustomTags["ResourceClass"]
-	default:
-		return fmt.Errorf(unsupportedExceptCreateEditClusterSpecErr, cluster, "", "", "")
-	}
-	if profile == "singleNode" && strings.HasPrefix(master, "local") && resourceClass == "SingleNode" {
-		return nil
-	}
-	return errors.New(numWorkerErr)
 }
 
 // This method is a duplicate of ModifyRequestOnInstancePool() in clusters/clusters_api.go that uses Go SDK.
@@ -443,9 +390,6 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, c *commo
 	clusters := w.Clusters
 	var createClusterRequest compute.CreateCluster
 	common.DataToStructPointer(d, clusterSchema, &createClusterRequest)
-	if err := Validate(createClusterRequest); err != nil {
-		return err
-	}
 	if err = ModifyRequestOnInstancePool(&createClusterRequest); err != nil {
 		return err
 	}
@@ -596,9 +540,6 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, c *commo
 
 	if hasClusterConfigChanged(d) {
 		log.Printf("[DEBUG] Cluster state has changed!")
-		if err := Validate(cluster); err != nil {
-			return err
-		}
 		if err = ModifyRequestOnInstancePool(&cluster); err != nil {
 			return err
 		}


### PR DESCRIPTION
## Changes
There were reports in https://github.com/databricks/cli/issues/1546 of customers unable to use cluster policies for single-node clusters due to Terraform performing this validation. This PR removes the validation altogether that a single-node cluster is correctly configured.

This PR removes this validation altogether to enable those use cases. Meanwhile, the clusters team is working on API-side improvements to improve the API interface for creating single-node clusters, which will make it much less likely for users to misconfigure their single-node clusters.

## Tests
Unit test and manually.