### PR TITLE
[Internal] Fix ReadOnly() for ListNestedAttribute and Validators for ListNestedBlock

### DIFF
--- a/internal/providers/pluginfw/tfschema/customizable_schema.go
+++ b/internal/providers/pluginfw/tfschema/customizable_schema.go
@@ -61,6 +61,8 @@ func (s *CustomizableSchema) AddValidator(v any, path ...string) *CustomizableSc
 			return a.AddValidator(v.(validator.List))
 		case ListNestedAttributeBuilder:
 			return a.AddValidator(v.(validator.List))
+		case ListNestedBlockBuilder:
+			return a.AddValidator(v.(validator.List))
 		case MapAttributeBuilder:
 			return a.AddValidator(v.(validator.Map))
 		case MapNestedAttributeBuilder:

--- a/internal/providers/pluginfw/tfschema/list_nested_attribute.go
+++ b/internal/providers/pluginfw/tfschema/list_nested_attribute.go
@@ -85,6 +85,7 @@ func (a ListNestedAttributeBuilder) SetReadOnly() AttributeBuilder {
 	a.Computed = true
 	a.Optional = false
 	a.Required = false
+	a.NestedObject.SetReadOnly()
 	return a
 }
 

--- a/internal/providers/pluginfw/tfschema/nested_attribute_object.go
+++ b/internal/providers/pluginfw/tfschema/nested_attribute_object.go
@@ -25,3 +25,9 @@ func (a NestedAttributeObject) BuildResourceAttribute() schema.NestedAttributeOb
 		Attributes: resourceAttributes,
 	}
 }
+
+func (a NestedAttributeObject) SetReadOnly() {
+	for attr, attrV := range a.Attributes {
+		a.Attributes[attr] = attrV.SetReadOnly()
+	}
+}


### PR DESCRIPTION
## Changes
Two small internal bugfixes in plugin framework support:
* ReadOnly() when applied to a list nested attribute should propagate recursively to all fields of the schema contained within the list.
* It should be possible to add a validator for a ListNestedBlock.

## Tests
Added unit tests for the ReadOnly() logic. 