### PR TITLE
[Internal] Restart Cluster before Library Installation

### DIFF
--- a/internal/providers/pluginfw/products/library/resource_library.go
+++ b/internal/providers/pluginfw/products/library/resource_library.go
@@ -141,7 +141,12 @@ func (r *LibraryResource) Create(ctx context.Context, req resource.CreateRequest
 		Libraries: []compute.Library{libGoSDK},
 	}
 	req.Plan.GetAttribute(ctx, path.Root("cluster_id"), &installLib.ClusterId)
-	err := w.Libraries.Install(ctx, installLib)
+	_, err := clusters.StartClusterAndGetInfo(ctx, w, installLib.ClusterId)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to start and get cluster", err.Error())
+		return
+	}
+	err = w.Libraries.Install(ctx, installLib)
 	if err != nil {
 		resp.Diagnostics.AddError("failed to install library", err.Error())
 		return

--- a/internal/providers/pluginfw/products/library/resource_library_acc_test.go
+++ b/internal/providers/pluginfw/products/library/resource_library_acc_test.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/databricks/databricks-sdk-go"
 	"github.com/databricks/databricks-sdk-go/apierr"
 	"github.com/databricks/databricks-sdk-go/retries"
+	"github.com/databricks/databricks-sdk-go/service/compute"
 	"github.com/databricks/terraform-provider-databricks/internal/acceptance"
 	"github.com/databricks/terraform-provider-databricks/internal/providers"
 	"github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw"
@@ -63,7 +65,7 @@ func TestAccLibraryReinstalledIfClusterDeleted(t *testing.T) {
 				return nil
 			},
 		},
-		// If the cluster is terminated before apply, it should be restarted and the library reinstalled.
+		// If the cluster is deleted before apply, it should be recreated and the library reinstalled on the new cluster.
 		acceptance.Step{
 			PreConfig: func() {
 				// Delete the created cluster
@@ -81,6 +83,43 @@ func TestAccLibraryReinstalledIfClusterDeleted(t *testing.T) {
 					}
 					return errClusterExists
 				})
+			},
+			Template: commonClusterConfig + `resource "databricks_library" "new_library" {
+				cluster_id = databricks_cluster.this.id
+				pypi {
+					repo = "https://pypi.org/dummy"
+					package = "databricks-sdk"
+				}
+		    }`,
+		})
+}
+
+func TestAccLibraryInstallIfClusterTerminated(t *testing.T) {
+	var clusterId string
+	acceptance.WorkspaceLevel(t,
+		acceptance.Step{
+			Template: commonClusterConfig,
+			Check: func(s *terraform.State) error {
+				clusterId = s.RootModule().Resources["databricks_cluster.this"].Primary.ID
+				return nil
+			},
+		},
+		// If the cluster is Terminated before apply, it should be restarted before installing library.
+		acceptance.Step{
+			PreConfig: func() {
+				// Delete the created cluster
+				w := databricks.Must(databricks.NewWorkspaceClient())
+				getter, err := w.Clusters.Delete(context.Background(), compute.DeleteCluster{
+					ClusterId: clusterId,
+				})
+				if err != nil {
+					// What to do
+				}
+				_, err = getter.GetWithTimeout(60 * time.Minute)
+				if err != nil {
+					// What to do
+				}
+				// Wait for the cluster to be completely deleted
 			},
 			Template: commonClusterConfig + `resource "databricks_library" "new_library" {
 				cluster_id = databricks_cluster.this.id


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
Library resource with SDK_V2 implementation waits for the cluster to get into the running state before starting installation. This PR mimics this behavior in the plugin framework implementation of the resource. 

Fixes https://github.com/databricks/terraform-provider-databricks/issues/4353
## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->
Added a integration test.
- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [x] covered with integration tests in `internal/acceptance`
- [ ] using Go SDK
- [ ] using TF Plugin Framework
