### PR TITLE
[Internal] Use isServiceProposedIfEmpty annotations for effective fields

### DIFF
--- a/.codegen/model.go.tmpl
+++ b/.codegen/model.go.tmpl
@@ -18,34 +18,28 @@ import (
 	"github.com/databricks/databricks-sdk-go/marshal"
     "github.com/hashicorp/terraform-plugin-framework/types"
 )
-{{- $excluded := dict "ShareInfo"        (list "CreatedAt" "CreatedBy" "UpdatedAt" "UpdatedBy")
-                      "SharedDataObject" (list "AddedAt" "AddedBy" "Status") -}}
 {{range .Types}}
 {{- if or .Fields .IsEmpty}}
 {{.Comment "// " 80}}
 type {{.PascalName}} struct {
-    {{- $excluded := getOrDefault $excluded .PascalName (list) -}}
     {{- range .Fields}}
     {{.Comment "    // " 80}}
-	{{- $data := dict "field" . "excluded" $excluded }}
-	{{template "field" $data}}{{if and .Entity.IsComputed (not (in $excluded .PascalName))}}{{ $data := dict "field" . "excluded" $excluded "effective" true }}{{printf "\n"}}{{template "field" $data}}{{end}}{{end}}
+	{{- $data := dict "field" . }}
+	{{template "field" $data}}{{if and (ne .Entity.Terraform nil) .Entity.Terraform.IsServiceProposedIfEmpty}}{{ $data := dict "field" . "effective" true }}{{printf "\n"}}{{template "field" $data}}{{end}}{{end}}
 }
 
 func (newState *{{.PascalName}}) SyncEffectiveFieldsDuringCreateOrUpdate(plan {{.PascalName}}) {
   {{- range .Fields -}}
-  {{- if and .Entity.IsComputed (or .Entity.IsString .Entity.IsBool .Entity.IsInt64 .Entity.IsFloat64 .Entity.IsInt .Entity.Enum) -}}
-  {{- if not (in $excluded .PascalName)}}
+  {{- if and (and (ne .Entity.Terraform nil) .Entity.Terraform.IsServiceProposedIfEmpty) (or .Entity.IsString .Entity.IsBool .Entity.IsInt64 .Entity.IsFloat64 .Entity.IsInt .Entity.Enum)}}
   newState.Effective{{.PascalName}} = newState.{{.PascalName}}
   newState.{{.PascalName}} = plan.{{.PascalName}}
-  {{- end}}
   {{- end}}
   {{- end}}
 }
 
 func (newState *{{.PascalName}}) SyncEffectiveFieldsDuringRead(existingState {{.PascalName}}) {
   {{- range .Fields -}}
-  {{- if and .Entity.IsComputed (or .Entity.IsString .Entity.IsBool .Entity.IsInt64 .Entity.IsFloat64 .Entity.IsInt .Entity.Enum) -}}
-  {{- if not (in $excluded .PascalName) -}}
+  {{- if and (and (ne .Entity.Terraform nil) .Entity.Terraform.IsServiceProposedIfEmpty) (or .Entity.IsString .Entity.IsBool .Entity.IsInt64 .Entity.IsFloat64 .Entity.IsInt .Entity.Enum)}}
   {{- $type := "" -}}
   {{- if .Entity.IsString}}{{$type = "String"}}{{end}}
   {{- if .Entity.IsBool}}{{$type = "Bool"}}{{end}}
@@ -59,7 +53,6 @@ func (newState *{{.PascalName}}) SyncEffectiveFieldsDuringRead(existingState {{.
   }
   {{- end}}
   {{- end}}
-  {{- end}}
 }
 
 {{end}}
@@ -71,9 +64,7 @@ func (newState *{{.PascalName}}) SyncEffectiveFieldsDuringRead(existingState {{.
 
 {{- define "field-tag" -}}
     {{- $annotations := "" -}}
-	{{- if in .excluded .field.PascalName -}}
-		{{- $annotations = (printf "%scomputed,optional," $annotations) -}}
-	{{- else if .effective -}}
+	{{- if or .field.Entity.IsComputed .effective -}}
 		{{- $annotations = (printf "%scomputed,optional," $annotations) -}}
 	{{- else -}}
 		{{- if not .field.Required -}}


### PR DESCRIPTION
This PR is a follow-up to #4057 and #4112. We're shifting away from using the "computed" annotation to decide if a field should have "effective field" behavior. Instead, we're adopting the more precise "isServiceProposedIfEmpty" annotation. This lines up better with what we aim to achieve with effective fields, without making all regular computed and non-effective fields generate effective field code.

We'll only merge this once the relevant fields are updated accordingly in the OpenAPI spec.

## Changes
<!-- Summary of your changes that are easy to understand -->

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [x] relevant acceptance tests are passing
- [ ] using Go SDK
