### PR TITLE
[Doc] Update mws_log_delivery.md to add time_sleep

### DIFF
--- a/docs/resources/mws_log_delivery.md
+++ b/docs/resources/mws_log_delivery.md
@@ -61,10 +61,20 @@ resource "aws_s3_bucket_policy" "logdelivery" {
   policy = data.databricks_aws_bucket_policy.logdelivery.json
 }
 
+resource "time_sleep" "wait" {
+  depends_on = [
+    aws_iam_role.logdelivery
+  ]
+  create_duration = "10s"
+}
+
 resource "databricks_mws_credentials" "log_writer" {
   account_id       = var.databricks_account_id
   credentials_name = "Usage Delivery"
   role_arn         = aws_iam_role.logdelivery.arn
+  depends_on = [
+    time_sleep.wait
+  ]
 }
 
 resource "databricks_mws_storage_configurations" "log_bucket" {


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

without this sleep, 

I faced the following error:

```log
02:58:20.315 STDERR tofu: │ Error: cannot create mws log delivery: Failed to perform putObject operations on s3Bucket:dbx-dev-logging-audit with deliveryPathPrefix:dbx-dev-logging-audit with the IAM Role:arn:aws:iam::577638361399:role/dbx-dev-logging-audit-delivery-role provided. Please add all required s3 actions as mentioned in API docs to role policy of your IAM Role.
02:58:20.315 STDERR tofu: │ 
02:58:20.315 STDERR tofu: │   with databricks_mws_log_delivery.audit_logs,
02:58:20.315 STDERR tofu: │   on main.tf line 42, in resource "databricks_mws_log_delivery" "audit_logs":
02:58:20.315 STDERR tofu: │   42: resource "databricks_mws_log_delivery" "audit_logs" {
```

Related issue: https://kb.databricks.com/terraform/failed-credential-validation-checks-error-with-terraform

By adding this time_sleep, I could avoid the error.


## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
