### PR TITLE
[Fix] recreate `databricks_obo_token` if it's removed/expired

### DIFF
--- a/tokens/resource_obo_token.go
+++ b/tokens/resource_obo_token.go
@@ -3,6 +3,8 @@ package tokens
 import (
 	"context"
 	"fmt"
+	"log"
+	"time"
 
 	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -62,10 +64,23 @@ func ResourceOboToken() common.Resource {
 		Read: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
 			ot, err := NewTokenManagementAPI(ctx, c).Read(d.Id())
 			if err != nil {
-				return err
+				err = common.IgnoreNotFoundError(err)
+				if err != nil {
+					return err
+				}
+				log.Printf("[INFO] OBO token with id %s not found, recreating it", d.Id())
+				d.SetId("")
+			} else { // check if token is expired
+				if time.Now().UnixMilli() > ot.TokenInfo.ExpiryTime {
+					log.Printf("[INFO] OBO token with id %s is expired, recreating it", d.Id())
+					d.SetId("")
+				}
 			}
-			// this method is just a shim to check if token does still exist
-			return d.Set("comment", ot.TokenInfo.Comment)
+			if d.Id() != "" {
+				// set comment only if token exists
+				d.Set("comment", ot.TokenInfo.Comment)
+			}
+			return nil
 		},
 		Delete: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
 			return NewTokenManagementAPI(ctx, c).Delete(d.Id())


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

The backend still returns a token if it's expired. This PR recreates OBO token when it's removed or expires.

Resolves #4427

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] using Go SDK
- [ ] using TF Plugin Framework
