### PR TITLE
[Exporter] Add listing for `databricks_permissions` so we can emit permissions for tokens

### DIFF
--- a/docs/guides/experimental-exporter.md
+++ b/docs/guides/experimental-exporter.md
@@ -113,7 +113,7 @@ Services are just logical groups of resources used for filtering and organizatio
 -> **Note**
   Please note that for services not marked with **listing**, we'll export resources only if they are referenced from other resources.
 
-* `access` - [databricks_permissions](../resources/permissions.md), [databricks_instance_profile](../resources/instance_profile.md), [databricks_ip_access_list](../resources/ip_access_list.md), [databricks_mws_permission_assignment](../resources/mws_permission_assignment.md) and [databricks_access_control_rule_set](../resources/access_control_rule_set.md).
+* `access` -  **listing** [databricks_permissions](../resources/permissions.md), [databricks_instance_profile](../resources/instance_profile.md), [databricks_ip_access_list](../resources/ip_access_list.md), [databricks_mws_permission_assignment](../resources/mws_permission_assignment.md) and [databricks_access_control_rule_set](../resources/access_control_rule_set.md).   *Please note that for `databricks_permissions` we list only `authorization = "tokens"`, the permissions for other objects (notebooks, ...) will be emitted when corresponding objects are processed!*
 * `alerts` - **listing** [databricks_alert](../resources/alert.md).
 * `compute` - **listing** [databricks_cluster](../resources/cluster.md).
 * `dashboards` - **listing** [databricks_dashboard](../resources/dashboard.md).

--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -234,6 +234,13 @@ var meAdminFixture = qa.HTTPFixture{
 	},
 }
 
+var getTokensPermissionsFixture = qa.HTTPFixture{
+	Method:       "GET",
+	Resource:     "/api/2.0/permissions/authorization/tokens?",
+	Response:     getJSONObject("test-data/get-tokens-permissions.json"),
+	ReuseRequest: true,
+}
+
 var emptyPipelines = qa.HTTPFixture{
 	Method:       "GET",
 	ReuseRequest: true,
@@ -730,6 +737,7 @@ func TestImportingUsersGroupsSecretScopes(t *testing.T) {
 					Key:   "b",
 				},
 			},
+			getTokensPermissionsFixture,
 		}, func(ctx context.Context, client *common.DatabricksClient) {
 			tmpDir := fmt.Sprintf("/tmp/tf-%s", qa.RandomName())
 			defer os.RemoveAll(tmpDir)
@@ -1782,6 +1790,7 @@ func TestImportingIPAccessLists(t *testing.T) {
 			emptyRepos,
 			emptyWorkspaceConf,
 			allKnownWorkspaceConfsNoData,
+			getTokensPermissionsFixture,
 			{
 				Method:   "GET",
 				Resource: "/api/2.0/global-init-scripts",

--- a/exporter/importables.go
+++ b/exporter/importables.go
@@ -1024,6 +1024,16 @@ var resourcesMap map[string]importable = map[string]importable{
 			s := strings.Split(d.Id(), "/")
 			return s[len(s)-1]
 		},
+		List: func(ic *importContext) error {
+			if ic.meAdmin {
+				ic.Emit(&resource{
+					Resource: "databricks_permissions",
+					ID:       "/authorization/tokens",
+					Name:     "tokens_usage",
+				})
+			}
+			return nil
+		},
 		Depends: []reference{
 			{Path: "job_id", Resource: "databricks_job"},
 			{Path: "pipeline_id", Resource: "databricks_pipeline"},

--- a/exporter/test-data/get-tokens-permissions.json
+++ b/exporter/test-data/get-tokens-permissions.json
@@ -1,0 +1,15 @@
+{
+  "access_control_list": [
+    {
+      "all_permissions": [
+        {
+          "inherited":false,
+          "permission_level":"CAN_MANAGE"
+        }
+      ],
+      "group_name":"admins"
+    }
+  ],
+  "object_id":"/authorization/tokens",
+  "object_type":"tokens"
+}


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

It was a missing functionality when we emitted all permissions on existing objects, but didn't do it for permissions of personal access tokens.

Resolves #4389

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] using Go SDK
- [ ] using TF Plugin Framework
