### PR TITLE
[Internal] Mark TestUcAccModelServingProvisionedThroughput as flaky. to be rever…

### DIFF
--- a/test-config.yaml
+++ b/test-config.yaml
@@ -18,3 +18,6 @@ ignored_tests:
     - package: github.com/databricks/terraform-provider-databricks/internal/acceptance
       test_name: TestUcAccVectorSearchEndpoint
       comment: Failure due to read-after-create inconsistency. https://databricks.atlassian.net/browse/ES-1243690
+    - package: github.com/databricks/terraform-provider-databricks/internal/acceptance
+      test_name: TestUcAccModelServingProvisionedThroughput
+      comment: Failure due to temporary incident. To be removed following resolution. https://databricks.atlassian.net/browse/ES-1306706


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
Temporarily mark TestUcAccModelServingProvisionedThroughput as flaky.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
