### PR TITLE
[Fix] Fix waiting for `databricks_vector_search_index` readiness

### DIFF
--- a/vectorsearch/resource_vector_search_index.go
+++ b/vectorsearch/resource_vector_search_index.go
@@ -37,7 +37,8 @@ func waitForSearchIndexCreation(w *databricks.WorkspaceClient, ctx context.Conte
 		if err != nil {
 			return retry.NonRetryableError(err)
 		}
-		if index.Status.Ready { // We really need to depend on the detailed status of the index, but it's not available in the API yet
+		// We really need to depend on the detailed status of the index, but it's not available in the API yet
+		if index.Status != nil && (index.Status.Ready || index.Status.IndexedRowCount > 0) {
 			return nil
 		}
 		return retry.RetryableError(fmt.Errorf("vector search index %s is still pending", searchIndexName))


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

Change the wait condition from waiting for the index to be fully ready to either fully ready or started indexing.

Resolves #4144

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [x] relevant acceptance tests are passing
- [ ] using Go SDK
