### PR TITLE
[Doc] Officially deprecate `databricks_table` and add migration instructions

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -13,6 +13,7 @@
 
  * Fix attribute name in `databricks_instance_profile` examples ([#4426](https://github.com/databricks/terraform-provider-databricks/pull/4426)).
  * Remove mention that databricks_credential is storage-only on GCP ([#4460](https://github.com/databricks/terraform-provider-databricks/pull/4460)).
+ * Officially document `databricks_table` as deprecated. Users of this resource should migrate to `databricks_sql_table`. See https://registry.terraform.io/providers/databricks/databricks/latest/docs/resources/sql_table for more information.
 
 ### Exporter
 

--- a/catalog/resource_table.go
+++ b/catalog/resource_table.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/databricks/terraform-provider-databricks/common"
+	"github.com/databricks/terraform-provider-databricks/internal/docs"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -103,5 +104,6 @@ func ResourceTable() common.Resource {
 		Delete: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
 			return NewTablesAPI(ctx, c).deleteTable(d.Id())
 		},
+		DeprecationMessage: fmt.Sprintf("databricks_table is deprecated in favor of databricks_sql_table. Please see %s for more information.", docs.ResourceDocumentationUrl("sql_table")),
 	}
 }

--- a/docs/resources/sql_table.md
+++ b/docs/resources/sql_table.md
@@ -201,8 +201,8 @@ terraform import databricks_sql_table.this <catalog_name>.<schema_name>.<name>
 
 The `databricks_table` resource has been deprecated in favor of `databricks_sql_table`. To migrate from `databricks_table` to `databricks_sql_table`:
 1. Define a `databricks_sql_table` resource with arguments corresponding to `databricks_table`.
-2. Add a `removed` block to remove the `databricks_table` resource without deleting the existing table by using the `lifecycle` block.
-3. Add an `import` block to add the `databricks_sql_table` resource, corresponding to the existing table.
+2. Add a `removed` block to remove the `databricks_table` resource without deleting the existing table by using the `lifecycle` block. If you're using Terraform version below v1.7.0, you will need to use the `terraform state rm` command instead.
+3. Add an `import` block to add the `databricks_sql_table` resource, corresponding to the existing table. If you're using Terraform version below v1.5.0, you will need to use `terraform import` command instead.
 
 For example, suppose we have the following `databricks_table` resource:
 ```hcl
@@ -211,7 +211,7 @@ resource "databricks_table" "this" {
   schema_name = "schema"
   name = "table"
   table_type = "MANAGED"
-  data_source_format = "FORMAT"
+  data_source_format = "DELTA"
   column {
     name = "col1"
     type_name = "STRING"
@@ -219,8 +219,6 @@ resource "databricks_table" "this" {
     comment = "comment"
     nullable = true
   }
-  storage_location = "path/to/location"
-  storage_credential_name = "credential"
   comment = "comment"
   properties = {
     key = "value"
@@ -253,7 +251,7 @@ resource "databricks_sql_table" "this" {
   schema_name = "schema"
   name = "table"
   table_type = "MANAGED"
-  data_source_format = "FORMAT"
+  data_source_format = "DELTA"
   column {
     name = "col1"
     type = "STRING"   # <-- changed from type_name
@@ -261,8 +259,6 @@ resource "databricks_sql_table" "this" {
     comment = "comment"
     nullable = true
   }
-  storage_location = "path/to/location"
-  storage_credential_name = "credential"
   comment = "comment"
   properties = {
     key = "value"
@@ -271,5 +267,3 @@ resource "databricks_sql_table" "this" {
 ```
 
 Finally, run `terraform plan` to verify the changes, followed by `terraform apply` to apply the changes.
-
-If you're using Terraform on a version before v1.7.0, you will need to use the `terraform state rm` CLI command to remove the `databricks_table` from your Terraform state. If you're using a version before v1.5.0, you will need to use `terraform import` to import the existing table into the new `databricks_sql_table` resource.

--- a/docs/resources/sql_table.md
+++ b/docs/resources/sql_table.md
@@ -196,3 +196,80 @@ This resource can be imported by its full name:
 ```bash
 terraform import databricks_sql_table.this <catalog_name>.<schema_name>.<name>
 ```
+
+## Migration from `databricks_table`
+
+The `databricks_table` resource has been deprecated in favor of `databricks_sql_table`. To migrate from `databricks_table` to `databricks_sql_table`:
+1. Define a `databricks_sql_table` resource with arguments corresponding to `databricks_table`.
+2. Add a `removed` block to remove the `databricks_table` resource without deleting the existing table by using the `lifecycle` block.
+3. Add an `import` block to add the `databricks_sql_table` resource, corresponding to the existing table.
+
+For example, suppose we have the following `databricks_table` resource:
+```hcl
+resource "databricks_table" "this" {
+  catalog_name = "catalog"
+  schema_name = "schema"
+  name = "table"
+  table_type = "MANAGED"
+  data_source_format = "FORMAT"
+  column {
+    name = "col1"
+    type_name = "STRING"
+    type_json = "{\"type\":\"STRING\"}"
+    comment = "comment"
+    nullable = true
+  }
+  storage_location = "path/to/location"
+  storage_credential_name = "credential"
+  comment = "comment"
+  properties = {
+    key = "value"
+  }
+}
+```
+
+The migration would look like this:
+```hcl
+# Leave this resource definition as-is.
+resource "databricks_table" "this" { ... }
+
+# Remove the old resource without destroying the existing table.
+removed {
+  from = databricks_table.this.id
+  lifecycle {
+    destroy = false
+  }
+}
+
+# Import the existing table as a databricks_sql_table.
+import {
+  to = databricks_sql_table.this
+  id = "<catalog_name>.<schema_name>.<name>"
+}
+
+# Define the new databricks_sql_table resource.
+resource "databricks_sql_table" "this" {
+  catalog_name = "catalog"
+  schema_name = "schema"
+  name = "table"
+  table_type = "MANAGED"
+  data_source_format = "FORMAT"
+  column {
+    name = "col1"
+    type = "STRING"   # <-- changed from type_name
+    type_json = "{\"type\":\"STRING\"}"
+    comment = "comment"
+    nullable = true
+  }
+  storage_location = "path/to/location"
+  storage_credential_name = "credential"
+  comment = "comment"
+  properties = {
+    key = "value"
+  }
+}
+```
+
+Finally, run `terraform plan` to verify the changes, followed by `terraform apply` to apply the changes.
+
+If you're using Terraform on a version before v1.7.0, you will need to use the `terraform state rm` CLI command to remove the `databricks_table` from your Terraform state. If you're using a version before v1.5.0, you will need to use `terraform import` to import the existing table into the new `databricks_sql_table` resource.


### PR DESCRIPTION
## Changes
Some customers are confused about the inconsistent state of the `databricks_table` resource. It is not documented, but it is also not deprecated officially. This PR clarifies this by finally marking the resource as deprecated, as it has been replaced by `databricks_sql_table`. The documentation explains how to migrate from the old resource to the new.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] using Go SDK
- [ ] using TF Plugin Framework
