### PR TITLE
[Internal] Ignore Databricks Go SDK updates by dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,6 @@ updates:
       interval: "daily"
     commit-message:
       prefix: "[Dependency] "
+    ignore:
+      # Ignore Databricks Go SDK because its upgrade requires code generation
+      - dependency-name: github.com/databricks/databricks-sdk-go


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

It make sense to silence dependabot on Go SDK upgrades because we need to generate code from the OpenAPI spec and bump SDK SHA checksum.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
