### PR TITLE
[Fix] Mark `task.spark_jar_task.run_as_repl` as `computed` to fix configuration drift

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Bug Fixes
 
  * Correctly handle PAT and OBO tokens without expiration ([#4444](https://github.com/databricks/terraform-provider-databricks/pull/4444)).
+ * Mark `task.spark_jar_task.run_as_repl` as `computed` to fix configuration drift ([#4452](https://github.com/databricks/terraform-provider-databricks/pull/4452)).
 
 ### Documentation
 

--- a/jobs/resource_job.go
+++ b/jobs/resource_job.go
@@ -530,6 +530,7 @@ func (JobSettingsResource) CustomizeSchema(s *common.CustomizableSchema) *common
 	s.SchemaPath("run_as").SetComputed()
 	s.SchemaPath("task", "retry_on_timeout").SetComputed()
 	s.SchemaPath("task", "for_each_task", "task", "retry_on_timeout").SetComputed()
+	s.SchemaPath("task", "spark_jar_task", "run_as_repl").SetComputed()
 	s.SchemaPath("format").SetComputed()
 
 	// Default


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

Resolves #4450

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] using Go SDK
- [ ] using TF Plugin Framework
