### PR TITLE
[Feature] support for `databricks_credential` in `databricks_workspace_binding`

### DIFF
--- a/catalog/resource_credential.go
+++ b/catalog/resource_credential.go
@@ -53,6 +53,9 @@ var credentialSchema = common.StructToSchema(catalog.CredentialInfo{},
 		return m
 	})
 
+// This is a custom securable type for credential - remove after OpenAPI spec is fixed.
+const UpdateBindingsSecurableTypeCredential catalog.UpdateBindingsSecurableType = `credential`
+
 func ResourceCredential() common.Resource {
 	return common.Resource{
 		Schema: credentialSchema,
@@ -83,7 +86,7 @@ func ResourceCredential() common.Resource {
 			}
 
 			// Bind the current workspace if the credential is isolated, otherwise the read will fail
-			return bindings.AddCurrentWorkspaceBindings(ctx, d, w, cred.Name, catalog.UpdateBindingsSecurableTypeServiceCredential)
+			return bindings.AddCurrentWorkspaceBindings(ctx, d, w, cred.Name, UpdateBindingsSecurableTypeCredential)
 		},
 		Read: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
 			w, err := c.WorkspaceClient()
@@ -150,7 +153,7 @@ func ResourceCredential() common.Resource {
 				return err
 			}
 			// Bind the current workspace if the credential is isolated, otherwise the read will fail
-			return bindings.AddCurrentWorkspaceBindings(ctx, d, w, updateCredRequest.NameArg, catalog.UpdateBindingsSecurableTypeServiceCredential)
+			return bindings.AddCurrentWorkspaceBindings(ctx, d, w, updateCredRequest.NameArg, UpdateBindingsSecurableTypeCredential)
 		},
 		Delete: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
 			force := d.Get("force_destroy").(bool)

--- a/catalog/resource_credential_test.go
+++ b/catalog/resource_credential_test.go
@@ -110,7 +110,7 @@ func TestCreateIsolatedCredential(t *testing.T) {
 			}, nil)
 			w.GetMockWorkspaceBindingsAPI().EXPECT().UpdateBindings(mock.Anything, catalog.UpdateWorkspaceBindingsParameters{
 				SecurableName: "a",
-				SecurableType: catalog.UpdateBindingsSecurableTypeServiceCredential,
+				SecurableType: UpdateBindingsSecurableTypeCredential,
 				Add: []catalog.WorkspaceBinding{
 					{
 						WorkspaceId: int64(123456789101112),

--- a/catalog/resource_workspace_binding.go
+++ b/catalog/resource_workspace_binding.go
@@ -44,11 +44,13 @@ func ResourceWorkspaceBinding() common.Resource {
 				Default:  "catalog",
 			}
 			common.CustomizeSchemaPath(m, "securable_type").SetValidateFunc(validation.StringInSlice([]string{
-				"catalog", "external_location", "storage_credential", "service_credential"}, false))
-			common.CustomizeSchemaPath(m, "binding_type").SetDefault(catalog.WorkspaceBindingBindingTypeBindingTypeReadWrite).SetValidateFunc(validation.StringInSlice([]string{
-				string(catalog.WorkspaceBindingBindingTypeBindingTypeReadWrite),
-				string(catalog.WorkspaceBindingBindingTypeBindingTypeReadOnly),
-			}, false))
+				"catalog", "external_location", "storage_credential", "credential"}, false))
+			common.CustomizeSchemaPath(m, "binding_type").SetDefault(
+				catalog.WorkspaceBindingBindingTypeBindingTypeReadWrite).SetValidateFunc(
+				validation.StringInSlice([]string{
+					string(catalog.WorkspaceBindingBindingTypeBindingTypeReadWrite),
+					string(catalog.WorkspaceBindingBindingTypeBindingTypeReadOnly),
+				}, false))
 			return m
 		},
 	)

--- a/catalog/resource_workspace_binding.go
+++ b/catalog/resource_workspace_binding.go
@@ -43,7 +43,8 @@ func ResourceWorkspaceBinding() common.Resource {
 				Optional: true,
 				Default:  "catalog",
 			}
-			common.CustomizeSchemaPath(m, "securable_type").SetValidateFunc(validation.StringInSlice([]string{"catalog", "external_location", "storage_credential"}, false))
+			common.CustomizeSchemaPath(m, "securable_type").SetValidateFunc(validation.StringInSlice([]string{
+				"catalog", "external_location", "storage_credential", "service_credential"}, false))
 			common.CustomizeSchemaPath(m, "binding_type").SetDefault(catalog.WorkspaceBindingBindingTypeBindingTypeReadWrite).SetValidateFunc(validation.StringInSlice([]string{
 				string(catalog.WorkspaceBindingBindingTypeBindingTypeReadWrite),
 				string(catalog.WorkspaceBindingBindingTypeBindingTypeReadOnly),

--- a/docs/resources/workspace_binding.md
+++ b/docs/resources/workspace_binding.md
@@ -9,7 +9,7 @@ If you use workspaces to isolate user data access, you may want to limit access 
 
 By default, Databricks assigns the securable to all workspaces attached to the current metastore. By using `databricks_workspace_binding`, the securable will be unassigned from all workspaces and only assigned explicitly using this resource.
 
--> To use this resource the securable must have its isolation mode set to `ISOLATED` (for [databricks_catalog](catalog.md)) or `ISOLATION_MODE_ISOLATED` (for  (for [databricks_external_location](external_location.md) or [databricks_storage_credential](storage_credential.md)) for the `isolation_mode` attribute. Alternatively, the isolation mode can be set using the UI or API by following [this guide](https://docs.databricks.com/data-governance/unity-catalog/create-catalogs.html#configuration), [this guide](https://docs.databricks.com/en/connect/unity-catalog/external-locations.html#workspace-binding) or [this guide](https://docs.databricks.com/en/connect/unity-catalog/storage-credentials.html#optional-assign-a-storage-credential-to-specific-workspaces).
+-> To use this resource the securable must have its isolation mode set to `ISOLATED` (for [databricks_catalog](catalog.md)) or `ISOLATION_MODE_ISOLATED` (for  (for [databricks_external_location](external_location.md), [databricks_storage_credential](storage_credential.md) or [databricks_credential](credential.md)) for the `isolation_mode` attribute. Alternatively, the isolation mode can be set using the UI or API by following [this guide](https://docs.databricks.com/data-governance/unity-catalog/create-catalogs.html#configuration), [this guide](https://docs.databricks.com/en/connect/unity-catalog/external-locations.html#workspace-binding) or [this guide](https://docs.databricks.com/en/connect/unity-catalog/storage-credentials.html#optional-assign-a-storage-credential-to-specific-workspaces).
 
 -> If the securable's isolation mode was set to `ISOLATED` using Terraform then the securable will have been automatically bound to the workspace it was created from.
 
@@ -33,7 +33,7 @@ The following arguments are required:
 
 * `workspace_id` - ID of the workspace. Change forces creation of a new resource.
 * `securable_name` - Name of securable. Change forces creation of a new resource.
-* `securable_type` - Type of securable. Can be `catalog`, `external-location` or `storage-credential`. Default to `catalog`. Change forces creation of a new resource.
+* `securable_type` - Type of securable. Can be `catalog`, `external-location`, `storage-credential` or `service_credential`. Default to `catalog`. Change forces creation of a new resource.
 * `binding_type` - (Optional) Binding mode. Default to `BINDING_TYPE_READ_WRITE`. Possible values are `BINDING_TYPE_READ_ONLY`, `BINDING_TYPE_READ_WRITE`.
 
 ## Import

--- a/docs/resources/workspace_binding.md
+++ b/docs/resources/workspace_binding.md
@@ -33,7 +33,7 @@ The following arguments are required:
 
 * `workspace_id` - ID of the workspace. Change forces creation of a new resource.
 * `securable_name` - Name of securable. Change forces creation of a new resource.
-* `securable_type` - Type of securable. Can be `catalog`, `external-location`, `storage-credential` or `service_credential`. Default to `catalog`. Change forces creation of a new resource.
+* `securable_type` - Type of securable. Can be `catalog`, `external_location`, `storage_credential` or `credential`. Default to `catalog`. Change forces creation of a new resource.
 * `binding_type` - (Optional) Binding mode. Default to `BINDING_TYPE_READ_WRITE`. Possible values are `BINDING_TYPE_READ_ONLY`, `BINDING_TYPE_READ_WRITE`.
 
 ## Import

--- a/internal/acceptance/workspace_binding_test.go
+++ b/internal/acceptance/workspace_binding_test.go
@@ -74,7 +74,7 @@ func workspaceBindingTemplateWithWorkspaceId(workspaceId string) string {
 		
 		resource "databricks_workspace_binding" "service_cred" {
 			securable_name = databricks_credential.credential.id
-			securable_type = "service_credential"
+			securable_type = "credential"
 			workspace_id   = %[1]s
 		}
 	`, workspaceId)

--- a/internal/acceptance/workspace_binding_test.go
+++ b/internal/acceptance/workspace_binding_test.go
@@ -30,6 +30,16 @@ func workspaceBindingTemplateWithWorkspaceId(workspaceId string) string {
 			}
 			isolation_mode = "ISOLATION_MODE_ISOLATED"
 		}
+
+		resource "databricks_credential" "credential" {
+			name = "service-cred-{var.RANDOM}"
+			aws_iam_role {
+				role_arn = "{env.TEST_METASTORE_DATA_ACCESS_ARN}"
+			}
+			purpose = "SERVICE"
+			skip_validation = true
+			isolation_mode = "ISOLATION_MODE_ISOLATED"
+		}
 		
 		resource "databricks_external_location" "some" {
 			name            = "external-{var.RANDOM}"
@@ -40,28 +50,34 @@ func workspaceBindingTemplateWithWorkspaceId(workspaceId string) string {
 
 		resource "databricks_workspace_binding" "dev" {
 			catalog_name = databricks_catalog.dev.name
-			workspace_id = %s
+			workspace_id = %[1]s
 		}
 
 		resource "databricks_workspace_binding" "prod" {
 			securable_name = databricks_catalog.prod.name
 			securable_type = "catalog"
-			workspace_id   = %s
+			workspace_id   = %[1]s
 			binding_type   = "BINDING_TYPE_READ_ONLY"
 		}		
 
 		resource "databricks_workspace_binding" "ext" {
 			securable_name = databricks_external_location.some.id
 			securable_type = "external_location"
-			workspace_id   = %s
+			workspace_id   = %[1]s
 		}
 
 		resource "databricks_workspace_binding" "cred" {
 			securable_name = databricks_storage_credential.external.id
 			securable_type = "storage_credential"
-			workspace_id   = %s
-		}		
-	`, workspaceId, workspaceId, workspaceId, workspaceId)
+			workspace_id   = %[1]s
+		}
+		
+		resource "databricks_workspace_binding" "service_cred" {
+			securable_name = databricks_credential.credential.id
+			securable_type = "service_credential"
+			workspace_id   = %[1]s
+		}
+	`, workspaceId)
 }
 
 func TestUcAccWorkspaceBindingToOtherWorkspace(t *testing.T) {


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

We have a separate binding type for `databricks_credential`, so it was added to validations (we really need to generate them automatically).  Because of the error in the OpenAPI spec, I was needed to redefine a constant until it's fixed in OpenAPI spec.

Also updated the documentation (resolves #4307).

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [x] covered with integration tests in `internal/acceptance`
- [x] relevant acceptance tests are passing
- [x] using Go SDK
