### PR TITLE
[Fix] Remove config drift if Azure SP is used in `databricks_credential`

### DIFF
--- a/catalog/resource_credential.go
+++ b/catalog/resource_credential.go
@@ -94,6 +94,14 @@ func ResourceCredential() common.Resource {
 			if err != nil {
 				return err
 			}
+			// azure client secret is sensitive, so we need to preserve it
+			var credOrig catalog.CredentialInfo
+			common.DataToStructPointer(d, credentialSchema, &credOrig)
+			if credOrig.AzureServicePrincipal != nil {
+				if credOrig.AzureServicePrincipal.ClientSecret != "" {
+					cred.AzureServicePrincipal.ClientSecret = credOrig.AzureServicePrincipal.ClientSecret
+				}
+			}
 			d.Set("credential_id", cred.Id)
 			return common.StructToData(cred, credentialSchema, d)
 		},


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

The same as in `databricks_storage_credential` - because Azure SP secret is sensitive value, it isn't returned by API, and we need to copy it from the previous state.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
