### PR TITLE
[Internal] Mark TestAccServicePrincipalResourceOnAzure test as flaky

### DIFF
--- a/test-config.yaml
+++ b/test-config.yaml
@@ -18,3 +18,6 @@ ignored_tests:
     - package: github.com/databricks/terraform-provider-databricks/internal/acceptance
       test_name: TestUcAccVectorSearchEndpoint
       comment: Failure due to read-after-create inconsistency. https://databricks.atlassian.net/browse/ES-1243690
+    - package: github.com/databricks/terraform-provider-databricks/internal/acceptance
+      test_name: TestAccServicePrincipalResourceOnAzure
+      comment: Failure due to read-after-write inconsistency. Tracked in https://databricks.atlassian.net/browse/ES-1100061


### PR DESCRIPTION
## Changes
Mark TestAccServicePrincipalResourceOnAzure test as flaky

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] using Go SDK
- [ ] using TF Plugin Framework
