### PR TITLE
[Internal] Simplify `databricks_storage_credential` code

### DIFF
--- a/catalog/resource_metastore_data_access.go
+++ b/catalog/resource_metastore_data_access.go
@@ -90,13 +90,8 @@ func ResourceMetastoreDataAccess() common.Resource {
 		Create: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
 			metastoreId := d.Get("metastore_id").(string)
 
-			tmpSchema := removeGcpSaField(dacSchema)
 			var create catalog.CreateStorageCredential
-			common.DataToStructPointer(d, tmpSchema, &create)
-			//manually add empty struct back for databricks_gcp_service_account
-			if _, ok := d.GetOk("databricks_gcp_service_account"); ok {
-				create.DatabricksGcpServiceAccount = &catalog.DatabricksGcpServiceAccountRequest{}
-			}
+			common.DataToStructPointer(d, dacSchema, &create)
 
 			return c.AccountOrWorkspaceRequest(func(acc *databricks.AccountClient) error {
 				dac, err := acc.StorageCredentials.Create(ctx,

--- a/docs/resources/storage_credential.md
+++ b/docs/resources/storage_credential.md
@@ -46,7 +46,7 @@ resource "databricks_storage_credential" "external_mi" {
 }
 
 resource "databricks_grants" "external_creds" {
-  storage_credential = databricks_storage_credential.external.id
+  storage_credential = databricks_storage_credential.external_mi.id
   grant {
     principal  = "Data Engineers"
     privileges = ["CREATE_EXTERNAL_TABLE"]


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

Previously, the `DatabricksGcpServiceAccount` type was defined as `any` and the led to the problems sending the Create request. Now this type is declared as struct, so we don't need the workaround anymore.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [x] using Go SDK
