### PR TITLE
[Doc] Remove mention that `databricks_credential` is storage-only on GCP

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Documentation
 
  * Fix attribute name in `databricks_instance_profile` examples ([#4426](https://github.com/databricks/terraform-provider-databricks/pull/4426)).
+ * Remove mention that databricks_credential is storage-only on GCP ([#4460](https://github.com/databricks/terraform-provider-databricks/pull/4460)).
 
 ### Exporter
 

--- a/docs/resources/credential.md
+++ b/docs/resources/credential.md
@@ -58,13 +58,13 @@ resource "databricks_grants" "external_creds" {
 }
 ```
 
-For GCP (only applicable when purpose is `STORAGE`)
+For GCP 
 
 ```hcl
 resource "databricks_credential" "external_gcp_sa" {
   name = "gcp_sa_credential"
   databricks_gcp_service_account {}
-  purpose = "STORAGE"
+  purpose = "SERVICE"
   comment = "GCP SA credential managed by TF"
 }
 
@@ -106,7 +106,7 @@ The following arguments are required:
 - `application_id` - The application ID of the application registration within the referenced AAD tenant
 - `client_secret` - The client secret generated for the above app ID in AAD. **This field is redacted on output**
 
-`databricks_gcp_service_account` optional configuration block for creating a Databricks-managed GCP Service Account.  Only applicable when purpose is `STORAGE`:
+`databricks_gcp_service_account` optional configuration block for creating a Databricks-managed GCP Service Account:
 
 - `email` (output only) - The email of the GCP service account created, to be granted access to relevant buckets.
 

--- a/internal/acceptance/credential_test.go
+++ b/internal/acceptance/credential_test.go
@@ -19,12 +19,11 @@ func awsCredentialWithComment(comment string) string {
 }
 
 func gcpCredentialWithComment(comment string) string {
-	// TODO: update purpose to SERVICE when it's released
 	return fmt.Sprintf(`
 				resource "databricks_credential" "external" {
-					name = "storage-cred-{var.STICKY_RANDOM}"
+					name = "service-cred-{var.STICKY_RANDOM}"
 					databricks_gcp_service_account {}
-					purpose = "STORAGE"
+					purpose = "SERVICE"
 					skip_validation = true
 					comment = "%s"
 				}`, comment)


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

As we started supporting service credentials on GCP, documentation should be updated to remove that `databricks_credential` could be used only with `purpose = "STORAGE"`.

Also, updated integration test to use `purpose = "SERVICE"`.



## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [x] relevant change in `docs/` folder
- [x] covered with integration tests in `internal/acceptance`
- [ ] using Go SDK
- [ ] using TF Plugin Framework
