### PR TITLE
[Internal] Remove unused configuration from blocks

### DIFF
--- a/internal/providers/pluginfw/tfschema/attribute_builder.go
+++ b/internal/providers/pluginfw/tfschema/attribute_builder.go
@@ -10,6 +10,25 @@ import (
 // This common interface prevents us from keeping two copies of StructToSchema and CustomizableSchema.
 type AttributeBuilder interface {
 	BaseSchemaBuilder
+
+	// SetOptional sets the attribute as optional in the schema. This does not affect whether the attribute is computed.
+	// It fails if the attribute is already optional.
+	SetOptional() BaseSchemaBuilder
+
+	// SetRequired sets the attribute as required in the schema. This does not affect whether the attribute is computed.
+	// It fails if the attribute is already required.
+	SetRequired() BaseSchemaBuilder
+
+	// SetSensitive sets the attribute as sensitive in the schema. It fails if the attribute is already sensitive.
+	SetSensitive() BaseSchemaBuilder
+
+	// SetComputed sets the attribute as computed in the schema. It fails if the attribute is already computed.
+	SetComputed() BaseSchemaBuilder
+
+	// Sets the attribute as read-only in the schema, i.e. computed and neither optional or required. It fails if the
+	// attribute is already read-only.
+	SetReadOnly() BaseSchemaBuilder
+
 	BuildDataSourceAttribute() dataschema.Attribute
 	BuildResourceAttribute() schema.Attribute
 }

--- a/internal/providers/pluginfw/tfschema/attribute_builder.go
+++ b/internal/providers/pluginfw/tfschema/attribute_builder.go
@@ -13,21 +13,21 @@ type AttributeBuilder interface {
 
 	// SetOptional sets the attribute as optional in the schema. This does not affect whether the attribute is computed.
 	// It fails if the attribute is already optional.
-	SetOptional() BaseSchemaBuilder
+	SetOptional() AttributeBuilder
 
 	// SetRequired sets the attribute as required in the schema. This does not affect whether the attribute is computed.
 	// It fails if the attribute is already required.
-	SetRequired() BaseSchemaBuilder
+	SetRequired() AttributeBuilder
 
 	// SetSensitive sets the attribute as sensitive in the schema. It fails if the attribute is already sensitive.
-	SetSensitive() BaseSchemaBuilder
+	SetSensitive() AttributeBuilder
 
 	// SetComputed sets the attribute as computed in the schema. It fails if the attribute is already computed.
-	SetComputed() BaseSchemaBuilder
+	SetComputed() AttributeBuilder
 
 	// Sets the attribute as read-only in the schema, i.e. computed and neither optional or required. It fails if the
 	// attribute is already read-only.
-	SetReadOnly() BaseSchemaBuilder
+	SetReadOnly() AttributeBuilder
 
 	BuildDataSourceAttribute() dataschema.Attribute
 	BuildResourceAttribute() schema.Attribute

--- a/internal/providers/pluginfw/tfschema/base_schema_builder.go
+++ b/internal/providers/pluginfw/tfschema/base_schema_builder.go
@@ -3,10 +3,5 @@ package tfschema
 // BaseSchemaBuilder is the common interface for all blocks and attributes, it can be used to build data source and resource.
 // Both AttributeBuilder and BlockBuilder extend this interface.
 type BaseSchemaBuilder interface {
-	SetOptional() BaseSchemaBuilder
-	SetRequired() BaseSchemaBuilder
-	SetSensitive() BaseSchemaBuilder
-	SetComputed() BaseSchemaBuilder
-	SetReadOnly() BaseSchemaBuilder
 	SetDeprecated(string) BaseSchemaBuilder
 }

--- a/internal/providers/pluginfw/tfschema/bool_attribute.go
+++ b/internal/providers/pluginfw/tfschema/bool_attribute.go
@@ -40,7 +40,7 @@ func (a BoolAttributeBuilder) BuildResourceAttribute() schema.Attribute {
 	}
 }
 
-func (a BoolAttributeBuilder) SetOptional() BaseSchemaBuilder {
+func (a BoolAttributeBuilder) SetOptional() AttributeBuilder {
 	if a.Optional && !a.Required {
 		panic("attribute is already optional")
 	}
@@ -49,7 +49,7 @@ func (a BoolAttributeBuilder) SetOptional() BaseSchemaBuilder {
 	return a
 }
 
-func (a BoolAttributeBuilder) SetRequired() BaseSchemaBuilder {
+func (a BoolAttributeBuilder) SetRequired() AttributeBuilder {
 	if !a.Optional && a.Required {
 		panic("attribute is already required")
 	}
@@ -58,7 +58,7 @@ func (a BoolAttributeBuilder) SetRequired() BaseSchemaBuilder {
 	return a
 }
 
-func (a BoolAttributeBuilder) SetSensitive() BaseSchemaBuilder {
+func (a BoolAttributeBuilder) SetSensitive() AttributeBuilder {
 	if a.Sensitive {
 		panic("attribute is already sensitive")
 	}
@@ -66,7 +66,7 @@ func (a BoolAttributeBuilder) SetSensitive() BaseSchemaBuilder {
 	return a
 }
 
-func (a BoolAttributeBuilder) SetComputed() BaseSchemaBuilder {
+func (a BoolAttributeBuilder) SetComputed() AttributeBuilder {
 	if a.Computed {
 		panic("attribute is already computed")
 	}
@@ -74,7 +74,7 @@ func (a BoolAttributeBuilder) SetComputed() BaseSchemaBuilder {
 	return a
 }
 
-func (a BoolAttributeBuilder) SetReadOnly() BaseSchemaBuilder {
+func (a BoolAttributeBuilder) SetReadOnly() AttributeBuilder {
 	if a.Computed && !a.Optional && !a.Required {
 		panic("attribute is already read only")
 	}
@@ -89,12 +89,12 @@ func (a BoolAttributeBuilder) SetDeprecated(msg string) BaseSchemaBuilder {
 	return a
 }
 
-func (a BoolAttributeBuilder) AddValidator(v validator.Bool) BaseSchemaBuilder {
+func (a BoolAttributeBuilder) AddValidator(v validator.Bool) AttributeBuilder {
 	a.Validators = append(a.Validators, v)
 	return a
 }
 
-func (a BoolAttributeBuilder) AddPlanModifier(v planmodifier.Bool) BaseSchemaBuilder {
+func (a BoolAttributeBuilder) AddPlanModifier(v planmodifier.Bool) AttributeBuilder {
 	a.PlanModifiers = append(a.PlanModifiers, v)
 	return a
 }

--- a/internal/providers/pluginfw/tfschema/customizable_schema.go
+++ b/internal/providers/pluginfw/tfschema/customizable_schema.go
@@ -16,8 +16,7 @@ type CustomizableSchema struct {
 
 // ConstructCustomizableSchema constructs a CustomizableSchema given a NestedBlockObject.
 func ConstructCustomizableSchema(nestedObject NestedBlockObject) *CustomizableSchema {
-	attr := AttributeBuilder(SingleNestedBlockBuilder{NestedObject: nestedObject})
-	return &CustomizableSchema{attr: attr}
+	return &CustomizableSchema{attr: SingleNestedBlockBuilder{NestedObject: nestedObject}}
 }
 
 // ToAttributeMap converts CustomizableSchema into BaseSchemaBuilder.
@@ -116,7 +115,12 @@ func (s *CustomizableSchema) AddPlanModifier(v any, path ...string) *Customizabl
 
 func (s *CustomizableSchema) SetOptional(path ...string) *CustomizableSchema {
 	cb := func(attr BaseSchemaBuilder) BaseSchemaBuilder {
-		return attr.SetOptional()
+		switch a := attr.(type) {
+		case AttributeBuilder:
+			return a.SetOptional()
+		default:
+			panic(fmt.Errorf("SetOptional called on invalid attribute type: %s. %s", reflect.TypeOf(attr).String(), common.TerraformBugErrorMessage))
+		}
 	}
 
 	navigateSchemaWithCallback(&s.attr, cb, path...)
@@ -126,7 +130,12 @@ func (s *CustomizableSchema) SetOptional(path ...string) *CustomizableSchema {
 
 func (s *CustomizableSchema) SetRequired(path ...string) *CustomizableSchema {
 	cb := func(attr BaseSchemaBuilder) BaseSchemaBuilder {
-		return attr.SetRequired()
+		switch a := attr.(type) {
+		case AttributeBuilder:
+			return a.SetRequired()
+		default:
+			panic(fmt.Errorf("SetRequired called on invalid attribute type: %s. %s", reflect.TypeOf(attr).String(), common.TerraformBugErrorMessage))
+		}
 	}
 
 	navigateSchemaWithCallback(&s.attr, cb, path...)
@@ -136,7 +145,12 @@ func (s *CustomizableSchema) SetRequired(path ...string) *CustomizableSchema {
 
 func (s *CustomizableSchema) SetSensitive(path ...string) *CustomizableSchema {
 	cb := func(attr BaseSchemaBuilder) BaseSchemaBuilder {
-		return attr.SetSensitive()
+		switch a := attr.(type) {
+		case AttributeBuilder:
+			return a.SetSensitive()
+		default:
+			panic(fmt.Errorf("SetSensitive called on invalid attribute type: %s. %s", reflect.TypeOf(attr).String(), common.TerraformBugErrorMessage))
+		}
 	}
 
 	navigateSchemaWithCallback(&s.attr, cb, path...)
@@ -155,7 +169,12 @@ func (s *CustomizableSchema) SetDeprecated(msg string, path ...string) *Customiz
 
 func (s *CustomizableSchema) SetComputed(path ...string) *CustomizableSchema {
 	cb := func(attr BaseSchemaBuilder) BaseSchemaBuilder {
-		return attr.SetComputed()
+		switch a := attr.(type) {
+		case AttributeBuilder:
+			return a.SetComputed()
+		default:
+			panic(fmt.Errorf("SetComputed called on invalid attribute type: %s. %s", reflect.TypeOf(attr).String(), common.TerraformBugErrorMessage))
+		}
 	}
 
 	navigateSchemaWithCallback(&s.attr, cb, path...)
@@ -167,7 +186,12 @@ func (s *CustomizableSchema) SetComputed(path ...string) *CustomizableSchema {
 // by the platform.
 func (s *CustomizableSchema) SetReadOnly(path ...string) *CustomizableSchema {
 	cb := func(attr BaseSchemaBuilder) BaseSchemaBuilder {
-		return attr.SetReadOnly()
+		switch a := attr.(type) {
+		case AttributeBuilder:
+			return a.SetReadOnly()
+		default:
+			panic(fmt.Errorf("SetReadOnly called on invalid attribute type: %s. %s", reflect.TypeOf(attr).String(), common.TerraformBugErrorMessage))
+		}
 	}
 
 	navigateSchemaWithCallback(&s.attr, cb, path...)

--- a/internal/providers/pluginfw/tfschema/customizable_schema_test.go
+++ b/internal/providers/pluginfw/tfschema/customizable_schema_test.go
@@ -130,3 +130,12 @@ func TestCustomizeSchemaObjectTypeValidatorAdded(t *testing.T) {
 
 	assert.True(t, len(scm.Blocks["nested_slice_object"].(schema.ListNestedBlock).Validators) == 1)
 }
+
+func TestCustomizeSchema_SetRequired_PanicOnBlock(t *testing.T) {
+	assert.Panics(t, func() {
+		_ = ResourceStructToSchema(TestTfSdk{}, func(c CustomizableSchema) CustomizableSchema {
+			c.SetRequired("nested")
+			return c
+		})
+	})
+}

--- a/internal/providers/pluginfw/tfschema/customizable_schema_test.go
+++ b/internal/providers/pluginfw/tfschema/customizable_schema_test.go
@@ -139,3 +139,39 @@ func TestCustomizeSchema_SetRequired_PanicOnBlock(t *testing.T) {
 		})
 	})
 }
+
+func TestCustomizeSchema_SetOptional_PanicOnBlock(t *testing.T) {
+	assert.Panics(t, func() {
+		_ = ResourceStructToSchema(TestTfSdk{}, func(c CustomizableSchema) CustomizableSchema {
+			c.SetOptional("nested")
+			return c
+		})
+	})
+}
+
+func TestCustomizeSchema_SetSensitive_PanicOnBlock(t *testing.T) {
+	assert.Panics(t, func() {
+		_ = ResourceStructToSchema(TestTfSdk{}, func(c CustomizableSchema) CustomizableSchema {
+			c.SetSensitive("nested")
+			return c
+		})
+	})
+}
+
+func TestCustomizeSchema_SetReadOnly_PanicOnBlock(t *testing.T) {
+	assert.Panics(t, func() {
+		_ = ResourceStructToSchema(TestTfSdk{}, func(c CustomizableSchema) CustomizableSchema {
+			c.SetReadOnly("nested")
+			return c
+		})
+	})
+}
+
+func TestCustomizeSchema_SetComputed_PanicOnBlock(t *testing.T) {
+	assert.Panics(t, func() {
+		_ = ResourceStructToSchema(TestTfSdk{}, func(c CustomizableSchema) CustomizableSchema {
+			c.SetComputed("nested")
+			return c
+		})
+	})
+}

--- a/internal/providers/pluginfw/tfschema/float64_attribute.go
+++ b/internal/providers/pluginfw/tfschema/float64_attribute.go
@@ -40,7 +40,7 @@ func (a Float64AttributeBuilder) BuildResourceAttribute() schema.Attribute {
 	}
 }
 
-func (a Float64AttributeBuilder) SetOptional() BaseSchemaBuilder {
+func (a Float64AttributeBuilder) SetOptional() AttributeBuilder {
 	if a.Optional && !a.Required {
 		panic("attribute is already optional")
 	}
@@ -49,7 +49,7 @@ func (a Float64AttributeBuilder) SetOptional() BaseSchemaBuilder {
 	return a
 }
 
-func (a Float64AttributeBuilder) SetRequired() BaseSchemaBuilder {
+func (a Float64AttributeBuilder) SetRequired() AttributeBuilder {
 	if !a.Optional && a.Required {
 		panic("attribute is already required")
 	}
@@ -58,7 +58,7 @@ func (a Float64AttributeBuilder) SetRequired() BaseSchemaBuilder {
 	return a
 }
 
-func (a Float64AttributeBuilder) SetSensitive() BaseSchemaBuilder {
+func (a Float64AttributeBuilder) SetSensitive() AttributeBuilder {
 	if a.Sensitive {
 		panic("attribute is already sensitive")
 	}
@@ -66,7 +66,7 @@ func (a Float64AttributeBuilder) SetSensitive() BaseSchemaBuilder {
 	return a
 }
 
-func (a Float64AttributeBuilder) SetComputed() BaseSchemaBuilder {
+func (a Float64AttributeBuilder) SetComputed() AttributeBuilder {
 	if a.Computed {
 		panic("attribute is already computed")
 	}
@@ -74,7 +74,7 @@ func (a Float64AttributeBuilder) SetComputed() BaseSchemaBuilder {
 	return a
 }
 
-func (a Float64AttributeBuilder) SetReadOnly() BaseSchemaBuilder {
+func (a Float64AttributeBuilder) SetReadOnly() AttributeBuilder {
 	if a.Computed && !a.Optional && !a.Required {
 		panic("attribute is already read only")
 	}
@@ -89,12 +89,12 @@ func (a Float64AttributeBuilder) SetDeprecated(msg string) BaseSchemaBuilder {
 	return a
 }
 
-func (a Float64AttributeBuilder) AddValidator(v validator.Float64) BaseSchemaBuilder {
+func (a Float64AttributeBuilder) AddValidator(v validator.Float64) AttributeBuilder {
 	a.Validators = append(a.Validators, v)
 	return a
 }
 
-func (a Float64AttributeBuilder) AddPlanModifier(v planmodifier.Float64) BaseSchemaBuilder {
+func (a Float64AttributeBuilder) AddPlanModifier(v planmodifier.Float64) AttributeBuilder {
 	a.PlanModifiers = append(a.PlanModifiers, v)
 	return a
 }

--- a/internal/providers/pluginfw/tfschema/int64_attribute.go
+++ b/internal/providers/pluginfw/tfschema/int64_attribute.go
@@ -40,7 +40,7 @@ func (a Int64AttributeBuilder) BuildResourceAttribute() schema.Attribute {
 	}
 }
 
-func (a Int64AttributeBuilder) SetOptional() BaseSchemaBuilder {
+func (a Int64AttributeBuilder) SetOptional() AttributeBuilder {
 	if a.Optional && !a.Required {
 		panic("attribute is already optional")
 	}
@@ -49,7 +49,7 @@ func (a Int64AttributeBuilder) SetOptional() BaseSchemaBuilder {
 	return a
 }
 
-func (a Int64AttributeBuilder) SetRequired() BaseSchemaBuilder {
+func (a Int64AttributeBuilder) SetRequired() AttributeBuilder {
 	if !a.Optional && a.Required {
 		panic("attribute is already required")
 	}
@@ -58,7 +58,7 @@ func (a Int64AttributeBuilder) SetRequired() BaseSchemaBuilder {
 	return a
 }
 
-func (a Int64AttributeBuilder) SetSensitive() BaseSchemaBuilder {
+func (a Int64AttributeBuilder) SetSensitive() AttributeBuilder {
 	if a.Sensitive {
 		panic("attribute is already sensitive")
 	}
@@ -66,7 +66,7 @@ func (a Int64AttributeBuilder) SetSensitive() BaseSchemaBuilder {
 	return a
 }
 
-func (a Int64AttributeBuilder) SetComputed() BaseSchemaBuilder {
+func (a Int64AttributeBuilder) SetComputed() AttributeBuilder {
 	if a.Computed {
 		panic("attribute is already computed")
 	}
@@ -74,7 +74,7 @@ func (a Int64AttributeBuilder) SetComputed() BaseSchemaBuilder {
 	return a
 }
 
-func (a Int64AttributeBuilder) SetReadOnly() BaseSchemaBuilder {
+func (a Int64AttributeBuilder) SetReadOnly() AttributeBuilder {
 	if a.Computed && !a.Optional && !a.Required {
 		panic("attribute is already read only")
 	}
@@ -89,12 +89,12 @@ func (a Int64AttributeBuilder) SetDeprecated(msg string) BaseSchemaBuilder {
 	return a
 }
 
-func (a Int64AttributeBuilder) AddValidator(v validator.Int64) BaseSchemaBuilder {
+func (a Int64AttributeBuilder) AddValidator(v validator.Int64) AttributeBuilder {
 	a.Validators = append(a.Validators, v)
 	return a
 }
 
-func (a Int64AttributeBuilder) AddPlanModifier(v planmodifier.Int64) BaseSchemaBuilder {
+func (a Int64AttributeBuilder) AddPlanModifier(v planmodifier.Int64) AttributeBuilder {
 	a.PlanModifiers = append(a.PlanModifiers, v)
 	return a
 }

--- a/internal/providers/pluginfw/tfschema/list_attribute.go
+++ b/internal/providers/pluginfw/tfschema/list_attribute.go
@@ -45,7 +45,7 @@ func (a ListAttributeBuilder) BuildResourceAttribute() schema.Attribute {
 	}
 }
 
-func (a ListAttributeBuilder) SetOptional() BaseSchemaBuilder {
+func (a ListAttributeBuilder) SetOptional() AttributeBuilder {
 	if a.Optional && !a.Required {
 		panic("attribute is already optional")
 	}
@@ -54,7 +54,7 @@ func (a ListAttributeBuilder) SetOptional() BaseSchemaBuilder {
 	return a
 }
 
-func (a ListAttributeBuilder) SetRequired() BaseSchemaBuilder {
+func (a ListAttributeBuilder) SetRequired() AttributeBuilder {
 	if !a.Optional && a.Required {
 		panic("attribute is already required")
 	}
@@ -63,7 +63,7 @@ func (a ListAttributeBuilder) SetRequired() BaseSchemaBuilder {
 	return a
 }
 
-func (a ListAttributeBuilder) SetSensitive() BaseSchemaBuilder {
+func (a ListAttributeBuilder) SetSensitive() AttributeBuilder {
 	if a.Sensitive {
 		panic("attribute is already sensitive")
 	}
@@ -71,7 +71,7 @@ func (a ListAttributeBuilder) SetSensitive() BaseSchemaBuilder {
 	return a
 }
 
-func (a ListAttributeBuilder) SetComputed() BaseSchemaBuilder {
+func (a ListAttributeBuilder) SetComputed() AttributeBuilder {
 	if a.Computed {
 		panic("attribute is already computed")
 	}
@@ -79,7 +79,7 @@ func (a ListAttributeBuilder) SetComputed() BaseSchemaBuilder {
 	return a
 }
 
-func (a ListAttributeBuilder) SetReadOnly() BaseSchemaBuilder {
+func (a ListAttributeBuilder) SetReadOnly() AttributeBuilder {
 	if a.Computed && !a.Optional && !a.Required {
 		panic("attribute is already read only")
 	}
@@ -94,12 +94,12 @@ func (a ListAttributeBuilder) SetDeprecated(msg string) BaseSchemaBuilder {
 	return a
 }
 
-func (a ListAttributeBuilder) AddValidator(v validator.List) BaseSchemaBuilder {
+func (a ListAttributeBuilder) AddValidator(v validator.List) AttributeBuilder {
 	a.Validators = append(a.Validators, v)
 	return a
 }
 
-func (a ListAttributeBuilder) AddPlanModifier(v planmodifier.List) BaseSchemaBuilder {
+func (a ListAttributeBuilder) AddPlanModifier(v planmodifier.List) AttributeBuilder {
 	a.PlanModifiers = append(a.PlanModifiers, v)
 	return a
 }

--- a/internal/providers/pluginfw/tfschema/list_nested_block.go
+++ b/internal/providers/pluginfw/tfschema/list_nested_block.go
@@ -11,10 +11,6 @@ import (
 // To be compatible with our sdkv2 schema, all struct types in the gosdk are represented with this type.
 type ListNestedBlockBuilder struct {
 	NestedObject       NestedBlockObject
-	Optional           bool
-	Required           bool
-	Sensitive          bool
-	Computed           bool
 	DeprecationMessage string
 	Validators         []validator.List
 	PlanModifiers      []planmodifier.List
@@ -35,50 +31,6 @@ func (a ListNestedBlockBuilder) BuildResourceBlock() schema.Block {
 		Validators:         a.Validators,
 		PlanModifiers:      a.PlanModifiers,
 	}
-}
-
-func (a ListNestedBlockBuilder) SetOptional() BaseSchemaBuilder {
-	if a.Optional && !a.Required {
-		panic("attribute is already optional")
-	}
-	a.Optional = true
-	a.Required = false
-	return a
-}
-
-func (a ListNestedBlockBuilder) SetRequired() BaseSchemaBuilder {
-	if !a.Optional && a.Required {
-		panic("attribute is already required")
-	}
-	a.Optional = false
-	a.Required = true
-	return a
-}
-
-func (a ListNestedBlockBuilder) SetSensitive() BaseSchemaBuilder {
-	if a.Sensitive {
-		panic("attribute is already sensitive")
-	}
-	a.Sensitive = true
-	return a
-}
-
-func (a ListNestedBlockBuilder) SetComputed() BaseSchemaBuilder {
-	if a.Computed {
-		panic("attribute is already computed")
-	}
-	a.Computed = true
-	return a
-}
-
-func (a ListNestedBlockBuilder) SetReadOnly() BaseSchemaBuilder {
-	if a.Computed && !a.Optional && !a.Required {
-		panic("attribute is already read only")
-	}
-	a.Computed = true
-	a.Optional = false
-	a.Required = false
-	return a
 }
 
 func (a ListNestedBlockBuilder) SetDeprecated(msg string) BaseSchemaBuilder {

--- a/internal/providers/pluginfw/tfschema/map_attribute.go
+++ b/internal/providers/pluginfw/tfschema/map_attribute.go
@@ -45,7 +45,7 @@ func (a MapAttributeBuilder) BuildResourceAttribute() schema.Attribute {
 	}
 }
 
-func (a MapAttributeBuilder) SetOptional() BaseSchemaBuilder {
+func (a MapAttributeBuilder) SetOptional() AttributeBuilder {
 	if a.Optional && !a.Required {
 		panic("attribute is already optional")
 	}
@@ -54,7 +54,7 @@ func (a MapAttributeBuilder) SetOptional() BaseSchemaBuilder {
 	return a
 }
 
-func (a MapAttributeBuilder) SetRequired() BaseSchemaBuilder {
+func (a MapAttributeBuilder) SetRequired() AttributeBuilder {
 	if !a.Optional && a.Required {
 		panic("attribute is already required")
 	}
@@ -63,7 +63,7 @@ func (a MapAttributeBuilder) SetRequired() BaseSchemaBuilder {
 	return a
 }
 
-func (a MapAttributeBuilder) SetSensitive() BaseSchemaBuilder {
+func (a MapAttributeBuilder) SetSensitive() AttributeBuilder {
 	if a.Sensitive {
 		panic("attribute is already sensitive")
 	}
@@ -71,7 +71,7 @@ func (a MapAttributeBuilder) SetSensitive() BaseSchemaBuilder {
 	return a
 }
 
-func (a MapAttributeBuilder) SetComputed() BaseSchemaBuilder {
+func (a MapAttributeBuilder) SetComputed() AttributeBuilder {
 	if a.Computed {
 		panic("attribute is already computed")
 	}
@@ -79,7 +79,7 @@ func (a MapAttributeBuilder) SetComputed() BaseSchemaBuilder {
 	return a
 }
 
-func (a MapAttributeBuilder) SetReadOnly() BaseSchemaBuilder {
+func (a MapAttributeBuilder) SetReadOnly() AttributeBuilder {
 	if a.Computed && !a.Optional && !a.Required {
 		panic("attribute is already read only")
 	}
@@ -94,12 +94,12 @@ func (a MapAttributeBuilder) SetDeprecated(msg string) BaseSchemaBuilder {
 	return a
 }
 
-func (a MapAttributeBuilder) AddValidator(v validator.Map) BaseSchemaBuilder {
+func (a MapAttributeBuilder) AddValidator(v validator.Map) AttributeBuilder {
 	a.Validators = append(a.Validators, v)
 	return a
 }
 
-func (a MapAttributeBuilder) AddPlanModifier(v planmodifier.Map) BaseSchemaBuilder {
+func (a MapAttributeBuilder) AddPlanModifier(v planmodifier.Map) AttributeBuilder {
 	a.PlanModifiers = append(a.PlanModifiers, v)
 	return a
 }

--- a/internal/providers/pluginfw/tfschema/map_nested_attribute.go
+++ b/internal/providers/pluginfw/tfschema/map_nested_attribute.go
@@ -44,7 +44,7 @@ func (a MapNestedAttributeBuilder) BuildResourceAttribute() schema.Attribute {
 	}
 }
 
-func (a MapNestedAttributeBuilder) SetOptional() BaseSchemaBuilder {
+func (a MapNestedAttributeBuilder) SetOptional() AttributeBuilder {
 	if a.Optional && !a.Required {
 		panic("attribute is already optional")
 	}
@@ -53,7 +53,7 @@ func (a MapNestedAttributeBuilder) SetOptional() BaseSchemaBuilder {
 	return a
 }
 
-func (a MapNestedAttributeBuilder) SetRequired() BaseSchemaBuilder {
+func (a MapNestedAttributeBuilder) SetRequired() AttributeBuilder {
 	if !a.Optional && a.Required {
 		panic("attribute is already required")
 	}
@@ -62,7 +62,7 @@ func (a MapNestedAttributeBuilder) SetRequired() BaseSchemaBuilder {
 	return a
 }
 
-func (a MapNestedAttributeBuilder) SetSensitive() BaseSchemaBuilder {
+func (a MapNestedAttributeBuilder) SetSensitive() AttributeBuilder {
 	if a.Sensitive {
 		panic("attribute is already sensitive")
 	}
@@ -70,7 +70,7 @@ func (a MapNestedAttributeBuilder) SetSensitive() BaseSchemaBuilder {
 	return a
 }
 
-func (a MapNestedAttributeBuilder) SetComputed() BaseSchemaBuilder {
+func (a MapNestedAttributeBuilder) SetComputed() AttributeBuilder {
 	if a.Computed {
 		panic("attribute is already computed")
 	}
@@ -78,7 +78,7 @@ func (a MapNestedAttributeBuilder) SetComputed() BaseSchemaBuilder {
 	return a
 }
 
-func (a MapNestedAttributeBuilder) SetReadOnly() BaseSchemaBuilder {
+func (a MapNestedAttributeBuilder) SetReadOnly() AttributeBuilder {
 	if a.Computed && !a.Optional && !a.Required {
 		panic("attribute is already read only")
 	}
@@ -93,12 +93,12 @@ func (a MapNestedAttributeBuilder) SetDeprecated(msg string) BaseSchemaBuilder {
 	return a
 }
 
-func (a MapNestedAttributeBuilder) AddValidator(v validator.Map) BaseSchemaBuilder {
+func (a MapNestedAttributeBuilder) AddValidator(v validator.Map) AttributeBuilder {
 	a.Validators = append(a.Validators, v)
 	return a
 }
 
-func (a MapNestedAttributeBuilder) AddPlanModifier(v planmodifier.Map) BaseSchemaBuilder {
+func (a MapNestedAttributeBuilder) AddPlanModifier(v planmodifier.Map) AttributeBuilder {
 	a.PlanModifiers = append(a.PlanModifiers, v)
 	return a
 }

--- a/internal/providers/pluginfw/tfschema/single_nested_attribute.go
+++ b/internal/providers/pluginfw/tfschema/single_nested_attribute.go
@@ -44,7 +44,7 @@ func (a SingleNestedAttributeBuilder) BuildResourceAttribute() schema.Attribute 
 	}
 }
 
-func (a SingleNestedAttributeBuilder) SetOptional() BaseSchemaBuilder {
+func (a SingleNestedAttributeBuilder) SetOptional() AttributeBuilder {
 	if a.Optional && !a.Required {
 		panic("attribute is already optional")
 	}
@@ -53,7 +53,7 @@ func (a SingleNestedAttributeBuilder) SetOptional() BaseSchemaBuilder {
 	return a
 }
 
-func (a SingleNestedAttributeBuilder) SetRequired() BaseSchemaBuilder {
+func (a SingleNestedAttributeBuilder) SetRequired() AttributeBuilder {
 	if !a.Optional && a.Required {
 		panic("attribute is already required")
 	}
@@ -62,7 +62,7 @@ func (a SingleNestedAttributeBuilder) SetRequired() BaseSchemaBuilder {
 	return a
 }
 
-func (a SingleNestedAttributeBuilder) SetSensitive() BaseSchemaBuilder {
+func (a SingleNestedAttributeBuilder) SetSensitive() AttributeBuilder {
 	if a.Sensitive {
 		panic("attribute is already sensitive")
 	}
@@ -70,7 +70,7 @@ func (a SingleNestedAttributeBuilder) SetSensitive() BaseSchemaBuilder {
 	return a
 }
 
-func (a SingleNestedAttributeBuilder) SetComputed() BaseSchemaBuilder {
+func (a SingleNestedAttributeBuilder) SetComputed() AttributeBuilder {
 	if a.Computed {
 		panic("attribute is already computed")
 	}
@@ -78,7 +78,7 @@ func (a SingleNestedAttributeBuilder) SetComputed() BaseSchemaBuilder {
 	return a
 }
 
-func (a SingleNestedAttributeBuilder) SetReadOnly() BaseSchemaBuilder {
+func (a SingleNestedAttributeBuilder) SetReadOnly() AttributeBuilder {
 	if a.Computed && !a.Optional && !a.Required {
 		panic("attribute is already read only")
 	}
@@ -93,12 +93,12 @@ func (a SingleNestedAttributeBuilder) SetDeprecated(msg string) BaseSchemaBuilde
 	return a
 }
 
-func (a SingleNestedAttributeBuilder) AddValidator(v validator.Object) BaseSchemaBuilder {
+func (a SingleNestedAttributeBuilder) AddValidator(v validator.Object) AttributeBuilder {
 	a.Validators = append(a.Validators, v)
 	return a
 }
 
-func (a SingleNestedAttributeBuilder) AddPlanModifier(v planmodifier.Object) BaseSchemaBuilder {
+func (a SingleNestedAttributeBuilder) AddPlanModifier(v planmodifier.Object) AttributeBuilder {
 	a.PlanModifiers = append(a.PlanModifiers, v)
 	return a
 }

--- a/internal/providers/pluginfw/tfschema/single_nested_block.go
+++ b/internal/providers/pluginfw/tfschema/single_nested_block.go
@@ -13,10 +13,6 @@ import (
 // SingleNestedBlockBuilder represents a single nested complex (non-primitive) type.
 type SingleNestedBlockBuilder struct {
 	NestedObject       NestedBlockObject
-	Optional           bool
-	Required           bool
-	Sensitive          bool
-	Computed           bool
 	DeprecationMessage string
 	Validators         []validator.Object
 	PlanModifiers      []planmodifier.Object
@@ -47,50 +43,6 @@ func (a SingleNestedBlockBuilder) BuildResourceBlock() schema.Block {
 		Validators:         a.Validators,
 		PlanModifiers:      a.PlanModifiers,
 	}
-}
-
-func (a SingleNestedBlockBuilder) SetOptional() BaseSchemaBuilder {
-	if a.Optional && !a.Required {
-		panic("attribute is already optional")
-	}
-	a.Optional = true
-	a.Required = false
-	return a
-}
-
-func (a SingleNestedBlockBuilder) SetRequired() BaseSchemaBuilder {
-	if !a.Optional && a.Required {
-		panic("attribute is already required")
-	}
-	a.Optional = false
-	a.Required = true
-	return a
-}
-
-func (a SingleNestedBlockBuilder) SetSensitive() BaseSchemaBuilder {
-	if a.Sensitive {
-		panic("attribute is already sensitive")
-	}
-	a.Sensitive = true
-	return a
-}
-
-func (a SingleNestedBlockBuilder) SetComputed() BaseSchemaBuilder {
-	if a.Computed {
-		panic("attribute is already computed")
-	}
-	a.Computed = true
-	return a
-}
-
-func (a SingleNestedBlockBuilder) SetReadOnly() BaseSchemaBuilder {
-	if a.Computed && !a.Optional && !a.Required {
-		panic("attribute is already read only")
-	}
-	a.Computed = true
-	a.Optional = false
-	a.Required = false
-	return a
 }
 
 func (a SingleNestedBlockBuilder) SetDeprecated(msg string) BaseSchemaBuilder {

--- a/internal/providers/pluginfw/tfschema/string_attribute.go
+++ b/internal/providers/pluginfw/tfschema/string_attribute.go
@@ -40,7 +40,7 @@ func (a StringAttributeBuilder) BuildResourceAttribute() schema.Attribute {
 	}
 }
 
-func (a StringAttributeBuilder) SetOptional() BaseSchemaBuilder {
+func (a StringAttributeBuilder) SetOptional() AttributeBuilder {
 	if a.Optional && !a.Required {
 		panic("attribute is already optional")
 	}
@@ -49,7 +49,7 @@ func (a StringAttributeBuilder) SetOptional() BaseSchemaBuilder {
 	return a
 }
 
-func (a StringAttributeBuilder) SetRequired() BaseSchemaBuilder {
+func (a StringAttributeBuilder) SetRequired() AttributeBuilder {
 	if !a.Optional && a.Required {
 		panic("attribute is already required")
 	}
@@ -58,7 +58,7 @@ func (a StringAttributeBuilder) SetRequired() BaseSchemaBuilder {
 	return a
 }
 
-func (a StringAttributeBuilder) SetSensitive() BaseSchemaBuilder {
+func (a StringAttributeBuilder) SetSensitive() AttributeBuilder {
 	if a.Sensitive {
 		panic("attribute is already sensitive")
 	}
@@ -66,7 +66,7 @@ func (a StringAttributeBuilder) SetSensitive() BaseSchemaBuilder {
 	return a
 }
 
-func (a StringAttributeBuilder) SetComputed() BaseSchemaBuilder {
+func (a StringAttributeBuilder) SetComputed() AttributeBuilder {
 	if a.Computed {
 		panic("attribute is already computed")
 	}
@@ -74,7 +74,7 @@ func (a StringAttributeBuilder) SetComputed() BaseSchemaBuilder {
 	return a
 }
 
-func (a StringAttributeBuilder) SetReadOnly() BaseSchemaBuilder {
+func (a StringAttributeBuilder) SetReadOnly() AttributeBuilder {
 	if a.Computed && !a.Optional && !a.Required {
 		panic("attribute is already read only")
 	}
@@ -89,12 +89,12 @@ func (a StringAttributeBuilder) SetDeprecated(msg string) BaseSchemaBuilder {
 	return a
 }
 
-func (a StringAttributeBuilder) AddValidator(v validator.String) BaseSchemaBuilder {
+func (a StringAttributeBuilder) AddValidator(v validator.String) AttributeBuilder {
 	a.Validators = append(a.Validators, v)
 	return a
 }
 
-func (a StringAttributeBuilder) AddPlanModifier(v planmodifier.String) BaseSchemaBuilder {
+func (a StringAttributeBuilder) AddPlanModifier(v planmodifier.String) AttributeBuilder {
 	a.PlanModifiers = append(a.PlanModifiers, v)
 	return a
 }

--- a/internal/providers/pluginfw/tfschema/struct_to_schema.go
+++ b/internal/providers/pluginfw/tfschema/struct_to_schema.go
@@ -96,9 +96,6 @@ func typeToSchema(v reflect.Value) NestedBlockObject {
 						Attributes: nestedScm.Attributes,
 						Blocks:     nestedScm.Blocks,
 					},
-					Optional:   structTag.optional,
-					Required:   !structTag.optional,
-					Computed:   structTag.computed,
 					Validators: validators,
 				}
 			}
@@ -188,9 +185,6 @@ func typeToSchema(v reflect.Value) NestedBlockObject {
 				nestedScm := typeToSchema(sv)
 				scmBlock[fieldName] = ListNestedBlockBuilder{
 					NestedObject: nestedScm,
-					Optional:     structTag.optional,
-					Required:     !structTag.optional,
-					Computed:     structTag.computed,
 				}
 			}
 		} else {


### PR DESCRIPTION
## Changes
Currently, our schema builder elements in the plugin framework components allow you to set Computed/Optional/Required/Sensitive fields on Block schema elements. However, these are simply dropped when converting to actual schema elements: only attributes have these fields. This PR moves the SetComputed/SetOptional/SetRequired/SetSensitive/SetReadOnly methods to the AttributeBuilder interface and panics if you attempt to set them on a block.

## Tests
Added a unit test to verify that these methods panic when called on an element that is converted into a block.