### PR TITLE
[Internal] Use tf_v1 genkit mode

### DIFF
--- a/.codegen.json
+++ b/.codegen.json
@@ -1,5 +1,6 @@
 {
     "formatter": "make fmt",
+    "mode": "tf_v1",
     "packages": {
         ".codegen/model.go.tmpl": "internal/service/{{.Name}}_tf/model.go"
     },


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
This PR updates Terraform code generation by switching to the new "tf_v1" mode in genkit. Right now, it replicates the existing process, but a future PR will enable support for templating and automatic creation of new resources.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
