### PR TITLE
[Internal] Panic if the provided path is invalid

### DIFF
--- a/internal/providers/pluginfw/tfschema/customizable_schema.go
+++ b/internal/providers/pluginfw/tfschema/customizable_schema.go
@@ -230,7 +230,7 @@ func (s *CustomizableSchema) ConvertToAttribute(path ...string) *CustomizableSch
 }
 
 // navigateSchemaWithCallback navigates through schema attributes and executes callback on the target, panics if path does not exist or invalid.
-func navigateSchemaWithCallback(s *BaseSchemaBuilder, cb func(BaseSchemaBuilder) BaseSchemaBuilder, path ...string) (BaseSchemaBuilder, error) {
+func navigateSchemaWithCallback(s *BaseSchemaBuilder, cb func(BaseSchemaBuilder) BaseSchemaBuilder, path ...string) {
 	currentScm := s
 	for i, p := range path {
 		m := attributeToNestedBlockObject(currentScm)
@@ -241,7 +241,7 @@ func navigateSchemaWithCallback(s *BaseSchemaBuilder, cb func(BaseSchemaBuilder)
 			if i == len(path)-1 {
 				newV := cb(v).(AttributeBuilder)
 				mAttr[p] = newV
-				return mAttr[p], nil
+				return
 			}
 			castedV := v.(BaseSchemaBuilder)
 			currentScm = &castedV
@@ -249,14 +249,14 @@ func navigateSchemaWithCallback(s *BaseSchemaBuilder, cb func(BaseSchemaBuilder)
 			if i == len(path)-1 {
 				newV := cb(v).(BlockBuilder)
 				mBlock[p] = newV
-				return mBlock[p], nil
+				return
 			}
 			castedV := v.(BaseSchemaBuilder)
 			currentScm = &castedV
 		} else {
-			return nil, fmt.Errorf("missing key %s", p)
+			panic(fmt.Errorf("missing key %s", p))
 		}
 
 	}
-	return nil, fmt.Errorf("path %v is incomplete", path)
+	panic(fmt.Errorf("path %v is incomplete", path))
 }


### PR DESCRIPTION
## Changes
Callers of `CustomizableSchema`'s methods can supply invalid paths. Currently, this returns an error, but this is never OK and should always be fixed before making any changes to a resource. Here, I change `navigateSchemaWithCallback` to panic if the supplied path does not exist.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
