### PR TITLE
[Fix] Send only what is required in Update of `databricks_credential`

### DIFF
--- a/catalog/resource_credential.go
+++ b/catalog/resource_credential.go
@@ -146,8 +146,8 @@ func ResourceCredential() common.Resource {
 			if updateCredRequest.AzureManagedIdentity != nil {
 				updateCredRequest.AzureManagedIdentity.CredentialId = "" // this is Computed attribute
 			}
-			if updateCredRequest.DatabricksGcpServiceAccount != nil { // all attributes are computed
-				updateCredRequest.DatabricksGcpServiceAccount = &catalog.DatabricksGcpServiceAccount{}
+			if updateCredRequest.DatabricksGcpServiceAccount != nil {
+				updateCredRequest.DatabricksGcpServiceAccount.CredentialId = ""
 			}
 			// End of workaround
 			_, err = w.Credentials.UpdateCredential(ctx, updateCredRequest)

--- a/catalog/resource_credential.go
+++ b/catalog/resource_credential.go
@@ -139,6 +139,11 @@ func ResourceCredential() common.Resource {
 			}
 
 			updateCredRequest.Owner = ""
+			// Workaround until backend team fixes API issue
+			if updateCredRequest.AwsIamRole != nil { // Update API accepts only RoleArn, not the rest of attributes
+				updateCredRequest.AwsIamRole = &catalog.AwsIamRole{RoleArn: updateCredRequest.AwsIamRole.RoleArn}
+			}
+			// End of workaround
 			_, err = w.Credentials.UpdateCredential(ctx, updateCredRequest)
 			if err != nil {
 				if d.HasChange("owner") {

--- a/catalog/resource_credential.go
+++ b/catalog/resource_credential.go
@@ -146,8 +146,8 @@ func ResourceCredential() common.Resource {
 			if updateCredRequest.AzureManagedIdentity != nil {
 				updateCredRequest.AzureManagedIdentity.CredentialId = "" // this is Computed attribute
 			}
-			if updateCredRequest.DatabricksGcpServiceAccount != nil {
-				updateCredRequest.DatabricksGcpServiceAccount.CredentialId = ""
+			if updateCredRequest.DatabricksGcpServiceAccount != nil { // we can't update it at all
+				updateCredRequest.DatabricksGcpServiceAccount = nil
 			}
 			// End of workaround
 			_, err = w.Credentials.UpdateCredential(ctx, updateCredRequest)

--- a/catalog/resource_credential.go
+++ b/catalog/resource_credential.go
@@ -143,6 +143,12 @@ func ResourceCredential() common.Resource {
 			if updateCredRequest.AwsIamRole != nil { // Update API accepts only RoleArn, not the rest of attributes
 				updateCredRequest.AwsIamRole = &catalog.AwsIamRole{RoleArn: updateCredRequest.AwsIamRole.RoleArn}
 			}
+			if updateCredRequest.AzureManagedIdentity != nil {
+				updateCredRequest.AzureManagedIdentity.CredentialId = "" // this is Computed attribute
+			}
+			if updateCredRequest.DatabricksGcpServiceAccount != nil { // all attributes are computed
+				updateCredRequest.DatabricksGcpServiceAccount = &catalog.DatabricksGcpServiceAccount{}
+			}
 			// End of workaround
 			_, err = w.Credentials.UpdateCredential(ctx, updateCredRequest)
 			if err != nil {

--- a/catalog/resource_storage_credential.go
+++ b/catalog/resource_storage_credential.go
@@ -185,6 +185,9 @@ func ResourceStorageCredential() common.Resource {
 				if d.HasChange("read_only") {
 					update.ForceSendFields = append(update.ForceSendFields, "ReadOnly")
 				}
+				if update.DatabricksGcpServiceAccount != nil { // we can't update it at all
+					update.DatabricksGcpServiceAccount = nil
+				}
 				update.Owner = ""
 				_, err := acc.StorageCredentials.Update(ctx, catalog.AccountsUpdateStorageCredential{
 					CredentialInfo:        &update,
@@ -231,6 +234,9 @@ func ResourceStorageCredential() common.Resource {
 
 				if d.HasChange("read_only") {
 					update.ForceSendFields = append(update.ForceSendFields, "ReadOnly")
+				}
+				if update.DatabricksGcpServiceAccount != nil { // we can't update it at all
+					update.DatabricksGcpServiceAccount = nil
 				}
 				update.Owner = ""
 				_, err = w.StorageCredentials.Update(ctx, update)

--- a/internal/acceptance/storage_credential_test.go
+++ b/internal/acceptance/storage_credential_test.go
@@ -1,8 +1,20 @@
 package acceptance
 
 import (
+	"fmt"
 	"testing"
 )
+
+func gcpStorageCredentialWithComment(comment string) string {
+	// TODO: update purpose to SERVICE when it's released
+	return fmt.Sprintf(`
+				resource "databricks_storage_credential" "external" {
+					name = "cred-{var.RANDOM}"
+					databricks_gcp_service_account {}
+					skip_validation = true
+					comment = "%s"
+				}`, comment)
+}
 
 func TestUcAccStorageCredential(t *testing.T) {
 	LoadUcwsEnv(t)
@@ -30,13 +42,9 @@ func TestUcAccStorageCredential(t *testing.T) {
 		})
 	} else if IsGcp(t) {
 		UnityWorkspaceLevel(t, Step{
-			Template: `
-				resource "databricks_storage_credential" "external" {
-					name = "cred-{var.RANDOM}"
-					databricks_gcp_service_account {}
-					skip_validation = true
-					comment = "Managed by TF"
-				}`,
+			Template: gcpStorageCredentialWithComment("Managed by TF"),
+		}, Step{
+			Template: gcpStorageCredentialWithComment("Managed by TF updated"),
 		})
 	}
 }


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

This is a workaround for a problem in the API spec - right now, the Update operation tries to send the full struct, although the API accepts only one attribute of that struct.   For GCP we should omit the struct completely...

The problem doesn't exist for `storage_credential` on AWS as it uses the correct structure for the Update request, but problem exists for GCP.

Resolves #4335

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [x] covered with integration tests in `internal/acceptance`
- [x] using Go SDK
- [ ] using TF Plugin Framework
