### PR TITLE
[Fix] Handle deleted cluster gracefully

### DIFF
--- a/clusters/resource_cluster.go
+++ b/clusters/resource_cluster.go
@@ -697,7 +697,7 @@ func resourceClusterDelete(ctx context.Context, d *schema.ResourceData, c *commo
 		return err
 	}
 	err = w.Clusters.PermanentDeleteByClusterId(ctx, d.Id())
-	if err == nil {
+	if err == nil || apierr.IsMissing(err) {
 		return nil
 	}
 	if !strings.Contains(err.Error(), "unpin the cluster first") {


### PR DESCRIPTION
## Changes
When migrating the `databricks_library` resource to the Plugin Framework, some logic that handled missing clusters was unintentionally reverted. This PR adds (back) explicit handling for deleted clusters in `databricks_library` resources.

Resolves #4277.
## Tests

Added an integration test that permanently deletes the cluster before running apply again. The cluster and library are then recreated.