### PR TITLE
[Feature] Allow to use GCP SA in `databricks_credential` (storage only)

### DIFF
--- a/catalog/resource_credential.go
+++ b/catalog/resource_credential.go
@@ -11,7 +11,8 @@ import (
 
 var credentialSchema = common.StructToSchema(catalog.CredentialInfo{},
 	func(m map[string]*schema.Schema) map[string]*schema.Schema {
-		var alofServiceCreds = []string{"aws_iam_role", "azure_managed_identity", "azure_service_principal"}
+		var alofServiceCreds = []string{"aws_iam_role", "azure_managed_identity", "azure_service_principal",
+			"databricks_gcp_service_account"}
 		for _, cred := range alofServiceCreds {
 			common.CustomizeSchemaPath(m, cred).SetExactlyOneOf(alofServiceCreds)
 		}
@@ -25,6 +26,10 @@ var credentialSchema = common.StructToSchema(catalog.CredentialInfo{},
 			common.CustomizeSchemaPath(m, computed).SetComputed()
 		}
 
+		common.CustomizeSchemaPath(m, "databricks_gcp_service_account").SetComputed()
+		common.CustomizeSchemaPath(m, "databricks_gcp_service_account", "email").SetComputed()
+		common.CustomizeSchemaPath(m, "databricks_gcp_service_account", "credential_id").SetComputed()
+		common.CustomizeSchemaPath(m, "databricks_gcp_service_account", "private_key_id").SetComputed()
 		common.MustSchemaPath(m, "aws_iam_role", "external_id").Computed = true
 		common.MustSchemaPath(m, "aws_iam_role", "unity_catalog_iam_arn").Computed = true
 		common.MustSchemaPath(m, "azure_managed_identity", "credential_id").Computed = true

--- a/docs/resources/credential.md
+++ b/docs/resources/credential.md
@@ -50,7 +50,26 @@ resource "databricks_credential" "external_mi" {
 }
 
 resource "databricks_grants" "external_creds" {
-  credential = databricks_credential.external.id
+  credential = databricks_credential.external_mi.id
+  grant {
+    principal  = "Data Engineers"
+    privileges = ["ACCESS"]
+  }
+}
+```
+
+For GCP
+
+```hcl
+resource "databricks_credential" "external_gcp_sa" {
+  name = "gcp_sa_credential"
+  databricks_gcp_service_account {}
+  purpose = "SERVICE"
+  comment = "GCP SA credential managed by TF"
+}
+
+resource "databricks_grants" "external_creds" {
+  credential = databricks_credential.external_gcp_sa.id
   grant {
     principal  = "Data Engineers"
     privileges = ["ACCESS"]
@@ -86,6 +105,11 @@ The following arguments are required:
 - `directory_id` - The directory ID corresponding to the Azure Active Directory (AAD) tenant of the application
 - `application_id` - The application ID of the application registration within the referenced AAD tenant
 - `client_secret` - The client secret generated for the above app ID in AAD. **This field is redacted on output**
+
+`databricks_gcp_service_account` optional configuration block for creating a Databricks-managed GCP Service Account.  Only applicable when purpose is `STORAGE`:
+
+- `email` (output only) - The email of the GCP service account created, to be granted access to relevant buckets.
+
 
 ## Attribute Reference
 

--- a/docs/resources/credential.md
+++ b/docs/resources/credential.md
@@ -58,13 +58,13 @@ resource "databricks_grants" "external_creds" {
 }
 ```
 
-For GCP
+For GCP (only applicable when purpose is `STORAGE`)
 
 ```hcl
 resource "databricks_credential" "external_gcp_sa" {
   name = "gcp_sa_credential"
   databricks_gcp_service_account {}
-  purpose = "SERVICE"
+  purpose = "STORAGE"
   comment = "GCP SA credential managed by TF"
 }
 

--- a/internal/acceptance/credential_test.go
+++ b/internal/acceptance/credential_test.go
@@ -10,11 +10,23 @@ func TestUcAccCredential(t *testing.T) {
 		UnityWorkspaceLevel(t, Step{
 			Template: `
 				resource "databricks_credential" "external" {
-					name = "cred-{var.RANDOM}"
+					name = "service-cred-{var.RANDOM}"
 					aws_iam_role {
 						role_arn = "{env.TEST_METASTORE_DATA_ACCESS_ARN}"
 					}
 					purpose = "SERVICE"
+					skip_validation = true
+					comment = "Managed by TF"
+				}`,
+		})
+	} else if isGcp(t) {
+		UnityWorkspaceLevel(t, Step{
+			// TODO: update purpose to SERVICE when it's released
+			Template: `
+				resource "databricks_credential" "external" {
+					name = "storage-cred-{var.RANDOM}"
+					databricks_gcp_service_account {}
+					purpose = "STORAGE"
 					skip_validation = true
 					comment = "Managed by TF"
 				}`,

--- a/internal/acceptance/credential_test.go
+++ b/internal/acceptance/credential_test.go
@@ -19,7 +19,7 @@ func TestUcAccCredential(t *testing.T) {
 					comment = "Managed by TF"
 				}`,
 		})
-	} else if isGcp(t) {
+	} else if IsGcp(t) {
 		UnityWorkspaceLevel(t, Step{
 			// TODO: update purpose to SERVICE when it's released
 			Template: `


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

Right now, it's only possible to use it only with `purpose = "STORAGE"`.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [x] covered with integration tests in `internal/acceptance`
- [x] relevant acceptance tests are passing
- [x] using Go SDK
