### PR TITLE
[Fix] Forced send `auto_stop_mins` for `databricks_sql_endpoint` resource

### DIFF
--- a/sql/resource_sql_endpoint.go
+++ b/sql/resource_sql_endpoint.go
@@ -95,7 +95,7 @@ func ResourceSqlEndpoint() common.Resource {
 			}
 			var se sql.CreateWarehouseRequest
 			common.DataToStructPointer(d, s, &se)
-			common.SetForceSendFields(&se, d, []string{"enable_serverless_compute", "enable_photon"})
+			common.SetForceSendFields(&se, d, []string{"enable_serverless_compute", "enable_photon", "auto_stop_mins"})
 			wait, err := w.Warehouses.Create(ctx, se)
 			if err != nil {
 				return fmt.Errorf("failed creating warehouse: %w", err)

--- a/sql/resource_sql_endpoint.go
+++ b/sql/resource_sql_endpoint.go
@@ -14,8 +14,9 @@ import (
 
 // ClusterSizes for SQL endpoints
 var (
-	ClusterSizes   = []string{"2X-Small", "X-Small", "Small", "Medium", "Large", "X-Large", "2X-Large", "3X-Large", "4X-Large"}
-	MaxNumClusters = 30
+	ClusterSizes    = []string{"2X-Small", "X-Small", "Small", "Medium", "Large", "X-Large", "2X-Large", "3X-Large", "4X-Large"}
+	MaxNumClusters  = 30
+	ForceSendFields = []string{"enable_serverless_compute", "enable_photon", "auto_stop_mins"}
 )
 
 type SqlWarehouse struct {
@@ -95,7 +96,7 @@ func ResourceSqlEndpoint() common.Resource {
 			}
 			var se sql.CreateWarehouseRequest
 			common.DataToStructPointer(d, s, &se)
-			common.SetForceSendFields(&se, d, []string{"enable_serverless_compute", "enable_photon", "auto_stop_mins"})
+			common.SetForceSendFields(&se, d, ForceSendFields)
 			wait, err := w.Warehouses.Create(ctx, se)
 			if err != nil {
 				return fmt.Errorf("failed creating warehouse: %w", err)
@@ -129,7 +130,7 @@ func ResourceSqlEndpoint() common.Resource {
 			}
 			var se sql.EditWarehouseRequest
 			common.DataToStructPointer(d, s, &se)
-			common.SetForceSendFields(&se, d, []string{"enable_serverless_compute", "enable_photon"})
+			common.SetForceSendFields(&se, d, ForceSendFields)
 			se.Id = d.Id()
 			_, err = w.Warehouses.Edit(ctx, se)
 			if err != nil {

--- a/sql/resource_sql_endpoint_test.go
+++ b/sql/resource_sql_endpoint_test.go
@@ -272,6 +272,38 @@ func TestResourceSQLEndpointUpdateHealthNoDiff(t *testing.T) {
 	}.ApplyNoError(t)
 }
 
+func TestResourceSQLEndpointUpdateNoAutoTermination(t *testing.T) {
+	qa.ResourceFixture{
+		Resource: ResourceSqlEndpoint(),
+		ID:       "abc",
+		InstanceState: map[string]string{
+			"name":                 "foo",
+			"cluster_size":         "Small",
+			"auto_stop_mins":       "120",
+			"enable_photon":        "true",
+			"max_num_clusters":     "1",
+			"spot_instance_policy": "COST_OPTIMIZED",
+		},
+		ExpectedDiff: map[string]*terraform.ResourceAttrDiff{
+			"auto_stop_mins":            {Old: "120", New: "0", NewComputed: false, NewRemoved: false, RequiresNew: false, Sensitive: false},
+			"state":                     {Old: "", New: "", NewComputed: true, NewRemoved: false, RequiresNew: false, Sensitive: false},
+			"odbc_params.#":             {Old: "", New: "", NewComputed: true, NewRemoved: false, RequiresNew: false, Sensitive: false},
+			"num_clusters":              {Old: "", New: "", NewComputed: true, NewRemoved: false, RequiresNew: false, Sensitive: false},
+			"num_active_sessions":       {Old: "", New: "", NewComputed: true, NewRemoved: false, RequiresNew: false, Sensitive: false},
+			"jdbc_url":                  {Old: "", New: "", NewComputed: true, NewRemoved: false, RequiresNew: false, Sensitive: false},
+			"id":                        {Old: "", New: "", NewComputed: true, NewRemoved: false, RequiresNew: false, Sensitive: false},
+			"enable_serverless_compute": {Old: "", New: "", NewComputed: true, NewRemoved: false, RequiresNew: false, Sensitive: false},
+			"data_source_id":            {Old: "", New: "", NewComputed: true, NewRemoved: false, RequiresNew: false, Sensitive: false},
+			"creator_name":              {Old: "", New: "", NewComputed: true, NewRemoved: false, RequiresNew: false, Sensitive: false},
+		},
+		HCL: `
+		name = "foo"
+  		cluster_size = "Small"
+		auto_stop_mins = 0
+		`,
+	}.ApplyNoError(t)
+}
+
 func TestResourceSQLEndpointDelete(t *testing.T) {
 	d, err := qa.ResourceFixture{
 		MockWorkspaceClientFunc: func(mwc *mocks.MockWorkspaceClient) {

--- a/sql/resource_sql_endpoint_test.go
+++ b/sql/resource_sql_endpoint_test.go
@@ -155,6 +155,7 @@ func TestResourceSQLEndpointCreateNoAutoTermination(t *testing.T) {
 				AutoStopMins:       0,
 				EnablePhoton:       true,
 				SpotInstancePolicy: "COST_OPTIMIZED",
+				ForceSendFields:    []string{"AutoStopMins"},
 			}).Return(&sql.WaitGetWarehouseRunning[sql.CreateWarehouseResponse]{
 				Poll: poll.Simple(getResponse),
 			}, nil)


### PR DESCRIPTION
## Changes
- Forced send `auto_stop_mins` for `databricks_sql_endpoint` resource. This allows creating SQL warehouses with auto stop turned off

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant acceptance tests are passing
- [x] using Go SDK
