### PR TITLE
[Internal] Fix integration tests failing due to parallel running

### DIFF
--- a/internal/acceptance/data_clusters_test.go
+++ b/internal/acceptance/data_clusters_test.go
@@ -72,7 +72,7 @@ func TestAccDataSourceClusters_FilterBy(t *testing.T) {
 	}, Step{
 		Template: `
 		resource "databricks_cluster_policy" "this" {
-			name = "test"
+			name = "test {var.RANDOM}"
 			definition = jsonencode({
 				"spark_conf.spark.hadoop.javax.jdo.option.ConnectionURL": {
 					"type": "fixed",

--- a/internal/acceptance/provider_test.go
+++ b/internal/acceptance/provider_test.go
@@ -8,7 +8,7 @@ func TestUcAccCreateProviderDb2Open(t *testing.T) {
 	UnityWorkspaceLevel(t, Step{
 		Template: `
 		resource "databricks_provider" "this" {
-			name = "terraform-test-provider"
+			name = "terraform-test-provider-{var.RANDOM}"
 			comment = "made by terraform"
 			authentication_type = "TOKEN"
 			recipient_profile_str = jsonencode({


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
This PR fixes a few integration tests that fail because of parallel running.
- Give different names for each resource that is created.
- Modify the notification test to verify the presence of the newly created notification destination within the existing notification destination resources, rather than checking if it is the sole resource in existence.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [x] covered with integration tests in `internal/acceptance`
- [ ] using Go SDK
- [ ] using TF Plugin Framework
