### PR TITLE
[Feature] Support updating `options` in `databricks_catalog`

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### New Features and Improvements
 
+ * Support updating `options` in `databricks_catalog`.
+
 ### Bug Fixes
 
 ### Documentation

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### New Features and Improvements
 
- * Support updating `options` in `databricks_catalog`.
+ * Support updating `options` in `databricks_catalog` ([#4476](https://github.com/databricks/terraform-provider-databricks/pull/4476)).
 
 ### Bug Fixes
 

--- a/catalog/resource_catalog.go
+++ b/catalog/resource_catalog.go
@@ -36,7 +36,7 @@ type CatalogInfo struct {
 	ShareName                    string            `json:"share_name,omitempty" tf:"force_new,conflicts:storage_root"`
 	ConnectionName               string            `json:"connection_name,omitempty" tf:"force_new,conflicts:storage_root"`
 	EnablePredictiveOptimization string            `json:"enable_predictive_optimization,omitempty" tf:"computed"`
-	Options                      map[string]string `json:"options,omitempty" tf:"force_new"`
+	Options                      map[string]string `json:"options,omitempty"`
 	Properties                   map[string]string `json:"properties,omitempty"`
 	Owner                        string            `json:"owner,omitempty" tf:"computed"`
 	IsolationMode                string            `json:"isolation_mode,omitempty" tf:"computed"`


### PR DESCRIPTION
## Changes
The `options` field was previously not exposed in the REST API, so it was not possible for Terraform to update options for a catalog. This has now been added, so we can remove `force_new` from `options`.

## Tests
- [ ] Manually created a catalog with no options, then added an option to it.
