### PR TITLE
[Fix] Treat trashed dashboard as deleted

### DIFF
--- a/dashboards/resource_dashboard.go
+++ b/dashboards/resource_dashboard.go
@@ -126,6 +126,14 @@ func ResourceDashboard() common.Resource {
 			if err != nil {
 				return err
 			}
+
+			// Deletion of a dashboard moves it to the trash and subsequent reads still return the trashed dashboard.
+			// It cannot be updated unless it is untrashed, so we treat it as deleted to force recreation.
+			if resp.LifecycleState == dashboards.LifecycleStateTrashed {
+				d.SetId("")
+				return nil
+			}
+
 			d.Set("dashboard_change_detected", (resp.Etag != d.Get("etag").(string)))
 			return common.StructToData(resp, dashboardSchema, d)
 		},

--- a/dashboards/resource_dashboard_test.go
+++ b/dashboards/resource_dashboard_test.go
@@ -157,6 +157,23 @@ func TestDashboardRead(t *testing.T) {
 	})
 }
 
+func TestDashboardReadTrashed(t *testing.T) {
+	qa.ResourceFixture{
+		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
+			w.GetMockLakeviewAPI().EXPECT().Get(mock.Anything, dashboards.GetDashboardRequest{
+				DashboardId: "xyz",
+			}).Return(&dashboards.Dashboard{
+				DashboardId:    "xyz",
+				LifecycleState: dashboards.LifecycleStateTrashed,
+			}, nil)
+		},
+		Resource: ResourceDashboard(),
+		Read:     true,
+		Removed:  true,
+		ID:       "xyz",
+	}.ApplyNoError(t)
+}
+
 func TestDashboardUpdate(t *testing.T) {
 	qa.ResourceFixture{
 		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {


### PR DESCRIPTION
## Changes

This is a follow-up to #4235, where the deletion of a trashed dashboard was fixed. This change treats trashed dashboards as deleted at read time, such that the resource shows up in the plan as new instead of a delete+create.

## Tests

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
