### PR TITLE
[Fix] Reflect backend updates in state for databricks_app

### DIFF
--- a/internal/providers/pluginfw/products/app/resource_app.go
+++ b/internal/providers/pluginfw/products/app/resource_app.go
@@ -177,7 +177,7 @@ func (a *resourceApp) Update(ctx context.Context, req resource.UpdateRequest, re
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	_, err := w.Apps.Update(ctx, apps.UpdateAppRequest{App: &appGoSdk, Name: app.Name.ValueString()})
+	response, err := w.Apps.Update(ctx, apps.UpdateAppRequest{App: &appGoSdk, Name: app.Name.ValueString()})
 	if err != nil {
 		resp.Diagnostics.AddError("failed to update app", err.Error())
 		return
@@ -185,7 +185,7 @@ func (a *resourceApp) Update(ctx context.Context, req resource.UpdateRequest, re
 
 	// Store the updated version of the app in state
 	var newApp apps_tf.App
-	resp.Diagnostics.Append(converters.GoSdkToTfSdkStruct(ctx, appGoSdk, &newApp)...)
+	resp.Diagnostics.Append(converters.GoSdkToTfSdkStruct(ctx, response, &newApp)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
Following #4099, updates to Databricks Apps only reflected the ones in the plan, and not the ones coming back from the backend call to update the app. This PR includes those changes in.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [x] covered with integration tests in `internal/acceptance`
- [x] using Go SDK
- [x] using TF Plugin Framework
