### PR TITLE
[Doc] Add a warning that attribute should be used in `databricks_permissions` for `databricks_vector_search_endpoint`

### DIFF
--- a/docs/resources/permissions.md
+++ b/docs/resources/permissions.md
@@ -643,6 +643,8 @@ resource "databricks_permissions" "ml_serving_usage" {
 
 Valid permission levels for [databricks_vector_search_endpoint](vector_search_endpoint.md) are: `CAN_USE` and `CAN_MANAGE`.
 
+-> You need to use the `endpoint_id` attribute of `databricks_vector_search_endpoint` as value for `vector_search_endpoint_id`, not the `id`!
+
 ```hcl
 resource "databricks_vector_search_endpoint" "this" {
   name          = "vector-search-test"


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

Resolves #4311

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK
