### PR TITLE
[Fix] Recreate `databricks_token` if it's not found or expired

### DIFF
--- a/docs/resources/token.md
+++ b/docs/resources/token.md
@@ -50,7 +50,7 @@ resource "databricks_token" "pat" {
 
 The following arguments are available:
 
-* `lifetime_seconds` - (Optional) (Integer) The lifetime of the token, in seconds. If no lifetime is specified, the token remains valid indefinitely.
+* `lifetime_seconds` - (Optional) (Integer) The lifetime of the token, in seconds. If no lifetime is specified, then expire time will be set to maximum allowed by the workspace configuration or platform.
 * `comment` - (Optional) (String) Comment that will appear on the user’s settings page for this token.
 
 ## Attribute Reference

--- a/tokens/resource_obo_token.go
+++ b/tokens/resource_obo_token.go
@@ -31,7 +31,8 @@ func (a TokenManagementAPI) CreateTokenOnBehalfOfServicePrincipal(request OboTok
 }
 
 func (a TokenManagementAPI) Delete(tokenID string) error {
-	return a.client.Delete(a.context, fmt.Sprintf("/token-management/tokens/%s", tokenID), map[string]any{})
+	err := a.client.Delete(a.context, fmt.Sprintf("/token-management/tokens/%s", tokenID), map[string]any{})
+	return common.IgnoreNotFoundError(err) // ignore not found error on delete, as it is idempotent
 }
 
 func (a TokenManagementAPI) Read(tokenID string) (ti TokenResponse, err error) {

--- a/tokens/resource_obo_token_test.go
+++ b/tokens/resource_obo_token_test.go
@@ -74,8 +74,8 @@ func TestResourceOboTokenRead_Error(t *testing.T) {
 		New:      true,
 		ID:       "abc",
 	}.ExpectError(t, "nope")
-}
 
+}
 func TestResourceOboTokenRead_NotFound(t *testing.T) {
 	qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

This is similar to #4428, but for `databricks_token`.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] using Go SDK
- [ ] using TF Plugin Framework
