### PR TITLE
[Internal] Retry on 504 when calling the permission API

### DIFF
--- a/common/retry_test.go
+++ b/common/retry_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/databricks/databricks-sdk-go/apierr"
 	"github.com/databricks/databricks-sdk-go/experimental/mocks"
 	"github.com/databricks/databricks-sdk-go/service/workspace"
 	"github.com/stretchr/testify/assert"
@@ -46,4 +47,88 @@ func TestRetryOnTimeout_NonRetriableError(t *testing.T) {
 		return w.WorkspaceClient.Workspace.GetStatusByPath(ctx, "path")
 	})
 	assert.ErrorIs(t, err, expected)
+}
+
+func TestRetryOn504_noError(t *testing.T) {
+	wantErr := error(nil)
+	wantRes := (*workspace.ObjectInfo)(nil)
+	wantCalls := 1
+
+	w := mocks.NewMockWorkspaceClient(t)
+	api := w.GetMockWorkspaceAPI().EXPECT()
+	api.GetStatusByPath(mock.Anything, mock.Anything).Return(wantRes, wantErr)
+
+	gotCalls := 0
+	gotRes, gotErr := RetryOn504(context.Background(), func(ctx context.Context) (*workspace.ObjectInfo, error) {
+		gotCalls += 1
+		return w.WorkspaceClient.Workspace.GetStatusByPath(ctx, "path")
+	})
+
+	assert.ErrorIs(t, gotErr, wantErr)
+	assert.Equal(t, gotRes, wantRes)
+	assert.Equal(t, gotCalls, wantCalls)
+}
+
+func TestRetryOn504_errorNot504(t *testing.T) {
+	wantErr := errors.New("test error")
+	wantRes := (*workspace.ObjectInfo)(nil)
+	wantCalls := 1
+
+	w := mocks.NewMockWorkspaceClient(t)
+	api := w.GetMockWorkspaceAPI().EXPECT()
+	api.GetStatusByPath(mock.Anything, mock.Anything).Return(wantRes, wantErr)
+
+	gotCalls := 0
+	gotRes, gotErr := RetryOn504(context.Background(), func(ctx context.Context) (*workspace.ObjectInfo, error) {
+		gotCalls += 1
+		return w.WorkspaceClient.Workspace.GetStatusByPath(ctx, "path")
+	})
+
+	assert.ErrorIs(t, gotErr, wantErr)
+	assert.Equal(t, gotRes, wantRes)
+	assert.Equal(t, gotCalls, wantCalls)
+}
+
+func TestRetryOn504_error504ThenFail(t *testing.T) {
+	wantErr := errors.New("test error")
+	wantRes := (*workspace.ObjectInfo)(nil)
+	wantCalls := 2
+
+	w := mocks.NewMockWorkspaceClient(t)
+	api := w.GetMockWorkspaceAPI().EXPECT()
+	call := api.GetStatusByPath(mock.Anything, mock.Anything).Return(nil, apierr.ErrDeadlineExceeded)
+	call.Repeatability = 1
+	api.GetStatusByPath(mock.Anything, mock.Anything).Return(wantRes, wantErr)
+
+	gotCalls := 0
+	gotRes, gotErr := RetryOn504(context.Background(), func(ctx context.Context) (*workspace.ObjectInfo, error) {
+		gotCalls++
+		return w.WorkspaceClient.Workspace.GetStatusByPath(ctx, "path")
+	})
+
+	assert.ErrorIs(t, gotErr, wantErr)
+	assert.Equal(t, gotRes, wantRes)
+	assert.Equal(t, gotCalls, wantCalls)
+}
+
+func TestRetryOn504_error504ThenSuccess(t *testing.T) {
+	wantErr := error(nil)
+	wantRes := &workspace.ObjectInfo{}
+	wantCalls := 2
+
+	w := mocks.NewMockWorkspaceClient(t)
+	api := w.GetMockWorkspaceAPI().EXPECT()
+	call := api.GetStatusByPath(mock.Anything, mock.Anything).Return(nil, apierr.ErrDeadlineExceeded)
+	call.Repeatability = 1
+	api.GetStatusByPath(mock.Anything, mock.Anything).Return(wantRes, wantErr)
+
+	gotCalls := 0
+	gotRes, gotErr := RetryOn504(context.Background(), func(ctx context.Context) (*workspace.ObjectInfo, error) {
+		gotCalls++
+		return w.WorkspaceClient.Workspace.GetStatusByPath(ctx, "path")
+	})
+
+	assert.ErrorIs(t, gotErr, wantErr)
+	assert.Equal(t, gotRes, wantRes)
+	assert.Equal(t, gotCalls, wantCalls)
 }


### PR DESCRIPTION
## Changes

This PR adds logic to retry failed get calls to the permissions API when the error is a 504. This solution is meant to be temporary and will be removed as soon as such retries are handled natively in the Databricks Go SDK. 

## Tests

Complete coverage of the added retrier. 
