### PR TITLE
[Doc] Added Queue Data Contributor role to Azure terraform docs

### DIFF
--- a/docs/guides/unity-catalog-azure.md
+++ b/docs/guides/unity-catalog-azure.md
@@ -152,6 +152,12 @@ resource "azurerm_role_assignment" "ext_storage" {
   role_definition_name = "Storage Blob Data Contributor"
   principal_id         = azurerm_databricks_access_connector.ext_access_connector.identity[0].principal_id
 }
+
+resource "azurerm_role_assignment" "ext_storage" {
+  scope                = azurerm_storage_account.ext_storage.id
+  role_definition_name = "Storage Queue Data Contributor"
+  principal_id         = azurerm_databricks_access_connector.ext_access_connector.identity[0].principal_id
+}
 ```
 
 Then create the [databricks_storage_credential](../resources/storage_credential.md) and [databricks_external_location](../resources/external_location.md) in Unity Catalog.


### PR DESCRIPTION
## Changes
The Queue Data Contributor role is required to support managed file events on Azure. This is already covered in the [Databricks user docs](https://learn.microsoft.com/en-us/azure/databricks/data-governance/unity-catalog/azure-managed-identities#grant-files), but not the terraform docs until now.

## Tests

- [ ] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] using Go SDK
- [ ] using TF Plugin Framework