### PR TITLE
[Internal] Revert "mark TestUcAccModelServingProvisionedThroughput as flaky. to …

### DIFF
--- a/test-config.yaml
+++ b/test-config.yaml
@@ -18,6 +18,3 @@ ignored_tests:
     - package: github.com/databricks/terraform-provider-databricks/internal/acceptance
       test_name: TestUcAccVectorSearchEndpoint
       comment: Failure due to read-after-create inconsistency. https://databricks.atlassian.net/browse/ES-1243690
-    - package: github.com/databricks/terraform-provider-databricks/internal/acceptance
-      test_name: TestUcAccModelServingProvisionedThroughput
-      comment: Failure due to temporary incident. To be removed following resolution. https://databricks.atlassian.net/browse/ES-1306706


### PR DESCRIPTION
This reverts commit cc9e5034bf3fd392b8616169173e7bbdf1a58139.

## Changes
<!-- Summary of your changes that are easy to understand -->

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
