### PR TITLE
[Doc] Update description of `group_id` in `databricks_mws_ncc_private_endpoint_rule`

### DIFF
--- a/docs/resources/mws_ncc_private_endpoint_rule.md
+++ b/docs/resources/mws_ncc_private_endpoint_rule.md
@@ -35,7 +35,7 @@ The following arguments are available:
 
 * `network_connectivity_config_id` - Canonical unique identifier of Network Connectivity Config in Databricks Account. Change forces creation of a new resource.
 * `resource_id` - The Azure resource ID of the target resource. Change forces creation of a new resource.
-* `group_id` - The sub-resource type (group ID) of the target resource. Must be one of `blob`, `dfs`, `sqlServer` or `mysqlServer`. Note that to connect to workspace root storage (root DBFS), you need two endpoints, one for blob and one for dfs. Change forces creation of a new resource.
+* `group_id` - The sub-resource type (group ID) of the target resource. Must be one of supported resource types (i.e., `blob`, `dfs`, `sqlServer` , etc. Consult the [Azure documentation](https://learn.microsoft.com/en-us/azure/private-link/private-endpoint-overview#private-link-resource) for full list of supported resources). Note that to connect to workspace root storage (root DBFS), you need two endpoints, one for `blob` and one for `dfs`. Change forces creation of a new resource.
 
 ## Attribute Reference
 


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

NCC [now supports](https://learn.microsoft.com/en-us/azure/databricks/release-notes/product/2024/november#private-connectivity-from-serverless-compute-support-for-azure-managed-resources) connections to any Azure service that supports private link.  So update docs to point to corresponding documentation.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
