### PR TITLE
[Fix] mishandling empty response in `databricks_mws_workspaces` data source

### DIFF
--- a/mws/data_mws_workspaces.go
+++ b/mws/data_mws_workspaces.go
@@ -9,7 +9,7 @@ import (
 
 func DataSourceMwsWorkspaces() common.Resource {
 	type mwsWorkspacesData struct {
-		Ids map[string]int64 `json:"ids,omitempty" tf:"computed"`
+		Ids map[string]int64 `json:"ids" tf:"computed"`
 	}
 	return common.DataResource(mwsWorkspacesData{}, func(ctx context.Context, e any, c *common.DatabricksClient) error {
 		data := e.(*mwsWorkspacesData)

--- a/mws/data_mws_workspaces_test.go
+++ b/mws/data_mws_workspaces_test.go
@@ -48,3 +48,23 @@ func TestCatalogsData_Error(t *testing.T) {
 		ID:          "_",
 	}.ExpectError(t, "i'm a teapot")
 }
+
+func TestDataSourceMwsWorkspaces_Empty(t *testing.T) {
+	qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "GET",
+				Resource: "/api/2.0/accounts/abc/workspaces",
+
+				Response: []Workspace{},
+			},
+		},
+		AccountID:   "abc",
+		Resource:    DataSourceMwsWorkspaces(),
+		Read:        true,
+		NonWritable: true,
+		ID:          "_",
+	}.ApplyAndExpectData(t, map[string]any{
+		"ids": map[string]any{},
+	})
+}


### PR DESCRIPTION
## Changes
This PR fixes the `databricks_mws_workspaces` datasource to correctly return an empty list when no mws workspaces are configured. It would previously return a nil, which caused certain Terraform programs to misbehave.

For example this would error instead of correctly returning 0:

```
data "databricks_mws_workspaces" "example" {}

output "workspace_ids" {
  value = data.databricks_mws_workspaces.example.ids
}

output "workspace_count" {
  value = length(data.databricks_mws_workspaces.example.ids)
}
```

## Tests
I've added a test similar to the existing tests for the mws_workspaces data source