### PR TITLE
[Fix] Correct handling of updates for empty comments and `force_destroy` in UC catalog, schema, registered models and volumes

### DIFF
--- a/catalog/resource_catalog.go
+++ b/catalog/resource_catalog.go
@@ -124,6 +124,9 @@ func ResourceCatalog() common.Resource {
 			if err != nil {
 				return err
 			}
+			if !d.HasChangeExcept("force_destroy") {
+				return nil
+			}
 
 			var updateCatalogRequest catalog.UpdateCatalog
 			common.DataToStructPointer(d, catalogSchema, &updateCatalogRequest)
@@ -141,6 +144,10 @@ func ResourceCatalog() common.Resource {
 
 			if !d.HasChangeExcept("owner") {
 				return nil
+			}
+
+			if d.HasChange("comment") && updateCatalogRequest.Comment == "" {
+				updateCatalogRequest.ForceSendFields = append(updateCatalogRequest.ForceSendFields, "Comment")
 			}
 
 			updateCatalogRequest.Owner = ""

--- a/catalog/resource_registered_model.go
+++ b/catalog/resource_registered_model.go
@@ -92,6 +92,9 @@ func ResourceRegisteredModel() common.Resource {
 				return nil
 			}
 
+			if d.HasChange("comment") && u.Comment == "" {
+				u.ForceSendFields = append(u.ForceSendFields, "Comment")
+			}
 			u.Owner = ""
 			_, err = w.RegisteredModels.Update(ctx, u)
 			if err != nil {

--- a/catalog/resource_registered_model_test.go
+++ b/catalog/resource_registered_model_test.go
@@ -196,6 +196,47 @@ func TestRegisteredModelUpdate(t *testing.T) {
 	}.ApplyNoError(t)
 }
 
+func TestRegisteredModelUpdateCommentOnly(t *testing.T) {
+	qa.ResourceFixture{
+		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
+			e := w.GetMockRegisteredModelsAPI().EXPECT()
+			e.Update(mock.Anything, catalog.UpdateRegisteredModelRequest{
+				FullName:        "catalog.schema.model",
+				Comment:         "",
+				ForceSendFields: []string{"Comment"},
+			}).Return(&catalog.RegisteredModelInfo{
+				Name:        "model",
+				CatalogName: "catalog",
+				SchemaName:  "schema",
+				FullName:    "catalog.schema.model",
+				Comment:     "",
+			}, nil)
+			e.GetByFullName(mock.Anything, "catalog.schema.model").Return(&catalog.RegisteredModelInfo{
+				Name:        "model",
+				CatalogName: "catalog",
+				SchemaName:  "schema",
+				FullName:    "catalog.schema.model",
+				Comment:     "",
+			}, nil)
+		},
+		Resource: ResourceRegisteredModel(),
+		Update:   true,
+		ID:       "catalog.schema.model",
+		InstanceState: map[string]string{
+			"name":         "model",
+			"catalog_name": "catalog",
+			"schema_name":  "schema",
+			"comment":      "comment",
+		},
+		HCL: `
+			name = "model"
+			catalog_name = "catalog"
+			schema_name = "schema"
+			comment = ""
+			`,
+	}.ApplyNoError(t)
+}
+
 func TestRegisteredModelUpdateOwner(t *testing.T) {
 	qa.ResourceFixture{
 		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {

--- a/catalog/resource_schema.go
+++ b/catalog/resource_schema.go
@@ -100,6 +100,9 @@ func ResourceSchema() common.Resource {
 			if err != nil {
 				return err
 			}
+			if !d.HasChangeExcept("force_destroy") {
+				return nil
+			}
 			var updateSchemaRequest catalog.UpdateSchema
 			common.DataToStructPointer(d, s, &updateSchemaRequest)
 			updateSchemaRequest.FullName = d.Id()
@@ -116,6 +119,10 @@ func ResourceSchema() common.Resource {
 
 			if !d.HasChangeExcept("owner") {
 				return nil
+			}
+
+			if d.HasChange("comment") && updateSchemaRequest.Comment == "" {
+				updateSchemaRequest.ForceSendFields = append(updateSchemaRequest.ForceSendFields, "Comment")
 			}
 
 			updateSchemaRequest.Owner = ""

--- a/catalog/resource_volume.go
+++ b/catalog/resource_volume.go
@@ -127,6 +127,10 @@ func ResourceVolume() common.Resource {
 				return nil
 			}
 
+			if d.HasChange("comment") && updateVolumeRequestContent.Comment == "" {
+				updateVolumeRequestContent.ForceSendFields = append(updateVolumeRequestContent.ForceSendFields, "Comment")
+			}
+
 			updateVolumeRequestContent.Owner = ""
 			v, err := w.Volumes.Update(ctx, updateVolumeRequestContent)
 			if err != nil {

--- a/catalog/resource_volume_test.go
+++ b/catalog/resource_volume_test.go
@@ -359,6 +359,65 @@ func TestVolumesUpdate(t *testing.T) {
 	assert.Equal(t, "/Volumes/testCatalogName/testSchemaName/testNameNew", d.Get("volume_path"))
 }
 
+func TestVolumesUpdateCommentOnly(t *testing.T) {
+	qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   http.MethodPatch,
+				Resource: "/api/2.1/unity-catalog/volumes/testCatalogName.testSchemaName.testName",
+				ExpectedRequest: catalog.UpdateVolumeRequestContent{
+					Comment:         "",
+					ForceSendFields: []string{"Comment"},
+				},
+				Response: catalog.VolumeInfo{
+					Name:        "testName",
+					VolumeType:  catalog.VolumeType("testVolumeType"),
+					CatalogName: "testCatalogName",
+					SchemaName:  "testSchemaName",
+					Comment:     "",
+					FullName:    "testCatalogName.testSchemaName.testName",
+				},
+			},
+			{
+				Method:   http.MethodGet,
+				Resource: "/api/2.1/unity-catalog/volumes/testCatalogName.testSchemaName.testName?",
+				Response: catalog.VolumeInfo{
+					Name:        "testName",
+					VolumeType:  catalog.VolumeType("testVolumeType"),
+					CatalogName: "testCatalogName",
+					SchemaName:  "testSchemaName",
+					Comment:     "",
+					FullName:    "testCatalogName.testSchemaName.testNameNew",
+				},
+			},
+		},
+		Resource: ResourceVolume(),
+		Update:   true,
+		InstanceState: map[string]string{
+			"name":         "testName",
+			"catalog_name": "testCatalogName",
+			"schema_name":  "testSchemaName",
+			"volume_type":  "testVolumeType",
+			"comment":      "this is a comment",
+		},
+		ID: "testCatalogName.testSchemaName.testName",
+		HCL: `
+		name = "testName"
+		volume_type = "testVolumeType"
+		catalog_name = "testCatalogName"
+		schema_name = "testSchemaName"
+		comment = ""
+		`,
+	}.ApplyAndExpectData(t, map[string]any{
+		"name":         "testName",
+		"volume_type":  "testVolumeType",
+		"catalog_name": "testCatalogName",
+		"schema_name":  "testSchemaName",
+		"comment":      "",
+		"volume_path":  "/Volumes/testCatalogName/testSchemaName/testNameNew",
+	})
+}
+
 func TestVolumesUpdateForceNewOnCatalog(t *testing.T) {
 	d, err := qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

Force sending of fields when `comment` is changing to empty value. Also, don't call Update API when the only change is in `force_destroy` attribute of schemas and catalogs

Resolves #4045

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
