### PR TITLE
[Fix] Do not send `run_as` when updating `databricks_pipeline` when not specified

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -1,10 +1,12 @@
 # NEXT CHANGELOG
 
-## Release v1.66.0
+## Release v1.65.1
 
 ### New Features and Improvements
 
 ### Bug Fixes
+
+ * Do not send `run_as` when updating `databricks_pipeline` resource if no change is planned.
 
 ### Documentation
 

--- a/pipelines/pipeline_test.go
+++ b/pipelines/pipeline_test.go
@@ -96,6 +96,9 @@ func TestAccPipelineResource_CreatePipeline(t *testing.T) {
 }
 
 func pipelineRunAsTemplate(runAs string) string {
+	if runAs != "" {
+		runAs = `run_as { ` + runAs + ` }`
+	}
 	return `
 	data "databricks_current_user" "me" {}
 
@@ -135,9 +138,7 @@ func pipelineRunAsTemplate(runAs string) string {
 
 		continuous = false
 
-		run_as {
-			` + runAs + `
-		}
+		` + runAs + `
 	}
 	` + dltNotebookResource
 }
@@ -179,6 +180,10 @@ func TestUcAccPipelineRunAsMutations(t *testing.T) {
 		// Update job back to a service principal `run_as`
 		acceptance.Step{
 			Template: pipelineRunAsTemplate(`service_principal_name = "` + spId + `"`),
+		},
+		// Remove run_as, and there should be no change.
+		acceptance.Step{
+			Template: pipelineRunAsTemplate(""),
 		},
 	)
 }

--- a/pipelines/resource_pipeline.go
+++ b/pipelines/resource_pipeline.go
@@ -71,6 +71,12 @@ func Update(w *databricks.WorkspaceClient, ctx context.Context, d *schema.Resour
 	common.DataToStructPointer(d, pipelineSchema, &updatePipelineRequest)
 	updatePipelineRequest.EditPipeline.PipelineId = d.Id()
 	adjustForceSendFields(&updatePipelineRequest.Clusters)
+	// Workspaces not enrolled in the private preview must not send run_as in the update request.
+	// If run_as was persisted in state because of a `terraform refresh`, there will not be a planned change
+	// as long as the user hasn't specified a value.
+	if !d.HasChange("run_as") {
+		updatePipelineRequest.RunAs = nil
+	}
 
 	err := w.Pipelines.Update(ctx, updatePipelineRequest.EditPipeline)
 	if err != nil {


### PR DESCRIPTION
## Changes
A recent change to add support for `run_as` in pipelines causes pipeline update requests to include the `run_as` field. The Get Pipeline always returns the `run_as_user_name` for a pipeline, even for workspaces not in the private preview. Some users may have `run_as` in their TF state now, even if they did not specify it in their configuration. As we are using SDKv2 for this resource, it isn't straightforward to see whether the user actually included `run_as` in their configuration or if it is only in the state because of the change to the `Read` method.

This PR addresses this by only sending `run_as` if there is a planned change in the `run_as` field. If the user doesn't set `run_as` explicitly (as in existing customers not in the private preview), or if it is set to the same value as the `run_as_user_name` field, the provider does not need to set `run_as`, so it can be removed from the request.

Resolves #4469.

## Tests

- [x] Created & updated a pipeline in a workspace without run_as preview enabled; succeeded.
- [x] Created & updated a pipeline in a workspace with run_as preview enabled; succeeded.