### PR TITLE
[Internal] Expose several integration test helpers for use in plugin framework integration tests

### DIFF
--- a/internal/acceptance/account_rule_set_test.go
+++ b/internal/acceptance/account_rule_set_test.go
@@ -14,7 +14,7 @@ import (
 
 // Application ID is mandatory in Azure today.
 func getServicePrincipalResource(t *testing.T) string {
-	if isAzure(t) {
+	if IsAzure(t) {
 		return `
 		resource "databricks_service_principal" "this" {
 			application_id = "{var.RANDOM_UUID}"
@@ -30,7 +30,7 @@ func getServicePrincipalResource(t *testing.T) string {
 }
 
 func TestMwsAccAccountServicePrincipalRuleSetsFullLifeCycle(t *testing.T) {
-	loadAccountEnv(t)
+	LoadAccountEnv(t)
 	spResource := getServicePrincipalResource(t)
 	AccountLevel(t, Step{
 		Template: spResource + `

--- a/internal/acceptance/budget_test.go
+++ b/internal/acceptance/budget_test.go
@@ -43,7 +43,7 @@ var (
 func TestMwsAccBudgetCreate(t *testing.T) {
 	LoadAccountEnv(t)
 	if IsGcp(t) {
-		skipf(t)("not available on GCP")
+		Skipf(t)("not available on GCP")
 	}
 	AccountLevel(t, Step{
 		Template: fmt.Sprintf(budgetTemplate, "840"),
@@ -53,7 +53,7 @@ func TestMwsAccBudgetCreate(t *testing.T) {
 func TestMwsAccBudgetUpdate(t *testing.T) {
 	LoadAccountEnv(t)
 	if IsGcp(t) {
-		skipf(t)("not available on GCP")
+		Skipf(t)("not available on GCP")
 	}
 	AccountLevel(t, Step{
 		Template: fmt.Sprintf(budgetTemplate, "840"),

--- a/internal/acceptance/budget_test.go
+++ b/internal/acceptance/budget_test.go
@@ -41,8 +41,8 @@ var (
 )
 
 func TestMwsAccBudgetCreate(t *testing.T) {
-	loadAccountEnv(t)
-	if isGcp(t) {
+	LoadAccountEnv(t)
+	if IsGcp(t) {
 		skipf(t)("not available on GCP")
 	}
 	AccountLevel(t, Step{
@@ -51,8 +51,8 @@ func TestMwsAccBudgetCreate(t *testing.T) {
 }
 
 func TestMwsAccBudgetUpdate(t *testing.T) {
-	loadAccountEnv(t)
-	if isGcp(t) {
+	LoadAccountEnv(t)
+	if IsGcp(t) {
 		skipf(t)("not available on GCP")
 	}
 	AccountLevel(t, Step{

--- a/internal/acceptance/catalog_test.go
+++ b/internal/acceptance/catalog_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestUcAccCatalog(t *testing.T) {
-	loadUcwsEnv(t)
+	LoadUcwsEnv(t)
 	UnityWorkspaceLevel(t, Step{
 		Template: fmt.Sprintf(`
 		resource "databricks_catalog" "sandbox" {
@@ -54,7 +54,7 @@ func TestUcAccCatalogIsolated(t *testing.T) {
 }
 
 func TestUcAccCatalogUpdate(t *testing.T) {
-	loadUcwsEnv(t)
+	LoadUcwsEnv(t)
 	UnityWorkspaceLevel(t, Step{
 		Template: fmt.Sprintf(`
 		resource "databricks_catalog" "sandbox" {

--- a/internal/acceptance/cluster_test.go
+++ b/internal/acceptance/cluster_test.go
@@ -102,8 +102,8 @@ func awsClusterTemplate(availability string) string {
 }
 
 func TestAccClusterResource_CreateAndUpdateAwsAttributes(t *testing.T) {
-	loadWorkspaceEnv(t)
-	if isAws(t) {
+	LoadWorkspaceEnv(t)
+	if IsAws(t) {
 		WorkspaceLevel(t, Step{
 			Template: awsClusterTemplate("SPOT"),
 		}, Step{

--- a/internal/acceptance/credential_test.go
+++ b/internal/acceptance/credential_test.go
@@ -5,8 +5,8 @@ import (
 )
 
 func TestUcAccCredential(t *testing.T) {
-	loadUcwsEnv(t)
-	if isAws(t) {
+	LoadUcwsEnv(t)
+	if IsAws(t) {
 		UnityWorkspaceLevel(t, Step{
 			Template: `
 				resource "databricks_credential" "external" {

--- a/internal/acceptance/custom_app_integration_test.go
+++ b/internal/acceptance/custom_app_integration_test.go
@@ -18,14 +18,14 @@ var (
 )
 
 func TestMwsAccCustomAppIntegrationCreate(t *testing.T) {
-	loadAccountEnv(t)
+	LoadAccountEnv(t)
 	AccountLevel(t, Step{
 		Template: fmt.Sprintf(customAppIntegrationTemplate, "30"),
 	})
 }
 
 func TestMwsAccCustomAppIntegrationUpdate(t *testing.T) {
-	loadAccountEnv(t)
+	LoadAccountEnv(t)
 	AccountLevel(t, Step{
 		Template: fmt.Sprintf(customAppIntegrationTemplate, "30"),
 	}, Step{

--- a/internal/acceptance/data_current_config_test.go
+++ b/internal/acceptance/data_current_config_test.go
@@ -22,18 +22,18 @@ func checkCurrentConfig(t *testing.T, cloudType string, isAccount string) func(s
 }
 
 func TestAccDataCurrentConfig(t *testing.T) {
-	loadWorkspaceEnv(t)
-	if isAws(t) {
+	LoadWorkspaceEnv(t)
+	if IsAws(t) {
 		WorkspaceLevel(t, Step{
 			Template: `data "databricks_current_config" "this" {}`,
 			Check:    checkCurrentConfig(t, "aws", "false"),
 		})
-	} else if isAzure(t) {
+	} else if IsAzure(t) {
 		WorkspaceLevel(t, Step{
 			Template: `data "databricks_current_config" "this" {}`,
 			Check:    checkCurrentConfig(t, "azure", "false"),
 		})
-	} else if isGcp(t) {
+	} else if IsGcp(t) {
 		WorkspaceLevel(t, Step{
 			Template: `data "databricks_current_config" "this" {}`,
 			Check:    checkCurrentConfig(t, "gcp", "false"),
@@ -42,18 +42,18 @@ func TestAccDataCurrentConfig(t *testing.T) {
 }
 
 func TestMwsAccDataCurrentConfig(t *testing.T) {
-	loadAccountEnv(t)
-	if isAws(t) {
+	LoadAccountEnv(t)
+	if IsAws(t) {
 		AccountLevel(t, Step{
 			Template: `data "databricks_current_config" "this" {}`,
 			Check:    checkCurrentConfig(t, "aws", "true"),
 		})
-	} else if isAzure(t) {
+	} else if IsAzure(t) {
 		AccountLevel(t, Step{
 			Template: `data "databricks_current_config" "this" {}`,
 			Check:    checkCurrentConfig(t, "azure", "true"),
 		})
-	} else if isGcp(t) {
+	} else if IsGcp(t) {
 		AccountLevel(t, Step{
 			Template: `data "databricks_current_config" "this" {}`,
 			Check:    checkCurrentConfig(t, "gcp", "true"),

--- a/internal/acceptance/data_mws_network_connectivity_config_test.go
+++ b/internal/acceptance/data_mws_network_connectivity_config_test.go
@@ -8,14 +8,14 @@ import (
 )
 
 func TestAccDataSourceMwsNetworkConnectivityConfigTest(t *testing.T) {
-	loadWorkspaceEnv(t)
-	if isGcp(t) {
+	LoadWorkspaceEnv(t)
+	if IsGcp(t) {
 		skipf(t)("GCP not supported")
 	}
 	var sourceRegion string
-	if isAzure(t) {
+	if IsAzure(t) {
 		sourceRegion = "eastus2"
-	} else if isAws(t) {
+	} else if IsAws(t) {
 		sourceRegion = "us-east-2"
 	}
 	AccountLevel(t,

--- a/internal/acceptance/data_mws_network_connectivity_config_test.go
+++ b/internal/acceptance/data_mws_network_connectivity_config_test.go
@@ -10,7 +10,7 @@ import (
 func TestAccDataSourceMwsNetworkConnectivityConfigTest(t *testing.T) {
 	LoadWorkspaceEnv(t)
 	if IsGcp(t) {
-		skipf(t)("GCP not supported")
+		Skipf(t)("GCP not supported")
 	}
 	var sourceRegion string
 	if IsAzure(t) {

--- a/internal/acceptance/data_mws_network_connectivity_configs_test.go
+++ b/internal/acceptance/data_mws_network_connectivity_configs_test.go
@@ -8,14 +8,14 @@ import (
 )
 
 func TestAccDataSourceMwsNetworkConnectivityConfigsTest(t *testing.T) {
-	loadWorkspaceEnv(t)
-	if isGcp(t) {
+	LoadWorkspaceEnv(t)
+	if IsGcp(t) {
 		skipf(t)("GCP not supported")
 	}
 	var region string
-	if isAzure(t) {
+	if IsAzure(t) {
 		region = "eastus2"
-	} else if isAws(t) {
+	} else if IsAws(t) {
 		region = "us-east-2"
 	}
 	AccountLevel(t,

--- a/internal/acceptance/data_mws_network_connectivity_configs_test.go
+++ b/internal/acceptance/data_mws_network_connectivity_configs_test.go
@@ -10,7 +10,7 @@ import (
 func TestAccDataSourceMwsNetworkConnectivityConfigsTest(t *testing.T) {
 	LoadWorkspaceEnv(t)
 	if IsGcp(t) {
-		skipf(t)("GCP not supported")
+		Skipf(t)("GCP not supported")
 	}
 	var region string
 	if IsAzure(t) {

--- a/internal/acceptance/entitlements_test.go
+++ b/internal/acceptance/entitlements_test.go
@@ -84,9 +84,9 @@ func makePreconfig(t *testing.T, r entitlementResource) func() {
 }
 
 func entitlementsTest(t *testing.T, f func(*testing.T, entitlementResource)) {
-	loadWorkspaceEnv(t)
+	LoadWorkspaceEnv(t)
 	sp := &servicePrincipalResource{}
-	if isAzure(t) {
+	if IsAzure(t) {
 		// A long-lived application is used in Azure.
 		sp.applicationId = GetEnvOrSkipTest(t, "ACCOUNT_LEVEL_SERVICE_PRINCIPAL_ID")
 		sp.cleanup = false

--- a/internal/acceptance/init.go
+++ b/internal/acceptance/init.go
@@ -125,7 +125,7 @@ func environmentTemplate(t *testing.T, template string, otherVars ...map[string]
 		"RANDOM_UUID": createUuid(),
 	}
 	if len(otherVars) > 1 {
-		skipf(t)("cannot have more than one custom variable map")
+		Skipf(t)("cannot have more than one custom variable map")
 	}
 	if len(otherVars) == 1 {
 		for k, v := range otherVars[0] {
@@ -147,14 +147,14 @@ func environmentTemplate(t *testing.T, template string, otherVars ...map[string]
 			value = vars[varName]
 		}
 		if value == "" {
-			skipf(t)("Missing %s %s variable.", varType, varName)
+			Skipf(t)("Missing %s %s variable.", varType, varName)
 			missing++
 			continue
 		}
 		template = strings.ReplaceAll(template, `{`+varType+`.`+varName+`}`, value)
 	}
 	if missing > 0 {
-		skipf(t)("please set %d variables and restart", missing)
+		Skipf(t)("please set %d variables and restart", missing)
 	}
 	return commands.TrimLeadingWhitespace(template)
 }
@@ -291,7 +291,7 @@ const hexCharset = "0123456789abcdef"
 func GetEnvOrSkipTest(t *testing.T, name string) string {
 	value := os.Getenv(name)
 	if value == "" {
-		skipf(t)("Environment variable %s is missing", name)
+		Skipf(t)("Environment variable %s is missing", name)
 	}
 	return value
 }
@@ -300,7 +300,7 @@ func GetEnvInt64OrSkipTest(t *testing.T, name string) int64 {
 	v := GetEnvOrSkipTest(t, name)
 	i, err := strconv.ParseInt(v, 10, 64)
 	if err != nil {
-		skipf(t)("`%s` is not int64: %s", v, err)
+		Skipf(t)("`%s` is not int64: %s", v, err)
 	}
 	return i
 }
@@ -338,7 +338,7 @@ func RandomHex(prefix string, randLen int) string {
 	return string(b)
 }
 
-func skipf(t *testing.T) func(format string, args ...any) {
+func Skipf(t *testing.T) func(format string, args ...any) {
 	if isInDebug() {
 		// VSCode "debug test" feature doesn't show dlv logs,
 		// so that we fail here for maintainer productivity.
@@ -362,34 +362,34 @@ func setDebugLogger() {
 func LoadWorkspaceEnv(t *testing.T) {
 	initTest(t, "workspace")
 	if os.Getenv("DATABRICKS_ACCOUNT_ID") != "" {
-		skipf(t)("Skipping workspace test on account level")
+		Skipf(t)("Skipping workspace test on account level")
 	}
 }
 
 func LoadAccountEnv(t *testing.T) {
 	initTest(t, "account")
 	if os.Getenv("DATABRICKS_ACCOUNT_ID") == "" {
-		skipf(t)("Skipping account test on workspace level")
+		Skipf(t)("Skipping account test on workspace level")
 	}
 }
 
 func LoadUcwsEnv(t *testing.T) {
 	initTest(t, "ucws")
 	if os.Getenv("TEST_METASTORE_ID") == "" {
-		skipf(t)("Skipping non-Unity Catalog test")
+		Skipf(t)("Skipping non-Unity Catalog test")
 	}
 	if os.Getenv("DATABRICKS_ACCOUNT_ID") != "" {
-		skipf(t)("Skipping workspace test on account level")
+		Skipf(t)("Skipping workspace test on account level")
 	}
 }
 
 func LoadUcacctEnv(t *testing.T) {
 	initTest(t, "ucacct")
 	if os.Getenv("TEST_METASTORE_ID") == "" {
-		skipf(t)("Skipping non-Unity Catalog test")
+		Skipf(t)("Skipping non-Unity Catalog test")
 	}
 	if os.Getenv("DATABRICKS_ACCOUNT_ID") == "" {
-		skipf(t)("Skipping account test on workspace level")
+		Skipf(t)("Skipping account test on workspace level")
 	}
 }
 
@@ -411,7 +411,7 @@ func IsGcp(t *testing.T) bool {
 func isCloudEnvInList(t *testing.T, cloudEnvs []string) bool {
 	cloudEnv := os.Getenv("CLOUD_ENV")
 	if cloudEnv == "" {
-		skipf(t)("Acceptance tests skipped unless env 'CLOUD_ENV' is set")
+		Skipf(t)("Acceptance tests skipped unless env 'CLOUD_ENV' is set")
 	}
 	return slices.Contains(cloudEnvs, cloudEnv)
 }

--- a/internal/acceptance/init.go
+++ b/internal/acceptance/init.go
@@ -37,22 +37,22 @@ func init() {
 }
 
 func WorkspaceLevel(t *testing.T, steps ...Step) {
-	loadWorkspaceEnv(t)
+	LoadWorkspaceEnv(t)
 	run(t, steps)
 }
 
 func AccountLevel(t *testing.T, steps ...Step) {
-	loadAccountEnv(t)
+	LoadAccountEnv(t)
 	run(t, steps)
 }
 
 func UnityWorkspaceLevel(t *testing.T, steps ...Step) {
-	loadUcwsEnv(t)
+	LoadUcwsEnv(t)
 	run(t, steps)
 }
 
 func UnityAccountLevel(t *testing.T, steps ...Step) {
-	loadUcacctEnv(t)
+	LoadUcacctEnv(t)
 	run(t, steps)
 }
 
@@ -359,21 +359,21 @@ func setDebugLogger() {
 	}
 }
 
-func loadWorkspaceEnv(t *testing.T) {
+func LoadWorkspaceEnv(t *testing.T) {
 	initTest(t, "workspace")
 	if os.Getenv("DATABRICKS_ACCOUNT_ID") != "" {
 		skipf(t)("Skipping workspace test on account level")
 	}
 }
 
-func loadAccountEnv(t *testing.T) {
+func LoadAccountEnv(t *testing.T) {
 	initTest(t, "account")
 	if os.Getenv("DATABRICKS_ACCOUNT_ID") == "" {
 		skipf(t)("Skipping account test on workspace level")
 	}
 }
 
-func loadUcwsEnv(t *testing.T) {
+func LoadUcwsEnv(t *testing.T) {
 	initTest(t, "ucws")
 	if os.Getenv("TEST_METASTORE_ID") == "" {
 		skipf(t)("Skipping non-Unity Catalog test")
@@ -383,7 +383,7 @@ func loadUcwsEnv(t *testing.T) {
 	}
 }
 
-func loadUcacctEnv(t *testing.T) {
+func LoadUcacctEnv(t *testing.T) {
 	initTest(t, "ucacct")
 	if os.Getenv("TEST_METASTORE_ID") == "" {
 		skipf(t)("Skipping non-Unity Catalog test")
@@ -393,17 +393,17 @@ func loadUcacctEnv(t *testing.T) {
 	}
 }
 
-func isAws(t *testing.T) bool {
+func IsAws(t *testing.T) bool {
 	awsCloudEnvs := []string{"MWS", "aws", "ucws", "ucacct"}
 	return isCloudEnvInList(t, awsCloudEnvs)
 }
 
-func isAzure(t *testing.T) bool {
+func IsAzure(t *testing.T) bool {
 	azureCloudEnvs := []string{"azure", "azure-ucacct"}
 	return isCloudEnvInList(t, azureCloudEnvs)
 }
 
-func isGcp(t *testing.T) bool {
+func IsGcp(t *testing.T) bool {
 	gcpCloudEnvs := []string{"gcp-accounts", "gcp-ucacct", "gcp-ucws", "gcp"}
 	return isCloudEnvInList(t, gcpCloudEnvs)
 }

--- a/internal/acceptance/job_test.go
+++ b/internal/acceptance/job_test.go
@@ -396,7 +396,7 @@ func TestUcAccJobRunAsMutations(t *testing.T) {
 }
 
 func TestAccRemoveWebhooks(t *testing.T) {
-	skipf(t)("There is no API to create notification destinations. Once available, add here and enable this test.")
+	Skipf(t)("There is no API to create notification destinations. Once available, add here and enable this test.")
 	WorkspaceLevel(t, Step{
 		Template: `
 		resource databricks_job test {

--- a/internal/acceptance/job_test.go
+++ b/internal/acceptance/job_test.go
@@ -356,7 +356,7 @@ func TestAccJobRunAsUser(t *testing.T) {
 }
 
 func TestUcAccJobRunAsServicePrincipal(t *testing.T) {
-	loadUcwsEnv(t)
+	LoadUcwsEnv(t)
 	spId := GetEnvOrSkipTest(t, "ACCOUNT_LEVEL_SERVICE_PRINCIPAL_ID")
 	UnityWorkspaceLevel(t, Step{
 		Template: runAsTemplate(`service_principal_name = "` + spId + `"`),
@@ -373,7 +373,7 @@ func getRunAsAttribute(t *testing.T, ctx context.Context) string {
 }
 
 func TestUcAccJobRunAsMutations(t *testing.T) {
-	loadUcwsEnv(t)
+	LoadUcwsEnv(t)
 	spId := GetEnvOrSkipTest(t, "ACCOUNT_LEVEL_SERVICE_PRINCIPAL_ID")
 	// Note: the attribute must match the type of principal that the test is run as.
 	ctx := context.Background()

--- a/internal/acceptance/metastore_test.go
+++ b/internal/acceptance/metastore_test.go
@@ -10,36 +10,36 @@ import (
 )
 
 func getStorageRoot(t *testing.T) string {
-	if isAws(t) {
+	if IsAws(t) {
 		return "s3://{env.TEST_BUCKET}/test{var.RANDOM}"
-	} else if isAzure(t) {
+	} else if IsAzure(t) {
 		return "abfss://{var.RANDOM}@{var.RANDOM}/"
-	} else if isGcp(t) {
+	} else if IsGcp(t) {
 		return "gs://{var.RANDOM}/metastore"
 	}
 	return ""
 }
 
 func getRegion(t *testing.T) string {
-	if isAws(t) {
+	if IsAws(t) {
 		return "us-east-1"
-	} else if isAzure(t) {
+	} else if IsAzure(t) {
 		return "eastus"
-	} else if isGcp(t) {
+	} else if IsGcp(t) {
 		return "us-east1"
 	}
 	return ""
 }
 
 func TestUcAccRootlessMetastore(t *testing.T) {
-	loadUcacctEnv(t)
+	LoadUcacctEnv(t)
 	runMetastoreTest(t, map[string]any{
 		"region": getRegion(t),
 	})
 }
 
 func TestUcAccMetastore(t *testing.T) {
-	loadUcacctEnv(t)
+	LoadUcacctEnv(t)
 	runMetastoreTest(t, map[string]any{
 		"storage_root": getStorageRoot(t),
 		"region":       getRegion(t),
@@ -47,7 +47,7 @@ func TestUcAccMetastore(t *testing.T) {
 }
 
 func TestUcAccMetastoreDeltaSharing(t *testing.T) {
-	loadUcacctEnv(t)
+	LoadUcacctEnv(t)
 	runMetastoreTest(t, map[string]any{
 		"storage_root":        getStorageRoot(t),
 		"region":              getRegion(t),
@@ -58,7 +58,7 @@ func TestUcAccMetastoreDeltaSharing(t *testing.T) {
 }
 
 func TestUcAccMetastoreDeltaSharingInfiniteLifetime(t *testing.T) {
-	loadUcacctEnv(t)
+	LoadUcacctEnv(t)
 	runMetastoreTest(t, map[string]any{
 		"storage_root":        getStorageRoot(t),
 		"region":              getRegion(t),
@@ -68,7 +68,7 @@ func TestUcAccMetastoreDeltaSharingInfiniteLifetime(t *testing.T) {
 }
 
 func TestUcAccMetastoreWithOwnerUpdates(t *testing.T) {
-	loadUcacctEnv(t)
+	LoadUcacctEnv(t)
 	runMetastoreTestWithOwnerUpdates(t, map[string]any{
 		"storage_root": getStorageRoot(t),
 		"region":       getRegion(t),

--- a/internal/acceptance/model_serving_test.go
+++ b/internal/acceptance/model_serving_test.go
@@ -8,8 +8,8 @@ import (
 )
 
 func TestAccModelServing(t *testing.T) {
-	loadWorkspaceEnv(t)
-	if isGcp(t) {
+	LoadWorkspaceEnv(t)
+	if IsGcp(t) {
 		skipf(t)("not available on GCP")
 	}
 
@@ -86,8 +86,8 @@ func TestAccModelServing(t *testing.T) {
 }
 
 func TestUcAccModelServingProvisionedThroughput(t *testing.T) {
-	loadWorkspaceEnv(t)
-	if isGcp(t) {
+	LoadWorkspaceEnv(t)
+	if IsGcp(t) {
 		skipf(t)("not available on GCP")
 	}
 
@@ -161,8 +161,8 @@ func TestUcAccModelServingProvisionedThroughput(t *testing.T) {
 }
 
 func TestAccModelServingExternalModel(t *testing.T) {
-	loadWorkspaceEnv(t)
-	if isGcp(t) {
+	LoadWorkspaceEnv(t)
+	if IsGcp(t) {
 		skipf(t)("not available on GCP")
 	}
 

--- a/internal/acceptance/model_serving_test.go
+++ b/internal/acceptance/model_serving_test.go
@@ -10,7 +10,7 @@ import (
 func TestAccModelServing(t *testing.T) {
 	LoadWorkspaceEnv(t)
 	if IsGcp(t) {
-		skipf(t)("not available on GCP")
+		Skipf(t)("not available on GCP")
 	}
 
 	name := fmt.Sprintf("terraform-test-model-serving-%s",
@@ -88,7 +88,7 @@ func TestAccModelServing(t *testing.T) {
 func TestUcAccModelServingProvisionedThroughput(t *testing.T) {
 	LoadWorkspaceEnv(t)
 	if IsGcp(t) {
-		skipf(t)("not available on GCP")
+		Skipf(t)("not available on GCP")
 	}
 
 	name := fmt.Sprintf("terraform-test-model-serving-pt-%s",
@@ -163,7 +163,7 @@ func TestUcAccModelServingProvisionedThroughput(t *testing.T) {
 func TestAccModelServingExternalModel(t *testing.T) {
 	LoadWorkspaceEnv(t)
 	if IsGcp(t) {
-		skipf(t)("not available on GCP")
+		Skipf(t)("not available on GCP")
 	}
 
 	name := fmt.Sprintf("terraform-test-model-serving-em-%s",

--- a/internal/acceptance/mws_network_connectivity_config_test.go
+++ b/internal/acceptance/mws_network_connectivity_config_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestMwsAccNetworkConnectivityConfig(t *testing.T) {
-	if isAzure(t) {
+	if IsAzure(t) {
 		AccountLevel(t, Step{
 			Template: `
 			resource "databricks_mws_network_connectivity_config" "this" {
@@ -34,7 +34,7 @@ func TestMwsAccNetworkConnectivityConfig(t *testing.T) {
 			`,
 		})
 	}
-	if isAws(t) {
+	if IsAws(t) {
 		AccountLevel(t, Step{
 			Template: `
 			resource "databricks_mws_network_connectivity_config" "this" {

--- a/internal/acceptance/mws_workspaces_test.go
+++ b/internal/acceptance/mws_workspaces_test.go
@@ -302,7 +302,7 @@ func TestMwsAccGcpPscWorkspaces(t *testing.T) {
 
 func TestMwsAccAwsChangeToServicePrincipal(t *testing.T) {
 	if !IsAws(t) {
-		skipf(t)("TestMwsAccAwsChangeToServicePrincipal should only run on AWS")
+		Skipf(t)("TestMwsAccAwsChangeToServicePrincipal should only run on AWS")
 	}
 	workspaceTemplate := func(tokenBlock string) string {
 		return `

--- a/internal/acceptance/mws_workspaces_test.go
+++ b/internal/acceptance/mws_workspaces_test.go
@@ -301,7 +301,7 @@ func TestMwsAccGcpPscWorkspaces(t *testing.T) {
 }
 
 func TestMwsAccAwsChangeToServicePrincipal(t *testing.T) {
-	if !isAws(t) {
+	if !IsAws(t) {
 		skipf(t)("TestMwsAccAwsChangeToServicePrincipal should only run on AWS")
 	}
 	workspaceTemplate := func(tokenBlock string) string {

--- a/internal/acceptance/permissions_test.go
+++ b/internal/acceptance/permissions_test.go
@@ -68,7 +68,7 @@ func currentPrincipalPermission(t *testing.T, permissionLevel string) func(*make
 		skipCreation:    true,
 	}
 	return func(config *makePermissionsConfig) {
-		if isGcp(t) {
+		if IsGcp(t) {
 			config.user = append(config.user, settings)
 		} else {
 			config.servicePrincipal = append(config.servicePrincipal, settings)
@@ -77,7 +77,7 @@ func currentPrincipalPermission(t *testing.T, permissionLevel string) func(*make
 }
 
 func currentPrincipalType(t *testing.T) string {
-	if isGcp(t) {
+	if IsGcp(t) {
 		return "user"
 	}
 	return "service_principal"
@@ -833,7 +833,7 @@ func TestAccPermissions_RegisteredModel_Root(t *testing.T) {
 
 func TestAccPermissions_ServingEndpoint(t *testing.T) {
 	loadDebugEnvIfRunsFromIDE(t, "workspace")
-	if isGcp(t) {
+	if IsGcp(t) {
 		skipf(t)("Serving endpoints are not supported on GCP")
 	}
 	endpointTemplate := `

--- a/internal/acceptance/permissions_test.go
+++ b/internal/acceptance/permissions_test.go
@@ -583,7 +583,7 @@ func TestAccPermissions_Repo_Path(t *testing.T) {
 }
 
 func TestAccPermissions_Authorization_Passwords(t *testing.T) {
-	skipf(t)("ACLs for passwords are disabled on testing workspaces")
+	Skipf(t)("ACLs for passwords are disabled on testing workspaces")
 	loadDebugEnvIfRunsFromIDE(t, "workspace")
 	WorkspaceLevel(t, Step{
 		Template: makePermissionsTestStage("authorization", "\"passwords\"", groupPermissions("CAN_USE")),
@@ -834,7 +834,7 @@ func TestAccPermissions_RegisteredModel_Root(t *testing.T) {
 func TestAccPermissions_ServingEndpoint(t *testing.T) {
 	loadDebugEnvIfRunsFromIDE(t, "workspace")
 	if IsGcp(t) {
-		skipf(t)("Serving endpoints are not supported on GCP")
+		Skipf(t)("Serving endpoints are not supported on GCP")
 	}
 	endpointTemplate := `
 	resource "databricks_model_serving" "endpoint" {

--- a/internal/acceptance/schema_test.go
+++ b/internal/acceptance/schema_test.go
@@ -90,7 +90,7 @@ func schemaTemplateWithOwner(t *testing.T, comment string, owner string) string 
 }
 
 func getPredictiveOptimizationSetting(t *testing.T, enabled bool) string {
-	if isGcp(t) {
+	if IsGcp(t) {
 		return ""
 	}
 	value := "ENABLE"
@@ -101,7 +101,7 @@ func getPredictiveOptimizationSetting(t *testing.T, enabled bool) string {
 }
 
 func TestUcAccSchemaUpdate(t *testing.T) {
-	loadUcwsEnv(t)
+	LoadUcwsEnv(t)
 	UnityWorkspaceLevel(t, Step{
 		Template: catalogTemplate + schemaTemplateWithOwner(t, "this database is managed by terraform", "account users"),
 	}, Step{

--- a/internal/acceptance/service_principal_test.go
+++ b/internal/acceptance/service_principal_test.go
@@ -22,8 +22,8 @@ const awsSpn = `resource "databricks_service_principal" "this" {
 }`
 
 func TestAccServicePrincipalHomeDeleteSuccess(t *testing.T) {
-	loadWorkspaceEnv(t)
-	if !isAzure(t) {
+	LoadWorkspaceEnv(t)
+	if !IsAzure(t) {
 		skipf(t)("Test only valid for Azure")
 	}
 	uuid := createUuid()
@@ -58,8 +58,8 @@ func TestAccServicePrincipalHomeDeleteSuccess(t *testing.T) {
 }
 
 func TestAccServicePrinicpalHomeDeleteNotDeleted(t *testing.T) {
-	loadWorkspaceEnv(t)
-	if !isAzure(t) {
+	LoadWorkspaceEnv(t)
+	if !IsAzure(t) {
 		skipf(t)("Test only valid for Azure")
 	}
 	uuid := createUuid()

--- a/internal/acceptance/service_principal_test.go
+++ b/internal/acceptance/service_principal_test.go
@@ -24,7 +24,7 @@ const awsSpn = `resource "databricks_service_principal" "this" {
 func TestAccServicePrincipalHomeDeleteSuccess(t *testing.T) {
 	LoadWorkspaceEnv(t)
 	if !IsAzure(t) {
-		skipf(t)("Test only valid for Azure")
+		Skipf(t)("Test only valid for Azure")
 	}
 	uuid := createUuid()
 	template := `
@@ -60,7 +60,7 @@ func TestAccServicePrincipalHomeDeleteSuccess(t *testing.T) {
 func TestAccServicePrinicpalHomeDeleteNotDeleted(t *testing.T) {
 	LoadWorkspaceEnv(t)
 	if !IsAzure(t) {
-		skipf(t)("Test only valid for Azure")
+		Skipf(t)("Test only valid for Azure")
 	}
 	uuid := createUuid()
 	template := `

--- a/internal/acceptance/sql_global_config_test.go
+++ b/internal/acceptance/sql_global_config_test.go
@@ -37,7 +37,7 @@ resource "databricks_sql_global_config" "this" {
 }
 
 func TestAccSQLGlobalConfig(t *testing.T) {
-	loadWorkspaceEnv(t)
+	LoadWorkspaceEnv(t)
 	WorkspaceLevel(t, Step{
 		PreConfig: func() {
 			ctx := context.Background()
@@ -49,8 +49,8 @@ func TestAccSQLGlobalConfig(t *testing.T) {
 }
 
 func TestAccSQLGlobalConfigServerless(t *testing.T) {
-	loadWorkspaceEnv(t)
-	if isGcp(t) {
+	LoadWorkspaceEnv(t)
+	if IsGcp(t) {
 		skipf(t)("GCP does not support serverless compute")
 	}
 

--- a/internal/acceptance/sql_global_config_test.go
+++ b/internal/acceptance/sql_global_config_test.go
@@ -51,7 +51,7 @@ func TestAccSQLGlobalConfig(t *testing.T) {
 func TestAccSQLGlobalConfigServerless(t *testing.T) {
 	LoadWorkspaceEnv(t)
 	if IsGcp(t) {
-		skipf(t)("GCP does not support serverless compute")
+		Skipf(t)("GCP does not support serverless compute")
 	}
 
 	checkServerlessEnabled := func(enabled bool) func(state *terraform.State) error {

--- a/internal/acceptance/sql_permissions_test.go
+++ b/internal/acceptance/sql_permissions_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestAccTableACL(t *testing.T) {
-	loadWorkspaceEnv(t)
+	LoadWorkspaceEnv(t)
 	tableName := qa.RandomName("table_acl_")
 	clusterId := GetEnvOrSkipTest(t, "TEST_TABLE_ACL_CLUSTER_ID")
 	ctx := context.Background()

--- a/internal/acceptance/sql_table_test.go
+++ b/internal/acceptance/sql_table_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestUcAccResourceSqlTable_Managed(t *testing.T) {
 	if os.Getenv("GOOGLE_CREDENTIALS") != "" {
-		skipf(t)("databricks_sql_table resource not available on GCP")
+		Skipf(t)("databricks_sql_table resource not available on GCP")
 	}
 	UnityWorkspaceLevel(t, Step{
 		Template: `
@@ -74,7 +74,7 @@ func TestUcAccResourceSqlTable_Managed(t *testing.T) {
 
 func TestUcAccResourceSqlTableWithIdentityColumn_Managed(t *testing.T) {
 	if os.Getenv("GOOGLE_CREDENTIALS") != "" {
-		skipf(t)("databricks_sql_table resource not available on GCP")
+		Skipf(t)("databricks_sql_table resource not available on GCP")
 	}
 	UnityWorkspaceLevel(t, Step{
 		Template: `
@@ -175,7 +175,7 @@ func TestUcAccResourceSqlTable_External(t *testing.T) {
 
 func TestUcAccResourceSqlTable_View(t *testing.T) {
 	if os.Getenv("GOOGLE_CREDENTIALS") != "" {
-		skipf(t)("databricks_sql_table resource not available on GCP")
+		Skipf(t)("databricks_sql_table resource not available on GCP")
 	}
 	UnityWorkspaceLevel(t, Step{
 		Template: `
@@ -226,7 +226,7 @@ func TestUcAccResourceSqlTable_View(t *testing.T) {
 
 func TestUcAccResourceSqlTable_WarehousePartition(t *testing.T) {
 	if os.Getenv("GOOGLE_CREDENTIALS") != "" {
-		skipf(t)("databricks_sql_table resource not available on GCP")
+		Skipf(t)("databricks_sql_table resource not available on GCP")
 	}
 	UnityWorkspaceLevel(t, Step{
 		Template: `
@@ -277,7 +277,7 @@ func TestUcAccResourceSqlTable_WarehousePartition(t *testing.T) {
 }
 func TestUcAccResourceSqlTable_Liquid(t *testing.T) {
 	if os.Getenv("GOOGLE_CREDENTIALS") != "" {
-		skipf(t)("databricks_sql_table resource not available on GCP")
+		Skipf(t)("databricks_sql_table resource not available on GCP")
 	}
 	UnityWorkspaceLevel(t, Step{
 		Template: `
@@ -381,7 +381,7 @@ var inlineAndMembershipChangeErrorRegex = regexp.MustCompile(inlineAndMembership
 
 func TestUcAccResourceSqlTable_RenameColumn(t *testing.T) {
 	if os.Getenv("GOOGLE_CREDENTIALS") != "" {
-		skipf(t)("databricks_sql_table resource not available on GCP")
+		Skipf(t)("databricks_sql_table resource not available on GCP")
 	}
 	tableName := RandomName()
 	UnityWorkspaceLevel(t, Step{
@@ -406,7 +406,7 @@ func constructManagedSqlTableTemplateWithColumnTypeUpdates(tableName string, col
 
 func TestUcAccResourceSqlTable_ColumnTypeSuppressDiff(t *testing.T) {
 	if os.Getenv("GOOGLE_CREDENTIALS") != "" {
-		skipf(t)("databricks_sql_table resource not available on GCP")
+		Skipf(t)("databricks_sql_table resource not available on GCP")
 	}
 	tableName := RandomName()
 	columnName := RandomName()
@@ -448,7 +448,7 @@ func TestUcAccResourceSqlTable_ColumnTypeSuppressDiff(t *testing.T) {
 
 func TestUcAccResourceSqlTable_AddColumnComment(t *testing.T) {
 	if os.Getenv("GOOGLE_CREDENTIALS") != "" {
-		skipf(t)("databricks_sql_table resource not available on GCP")
+		Skipf(t)("databricks_sql_table resource not available on GCP")
 	}
 	tableName := RandomName()
 	UnityWorkspaceLevel(t, Step{
@@ -460,7 +460,7 @@ func TestUcAccResourceSqlTable_AddColumnComment(t *testing.T) {
 
 func TestUcAccResourceSqlTable_DropColumnNullable(t *testing.T) {
 	if os.Getenv("GOOGLE_CREDENTIALS") != "" {
-		skipf(t)("databricks_sql_table resource not available on GCP")
+		Skipf(t)("databricks_sql_table resource not available on GCP")
 	}
 	tableName := RandomName()
 	UnityWorkspaceLevel(t, Step{
@@ -472,7 +472,7 @@ func TestUcAccResourceSqlTable_DropColumnNullable(t *testing.T) {
 
 func TestUcAccResourceSqlTable_MultipleColumnUpdates(t *testing.T) {
 	if os.Getenv("GOOGLE_CREDENTIALS") != "" {
-		skipf(t)("databricks_sql_table resource not available on GCP")
+		Skipf(t)("databricks_sql_table resource not available on GCP")
 	}
 	tableName := RandomName()
 	UnityWorkspaceLevel(t, Step{
@@ -484,7 +484,7 @@ func TestUcAccResourceSqlTable_MultipleColumnUpdates(t *testing.T) {
 
 func TestUcAccResourceSqlTable_ChangeColumnTypeThrows(t *testing.T) {
 	if os.Getenv("GOOGLE_CREDENTIALS") != "" {
-		skipf(t)("databricks_sql_table resource not available on GCP")
+		Skipf(t)("databricks_sql_table resource not available on GCP")
 	}
 	tableName := RandomName()
 
@@ -498,7 +498,7 @@ func TestUcAccResourceSqlTable_ChangeColumnTypeThrows(t *testing.T) {
 
 func TestUcAccResourceSqlTable_DropColumn(t *testing.T) {
 	if os.Getenv("GOOGLE_CREDENTIALS") != "" {
-		skipf(t)("databricks_sql_table resource not available on GCP")
+		Skipf(t)("databricks_sql_table resource not available on GCP")
 	}
 	tableName := RandomName()
 	UnityWorkspaceLevel(t, Step{
@@ -513,7 +513,7 @@ func TestUcAccResourceSqlTable_DropColumn(t *testing.T) {
 
 func TestUcAccResourceSqlTable_DropMultipleColumns(t *testing.T) {
 	if os.Getenv("GOOGLE_CREDENTIALS") != "" {
-		skipf(t)("databricks_sql_table resource not available on GCP")
+		Skipf(t)("databricks_sql_table resource not available on GCP")
 	}
 	tableName := RandomName()
 	UnityWorkspaceLevel(t, Step{
@@ -529,7 +529,7 @@ func TestUcAccResourceSqlTable_DropMultipleColumns(t *testing.T) {
 
 func TestUcAccResourceSqlTable_AddColumn(t *testing.T) {
 	if os.Getenv("GOOGLE_CREDENTIALS") != "" {
-		skipf(t)("databricks_sql_table resource not available on GCP")
+		Skipf(t)("databricks_sql_table resource not available on GCP")
 	}
 	tableName := RandomName()
 	UnityWorkspaceLevel(t, Step{
@@ -544,7 +544,7 @@ func TestUcAccResourceSqlTable_AddColumn(t *testing.T) {
 
 func TestUcAccResourceSqlTable_AddMultipleColumns(t *testing.T) {
 	if os.Getenv("GOOGLE_CREDENTIALS") != "" {
-		skipf(t)("databricks_sql_table resource not available on GCP")
+		Skipf(t)("databricks_sql_table resource not available on GCP")
 	}
 	tableName := RandomName()
 	UnityWorkspaceLevel(t, Step{
@@ -560,7 +560,7 @@ func TestUcAccResourceSqlTable_AddMultipleColumns(t *testing.T) {
 
 func TestUcAccResourceSqlTable_AddColumnAndUpdateThrows(t *testing.T) {
 	if os.Getenv("GOOGLE_CREDENTIALS") != "" {
-		skipf(t)("databricks_sql_table resource not available on GCP")
+		Skipf(t)("databricks_sql_table resource not available on GCP")
 	}
 
 	tableName := RandomName()
@@ -577,7 +577,7 @@ func TestUcAccResourceSqlTable_AddColumnAndUpdateThrows(t *testing.T) {
 
 func TestUcAccResourceSqlTable_DropColumnAndUpdateThrows(t *testing.T) {
 	if os.Getenv("GOOGLE_CREDENTIALS") != "" {
-		skipf(t)("databricks_sql_table resource not available on GCP")
+		Skipf(t)("databricks_sql_table resource not available on GCP")
 	}
 
 	tableName := RandomName()

--- a/internal/acceptance/storage_credential_test.go
+++ b/internal/acceptance/storage_credential_test.go
@@ -5,8 +5,8 @@ import (
 )
 
 func TestUcAccStorageCredential(t *testing.T) {
-	loadUcwsEnv(t)
-	if isAws(t) {
+	LoadUcwsEnv(t)
+	if IsAws(t) {
 		UnityWorkspaceLevel(t, Step{
 			Template: `
 				resource "databricks_storage_credential" "external" {
@@ -28,7 +28,7 @@ func TestUcAccStorageCredential(t *testing.T) {
 					comment = "Managed by TF"
 				}`,
 		})
-	} else if isGcp(t) {
+	} else if IsGcp(t) {
 		UnityWorkspaceLevel(t, Step{
 			Template: `
 				resource "databricks_storage_credential" "external" {

--- a/internal/acceptance/vector_search_test.go
+++ b/internal/acceptance/vector_search_test.go
@@ -10,7 +10,7 @@ import (
 func TestUcAccVectorSearchEndpoint(t *testing.T) {
 	LoadUcwsEnv(t)
 	if IsGcp(t) {
-		skipf(t)("not available on GCP")
+		Skipf(t)("not available on GCP")
 	}
 
 	name := fmt.Sprintf("terraform-test-vector-search-%[1]s",

--- a/internal/acceptance/vector_search_test.go
+++ b/internal/acceptance/vector_search_test.go
@@ -8,8 +8,8 @@ import (
 )
 
 func TestUcAccVectorSearchEndpoint(t *testing.T) {
-	loadUcwsEnv(t)
-	if isGcp(t) {
+	LoadUcwsEnv(t)
+	if IsGcp(t) {
 		skipf(t)("not available on GCP")
 	}
 

--- a/internal/acceptance/workspace_conf_test.go
+++ b/internal/acceptance/workspace_conf_test.go
@@ -82,7 +82,7 @@ func TestAccWorkspaceConfFullLifecycle(t *testing.T) {
 }
 
 func TestAccWorkspaceConf_GetValidKey(t *testing.T) {
-	loadWorkspaceEnv(t)
+	LoadWorkspaceEnv(t)
 	ctx := context.Background()
 	w := databricks.Must(databricks.NewWorkspaceClient())
 	conf, err := workspace.SafeGetStatus(ctx, w, []string{"enableIpAccessLists"})
@@ -91,7 +91,7 @@ func TestAccWorkspaceConf_GetValidKey(t *testing.T) {
 }
 
 func TestAccWorkspaceConf_GetInvalidKey(t *testing.T) {
-	loadWorkspaceEnv(t)
+	LoadWorkspaceEnv(t)
 	ctx := context.Background()
 	w := databricks.Must(databricks.NewWorkspaceClient())
 	conf, err := workspace.SafeGetStatus(ctx, w, []string{"invalidKey", "enableIpAccessLists"})
@@ -100,7 +100,7 @@ func TestAccWorkspaceConf_GetInvalidKey(t *testing.T) {
 }
 
 func TestAccWorkspaceConf_GetOnlyInvalidKeys(t *testing.T) {
-	loadWorkspaceEnv(t)
+	LoadWorkspaceEnv(t)
 	ctx := context.Background()
 	w := databricks.Must(databricks.NewWorkspaceClient())
 	_, err := workspace.SafeGetStatus(ctx, w, []string{"invalidKey"})
@@ -108,7 +108,7 @@ func TestAccWorkspaceConf_GetOnlyInvalidKeys(t *testing.T) {
 }
 
 func TestAccWorkspaceConf_SetInvalidKey(t *testing.T) {
-	loadWorkspaceEnv(t)
+	LoadWorkspaceEnv(t)
 	ctx := context.Background()
 	w := databricks.Must(databricks.NewWorkspaceClient())
 	err := workspace.SafeSetStatus(ctx, w, map[string]struct{}{}, map[string]string{
@@ -118,7 +118,7 @@ func TestAccWorkspaceConf_SetInvalidKey(t *testing.T) {
 }
 
 func TestAccWorkspaceConf_DeleteInvalidKey(t *testing.T) {
-	loadWorkspaceEnv(t)
+	LoadWorkspaceEnv(t)
 	ctx := context.Background()
 	w := databricks.Must(databricks.NewWorkspaceClient())
 	err := workspace.SafeSetStatus(ctx, w, map[string]struct{}{"invalidKey": {}}, map[string]string{


### PR DESCRIPTION
## Changes
Plugin Framework resources may have integration tests that depend on some of the methods defined in `internal/acceptance/init.go`, namely the isAws/isGcp/isAzure functions, skipF, and load*Env functions. These are now exported and can be used by those integration test authors.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
