### PR TITLE
[WIP][Feature] Validate enum values in the plugin framework

### DIFF
--- a/internal/providers/pluginfw/auto_generation.go
+++ b/internal/providers/pluginfw/auto_generation.go
@@ -1,4 +1,5 @@
 // Code generated from OpenAPI specs by Databricks SDK Generator. DO NOT EDIT.
+
 package pluginfw
 
 import (

--- a/internal/service/apps_tf/legacy_model.go
+++ b/internal/service/apps_tf/legacy_model.go
@@ -18,6 +18,7 @@ import (
 	"github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/tfschema"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
@@ -321,6 +322,7 @@ func (newState *AppAccessControlRequest_SdkV2) SyncEffectiveFieldsDuringRead(exi
 func (c AppAccessControlRequest_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["group_name"] = attrs["group_name"].SetOptional()
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_MANAGE", "CAN_USE"))
 	attrs["service_principal_name"] = attrs["service_principal_name"].SetOptional()
 	attrs["user_name"] = attrs["user_name"].SetOptional()
 
@@ -500,6 +502,7 @@ func (c AppDeployment_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema
 	attrs["deployment_artifacts"] = attrs["deployment_artifacts"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["deployment_id"] = attrs["deployment_id"].SetOptional()
 	attrs["mode"] = attrs["mode"].SetOptional()
+	attrs["mode"] = attrs["mode"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("AUTO_SYNC", "SNAPSHOT"))
 	attrs["source_code_path"] = attrs["source_code_path"].SetOptional()
 	attrs["status"] = attrs["status"].SetComputed()
 	attrs["status"] = attrs["status"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
@@ -677,6 +680,7 @@ func (newState *AppDeploymentStatus_SdkV2) SyncEffectiveFieldsDuringRead(existin
 func (c AppDeploymentStatus_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["message"] = attrs["message"].SetComputed()
 	attrs["state"] = attrs["state"].SetComputed()
+	attrs["state"] = attrs["state"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CANCELLED", "FAILED", "IN_PROGRESS", "SUCCEEDED"))
 
 	return attrs
 }
@@ -732,6 +736,7 @@ func (c AppPermission_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema
 	attrs["inherited"] = attrs["inherited"].SetOptional()
 	attrs["inherited_from_object"] = attrs["inherited_from_object"].SetOptional()
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_MANAGE", "CAN_USE"))
 
 	return attrs
 }
@@ -903,6 +908,7 @@ func (newState *AppPermissionsDescription_SdkV2) SyncEffectiveFieldsDuringRead(e
 func (c AppPermissionsDescription_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["description"] = attrs["description"].SetOptional()
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_MANAGE", "CAN_USE"))
 
 	return attrs
 }
@@ -1233,6 +1239,7 @@ func (newState *AppResourceJob_SdkV2) SyncEffectiveFieldsDuringRead(existingStat
 func (c AppResourceJob_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["id"] = attrs["id"].SetRequired()
 	attrs["permission"] = attrs["permission"].SetRequired()
+	attrs["permission"] = attrs["permission"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_MANAGE", "CAN_MANAGE_RUN", "CAN_VIEW", "IS_OWNER"))
 
 	return attrs
 }
@@ -1289,6 +1296,7 @@ func (newState *AppResourceSecret_SdkV2) SyncEffectiveFieldsDuringRead(existingS
 func (c AppResourceSecret_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["key"] = attrs["key"].SetRequired()
 	attrs["permission"] = attrs["permission"].SetRequired()
+	attrs["permission"] = attrs["permission"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("MANAGE", "READ", "WRITE"))
 	attrs["scope"] = attrs["scope"].SetRequired()
 
 	return attrs
@@ -1346,6 +1354,7 @@ func (newState *AppResourceServingEndpoint_SdkV2) SyncEffectiveFieldsDuringRead(
 func (c AppResourceServingEndpoint_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["name"] = attrs["name"].SetRequired()
 	attrs["permission"] = attrs["permission"].SetRequired()
+	attrs["permission"] = attrs["permission"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_MANAGE", "CAN_QUERY", "CAN_VIEW"))
 
 	return attrs
 }
@@ -1400,6 +1409,7 @@ func (newState *AppResourceSqlWarehouse_SdkV2) SyncEffectiveFieldsDuringRead(exi
 func (c AppResourceSqlWarehouse_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["id"] = attrs["id"].SetRequired()
 	attrs["permission"] = attrs["permission"].SetRequired()
+	attrs["permission"] = attrs["permission"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_MANAGE", "CAN_USE", "IS_OWNER"))
 
 	return attrs
 }
@@ -1453,6 +1463,7 @@ func (newState *ApplicationStatus_SdkV2) SyncEffectiveFieldsDuringRead(existingS
 func (c ApplicationStatus_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["message"] = attrs["message"].SetComputed()
 	attrs["state"] = attrs["state"].SetComputed()
+	attrs["state"] = attrs["state"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CRASHED", "DEPLOYING", "RUNNING", "UNAVAILABLE"))
 
 	return attrs
 }
@@ -1506,6 +1517,7 @@ func (newState *ComputeStatus_SdkV2) SyncEffectiveFieldsDuringRead(existingState
 func (c ComputeStatus_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["message"] = attrs["message"].SetComputed()
 	attrs["state"] = attrs["state"].SetComputed()
+	attrs["state"] = attrs["state"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ACTIVE", "DELETING", "ERROR", "STARTING", "STOPPED", "STOPPING", "UPDATING"))
 
 	return attrs
 }

--- a/internal/service/apps_tf/model.go
+++ b/internal/service/apps_tf/model.go
@@ -17,6 +17,7 @@ import (
 	pluginfwcommon "github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/common"
 	"github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/tfschema"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
@@ -316,6 +317,7 @@ func (newState *AppAccessControlRequest) SyncEffectiveFieldsDuringRead(existingS
 func (c AppAccessControlRequest) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["group_name"] = attrs["group_name"].SetOptional()
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_MANAGE", "CAN_USE"))
 	attrs["service_principal_name"] = attrs["service_principal_name"].SetOptional()
 	attrs["user_name"] = attrs["user_name"].SetOptional()
 
@@ -494,6 +496,7 @@ func (c AppDeployment) ApplySchemaCustomizations(attrs map[string]tfschema.Attri
 	attrs["deployment_artifacts"] = attrs["deployment_artifacts"].SetComputed()
 	attrs["deployment_id"] = attrs["deployment_id"].SetOptional()
 	attrs["mode"] = attrs["mode"].SetOptional()
+	attrs["mode"] = attrs["mode"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("AUTO_SYNC", "SNAPSHOT"))
 	attrs["source_code_path"] = attrs["source_code_path"].SetOptional()
 	attrs["status"] = attrs["status"].SetComputed()
 	attrs["update_time"] = attrs["update_time"].SetComputed()
@@ -670,6 +673,7 @@ func (newState *AppDeploymentStatus) SyncEffectiveFieldsDuringRead(existingState
 func (c AppDeploymentStatus) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["message"] = attrs["message"].SetComputed()
 	attrs["state"] = attrs["state"].SetComputed()
+	attrs["state"] = attrs["state"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CANCELLED", "FAILED", "IN_PROGRESS", "SUCCEEDED"))
 
 	return attrs
 }
@@ -725,6 +729,7 @@ func (c AppPermission) ApplySchemaCustomizations(attrs map[string]tfschema.Attri
 	attrs["inherited"] = attrs["inherited"].SetOptional()
 	attrs["inherited_from_object"] = attrs["inherited_from_object"].SetOptional()
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_MANAGE", "CAN_USE"))
 
 	return attrs
 }
@@ -896,6 +901,7 @@ func (newState *AppPermissionsDescription) SyncEffectiveFieldsDuringRead(existin
 func (c AppPermissionsDescription) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["description"] = attrs["description"].SetOptional()
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_MANAGE", "CAN_USE"))
 
 	return attrs
 }
@@ -1222,6 +1228,7 @@ func (newState *AppResourceJob) SyncEffectiveFieldsDuringRead(existingState AppR
 func (c AppResourceJob) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["id"] = attrs["id"].SetRequired()
 	attrs["permission"] = attrs["permission"].SetRequired()
+	attrs["permission"] = attrs["permission"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_MANAGE", "CAN_MANAGE_RUN", "CAN_VIEW", "IS_OWNER"))
 
 	return attrs
 }
@@ -1278,6 +1285,7 @@ func (newState *AppResourceSecret) SyncEffectiveFieldsDuringRead(existingState A
 func (c AppResourceSecret) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["key"] = attrs["key"].SetRequired()
 	attrs["permission"] = attrs["permission"].SetRequired()
+	attrs["permission"] = attrs["permission"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("MANAGE", "READ", "WRITE"))
 	attrs["scope"] = attrs["scope"].SetRequired()
 
 	return attrs
@@ -1335,6 +1343,7 @@ func (newState *AppResourceServingEndpoint) SyncEffectiveFieldsDuringRead(existi
 func (c AppResourceServingEndpoint) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["name"] = attrs["name"].SetRequired()
 	attrs["permission"] = attrs["permission"].SetRequired()
+	attrs["permission"] = attrs["permission"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_MANAGE", "CAN_QUERY", "CAN_VIEW"))
 
 	return attrs
 }
@@ -1389,6 +1398,7 @@ func (newState *AppResourceSqlWarehouse) SyncEffectiveFieldsDuringRead(existingS
 func (c AppResourceSqlWarehouse) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["id"] = attrs["id"].SetRequired()
 	attrs["permission"] = attrs["permission"].SetRequired()
+	attrs["permission"] = attrs["permission"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_MANAGE", "CAN_USE", "IS_OWNER"))
 
 	return attrs
 }
@@ -1442,6 +1452,7 @@ func (newState *ApplicationStatus) SyncEffectiveFieldsDuringRead(existingState A
 func (c ApplicationStatus) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["message"] = attrs["message"].SetComputed()
 	attrs["state"] = attrs["state"].SetComputed()
+	attrs["state"] = attrs["state"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CRASHED", "DEPLOYING", "RUNNING", "UNAVAILABLE"))
 
 	return attrs
 }
@@ -1495,6 +1506,7 @@ func (newState *ComputeStatus) SyncEffectiveFieldsDuringRead(existingState Compu
 func (c ComputeStatus) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["message"] = attrs["message"].SetComputed()
 	attrs["state"] = attrs["state"].SetComputed()
+	attrs["state"] = attrs["state"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ACTIVE", "DELETING", "ERROR", "STARTING", "STOPPED", "STOPPING", "UPDATING"))
 
 	return attrs
 }

--- a/internal/service/billing_tf/legacy_model.go
+++ b/internal/service/billing_tf/legacy_model.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/databricks/terraform-provider-databricks/internal/service/compute_tf"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
@@ -42,6 +43,7 @@ func (newState *ActionConfiguration_SdkV2) SyncEffectiveFieldsDuringRead(existin
 func (c ActionConfiguration_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["action_configuration_id"] = attrs["action_configuration_id"].SetOptional()
 	attrs["action_type"] = attrs["action_type"].SetOptional()
+	attrs["action_type"] = attrs["action_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("EMAIL_NOTIFICATION"))
 	attrs["target"] = attrs["target"].SetOptional()
 
 	return attrs
@@ -112,8 +114,11 @@ func (c AlertConfiguration_SdkV2) ApplySchemaCustomizations(attrs map[string]tfs
 	attrs["alert_configuration_id"] = attrs["alert_configuration_id"].SetOptional()
 	attrs["quantity_threshold"] = attrs["quantity_threshold"].SetOptional()
 	attrs["quantity_type"] = attrs["quantity_type"].SetOptional()
+	attrs["quantity_type"] = attrs["quantity_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("LIST_PRICE_DOLLARS_USD"))
 	attrs["time_period"] = attrs["time_period"].SetOptional()
+	attrs["time_period"] = attrs["time_period"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("MONTH"))
 	attrs["trigger_type"] = attrs["trigger_type"].SetOptional()
+	attrs["trigger_type"] = attrs["trigger_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CUMULATIVE_SPENDING_EXCEEDED"))
 
 	return attrs
 }
@@ -460,6 +465,7 @@ func (newState *BudgetConfigurationFilterClause_SdkV2) SyncEffectiveFieldsDuring
 
 func (c BudgetConfigurationFilterClause_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["operator"] = attrs["operator"].SetOptional()
+	attrs["operator"] = attrs["operator"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("IN"))
 	attrs["values"] = attrs["values"].SetOptional()
 
 	return attrs
@@ -625,6 +631,7 @@ func (newState *BudgetConfigurationFilterWorkspaceIdClause_SdkV2) SyncEffectiveF
 
 func (c BudgetConfigurationFilterWorkspaceIdClause_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["operator"] = attrs["operator"].SetOptional()
+	attrs["operator"] = attrs["operator"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("IN"))
 	attrs["values"] = attrs["values"].SetOptional()
 
 	return attrs
@@ -803,6 +810,7 @@ func (newState *CreateBillingUsageDashboardRequest_SdkV2) SyncEffectiveFieldsDur
 
 func (c CreateBillingUsageDashboardRequest_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["dashboard_type"] = attrs["dashboard_type"].SetOptional()
+	attrs["dashboard_type"] = attrs["dashboard_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("USAGE_DASHBOARD_TYPE_GLOBAL", "USAGE_DASHBOARD_TYPE_WORKSPACE"))
 	attrs["workspace_id"] = attrs["workspace_id"].SetOptional()
 
 	return attrs
@@ -1031,6 +1039,7 @@ func (newState *CreateBudgetConfigurationBudgetActionConfigurations_SdkV2) SyncE
 
 func (c CreateBudgetConfigurationBudgetActionConfigurations_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["action_type"] = attrs["action_type"].SetOptional()
+	attrs["action_type"] = attrs["action_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("EMAIL_NOTIFICATION"))
 	attrs["target"] = attrs["target"].SetOptional()
 
 	return attrs
@@ -1096,8 +1105,11 @@ func (c CreateBudgetConfigurationBudgetAlertConfigurations_SdkV2) ApplySchemaCus
 	attrs["action_configurations"] = attrs["action_configurations"].SetOptional()
 	attrs["quantity_threshold"] = attrs["quantity_threshold"].SetOptional()
 	attrs["quantity_type"] = attrs["quantity_type"].SetOptional()
+	attrs["quantity_type"] = attrs["quantity_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("LIST_PRICE_DOLLARS_USD"))
 	attrs["time_period"] = attrs["time_period"].SetOptional()
+	attrs["time_period"] = attrs["time_period"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("MONTH"))
 	attrs["trigger_type"] = attrs["trigger_type"].SetOptional()
+	attrs["trigger_type"] = attrs["trigger_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CUMULATIVE_SPENDING_EXCEEDED"))
 
 	return attrs
 }
@@ -1507,8 +1519,11 @@ func (c CreateLogDeliveryConfigurationParams_SdkV2) ApplySchemaCustomizations(at
 	attrs["delivery_path_prefix"] = attrs["delivery_path_prefix"].SetOptional()
 	attrs["delivery_start_time"] = attrs["delivery_start_time"].SetOptional()
 	attrs["log_type"] = attrs["log_type"].SetRequired()
+	attrs["log_type"] = attrs["log_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("AUDIT_LOGS", "BILLABLE_USAGE"))
 	attrs["output_format"] = attrs["output_format"].SetRequired()
+	attrs["output_format"] = attrs["output_format"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CSV", "JSON"))
 	attrs["status"] = attrs["status"].SetOptional()
+	attrs["status"] = attrs["status"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DISABLED", "ENABLED"))
 	attrs["storage_configuration_id"] = attrs["storage_configuration_id"].SetRequired()
 	attrs["workspace_ids_filter"] = attrs["workspace_ids_filter"].SetOptional()
 
@@ -2645,8 +2660,11 @@ func (c LogDeliveryConfiguration_SdkV2) ApplySchemaCustomizations(attrs map[stri
 	attrs["log_delivery_status"] = attrs["log_delivery_status"].SetOptional()
 	attrs["log_delivery_status"] = attrs["log_delivery_status"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["log_type"] = attrs["log_type"].SetOptional()
+	attrs["log_type"] = attrs["log_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("AUDIT_LOGS", "BILLABLE_USAGE"))
 	attrs["output_format"] = attrs["output_format"].SetOptional()
+	attrs["output_format"] = attrs["output_format"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CSV", "JSON"))
 	attrs["status"] = attrs["status"].SetOptional()
+	attrs["status"] = attrs["status"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DISABLED", "ENABLED"))
 	attrs["storage_configuration_id"] = attrs["storage_configuration_id"].SetOptional()
 	attrs["update_time"] = attrs["update_time"].SetOptional()
 	attrs["workspace_ids_filter"] = attrs["workspace_ids_filter"].SetOptional()
@@ -2804,6 +2822,7 @@ func (c LogDeliveryStatus_SdkV2) ApplySchemaCustomizations(attrs map[string]tfsc
 	attrs["last_successful_attempt_time"] = attrs["last_successful_attempt_time"].SetOptional()
 	attrs["message"] = attrs["message"].SetOptional()
 	attrs["status"] = attrs["status"].SetOptional()
+	attrs["status"] = attrs["status"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CREATED", "NOT_FOUND", "SUCCEEDED", "SYSTEM_FAILURE", "USER_FAILURE"))
 
 	return attrs
 }
@@ -2891,6 +2910,7 @@ func (newState *SortSpec_SdkV2) SyncEffectiveFieldsDuringRead(existingState Sort
 func (c SortSpec_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["descending"] = attrs["descending"].SetOptional()
 	attrs["field"] = attrs["field"].SetOptional()
+	attrs["field"] = attrs["field"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("POLICY_NAME"))
 
 	return attrs
 }
@@ -3316,6 +3336,7 @@ func (newState *UpdateLogDeliveryConfigurationStatusRequest_SdkV2) SyncEffective
 func (c UpdateLogDeliveryConfigurationStatusRequest_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["log_delivery_configuration_id"] = attrs["log_delivery_configuration_id"].SetRequired()
 	attrs["status"] = attrs["status"].SetRequired()
+	attrs["status"] = attrs["status"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DISABLED", "ENABLED"))
 
 	return attrs
 }

--- a/internal/service/billing_tf/model.go
+++ b/internal/service/billing_tf/model.go
@@ -18,6 +18,7 @@ import (
 	"github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/tfschema"
 
 	"github.com/databricks/terraform-provider-databricks/internal/service/compute_tf"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
@@ -41,6 +42,7 @@ func (newState *ActionConfiguration) SyncEffectiveFieldsDuringRead(existingState
 func (c ActionConfiguration) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["action_configuration_id"] = attrs["action_configuration_id"].SetOptional()
 	attrs["action_type"] = attrs["action_type"].SetOptional()
+	attrs["action_type"] = attrs["action_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("EMAIL_NOTIFICATION"))
 	attrs["target"] = attrs["target"].SetOptional()
 
 	return attrs
@@ -111,8 +113,11 @@ func (c AlertConfiguration) ApplySchemaCustomizations(attrs map[string]tfschema.
 	attrs["alert_configuration_id"] = attrs["alert_configuration_id"].SetOptional()
 	attrs["quantity_threshold"] = attrs["quantity_threshold"].SetOptional()
 	attrs["quantity_type"] = attrs["quantity_type"].SetOptional()
+	attrs["quantity_type"] = attrs["quantity_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("LIST_PRICE_DOLLARS_USD"))
 	attrs["time_period"] = attrs["time_period"].SetOptional()
+	attrs["time_period"] = attrs["time_period"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("MONTH"))
 	attrs["trigger_type"] = attrs["trigger_type"].SetOptional()
+	attrs["trigger_type"] = attrs["trigger_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CUMULATIVE_SPENDING_EXCEEDED"))
 
 	return attrs
 }
@@ -457,6 +462,7 @@ func (newState *BudgetConfigurationFilterClause) SyncEffectiveFieldsDuringRead(e
 
 func (c BudgetConfigurationFilterClause) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["operator"] = attrs["operator"].SetOptional()
+	attrs["operator"] = attrs["operator"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("IN"))
 	attrs["values"] = attrs["values"].SetOptional()
 
 	return attrs
@@ -621,6 +627,7 @@ func (newState *BudgetConfigurationFilterWorkspaceIdClause) SyncEffectiveFieldsD
 
 func (c BudgetConfigurationFilterWorkspaceIdClause) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["operator"] = attrs["operator"].SetOptional()
+	attrs["operator"] = attrs["operator"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("IN"))
 	attrs["values"] = attrs["values"].SetOptional()
 
 	return attrs
@@ -799,6 +806,7 @@ func (newState *CreateBillingUsageDashboardRequest) SyncEffectiveFieldsDuringRea
 
 func (c CreateBillingUsageDashboardRequest) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["dashboard_type"] = attrs["dashboard_type"].SetOptional()
+	attrs["dashboard_type"] = attrs["dashboard_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("USAGE_DASHBOARD_TYPE_GLOBAL", "USAGE_DASHBOARD_TYPE_WORKSPACE"))
 	attrs["workspace_id"] = attrs["workspace_id"].SetOptional()
 
 	return attrs
@@ -1026,6 +1034,7 @@ func (newState *CreateBudgetConfigurationBudgetActionConfigurations) SyncEffecti
 
 func (c CreateBudgetConfigurationBudgetActionConfigurations) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["action_type"] = attrs["action_type"].SetOptional()
+	attrs["action_type"] = attrs["action_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("EMAIL_NOTIFICATION"))
 	attrs["target"] = attrs["target"].SetOptional()
 
 	return attrs
@@ -1091,8 +1100,11 @@ func (c CreateBudgetConfigurationBudgetAlertConfigurations) ApplySchemaCustomiza
 	attrs["action_configurations"] = attrs["action_configurations"].SetOptional()
 	attrs["quantity_threshold"] = attrs["quantity_threshold"].SetOptional()
 	attrs["quantity_type"] = attrs["quantity_type"].SetOptional()
+	attrs["quantity_type"] = attrs["quantity_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("LIST_PRICE_DOLLARS_USD"))
 	attrs["time_period"] = attrs["time_period"].SetOptional()
+	attrs["time_period"] = attrs["time_period"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("MONTH"))
 	attrs["trigger_type"] = attrs["trigger_type"].SetOptional()
+	attrs["trigger_type"] = attrs["trigger_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CUMULATIVE_SPENDING_EXCEEDED"))
 
 	return attrs
 }
@@ -1500,8 +1512,11 @@ func (c CreateLogDeliveryConfigurationParams) ApplySchemaCustomizations(attrs ma
 	attrs["delivery_path_prefix"] = attrs["delivery_path_prefix"].SetOptional()
 	attrs["delivery_start_time"] = attrs["delivery_start_time"].SetOptional()
 	attrs["log_type"] = attrs["log_type"].SetRequired()
+	attrs["log_type"] = attrs["log_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("AUDIT_LOGS", "BILLABLE_USAGE"))
 	attrs["output_format"] = attrs["output_format"].SetRequired()
+	attrs["output_format"] = attrs["output_format"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CSV", "JSON"))
 	attrs["status"] = attrs["status"].SetOptional()
+	attrs["status"] = attrs["status"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DISABLED", "ENABLED"))
 	attrs["storage_configuration_id"] = attrs["storage_configuration_id"].SetRequired()
 	attrs["workspace_ids_filter"] = attrs["workspace_ids_filter"].SetOptional()
 
@@ -2636,8 +2651,11 @@ func (c LogDeliveryConfiguration) ApplySchemaCustomizations(attrs map[string]tfs
 	attrs["delivery_start_time"] = attrs["delivery_start_time"].SetOptional()
 	attrs["log_delivery_status"] = attrs["log_delivery_status"].SetOptional()
 	attrs["log_type"] = attrs["log_type"].SetOptional()
+	attrs["log_type"] = attrs["log_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("AUDIT_LOGS", "BILLABLE_USAGE"))
 	attrs["output_format"] = attrs["output_format"].SetOptional()
+	attrs["output_format"] = attrs["output_format"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CSV", "JSON"))
 	attrs["status"] = attrs["status"].SetOptional()
+	attrs["status"] = attrs["status"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DISABLED", "ENABLED"))
 	attrs["storage_configuration_id"] = attrs["storage_configuration_id"].SetOptional()
 	attrs["update_time"] = attrs["update_time"].SetOptional()
 	attrs["workspace_ids_filter"] = attrs["workspace_ids_filter"].SetOptional()
@@ -2795,6 +2813,7 @@ func (c LogDeliveryStatus) ApplySchemaCustomizations(attrs map[string]tfschema.A
 	attrs["last_successful_attempt_time"] = attrs["last_successful_attempt_time"].SetOptional()
 	attrs["message"] = attrs["message"].SetOptional()
 	attrs["status"] = attrs["status"].SetOptional()
+	attrs["status"] = attrs["status"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CREATED", "NOT_FOUND", "SUCCEEDED", "SYSTEM_FAILURE", "USER_FAILURE"))
 
 	return attrs
 }
@@ -2882,6 +2901,7 @@ func (newState *SortSpec) SyncEffectiveFieldsDuringRead(existingState SortSpec) 
 func (c SortSpec) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["descending"] = attrs["descending"].SetOptional()
 	attrs["field"] = attrs["field"].SetOptional()
+	attrs["field"] = attrs["field"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("POLICY_NAME"))
 
 	return attrs
 }
@@ -3304,6 +3324,7 @@ func (newState *UpdateLogDeliveryConfigurationStatusRequest) SyncEffectiveFields
 func (c UpdateLogDeliveryConfigurationStatusRequest) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["log_delivery_configuration_id"] = attrs["log_delivery_configuration_id"].SetRequired()
 	attrs["status"] = attrs["status"].SetRequired()
+	attrs["status"] = attrs["status"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DISABLED", "ENABLED"))
 
 	return attrs
 }

--- a/internal/service/catalog_tf/legacy_model.go
+++ b/internal/service/catalog_tf/legacy_model.go
@@ -18,6 +18,7 @@ import (
 	"github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/tfschema"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
@@ -875,6 +876,7 @@ func (newState *ArtifactMatcher_SdkV2) SyncEffectiveFieldsDuringRead(existingSta
 func (c ArtifactMatcher_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["artifact"] = attrs["artifact"].SetRequired()
 	attrs["match_type"] = attrs["match_type"].SetRequired()
+	attrs["match_type"] = attrs["match_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("PREFIX_MATCH"))
 
 	return attrs
 }
@@ -1673,6 +1675,7 @@ func (newState *CatalogInfo_SdkV2) SyncEffectiveFieldsDuringRead(existingState C
 func (c CatalogInfo_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["browse_only"] = attrs["browse_only"].SetOptional()
 	attrs["catalog_type"] = attrs["catalog_type"].SetOptional()
+	attrs["catalog_type"] = attrs["catalog_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DELTASHARING_CATALOG", "MANAGED_CATALOG", "SYSTEM_CATALOG"))
 	attrs["comment"] = attrs["comment"].SetOptional()
 	attrs["connection_name"] = attrs["connection_name"].SetOptional()
 	attrs["created_at"] = attrs["created_at"].SetOptional()
@@ -1680,8 +1683,10 @@ func (c CatalogInfo_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.A
 	attrs["effective_predictive_optimization_flag"] = attrs["effective_predictive_optimization_flag"].SetOptional()
 	attrs["effective_predictive_optimization_flag"] = attrs["effective_predictive_optimization_flag"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["enable_predictive_optimization"] = attrs["enable_predictive_optimization"].SetOptional()
+	attrs["enable_predictive_optimization"] = attrs["enable_predictive_optimization"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DISABLE", "ENABLE", "INHERIT"))
 	attrs["full_name"] = attrs["full_name"].SetOptional()
 	attrs["isolation_mode"] = attrs["isolation_mode"].SetOptional()
+	attrs["isolation_mode"] = attrs["isolation_mode"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ISOLATED", "OPEN"))
 	attrs["metastore_id"] = attrs["metastore_id"].SetOptional()
 	attrs["name"] = attrs["name"].SetOptional()
 	attrs["options"] = attrs["options"].SetOptional()
@@ -1994,6 +1999,7 @@ func (c ColumnInfo_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.At
 	attrs["type_interval_type"] = attrs["type_interval_type"].SetOptional()
 	attrs["type_json"] = attrs["type_json"].SetOptional()
 	attrs["type_name"] = attrs["type_name"].SetOptional()
+	attrs["type_name"] = attrs["type_name"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ARRAY", "BINARY", "BOOLEAN", "BYTE", "CHAR", "DATE", "DECIMAL", "DOUBLE", "FLOAT", "INT", "INTERVAL", "LONG", "MAP", "NULL", "SHORT", "STRING", "STRUCT", "TABLE_TYPE", "TIMESTAMP", "TIMESTAMP_NTZ", "USER_DEFINED_TYPE", "VARIANT"))
 	attrs["type_precision"] = attrs["type_precision"].SetOptional()
 	attrs["type_scale"] = attrs["type_scale"].SetOptional()
 	attrs["type_text"] = attrs["type_text"].SetOptional()
@@ -2220,9 +2226,11 @@ func (c ConnectionInfo_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschem
 	attrs["comment"] = attrs["comment"].SetOptional()
 	attrs["connection_id"] = attrs["connection_id"].SetOptional()
 	attrs["connection_type"] = attrs["connection_type"].SetOptional()
+	attrs["connection_type"] = attrs["connection_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("BIGQUERY", "DATABRICKS", "GLUE", "HIVE_METASTORE", "HTTP", "MYSQL", "POSTGRESQL", "REDSHIFT", "SNOWFLAKE", "SQLDW", "SQLSERVER"))
 	attrs["created_at"] = attrs["created_at"].SetOptional()
 	attrs["created_by"] = attrs["created_by"].SetOptional()
 	attrs["credential_type"] = attrs["credential_type"].SetOptional()
+	attrs["credential_type"] = attrs["credential_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("BEARER_TOKEN", "USERNAME_PASSWORD"))
 	attrs["full_name"] = attrs["full_name"].SetOptional()
 	attrs["metastore_id"] = attrs["metastore_id"].SetOptional()
 	attrs["name"] = attrs["name"].SetOptional()
@@ -2657,6 +2665,7 @@ func (newState *CreateConnection_SdkV2) SyncEffectiveFieldsDuringRead(existingSt
 func (c CreateConnection_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["comment"] = attrs["comment"].SetOptional()
 	attrs["connection_type"] = attrs["connection_type"].SetRequired()
+	attrs["connection_type"] = attrs["connection_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("BIGQUERY", "DATABRICKS", "GLUE", "HIVE_METASTORE", "HTTP", "MYSQL", "POSTGRESQL", "REDSHIFT", "SNOWFLAKE", "SQLDW", "SQLSERVER"))
 	attrs["name"] = attrs["name"].SetRequired()
 	attrs["options"] = attrs["options"].SetRequired()
 	attrs["properties"] = attrs["properties"].SetOptional()
@@ -2809,6 +2818,7 @@ func (c CreateCredentialRequest_SdkV2) ApplySchemaCustomizations(attrs map[strin
 	attrs["databricks_gcp_service_account"] = attrs["databricks_gcp_service_account"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["name"] = attrs["name"].SetRequired()
 	attrs["purpose"] = attrs["purpose"].SetOptional()
+	attrs["purpose"] = attrs["purpose"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("SERVICE", "STORAGE"))
 	attrs["read_only"] = attrs["read_only"].SetOptional()
 	attrs["skip_validation"] = attrs["skip_validation"].SetOptional()
 
@@ -3160,6 +3170,7 @@ func (c CreateFunction_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschem
 	attrs["catalog_name"] = attrs["catalog_name"].SetRequired()
 	attrs["comment"] = attrs["comment"].SetOptional()
 	attrs["data_type"] = attrs["data_type"].SetRequired()
+	attrs["data_type"] = attrs["data_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ARRAY", "BINARY", "BOOLEAN", "BYTE", "CHAR", "DATE", "DECIMAL", "DOUBLE", "FLOAT", "INT", "INTERVAL", "LONG", "MAP", "NULL", "SHORT", "STRING", "STRUCT", "TABLE_TYPE", "TIMESTAMP", "TIMESTAMP_NTZ", "USER_DEFINED_TYPE", "VARIANT"))
 	attrs["external_language"] = attrs["external_language"].SetOptional()
 	attrs["external_name"] = attrs["external_name"].SetOptional()
 	attrs["full_data_type"] = attrs["full_data_type"].SetRequired()
@@ -3169,17 +3180,21 @@ func (c CreateFunction_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschem
 	attrs["is_null_call"] = attrs["is_null_call"].SetRequired()
 	attrs["name"] = attrs["name"].SetRequired()
 	attrs["parameter_style"] = attrs["parameter_style"].SetRequired()
+	attrs["parameter_style"] = attrs["parameter_style"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("S"))
 	attrs["properties"] = attrs["properties"].SetOptional()
 	attrs["return_params"] = attrs["return_params"].SetOptional()
 	attrs["return_params"] = attrs["return_params"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["routine_body"] = attrs["routine_body"].SetRequired()
+	attrs["routine_body"] = attrs["routine_body"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("EXTERNAL", "SQL"))
 	attrs["routine_definition"] = attrs["routine_definition"].SetRequired()
 	attrs["routine_dependencies"] = attrs["routine_dependencies"].SetOptional()
 	attrs["routine_dependencies"] = attrs["routine_dependencies"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["schema_name"] = attrs["schema_name"].SetRequired()
 	attrs["security_type"] = attrs["security_type"].SetRequired()
+	attrs["security_type"] = attrs["security_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DEFINER"))
 	attrs["specific_name"] = attrs["specific_name"].SetRequired()
 	attrs["sql_data_access"] = attrs["sql_data_access"].SetRequired()
+	attrs["sql_data_access"] = attrs["sql_data_access"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CONTAINS_SQL", "NO_SQL", "READS_SQL_DATA"))
 	attrs["sql_path"] = attrs["sql_path"].SetOptional()
 
 	return attrs
@@ -4524,6 +4539,7 @@ func (c CreateVolumeRequestContent_SdkV2) ApplySchemaCustomizations(attrs map[st
 	attrs["schema_name"] = attrs["schema_name"].SetRequired()
 	attrs["storage_location"] = attrs["storage_location"].SetOptional()
 	attrs["volume_type"] = attrs["volume_type"].SetRequired()
+	attrs["volume_type"] = attrs["volume_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("EXTERNAL", "MANAGED"))
 
 	return attrs
 }
@@ -4635,10 +4651,12 @@ func (c CredentialInfo_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschem
 	attrs["full_name"] = attrs["full_name"].SetOptional()
 	attrs["id"] = attrs["id"].SetOptional()
 	attrs["isolation_mode"] = attrs["isolation_mode"].SetOptional()
+	attrs["isolation_mode"] = attrs["isolation_mode"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ISOLATION_MODE_ISOLATED", "ISOLATION_MODE_OPEN"))
 	attrs["metastore_id"] = attrs["metastore_id"].SetOptional()
 	attrs["name"] = attrs["name"].SetOptional()
 	attrs["owner"] = attrs["owner"].SetOptional()
 	attrs["purpose"] = attrs["purpose"].SetOptional()
+	attrs["purpose"] = attrs["purpose"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("SERVICE", "STORAGE"))
 	attrs["read_only"] = attrs["read_only"].SetOptional()
 	attrs["updated_at"] = attrs["updated_at"].SetOptional()
 	attrs["updated_by"] = attrs["updated_by"].SetOptional()
@@ -4845,6 +4863,7 @@ func (newState *CredentialValidationResult_SdkV2) SyncEffectiveFieldsDuringRead(
 func (c CredentialValidationResult_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["message"] = attrs["message"].SetOptional()
 	attrs["result"] = attrs["result"].SetOptional()
+	attrs["result"] = attrs["result"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("FAIL", "PASS", "SKIP"))
 
 	return attrs
 }
@@ -6437,7 +6456,9 @@ func (newState *EffectivePredictiveOptimizationFlag_SdkV2) SyncEffectiveFieldsDu
 func (c EffectivePredictiveOptimizationFlag_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["inherited_from_name"] = attrs["inherited_from_name"].SetOptional()
 	attrs["inherited_from_type"] = attrs["inherited_from_type"].SetOptional()
+	attrs["inherited_from_type"] = attrs["inherited_from_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CATALOG", "SCHEMA"))
 	attrs["value"] = attrs["value"].SetRequired()
+	attrs["value"] = attrs["value"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DISABLE", "ENABLE", "INHERIT"))
 
 	return attrs
 }
@@ -6499,7 +6520,9 @@ func (newState *EffectivePrivilege_SdkV2) SyncEffectiveFieldsDuringRead(existing
 func (c EffectivePrivilege_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["inherited_from_name"] = attrs["inherited_from_name"].SetOptional()
 	attrs["inherited_from_type"] = attrs["inherited_from_type"].SetOptional()
+	attrs["inherited_from_type"] = attrs["inherited_from_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CATALOG", "CLEAN_ROOM", "CONNECTION", "CREDENTIAL", "EXTERNAL_LOCATION", "FUNCTION", "METASTORE", "PIPELINE", "PROVIDER", "RECIPIENT", "SCHEMA", "SHARE", "STORAGE_CREDENTIAL", "TABLE", "VOLUME"))
 	attrs["privilege"] = attrs["privilege"].SetOptional()
+	attrs["privilege"] = attrs["privilege"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ACCESS", "ALL_PRIVILEGES", "APPLY_TAG", "CREATE", "CREATE_CATALOG", "CREATE_CONNECTION", "CREATE_EXTERNAL_LOCATION", "CREATE_EXTERNAL_TABLE", "CREATE_EXTERNAL_VOLUME", "CREATE_FOREIGN_CATALOG", "CREATE_FOREIGN_SECURABLE", "CREATE_FUNCTION", "CREATE_MANAGED_STORAGE", "CREATE_MATERIALIZED_VIEW", "CREATE_MODEL", "CREATE_PROVIDER", "CREATE_RECIPIENT", "CREATE_SCHEMA", "CREATE_SERVICE_CREDENTIAL", "CREATE_SHARE", "CREATE_STORAGE_CREDENTIAL", "CREATE_TABLE", "CREATE_VIEW", "CREATE_VOLUME", "EXECUTE", "MANAGE", "MANAGE_ALLOWLIST", "MODIFY", "READ_FILES", "READ_PRIVATE_FILES", "READ_VOLUME", "REFRESH", "SELECT", "SET_SHARE_PERMISSION", "USAGE", "USE_CATALOG", "USE_CONNECTION", "USE_MARKETPLACE_ASSETS", "USE_PROVIDER", "USE_RECIPIENT", "USE_SCHEMA", "USE_SHARE", "WRITE_FILES", "WRITE_PRIVATE_FILES", "WRITE_VOLUME"))
 
 	return attrs
 }
@@ -6871,6 +6894,7 @@ func (c ExternalLocationInfo_SdkV2) ApplySchemaCustomizations(attrs map[string]t
 	attrs["encryption_details"] = attrs["encryption_details"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["fallback"] = attrs["fallback"].SetOptional()
 	attrs["isolation_mode"] = attrs["isolation_mode"].SetOptional()
+	attrs["isolation_mode"] = attrs["isolation_mode"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ISOLATION_MODE_ISOLATED", "ISOLATION_MODE_OPEN"))
 	attrs["metastore_id"] = attrs["metastore_id"].SetOptional()
 	attrs["name"] = attrs["name"].SetOptional()
 	attrs["owner"] = attrs["owner"].SetOptional()
@@ -7290,6 +7314,7 @@ func (c FunctionInfo_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.
 	attrs["created_at"] = attrs["created_at"].SetOptional()
 	attrs["created_by"] = attrs["created_by"].SetOptional()
 	attrs["data_type"] = attrs["data_type"].SetOptional()
+	attrs["data_type"] = attrs["data_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ARRAY", "BINARY", "BOOLEAN", "BYTE", "CHAR", "DATE", "DECIMAL", "DOUBLE", "FLOAT", "INT", "INTERVAL", "LONG", "MAP", "NULL", "SHORT", "STRING", "STRUCT", "TABLE_TYPE", "TIMESTAMP", "TIMESTAMP_NTZ", "USER_DEFINED_TYPE", "VARIANT"))
 	attrs["external_language"] = attrs["external_language"].SetOptional()
 	attrs["external_name"] = attrs["external_name"].SetOptional()
 	attrs["full_data_type"] = attrs["full_data_type"].SetOptional()
@@ -7303,17 +7328,21 @@ func (c FunctionInfo_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.
 	attrs["name"] = attrs["name"].SetOptional()
 	attrs["owner"] = attrs["owner"].SetOptional()
 	attrs["parameter_style"] = attrs["parameter_style"].SetOptional()
+	attrs["parameter_style"] = attrs["parameter_style"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("S"))
 	attrs["properties"] = attrs["properties"].SetOptional()
 	attrs["return_params"] = attrs["return_params"].SetOptional()
 	attrs["return_params"] = attrs["return_params"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["routine_body"] = attrs["routine_body"].SetOptional()
+	attrs["routine_body"] = attrs["routine_body"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("EXTERNAL", "SQL"))
 	attrs["routine_definition"] = attrs["routine_definition"].SetOptional()
 	attrs["routine_dependencies"] = attrs["routine_dependencies"].SetOptional()
 	attrs["routine_dependencies"] = attrs["routine_dependencies"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["schema_name"] = attrs["schema_name"].SetOptional()
 	attrs["security_type"] = attrs["security_type"].SetOptional()
+	attrs["security_type"] = attrs["security_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DEFINER"))
 	attrs["specific_name"] = attrs["specific_name"].SetOptional()
 	attrs["sql_data_access"] = attrs["sql_data_access"].SetOptional()
+	attrs["sql_data_access"] = attrs["sql_data_access"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CONTAINS_SQL", "NO_SQL", "READS_SQL_DATA"))
 	attrs["sql_path"] = attrs["sql_path"].SetOptional()
 	attrs["updated_at"] = attrs["updated_at"].SetOptional()
 	attrs["updated_by"] = attrs["updated_by"].SetOptional()
@@ -7536,11 +7565,14 @@ func (c FunctionParameterInfo_SdkV2) ApplySchemaCustomizations(attrs map[string]
 	attrs["name"] = attrs["name"].SetRequired()
 	attrs["parameter_default"] = attrs["parameter_default"].SetOptional()
 	attrs["parameter_mode"] = attrs["parameter_mode"].SetOptional()
+	attrs["parameter_mode"] = attrs["parameter_mode"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("IN"))
 	attrs["parameter_type"] = attrs["parameter_type"].SetOptional()
+	attrs["parameter_type"] = attrs["parameter_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("COLUMN", "PARAM"))
 	attrs["position"] = attrs["position"].SetRequired()
 	attrs["type_interval_type"] = attrs["type_interval_type"].SetOptional()
 	attrs["type_json"] = attrs["type_json"].SetOptional()
 	attrs["type_name"] = attrs["type_name"].SetRequired()
+	attrs["type_name"] = attrs["type_name"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ARRAY", "BINARY", "BOOLEAN", "BYTE", "CHAR", "DATE", "DECIMAL", "DOUBLE", "FLOAT", "INT", "INTERVAL", "LONG", "MAP", "NULL", "SHORT", "STRING", "STRUCT", "TABLE_TYPE", "TIMESTAMP", "TIMESTAMP_NTZ", "USER_DEFINED_TYPE", "VARIANT"))
 	attrs["type_precision"] = attrs["type_precision"].SetOptional()
 	attrs["type_scale"] = attrs["type_scale"].SetOptional()
 	attrs["type_text"] = attrs["type_text"].SetRequired()
@@ -8028,6 +8060,7 @@ func (newState *GenerateTemporaryTableCredentialRequest_SdkV2) SyncEffectiveFiel
 
 func (c GenerateTemporaryTableCredentialRequest_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["operation"] = attrs["operation"].SetOptional()
+	attrs["operation"] = attrs["operation"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("READ", "READ_WRITE"))
 	attrs["table_id"] = attrs["table_id"].SetOptional()
 
 	return attrs
@@ -8943,6 +8976,7 @@ func (c GetMetastoreSummaryResponse_SdkV2) ApplySchemaCustomizations(attrs map[s
 	attrs["delta_sharing_organization_name"] = attrs["delta_sharing_organization_name"].SetOptional()
 	attrs["delta_sharing_recipient_token_lifetime_in_seconds"] = attrs["delta_sharing_recipient_token_lifetime_in_seconds"].SetOptional()
 	attrs["delta_sharing_scope"] = attrs["delta_sharing_scope"].SetOptional()
+	attrs["delta_sharing_scope"] = attrs["delta_sharing_scope"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("INTERNAL", "INTERNAL_AND_EXTERNAL"))
 	attrs["external_access_enabled"] = attrs["external_access_enabled"].SetOptional()
 	attrs["global_metastore_id"] = attrs["global_metastore_id"].SetOptional()
 	attrs["metastore_id"] = attrs["metastore_id"].SetOptional()
@@ -11970,6 +12004,7 @@ func (c MetastoreInfo_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema
 	attrs["delta_sharing_organization_name"] = attrs["delta_sharing_organization_name"].SetOptional()
 	attrs["delta_sharing_recipient_token_lifetime_in_seconds"] = attrs["delta_sharing_recipient_token_lifetime_in_seconds"].SetOptional()
 	attrs["delta_sharing_scope"] = attrs["delta_sharing_scope"].SetOptional()
+	attrs["delta_sharing_scope"] = attrs["delta_sharing_scope"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("INTERNAL", "INTERNAL_AND_EXTERNAL"))
 	attrs["external_access_enabled"] = attrs["external_access_enabled"].SetOptional()
 	attrs["global_metastore_id"] = attrs["global_metastore_id"].SetOptional()
 	attrs["metastore_id"] = attrs["metastore_id"].SetOptional()
@@ -12129,6 +12164,7 @@ func (c ModelVersionInfo_SdkV2) ApplySchemaCustomizations(attrs map[string]tfsch
 	attrs["schema_name"] = attrs["schema_name"].SetOptional()
 	attrs["source"] = attrs["source"].SetOptional()
 	attrs["status"] = attrs["status"].SetOptional()
+	attrs["status"] = attrs["status"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("FAILED_REGISTRATION", "PENDING_REGISTRATION", "READY"))
 	attrs["storage_location"] = attrs["storage_location"].SetOptional()
 	attrs["updated_at"] = attrs["updated_at"].SetOptional()
 	attrs["updated_by"] = attrs["updated_by"].SetOptional()
@@ -12283,6 +12319,7 @@ func (newState *MonitorCronSchedule_SdkV2) SyncEffectiveFieldsDuringRead(existin
 
 func (c MonitorCronSchedule_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["pause_status"] = attrs["pause_status"].SetOptional()
+	attrs["pause_status"] = attrs["pause_status"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("PAUSED", "UNPAUSED"))
 	attrs["quartz_cron_expression"] = attrs["quartz_cron_expression"].SetRequired()
 	attrs["timezone_id"] = attrs["timezone_id"].SetRequired()
 
@@ -12495,6 +12532,7 @@ func (c MonitorInferenceLog_SdkV2) ApplySchemaCustomizations(attrs map[string]tf
 	attrs["prediction_col"] = attrs["prediction_col"].SetRequired()
 	attrs["prediction_proba_col"] = attrs["prediction_proba_col"].SetOptional()
 	attrs["problem_type"] = attrs["problem_type"].SetRequired()
+	attrs["problem_type"] = attrs["problem_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("PROBLEM_TYPE_CLASSIFICATION", "PROBLEM_TYPE_REGRESSION"))
 	attrs["timestamp_col"] = attrs["timestamp_col"].SetRequired()
 
 	return attrs
@@ -12653,6 +12691,7 @@ func (c MonitorInfo_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.A
 	attrs["snapshot"] = attrs["snapshot"].SetOptional()
 	attrs["snapshot"] = attrs["snapshot"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["status"] = attrs["status"].SetRequired()
+	attrs["status"] = attrs["status"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("MONITOR_STATUS_ACTIVE", "MONITOR_STATUS_DELETE_PENDING", "MONITOR_STATUS_ERROR", "MONITOR_STATUS_FAILED", "MONITOR_STATUS_PENDING"))
 	attrs["table_name"] = attrs["table_name"].SetRequired()
 	attrs["time_series"] = attrs["time_series"].SetOptional()
 	attrs["time_series"] = attrs["time_series"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
@@ -12997,6 +13036,7 @@ func (c MonitorMetric_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema
 	attrs["name"] = attrs["name"].SetRequired()
 	attrs["output_data_type"] = attrs["output_data_type"].SetRequired()
 	attrs["type"] = attrs["type"].SetRequired()
+	attrs["type"] = attrs["type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CUSTOM_METRIC_TYPE_AGGREGATE", "CUSTOM_METRIC_TYPE_DERIVED", "CUSTOM_METRIC_TYPE_DRIFT"))
 
 	return attrs
 }
@@ -13215,7 +13255,9 @@ func (c MonitorRefreshInfo_SdkV2) ApplySchemaCustomizations(attrs map[string]tfs
 	attrs["refresh_id"] = attrs["refresh_id"].SetRequired()
 	attrs["start_time_ms"] = attrs["start_time_ms"].SetRequired()
 	attrs["state"] = attrs["state"].SetRequired()
+	attrs["state"] = attrs["state"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CANCELED", "FAILED", "PENDING", "RUNNING", "SUCCESS"))
 	attrs["trigger"] = attrs["trigger"].SetOptional()
+	attrs["trigger"] = attrs["trigger"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("MANUAL", "SCHEDULE"))
 
 	return attrs
 }
@@ -13550,6 +13592,7 @@ func (c OnlineTable_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.A
 	attrs["status"] = attrs["status"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["table_serving_url"] = attrs["table_serving_url"].SetComputed()
 	attrs["unity_catalog_provisioning_state"] = attrs["unity_catalog_provisioning_state"].SetComputed()
+	attrs["unity_catalog_provisioning_state"] = attrs["unity_catalog_provisioning_state"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ACTIVE", "DEGRADED", "DELETING", "FAILED", "PROVISIONING", "UPDATING"))
 
 	return attrs
 }
@@ -13943,6 +13986,7 @@ func (c OnlineTableStatus_SdkV2) ApplySchemaCustomizations(attrs map[string]tfsc
 	attrs["continuous_update_status"] = attrs["continuous_update_status"].SetOptional()
 	attrs["continuous_update_status"] = attrs["continuous_update_status"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["detailed_state"] = attrs["detailed_state"].SetOptional()
+	attrs["detailed_state"] = attrs["detailed_state"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("OFFLINE", "OFFLINE_FAILED", "ONLINE", "ONLINE_CONTINUOUS_UPDATE", "ONLINE_NO_PENDING_UPDATE", "ONLINE_PIPELINE_FAILED", "ONLINE_TRIGGERED_UPDATE", "ONLINE_UPDATING_PIPELINE_RESOURCES", "PROVISIONING", "PROVISIONING_INITIAL_SNAPSHOT", "PROVISIONING_PIPELINE_RESOURCES"))
 	attrs["failed_status"] = attrs["failed_status"].SetOptional()
 	attrs["failed_status"] = attrs["failed_status"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["message"] = attrs["message"].SetOptional()
@@ -14557,6 +14601,7 @@ func (newState *ProvisioningInfo_SdkV2) SyncEffectiveFieldsDuringRead(existingSt
 
 func (c ProvisioningInfo_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["state"] = attrs["state"].SetOptional()
+	attrs["state"] = attrs["state"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ACTIVE", "DEGRADED", "DELETING", "FAILED", "PROVISIONING", "UPDATING"))
 
 	return attrs
 }
@@ -14700,6 +14745,7 @@ func (c QuotaInfo_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.Att
 	attrs["last_refreshed_at"] = attrs["last_refreshed_at"].SetOptional()
 	attrs["parent_full_name"] = attrs["parent_full_name"].SetOptional()
 	attrs["parent_securable_type"] = attrs["parent_securable_type"].SetOptional()
+	attrs["parent_securable_type"] = attrs["parent_securable_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CATALOG", "CLEAN_ROOM", "CONNECTION", "CREDENTIAL", "EXTERNAL_LOCATION", "FUNCTION", "METASTORE", "PIPELINE", "PROVIDER", "RECIPIENT", "SCHEMA", "SHARE", "STORAGE_CREDENTIAL", "TABLE", "VOLUME"))
 	attrs["quota_count"] = attrs["quota_count"].SetOptional()
 	attrs["quota_limit"] = attrs["quota_limit"].SetOptional()
 	attrs["quota_name"] = attrs["quota_name"].SetOptional()
@@ -15254,6 +15300,7 @@ func (c SchemaInfo_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.At
 	attrs["effective_predictive_optimization_flag"] = attrs["effective_predictive_optimization_flag"].SetOptional()
 	attrs["effective_predictive_optimization_flag"] = attrs["effective_predictive_optimization_flag"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["enable_predictive_optimization"] = attrs["enable_predictive_optimization"].SetOptional()
+	attrs["enable_predictive_optimization"] = attrs["enable_predictive_optimization"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DISABLE", "ENABLE", "INHERIT"))
 	attrs["full_name"] = attrs["full_name"].SetOptional()
 	attrs["metastore_id"] = attrs["metastore_id"].SetOptional()
 	attrs["name"] = attrs["name"].SetOptional()
@@ -15408,6 +15455,7 @@ func (newState *SetArtifactAllowlist_SdkV2) SyncEffectiveFieldsDuringRead(existi
 func (c SetArtifactAllowlist_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["artifact_matchers"] = attrs["artifact_matchers"].SetRequired()
 	attrs["artifact_type"] = attrs["artifact_type"].SetRequired()
+	attrs["artifact_type"] = attrs["artifact_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("INIT_SCRIPT", "LIBRARY_JAR", "LIBRARY_MAVEN"))
 
 	return attrs
 }
@@ -15550,6 +15598,7 @@ func (newState *SseEncryptionDetails_SdkV2) SyncEffectiveFieldsDuringRead(existi
 
 func (c SseEncryptionDetails_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["algorithm"] = attrs["algorithm"].SetOptional()
+	attrs["algorithm"] = attrs["algorithm"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("AWS_SSE_KMS", "AWS_SSE_S3"))
 	attrs["aws_kms_key_arn"] = attrs["aws_kms_key_arn"].SetOptional()
 
 	return attrs
@@ -15651,6 +15700,7 @@ func (c StorageCredentialInfo_SdkV2) ApplySchemaCustomizations(attrs map[string]
 	attrs["full_name"] = attrs["full_name"].SetOptional()
 	attrs["id"] = attrs["id"].SetOptional()
 	attrs["isolation_mode"] = attrs["isolation_mode"].SetOptional()
+	attrs["isolation_mode"] = attrs["isolation_mode"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ISOLATION_MODE_ISOLATED", "ISOLATION_MODE_OPEN"))
 	attrs["metastore_id"] = attrs["metastore_id"].SetOptional()
 	attrs["name"] = attrs["name"].SetOptional()
 	attrs["owner"] = attrs["owner"].SetOptional()
@@ -15890,6 +15940,7 @@ func (newState *SystemSchemaInfo_SdkV2) SyncEffectiveFieldsDuringRead(existingSt
 func (c SystemSchemaInfo_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["schema"] = attrs["schema"].SetOptional()
 	attrs["state"] = attrs["state"].SetOptional()
+	attrs["state"] = attrs["state"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("AVAILABLE", "DISABLE_INITIALIZED", "ENABLE_COMPLETED", "ENABLE_INITIALIZED", "UNAVAILABLE"))
 
 	return attrs
 }
@@ -16272,12 +16323,14 @@ func (c TableInfo_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.Att
 	attrs["created_by"] = attrs["created_by"].SetOptional()
 	attrs["data_access_configuration_id"] = attrs["data_access_configuration_id"].SetOptional()
 	attrs["data_source_format"] = attrs["data_source_format"].SetOptional()
+	attrs["data_source_format"] = attrs["data_source_format"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("AVRO", "BIGQUERY_FORMAT", "CSV", "DATABRICKS_FORMAT", "DELTA", "DELTASHARING", "HIVE_CUSTOM", "HIVE_SERDE", "JSON", "MYSQL_FORMAT", "NETSUITE_FORMAT", "ORC", "PARQUET", "POSTGRESQL_FORMAT", "REDSHIFT_FORMAT", "SALESFORCE_FORMAT", "SNOWFLAKE_FORMAT", "SQLDW_FORMAT", "SQLSERVER_FORMAT", "TEXT", "UNITY_CATALOG", "VECTOR_INDEX_FORMAT", "WORKDAY_RAAS_FORMAT"))
 	attrs["deleted_at"] = attrs["deleted_at"].SetOptional()
 	attrs["delta_runtime_properties_kvpairs"] = attrs["delta_runtime_properties_kvpairs"].SetOptional()
 	attrs["delta_runtime_properties_kvpairs"] = attrs["delta_runtime_properties_kvpairs"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["effective_predictive_optimization_flag"] = attrs["effective_predictive_optimization_flag"].SetOptional()
 	attrs["effective_predictive_optimization_flag"] = attrs["effective_predictive_optimization_flag"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["enable_predictive_optimization"] = attrs["enable_predictive_optimization"].SetOptional()
+	attrs["enable_predictive_optimization"] = attrs["enable_predictive_optimization"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DISABLE", "ENABLE", "INHERIT"))
 	attrs["encryption_details"] = attrs["encryption_details"].SetOptional()
 	attrs["encryption_details"] = attrs["encryption_details"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["full_name"] = attrs["full_name"].SetOptional()
@@ -16295,6 +16348,7 @@ func (c TableInfo_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.Att
 	attrs["table_constraints"] = attrs["table_constraints"].SetOptional()
 	attrs["table_id"] = attrs["table_id"].SetOptional()
 	attrs["table_type"] = attrs["table_type"].SetOptional()
+	attrs["table_type"] = attrs["table_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("EXTERNAL", "EXTERNAL_SHALLOW_CLONE", "FOREIGN", "MANAGED", "MANAGED_SHALLOW_CLONE", "MATERIALIZED_VIEW", "STREAMING_TABLE", "VIEW"))
 	attrs["updated_at"] = attrs["updated_at"].SetOptional()
 	attrs["updated_by"] = attrs["updated_by"].SetOptional()
 	attrs["view_definition"] = attrs["view_definition"].SetOptional()
@@ -16731,6 +16785,7 @@ func (newState *TableSummary_SdkV2) SyncEffectiveFieldsDuringRead(existingState 
 func (c TableSummary_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["full_name"] = attrs["full_name"].SetOptional()
 	attrs["table_type"] = attrs["table_type"].SetOptional()
+	attrs["table_type"] = attrs["table_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("EXTERNAL", "EXTERNAL_SHALLOW_CLONE", "FOREIGN", "MANAGED", "MANAGED_SHALLOW_CLONE", "MATERIALIZED_VIEW", "STREAMING_TABLE", "VIEW"))
 
 	return attrs
 }
@@ -17152,7 +17207,9 @@ func (newState *UpdateCatalog_SdkV2) SyncEffectiveFieldsDuringRead(existingState
 func (c UpdateCatalog_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["comment"] = attrs["comment"].SetOptional()
 	attrs["enable_predictive_optimization"] = attrs["enable_predictive_optimization"].SetOptional()
+	attrs["enable_predictive_optimization"] = attrs["enable_predictive_optimization"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DISABLE", "ENABLE", "INHERIT"))
 	attrs["isolation_mode"] = attrs["isolation_mode"].SetOptional()
+	attrs["isolation_mode"] = attrs["isolation_mode"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ISOLATED", "OPEN"))
 	attrs["name"] = attrs["name"].SetRequired()
 	attrs["new_name"] = attrs["new_name"].SetOptional()
 	attrs["options"] = attrs["options"].SetOptional()
@@ -17411,6 +17468,7 @@ func (c UpdateCredentialRequest_SdkV2) ApplySchemaCustomizations(attrs map[strin
 	attrs["databricks_gcp_service_account"] = attrs["databricks_gcp_service_account"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["force"] = attrs["force"].SetOptional()
 	attrs["isolation_mode"] = attrs["isolation_mode"].SetOptional()
+	attrs["isolation_mode"] = attrs["isolation_mode"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ISOLATION_MODE_ISOLATED", "ISOLATION_MODE_OPEN"))
 	attrs["name_arg"] = attrs["name_arg"].SetRequired()
 	attrs["new_name"] = attrs["new_name"].SetOptional()
 	attrs["owner"] = attrs["owner"].SetOptional()
@@ -17638,6 +17696,7 @@ func (c UpdateExternalLocation_SdkV2) ApplySchemaCustomizations(attrs map[string
 	attrs["fallback"] = attrs["fallback"].SetOptional()
 	attrs["force"] = attrs["force"].SetOptional()
 	attrs["isolation_mode"] = attrs["isolation_mode"].SetOptional()
+	attrs["isolation_mode"] = attrs["isolation_mode"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ISOLATION_MODE_ISOLATED", "ISOLATION_MODE_OPEN"))
 	attrs["name"] = attrs["name"].SetRequired()
 	attrs["new_name"] = attrs["new_name"].SetOptional()
 	attrs["owner"] = attrs["owner"].SetOptional()
@@ -17818,6 +17877,7 @@ func (c UpdateMetastore_SdkV2) ApplySchemaCustomizations(attrs map[string]tfsche
 	attrs["delta_sharing_organization_name"] = attrs["delta_sharing_organization_name"].SetOptional()
 	attrs["delta_sharing_recipient_token_lifetime_in_seconds"] = attrs["delta_sharing_recipient_token_lifetime_in_seconds"].SetOptional()
 	attrs["delta_sharing_scope"] = attrs["delta_sharing_scope"].SetOptional()
+	attrs["delta_sharing_scope"] = attrs["delta_sharing_scope"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("INTERNAL", "INTERNAL_AND_EXTERNAL"))
 	attrs["id"] = attrs["id"].SetRequired()
 	attrs["new_name"] = attrs["new_name"].SetOptional()
 	attrs["owner"] = attrs["owner"].SetOptional()
@@ -18360,6 +18420,7 @@ func (c UpdatePermissions_SdkV2) ApplySchemaCustomizations(attrs map[string]tfsc
 	attrs["changes"] = attrs["changes"].SetOptional()
 	attrs["full_name"] = attrs["full_name"].SetRequired()
 	attrs["securable_type"] = attrs["securable_type"].SetRequired()
+	attrs["securable_type"] = attrs["securable_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CATALOG", "CLEAN_ROOM", "CONNECTION", "CREDENTIAL", "EXTERNAL_LOCATION", "FUNCTION", "METASTORE", "PIPELINE", "PROVIDER", "RECIPIENT", "SCHEMA", "SHARE", "STORAGE_CREDENTIAL", "TABLE", "VOLUME"))
 
 	return attrs
 }
@@ -18547,6 +18608,7 @@ func (newState *UpdateSchema_SdkV2) SyncEffectiveFieldsDuringRead(existingState 
 func (c UpdateSchema_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["comment"] = attrs["comment"].SetOptional()
 	attrs["enable_predictive_optimization"] = attrs["enable_predictive_optimization"].SetOptional()
+	attrs["enable_predictive_optimization"] = attrs["enable_predictive_optimization"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DISABLE", "ENABLE", "INHERIT"))
 	attrs["full_name"] = attrs["full_name"].SetRequired()
 	attrs["new_name"] = attrs["new_name"].SetOptional()
 	attrs["owner"] = attrs["owner"].SetOptional()
@@ -18677,6 +18739,7 @@ func (c UpdateStorageCredential_SdkV2) ApplySchemaCustomizations(attrs map[strin
 	attrs["databricks_gcp_service_account"] = attrs["databricks_gcp_service_account"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["force"] = attrs["force"].SetOptional()
 	attrs["isolation_mode"] = attrs["isolation_mode"].SetOptional()
+	attrs["isolation_mode"] = attrs["isolation_mode"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ISOLATION_MODE_ISOLATED", "ISOLATION_MODE_OPEN"))
 	attrs["name"] = attrs["name"].SetRequired()
 	attrs["new_name"] = attrs["new_name"].SetOptional()
 	attrs["owner"] = attrs["owner"].SetOptional()
@@ -19130,6 +19193,7 @@ func (c UpdateWorkspaceBindingsParameters_SdkV2) ApplySchemaCustomizations(attrs
 	attrs["remove"] = attrs["remove"].SetOptional()
 	attrs["securable_name"] = attrs["securable_name"].SetRequired()
 	attrs["securable_type"] = attrs["securable_type"].SetRequired()
+	attrs["securable_type"] = attrs["securable_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("catalog", "credential", "external_location", "storage_credential"))
 
 	return attrs
 }
@@ -19266,6 +19330,7 @@ func (c ValidateCredentialRequest_SdkV2) ApplySchemaCustomizations(attrs map[str
 	attrs["credential_name"] = attrs["credential_name"].SetOptional()
 	attrs["external_location_name"] = attrs["external_location_name"].SetOptional()
 	attrs["purpose"] = attrs["purpose"].SetOptional()
+	attrs["purpose"] = attrs["purpose"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("SERVICE", "STORAGE"))
 	attrs["read_only"] = attrs["read_only"].SetOptional()
 	attrs["url"] = attrs["url"].SetOptional()
 
@@ -19798,7 +19863,9 @@ func (newState *ValidationResult_SdkV2) SyncEffectiveFieldsDuringRead(existingSt
 func (c ValidationResult_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["message"] = attrs["message"].SetOptional()
 	attrs["operation"] = attrs["operation"].SetOptional()
+	attrs["operation"] = attrs["operation"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DELETE", "LIST", "PATH_EXISTS", "READ", "WRITE"))
 	attrs["result"] = attrs["result"].SetOptional()
+	attrs["result"] = attrs["result"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("FAIL", "PASS", "SKIP"))
 
 	return attrs
 }
@@ -19902,6 +19969,7 @@ func (c VolumeInfo_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.At
 	attrs["updated_by"] = attrs["updated_by"].SetOptional()
 	attrs["volume_id"] = attrs["volume_id"].SetOptional()
 	attrs["volume_type"] = attrs["volume_type"].SetOptional()
+	attrs["volume_type"] = attrs["volume_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("EXTERNAL", "MANAGED"))
 
 	return attrs
 }
@@ -20013,6 +20081,7 @@ func (newState *WorkspaceBinding_SdkV2) SyncEffectiveFieldsDuringRead(existingSt
 
 func (c WorkspaceBinding_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["binding_type"] = attrs["binding_type"].SetOptional()
+	attrs["binding_type"] = attrs["binding_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("BINDING_TYPE_READ_ONLY", "BINDING_TYPE_READ_WRITE"))
 	attrs["workspace_id"] = attrs["workspace_id"].SetOptional()
 
 	return attrs

--- a/internal/service/catalog_tf/model.go
+++ b/internal/service/catalog_tf/model.go
@@ -17,6 +17,7 @@ import (
 	pluginfwcommon "github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/common"
 	"github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/tfschema"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
@@ -865,6 +866,7 @@ func (newState *ArtifactMatcher) SyncEffectiveFieldsDuringRead(existingState Art
 func (c ArtifactMatcher) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["artifact"] = attrs["artifact"].SetRequired()
 	attrs["match_type"] = attrs["match_type"].SetRequired()
+	attrs["match_type"] = attrs["match_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("PREFIX_MATCH"))
 
 	return attrs
 }
@@ -1663,14 +1665,17 @@ func (newState *CatalogInfo) SyncEffectiveFieldsDuringRead(existingState Catalog
 func (c CatalogInfo) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["browse_only"] = attrs["browse_only"].SetOptional()
 	attrs["catalog_type"] = attrs["catalog_type"].SetOptional()
+	attrs["catalog_type"] = attrs["catalog_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DELTASHARING_CATALOG", "MANAGED_CATALOG", "SYSTEM_CATALOG"))
 	attrs["comment"] = attrs["comment"].SetOptional()
 	attrs["connection_name"] = attrs["connection_name"].SetOptional()
 	attrs["created_at"] = attrs["created_at"].SetOptional()
 	attrs["created_by"] = attrs["created_by"].SetOptional()
 	attrs["effective_predictive_optimization_flag"] = attrs["effective_predictive_optimization_flag"].SetOptional()
 	attrs["enable_predictive_optimization"] = attrs["enable_predictive_optimization"].SetOptional()
+	attrs["enable_predictive_optimization"] = attrs["enable_predictive_optimization"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DISABLE", "ENABLE", "INHERIT"))
 	attrs["full_name"] = attrs["full_name"].SetOptional()
 	attrs["isolation_mode"] = attrs["isolation_mode"].SetOptional()
+	attrs["isolation_mode"] = attrs["isolation_mode"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ISOLATED", "OPEN"))
 	attrs["metastore_id"] = attrs["metastore_id"].SetOptional()
 	attrs["name"] = attrs["name"].SetOptional()
 	attrs["options"] = attrs["options"].SetOptional()
@@ -1981,6 +1986,7 @@ func (c ColumnInfo) ApplySchemaCustomizations(attrs map[string]tfschema.Attribut
 	attrs["type_interval_type"] = attrs["type_interval_type"].SetOptional()
 	attrs["type_json"] = attrs["type_json"].SetOptional()
 	attrs["type_name"] = attrs["type_name"].SetOptional()
+	attrs["type_name"] = attrs["type_name"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ARRAY", "BINARY", "BOOLEAN", "BYTE", "CHAR", "DATE", "DECIMAL", "DOUBLE", "FLOAT", "INT", "INTERVAL", "LONG", "MAP", "NULL", "SHORT", "STRING", "STRUCT", "TABLE_TYPE", "TIMESTAMP", "TIMESTAMP_NTZ", "USER_DEFINED_TYPE", "VARIANT"))
 	attrs["type_precision"] = attrs["type_precision"].SetOptional()
 	attrs["type_scale"] = attrs["type_scale"].SetOptional()
 	attrs["type_text"] = attrs["type_text"].SetOptional()
@@ -2207,9 +2213,11 @@ func (c ConnectionInfo) ApplySchemaCustomizations(attrs map[string]tfschema.Attr
 	attrs["comment"] = attrs["comment"].SetOptional()
 	attrs["connection_id"] = attrs["connection_id"].SetOptional()
 	attrs["connection_type"] = attrs["connection_type"].SetOptional()
+	attrs["connection_type"] = attrs["connection_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("BIGQUERY", "DATABRICKS", "GLUE", "HIVE_METASTORE", "HTTP", "MYSQL", "POSTGRESQL", "REDSHIFT", "SNOWFLAKE", "SQLDW", "SQLSERVER"))
 	attrs["created_at"] = attrs["created_at"].SetOptional()
 	attrs["created_by"] = attrs["created_by"].SetOptional()
 	attrs["credential_type"] = attrs["credential_type"].SetOptional()
+	attrs["credential_type"] = attrs["credential_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("BEARER_TOKEN", "USERNAME_PASSWORD"))
 	attrs["full_name"] = attrs["full_name"].SetOptional()
 	attrs["metastore_id"] = attrs["metastore_id"].SetOptional()
 	attrs["name"] = attrs["name"].SetOptional()
@@ -2642,6 +2650,7 @@ func (newState *CreateConnection) SyncEffectiveFieldsDuringRead(existingState Cr
 func (c CreateConnection) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["comment"] = attrs["comment"].SetOptional()
 	attrs["connection_type"] = attrs["connection_type"].SetRequired()
+	attrs["connection_type"] = attrs["connection_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("BIGQUERY", "DATABRICKS", "GLUE", "HIVE_METASTORE", "HTTP", "MYSQL", "POSTGRESQL", "REDSHIFT", "SNOWFLAKE", "SQLDW", "SQLSERVER"))
 	attrs["name"] = attrs["name"].SetRequired()
 	attrs["options"] = attrs["options"].SetRequired()
 	attrs["properties"] = attrs["properties"].SetOptional()
@@ -2790,6 +2799,7 @@ func (c CreateCredentialRequest) ApplySchemaCustomizations(attrs map[string]tfsc
 	attrs["databricks_gcp_service_account"] = attrs["databricks_gcp_service_account"].SetOptional()
 	attrs["name"] = attrs["name"].SetRequired()
 	attrs["purpose"] = attrs["purpose"].SetOptional()
+	attrs["purpose"] = attrs["purpose"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("SERVICE", "STORAGE"))
 	attrs["read_only"] = attrs["read_only"].SetOptional()
 	attrs["skip_validation"] = attrs["skip_validation"].SetOptional()
 
@@ -3140,6 +3150,7 @@ func (c CreateFunction) ApplySchemaCustomizations(attrs map[string]tfschema.Attr
 	attrs["catalog_name"] = attrs["catalog_name"].SetRequired()
 	attrs["comment"] = attrs["comment"].SetOptional()
 	attrs["data_type"] = attrs["data_type"].SetRequired()
+	attrs["data_type"] = attrs["data_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ARRAY", "BINARY", "BOOLEAN", "BYTE", "CHAR", "DATE", "DECIMAL", "DOUBLE", "FLOAT", "INT", "INTERVAL", "LONG", "MAP", "NULL", "SHORT", "STRING", "STRUCT", "TABLE_TYPE", "TIMESTAMP", "TIMESTAMP_NTZ", "USER_DEFINED_TYPE", "VARIANT"))
 	attrs["external_language"] = attrs["external_language"].SetOptional()
 	attrs["external_name"] = attrs["external_name"].SetOptional()
 	attrs["full_data_type"] = attrs["full_data_type"].SetRequired()
@@ -3148,15 +3159,19 @@ func (c CreateFunction) ApplySchemaCustomizations(attrs map[string]tfschema.Attr
 	attrs["is_null_call"] = attrs["is_null_call"].SetRequired()
 	attrs["name"] = attrs["name"].SetRequired()
 	attrs["parameter_style"] = attrs["parameter_style"].SetRequired()
+	attrs["parameter_style"] = attrs["parameter_style"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("S"))
 	attrs["properties"] = attrs["properties"].SetOptional()
 	attrs["return_params"] = attrs["return_params"].SetOptional()
 	attrs["routine_body"] = attrs["routine_body"].SetRequired()
+	attrs["routine_body"] = attrs["routine_body"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("EXTERNAL", "SQL"))
 	attrs["routine_definition"] = attrs["routine_definition"].SetRequired()
 	attrs["routine_dependencies"] = attrs["routine_dependencies"].SetOptional()
 	attrs["schema_name"] = attrs["schema_name"].SetRequired()
 	attrs["security_type"] = attrs["security_type"].SetRequired()
+	attrs["security_type"] = attrs["security_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DEFINER"))
 	attrs["specific_name"] = attrs["specific_name"].SetRequired()
 	attrs["sql_data_access"] = attrs["sql_data_access"].SetRequired()
+	attrs["sql_data_access"] = attrs["sql_data_access"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CONTAINS_SQL", "NO_SQL", "READS_SQL_DATA"))
 	attrs["sql_path"] = attrs["sql_path"].SetOptional()
 
 	return attrs
@@ -4488,6 +4503,7 @@ func (c CreateVolumeRequestContent) ApplySchemaCustomizations(attrs map[string]t
 	attrs["schema_name"] = attrs["schema_name"].SetRequired()
 	attrs["storage_location"] = attrs["storage_location"].SetOptional()
 	attrs["volume_type"] = attrs["volume_type"].SetRequired()
+	attrs["volume_type"] = attrs["volume_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("EXTERNAL", "MANAGED"))
 
 	return attrs
 }
@@ -4595,10 +4611,12 @@ func (c CredentialInfo) ApplySchemaCustomizations(attrs map[string]tfschema.Attr
 	attrs["full_name"] = attrs["full_name"].SetOptional()
 	attrs["id"] = attrs["id"].SetOptional()
 	attrs["isolation_mode"] = attrs["isolation_mode"].SetOptional()
+	attrs["isolation_mode"] = attrs["isolation_mode"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ISOLATION_MODE_ISOLATED", "ISOLATION_MODE_OPEN"))
 	attrs["metastore_id"] = attrs["metastore_id"].SetOptional()
 	attrs["name"] = attrs["name"].SetOptional()
 	attrs["owner"] = attrs["owner"].SetOptional()
 	attrs["purpose"] = attrs["purpose"].SetOptional()
+	attrs["purpose"] = attrs["purpose"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("SERVICE", "STORAGE"))
 	attrs["read_only"] = attrs["read_only"].SetOptional()
 	attrs["updated_at"] = attrs["updated_at"].SetOptional()
 	attrs["updated_by"] = attrs["updated_by"].SetOptional()
@@ -4805,6 +4823,7 @@ func (newState *CredentialValidationResult) SyncEffectiveFieldsDuringRead(existi
 func (c CredentialValidationResult) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["message"] = attrs["message"].SetOptional()
 	attrs["result"] = attrs["result"].SetOptional()
+	attrs["result"] = attrs["result"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("FAIL", "PASS", "SKIP"))
 
 	return attrs
 }
@@ -6395,7 +6414,9 @@ func (newState *EffectivePredictiveOptimizationFlag) SyncEffectiveFieldsDuringRe
 func (c EffectivePredictiveOptimizationFlag) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["inherited_from_name"] = attrs["inherited_from_name"].SetOptional()
 	attrs["inherited_from_type"] = attrs["inherited_from_type"].SetOptional()
+	attrs["inherited_from_type"] = attrs["inherited_from_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CATALOG", "SCHEMA"))
 	attrs["value"] = attrs["value"].SetRequired()
+	attrs["value"] = attrs["value"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DISABLE", "ENABLE", "INHERIT"))
 
 	return attrs
 }
@@ -6457,7 +6478,9 @@ func (newState *EffectivePrivilege) SyncEffectiveFieldsDuringRead(existingState 
 func (c EffectivePrivilege) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["inherited_from_name"] = attrs["inherited_from_name"].SetOptional()
 	attrs["inherited_from_type"] = attrs["inherited_from_type"].SetOptional()
+	attrs["inherited_from_type"] = attrs["inherited_from_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CATALOG", "CLEAN_ROOM", "CONNECTION", "CREDENTIAL", "EXTERNAL_LOCATION", "FUNCTION", "METASTORE", "PIPELINE", "PROVIDER", "RECIPIENT", "SCHEMA", "SHARE", "STORAGE_CREDENTIAL", "TABLE", "VOLUME"))
 	attrs["privilege"] = attrs["privilege"].SetOptional()
+	attrs["privilege"] = attrs["privilege"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ACCESS", "ALL_PRIVILEGES", "APPLY_TAG", "CREATE", "CREATE_CATALOG", "CREATE_CONNECTION", "CREATE_EXTERNAL_LOCATION", "CREATE_EXTERNAL_TABLE", "CREATE_EXTERNAL_VOLUME", "CREATE_FOREIGN_CATALOG", "CREATE_FOREIGN_SECURABLE", "CREATE_FUNCTION", "CREATE_MANAGED_STORAGE", "CREATE_MATERIALIZED_VIEW", "CREATE_MODEL", "CREATE_PROVIDER", "CREATE_RECIPIENT", "CREATE_SCHEMA", "CREATE_SERVICE_CREDENTIAL", "CREATE_SHARE", "CREATE_STORAGE_CREDENTIAL", "CREATE_TABLE", "CREATE_VIEW", "CREATE_VOLUME", "EXECUTE", "MANAGE", "MANAGE_ALLOWLIST", "MODIFY", "READ_FILES", "READ_PRIVATE_FILES", "READ_VOLUME", "REFRESH", "SELECT", "SET_SHARE_PERMISSION", "USAGE", "USE_CATALOG", "USE_CONNECTION", "USE_MARKETPLACE_ASSETS", "USE_PROVIDER", "USE_RECIPIENT", "USE_SCHEMA", "USE_SHARE", "WRITE_FILES", "WRITE_PRIVATE_FILES", "WRITE_VOLUME"))
 
 	return attrs
 }
@@ -6827,6 +6850,7 @@ func (c ExternalLocationInfo) ApplySchemaCustomizations(attrs map[string]tfschem
 	attrs["encryption_details"] = attrs["encryption_details"].SetOptional()
 	attrs["fallback"] = attrs["fallback"].SetOptional()
 	attrs["isolation_mode"] = attrs["isolation_mode"].SetOptional()
+	attrs["isolation_mode"] = attrs["isolation_mode"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ISOLATION_MODE_ISOLATED", "ISOLATION_MODE_OPEN"))
 	attrs["metastore_id"] = attrs["metastore_id"].SetOptional()
 	attrs["name"] = attrs["name"].SetOptional()
 	attrs["owner"] = attrs["owner"].SetOptional()
@@ -7246,6 +7270,7 @@ func (c FunctionInfo) ApplySchemaCustomizations(attrs map[string]tfschema.Attrib
 	attrs["created_at"] = attrs["created_at"].SetOptional()
 	attrs["created_by"] = attrs["created_by"].SetOptional()
 	attrs["data_type"] = attrs["data_type"].SetOptional()
+	attrs["data_type"] = attrs["data_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ARRAY", "BINARY", "BOOLEAN", "BYTE", "CHAR", "DATE", "DECIMAL", "DOUBLE", "FLOAT", "INT", "INTERVAL", "LONG", "MAP", "NULL", "SHORT", "STRING", "STRUCT", "TABLE_TYPE", "TIMESTAMP", "TIMESTAMP_NTZ", "USER_DEFINED_TYPE", "VARIANT"))
 	attrs["external_language"] = attrs["external_language"].SetOptional()
 	attrs["external_name"] = attrs["external_name"].SetOptional()
 	attrs["full_data_type"] = attrs["full_data_type"].SetOptional()
@@ -7258,15 +7283,19 @@ func (c FunctionInfo) ApplySchemaCustomizations(attrs map[string]tfschema.Attrib
 	attrs["name"] = attrs["name"].SetOptional()
 	attrs["owner"] = attrs["owner"].SetOptional()
 	attrs["parameter_style"] = attrs["parameter_style"].SetOptional()
+	attrs["parameter_style"] = attrs["parameter_style"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("S"))
 	attrs["properties"] = attrs["properties"].SetOptional()
 	attrs["return_params"] = attrs["return_params"].SetOptional()
 	attrs["routine_body"] = attrs["routine_body"].SetOptional()
+	attrs["routine_body"] = attrs["routine_body"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("EXTERNAL", "SQL"))
 	attrs["routine_definition"] = attrs["routine_definition"].SetOptional()
 	attrs["routine_dependencies"] = attrs["routine_dependencies"].SetOptional()
 	attrs["schema_name"] = attrs["schema_name"].SetOptional()
 	attrs["security_type"] = attrs["security_type"].SetOptional()
+	attrs["security_type"] = attrs["security_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DEFINER"))
 	attrs["specific_name"] = attrs["specific_name"].SetOptional()
 	attrs["sql_data_access"] = attrs["sql_data_access"].SetOptional()
+	attrs["sql_data_access"] = attrs["sql_data_access"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CONTAINS_SQL", "NO_SQL", "READS_SQL_DATA"))
 	attrs["sql_path"] = attrs["sql_path"].SetOptional()
 	attrs["updated_at"] = attrs["updated_at"].SetOptional()
 	attrs["updated_by"] = attrs["updated_by"].SetOptional()
@@ -7489,11 +7518,14 @@ func (c FunctionParameterInfo) ApplySchemaCustomizations(attrs map[string]tfsche
 	attrs["name"] = attrs["name"].SetRequired()
 	attrs["parameter_default"] = attrs["parameter_default"].SetOptional()
 	attrs["parameter_mode"] = attrs["parameter_mode"].SetOptional()
+	attrs["parameter_mode"] = attrs["parameter_mode"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("IN"))
 	attrs["parameter_type"] = attrs["parameter_type"].SetOptional()
+	attrs["parameter_type"] = attrs["parameter_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("COLUMN", "PARAM"))
 	attrs["position"] = attrs["position"].SetRequired()
 	attrs["type_interval_type"] = attrs["type_interval_type"].SetOptional()
 	attrs["type_json"] = attrs["type_json"].SetOptional()
 	attrs["type_name"] = attrs["type_name"].SetRequired()
+	attrs["type_name"] = attrs["type_name"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ARRAY", "BINARY", "BOOLEAN", "BYTE", "CHAR", "DATE", "DECIMAL", "DOUBLE", "FLOAT", "INT", "INTERVAL", "LONG", "MAP", "NULL", "SHORT", "STRING", "STRUCT", "TABLE_TYPE", "TIMESTAMP", "TIMESTAMP_NTZ", "USER_DEFINED_TYPE", "VARIANT"))
 	attrs["type_precision"] = attrs["type_precision"].SetOptional()
 	attrs["type_scale"] = attrs["type_scale"].SetOptional()
 	attrs["type_text"] = attrs["type_text"].SetRequired()
@@ -7979,6 +8011,7 @@ func (newState *GenerateTemporaryTableCredentialRequest) SyncEffectiveFieldsDuri
 
 func (c GenerateTemporaryTableCredentialRequest) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["operation"] = attrs["operation"].SetOptional()
+	attrs["operation"] = attrs["operation"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("READ", "READ_WRITE"))
 	attrs["table_id"] = attrs["table_id"].SetOptional()
 
 	return attrs
@@ -8889,6 +8922,7 @@ func (c GetMetastoreSummaryResponse) ApplySchemaCustomizations(attrs map[string]
 	attrs["delta_sharing_organization_name"] = attrs["delta_sharing_organization_name"].SetOptional()
 	attrs["delta_sharing_recipient_token_lifetime_in_seconds"] = attrs["delta_sharing_recipient_token_lifetime_in_seconds"].SetOptional()
 	attrs["delta_sharing_scope"] = attrs["delta_sharing_scope"].SetOptional()
+	attrs["delta_sharing_scope"] = attrs["delta_sharing_scope"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("INTERNAL", "INTERNAL_AND_EXTERNAL"))
 	attrs["external_access_enabled"] = attrs["external_access_enabled"].SetOptional()
 	attrs["global_metastore_id"] = attrs["global_metastore_id"].SetOptional()
 	attrs["metastore_id"] = attrs["metastore_id"].SetOptional()
@@ -11915,6 +11949,7 @@ func (c MetastoreInfo) ApplySchemaCustomizations(attrs map[string]tfschema.Attri
 	attrs["delta_sharing_organization_name"] = attrs["delta_sharing_organization_name"].SetOptional()
 	attrs["delta_sharing_recipient_token_lifetime_in_seconds"] = attrs["delta_sharing_recipient_token_lifetime_in_seconds"].SetOptional()
 	attrs["delta_sharing_scope"] = attrs["delta_sharing_scope"].SetOptional()
+	attrs["delta_sharing_scope"] = attrs["delta_sharing_scope"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("INTERNAL", "INTERNAL_AND_EXTERNAL"))
 	attrs["external_access_enabled"] = attrs["external_access_enabled"].SetOptional()
 	attrs["global_metastore_id"] = attrs["global_metastore_id"].SetOptional()
 	attrs["metastore_id"] = attrs["metastore_id"].SetOptional()
@@ -12073,6 +12108,7 @@ func (c ModelVersionInfo) ApplySchemaCustomizations(attrs map[string]tfschema.At
 	attrs["schema_name"] = attrs["schema_name"].SetOptional()
 	attrs["source"] = attrs["source"].SetOptional()
 	attrs["status"] = attrs["status"].SetOptional()
+	attrs["status"] = attrs["status"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("FAILED_REGISTRATION", "PENDING_REGISTRATION", "READY"))
 	attrs["storage_location"] = attrs["storage_location"].SetOptional()
 	attrs["updated_at"] = attrs["updated_at"].SetOptional()
 	attrs["updated_by"] = attrs["updated_by"].SetOptional()
@@ -12227,6 +12263,7 @@ func (newState *MonitorCronSchedule) SyncEffectiveFieldsDuringRead(existingState
 
 func (c MonitorCronSchedule) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["pause_status"] = attrs["pause_status"].SetOptional()
+	attrs["pause_status"] = attrs["pause_status"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("PAUSED", "UNPAUSED"))
 	attrs["quartz_cron_expression"] = attrs["quartz_cron_expression"].SetRequired()
 	attrs["timezone_id"] = attrs["timezone_id"].SetRequired()
 
@@ -12439,6 +12476,7 @@ func (c MonitorInferenceLog) ApplySchemaCustomizations(attrs map[string]tfschema
 	attrs["prediction_col"] = attrs["prediction_col"].SetRequired()
 	attrs["prediction_proba_col"] = attrs["prediction_proba_col"].SetOptional()
 	attrs["problem_type"] = attrs["problem_type"].SetRequired()
+	attrs["problem_type"] = attrs["problem_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("PROBLEM_TYPE_CLASSIFICATION", "PROBLEM_TYPE_REGRESSION"))
 	attrs["timestamp_col"] = attrs["timestamp_col"].SetRequired()
 
 	return attrs
@@ -12592,6 +12630,7 @@ func (c MonitorInfo) ApplySchemaCustomizations(attrs map[string]tfschema.Attribu
 	attrs["slicing_exprs"] = attrs["slicing_exprs"].SetOptional()
 	attrs["snapshot"] = attrs["snapshot"].SetOptional()
 	attrs["status"] = attrs["status"].SetRequired()
+	attrs["status"] = attrs["status"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("MONITOR_STATUS_ACTIVE", "MONITOR_STATUS_DELETE_PENDING", "MONITOR_STATUS_ERROR", "MONITOR_STATUS_FAILED", "MONITOR_STATUS_PENDING"))
 	attrs["table_name"] = attrs["table_name"].SetRequired()
 	attrs["time_series"] = attrs["time_series"].SetOptional()
 
@@ -12935,6 +12974,7 @@ func (c MonitorMetric) ApplySchemaCustomizations(attrs map[string]tfschema.Attri
 	attrs["name"] = attrs["name"].SetRequired()
 	attrs["output_data_type"] = attrs["output_data_type"].SetRequired()
 	attrs["type"] = attrs["type"].SetRequired()
+	attrs["type"] = attrs["type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CUSTOM_METRIC_TYPE_AGGREGATE", "CUSTOM_METRIC_TYPE_DERIVED", "CUSTOM_METRIC_TYPE_DRIFT"))
 
 	return attrs
 }
@@ -13151,7 +13191,9 @@ func (c MonitorRefreshInfo) ApplySchemaCustomizations(attrs map[string]tfschema.
 	attrs["refresh_id"] = attrs["refresh_id"].SetRequired()
 	attrs["start_time_ms"] = attrs["start_time_ms"].SetRequired()
 	attrs["state"] = attrs["state"].SetRequired()
+	attrs["state"] = attrs["state"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CANCELED", "FAILED", "PENDING", "RUNNING", "SUCCESS"))
 	attrs["trigger"] = attrs["trigger"].SetOptional()
+	attrs["trigger"] = attrs["trigger"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("MANUAL", "SCHEDULE"))
 
 	return attrs
 }
@@ -13484,6 +13526,7 @@ func (c OnlineTable) ApplySchemaCustomizations(attrs map[string]tfschema.Attribu
 	attrs["status"] = attrs["status"].SetComputed()
 	attrs["table_serving_url"] = attrs["table_serving_url"].SetComputed()
 	attrs["unity_catalog_provisioning_state"] = attrs["unity_catalog_provisioning_state"].SetComputed()
+	attrs["unity_catalog_provisioning_state"] = attrs["unity_catalog_provisioning_state"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ACTIVE", "DEGRADED", "DELETING", "FAILED", "PROVISIONING", "UPDATING"))
 
 	return attrs
 }
@@ -13874,6 +13917,7 @@ func (newState *OnlineTableStatus) SyncEffectiveFieldsDuringRead(existingState O
 func (c OnlineTableStatus) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["continuous_update_status"] = attrs["continuous_update_status"].SetOptional()
 	attrs["detailed_state"] = attrs["detailed_state"].SetOptional()
+	attrs["detailed_state"] = attrs["detailed_state"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("OFFLINE", "OFFLINE_FAILED", "ONLINE", "ONLINE_CONTINUOUS_UPDATE", "ONLINE_NO_PENDING_UPDATE", "ONLINE_PIPELINE_FAILED", "ONLINE_TRIGGERED_UPDATE", "ONLINE_UPDATING_PIPELINE_RESOURCES", "PROVISIONING", "PROVISIONING_INITIAL_SNAPSHOT", "PROVISIONING_PIPELINE_RESOURCES"))
 	attrs["failed_status"] = attrs["failed_status"].SetOptional()
 	attrs["message"] = attrs["message"].SetOptional()
 	attrs["provisioning_status"] = attrs["provisioning_status"].SetOptional()
@@ -14485,6 +14529,7 @@ func (newState *ProvisioningInfo) SyncEffectiveFieldsDuringRead(existingState Pr
 
 func (c ProvisioningInfo) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["state"] = attrs["state"].SetOptional()
+	attrs["state"] = attrs["state"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ACTIVE", "DEGRADED", "DELETING", "FAILED", "PROVISIONING", "UPDATING"))
 
 	return attrs
 }
@@ -14627,6 +14672,7 @@ func (c QuotaInfo) ApplySchemaCustomizations(attrs map[string]tfschema.Attribute
 	attrs["last_refreshed_at"] = attrs["last_refreshed_at"].SetOptional()
 	attrs["parent_full_name"] = attrs["parent_full_name"].SetOptional()
 	attrs["parent_securable_type"] = attrs["parent_securable_type"].SetOptional()
+	attrs["parent_securable_type"] = attrs["parent_securable_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CATALOG", "CLEAN_ROOM", "CONNECTION", "CREDENTIAL", "EXTERNAL_LOCATION", "FUNCTION", "METASTORE", "PIPELINE", "PROVIDER", "RECIPIENT", "SCHEMA", "SHARE", "STORAGE_CREDENTIAL", "TABLE", "VOLUME"))
 	attrs["quota_count"] = attrs["quota_count"].SetOptional()
 	attrs["quota_limit"] = attrs["quota_limit"].SetOptional()
 	attrs["quota_name"] = attrs["quota_name"].SetOptional()
@@ -15180,6 +15226,7 @@ func (c SchemaInfo) ApplySchemaCustomizations(attrs map[string]tfschema.Attribut
 	attrs["created_by"] = attrs["created_by"].SetOptional()
 	attrs["effective_predictive_optimization_flag"] = attrs["effective_predictive_optimization_flag"].SetOptional()
 	attrs["enable_predictive_optimization"] = attrs["enable_predictive_optimization"].SetOptional()
+	attrs["enable_predictive_optimization"] = attrs["enable_predictive_optimization"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DISABLE", "ENABLE", "INHERIT"))
 	attrs["full_name"] = attrs["full_name"].SetOptional()
 	attrs["metastore_id"] = attrs["metastore_id"].SetOptional()
 	attrs["name"] = attrs["name"].SetOptional()
@@ -15334,6 +15381,7 @@ func (newState *SetArtifactAllowlist) SyncEffectiveFieldsDuringRead(existingStat
 func (c SetArtifactAllowlist) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["artifact_matchers"] = attrs["artifact_matchers"].SetRequired()
 	attrs["artifact_type"] = attrs["artifact_type"].SetRequired()
+	attrs["artifact_type"] = attrs["artifact_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("INIT_SCRIPT", "LIBRARY_JAR", "LIBRARY_MAVEN"))
 
 	return attrs
 }
@@ -15476,6 +15524,7 @@ func (newState *SseEncryptionDetails) SyncEffectiveFieldsDuringRead(existingStat
 
 func (c SseEncryptionDetails) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["algorithm"] = attrs["algorithm"].SetOptional()
+	attrs["algorithm"] = attrs["algorithm"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("AWS_SSE_KMS", "AWS_SSE_S3"))
 	attrs["aws_kms_key_arn"] = attrs["aws_kms_key_arn"].SetOptional()
 
 	return attrs
@@ -15572,6 +15621,7 @@ func (c StorageCredentialInfo) ApplySchemaCustomizations(attrs map[string]tfsche
 	attrs["full_name"] = attrs["full_name"].SetOptional()
 	attrs["id"] = attrs["id"].SetOptional()
 	attrs["isolation_mode"] = attrs["isolation_mode"].SetOptional()
+	attrs["isolation_mode"] = attrs["isolation_mode"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ISOLATION_MODE_ISOLATED", "ISOLATION_MODE_OPEN"))
 	attrs["metastore_id"] = attrs["metastore_id"].SetOptional()
 	attrs["name"] = attrs["name"].SetOptional()
 	attrs["owner"] = attrs["owner"].SetOptional()
@@ -15811,6 +15861,7 @@ func (newState *SystemSchemaInfo) SyncEffectiveFieldsDuringRead(existingState Sy
 func (c SystemSchemaInfo) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["schema"] = attrs["schema"].SetOptional()
 	attrs["state"] = attrs["state"].SetOptional()
+	attrs["state"] = attrs["state"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("AVAILABLE", "DISABLE_INITIALIZED", "ENABLE_COMPLETED", "ENABLE_INITIALIZED", "UNAVAILABLE"))
 
 	return attrs
 }
@@ -16190,10 +16241,12 @@ func (c TableInfo) ApplySchemaCustomizations(attrs map[string]tfschema.Attribute
 	attrs["created_by"] = attrs["created_by"].SetOptional()
 	attrs["data_access_configuration_id"] = attrs["data_access_configuration_id"].SetOptional()
 	attrs["data_source_format"] = attrs["data_source_format"].SetOptional()
+	attrs["data_source_format"] = attrs["data_source_format"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("AVRO", "BIGQUERY_FORMAT", "CSV", "DATABRICKS_FORMAT", "DELTA", "DELTASHARING", "HIVE_CUSTOM", "HIVE_SERDE", "JSON", "MYSQL_FORMAT", "NETSUITE_FORMAT", "ORC", "PARQUET", "POSTGRESQL_FORMAT", "REDSHIFT_FORMAT", "SALESFORCE_FORMAT", "SNOWFLAKE_FORMAT", "SQLDW_FORMAT", "SQLSERVER_FORMAT", "TEXT", "UNITY_CATALOG", "VECTOR_INDEX_FORMAT", "WORKDAY_RAAS_FORMAT"))
 	attrs["deleted_at"] = attrs["deleted_at"].SetOptional()
 	attrs["delta_runtime_properties_kvpairs"] = attrs["delta_runtime_properties_kvpairs"].SetOptional()
 	attrs["effective_predictive_optimization_flag"] = attrs["effective_predictive_optimization_flag"].SetOptional()
 	attrs["enable_predictive_optimization"] = attrs["enable_predictive_optimization"].SetOptional()
+	attrs["enable_predictive_optimization"] = attrs["enable_predictive_optimization"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DISABLE", "ENABLE", "INHERIT"))
 	attrs["encryption_details"] = attrs["encryption_details"].SetOptional()
 	attrs["full_name"] = attrs["full_name"].SetOptional()
 	attrs["metastore_id"] = attrs["metastore_id"].SetOptional()
@@ -16209,6 +16262,7 @@ func (c TableInfo) ApplySchemaCustomizations(attrs map[string]tfschema.Attribute
 	attrs["table_constraints"] = attrs["table_constraints"].SetOptional()
 	attrs["table_id"] = attrs["table_id"].SetOptional()
 	attrs["table_type"] = attrs["table_type"].SetOptional()
+	attrs["table_type"] = attrs["table_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("EXTERNAL", "EXTERNAL_SHALLOW_CLONE", "FOREIGN", "MANAGED", "MANAGED_SHALLOW_CLONE", "MATERIALIZED_VIEW", "STREAMING_TABLE", "VIEW"))
 	attrs["updated_at"] = attrs["updated_at"].SetOptional()
 	attrs["updated_by"] = attrs["updated_by"].SetOptional()
 	attrs["view_definition"] = attrs["view_definition"].SetOptional()
@@ -16644,6 +16698,7 @@ func (newState *TableSummary) SyncEffectiveFieldsDuringRead(existingState TableS
 func (c TableSummary) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["full_name"] = attrs["full_name"].SetOptional()
 	attrs["table_type"] = attrs["table_type"].SetOptional()
+	attrs["table_type"] = attrs["table_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("EXTERNAL", "EXTERNAL_SHALLOW_CLONE", "FOREIGN", "MANAGED", "MANAGED_SHALLOW_CLONE", "MATERIALIZED_VIEW", "STREAMING_TABLE", "VIEW"))
 
 	return attrs
 }
@@ -17061,7 +17116,9 @@ func (newState *UpdateCatalog) SyncEffectiveFieldsDuringRead(existingState Updat
 func (c UpdateCatalog) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["comment"] = attrs["comment"].SetOptional()
 	attrs["enable_predictive_optimization"] = attrs["enable_predictive_optimization"].SetOptional()
+	attrs["enable_predictive_optimization"] = attrs["enable_predictive_optimization"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DISABLE", "ENABLE", "INHERIT"))
 	attrs["isolation_mode"] = attrs["isolation_mode"].SetOptional()
+	attrs["isolation_mode"] = attrs["isolation_mode"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ISOLATED", "OPEN"))
 	attrs["name"] = attrs["name"].SetRequired()
 	attrs["new_name"] = attrs["new_name"].SetOptional()
 	attrs["options"] = attrs["options"].SetOptional()
@@ -17316,6 +17373,7 @@ func (c UpdateCredentialRequest) ApplySchemaCustomizations(attrs map[string]tfsc
 	attrs["databricks_gcp_service_account"] = attrs["databricks_gcp_service_account"].SetOptional()
 	attrs["force"] = attrs["force"].SetOptional()
 	attrs["isolation_mode"] = attrs["isolation_mode"].SetOptional()
+	attrs["isolation_mode"] = attrs["isolation_mode"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ISOLATION_MODE_ISOLATED", "ISOLATION_MODE_OPEN"))
 	attrs["name_arg"] = attrs["name_arg"].SetRequired()
 	attrs["new_name"] = attrs["new_name"].SetOptional()
 	attrs["owner"] = attrs["owner"].SetOptional()
@@ -17542,6 +17600,7 @@ func (c UpdateExternalLocation) ApplySchemaCustomizations(attrs map[string]tfsch
 	attrs["fallback"] = attrs["fallback"].SetOptional()
 	attrs["force"] = attrs["force"].SetOptional()
 	attrs["isolation_mode"] = attrs["isolation_mode"].SetOptional()
+	attrs["isolation_mode"] = attrs["isolation_mode"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ISOLATION_MODE_ISOLATED", "ISOLATION_MODE_OPEN"))
 	attrs["name"] = attrs["name"].SetRequired()
 	attrs["new_name"] = attrs["new_name"].SetOptional()
 	attrs["owner"] = attrs["owner"].SetOptional()
@@ -17722,6 +17781,7 @@ func (c UpdateMetastore) ApplySchemaCustomizations(attrs map[string]tfschema.Att
 	attrs["delta_sharing_organization_name"] = attrs["delta_sharing_organization_name"].SetOptional()
 	attrs["delta_sharing_recipient_token_lifetime_in_seconds"] = attrs["delta_sharing_recipient_token_lifetime_in_seconds"].SetOptional()
 	attrs["delta_sharing_scope"] = attrs["delta_sharing_scope"].SetOptional()
+	attrs["delta_sharing_scope"] = attrs["delta_sharing_scope"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("INTERNAL", "INTERNAL_AND_EXTERNAL"))
 	attrs["id"] = attrs["id"].SetRequired()
 	attrs["new_name"] = attrs["new_name"].SetOptional()
 	attrs["owner"] = attrs["owner"].SetOptional()
@@ -18258,6 +18318,7 @@ func (c UpdatePermissions) ApplySchemaCustomizations(attrs map[string]tfschema.A
 	attrs["changes"] = attrs["changes"].SetOptional()
 	attrs["full_name"] = attrs["full_name"].SetRequired()
 	attrs["securable_type"] = attrs["securable_type"].SetRequired()
+	attrs["securable_type"] = attrs["securable_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CATALOG", "CLEAN_ROOM", "CONNECTION", "CREDENTIAL", "EXTERNAL_LOCATION", "FUNCTION", "METASTORE", "PIPELINE", "PROVIDER", "RECIPIENT", "SCHEMA", "SHARE", "STORAGE_CREDENTIAL", "TABLE", "VOLUME"))
 
 	return attrs
 }
@@ -18445,6 +18506,7 @@ func (newState *UpdateSchema) SyncEffectiveFieldsDuringRead(existingState Update
 func (c UpdateSchema) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["comment"] = attrs["comment"].SetOptional()
 	attrs["enable_predictive_optimization"] = attrs["enable_predictive_optimization"].SetOptional()
+	attrs["enable_predictive_optimization"] = attrs["enable_predictive_optimization"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DISABLE", "ENABLE", "INHERIT"))
 	attrs["full_name"] = attrs["full_name"].SetRequired()
 	attrs["new_name"] = attrs["new_name"].SetOptional()
 	attrs["owner"] = attrs["owner"].SetOptional()
@@ -18570,6 +18632,7 @@ func (c UpdateStorageCredential) ApplySchemaCustomizations(attrs map[string]tfsc
 	attrs["databricks_gcp_service_account"] = attrs["databricks_gcp_service_account"].SetOptional()
 	attrs["force"] = attrs["force"].SetOptional()
 	attrs["isolation_mode"] = attrs["isolation_mode"].SetOptional()
+	attrs["isolation_mode"] = attrs["isolation_mode"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ISOLATION_MODE_ISOLATED", "ISOLATION_MODE_OPEN"))
 	attrs["name"] = attrs["name"].SetRequired()
 	attrs["new_name"] = attrs["new_name"].SetOptional()
 	attrs["owner"] = attrs["owner"].SetOptional()
@@ -19023,6 +19086,7 @@ func (c UpdateWorkspaceBindingsParameters) ApplySchemaCustomizations(attrs map[s
 	attrs["remove"] = attrs["remove"].SetOptional()
 	attrs["securable_name"] = attrs["securable_name"].SetRequired()
 	attrs["securable_type"] = attrs["securable_type"].SetRequired()
+	attrs["securable_type"] = attrs["securable_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("catalog", "credential", "external_location", "storage_credential"))
 
 	return attrs
 }
@@ -19157,6 +19221,7 @@ func (c ValidateCredentialRequest) ApplySchemaCustomizations(attrs map[string]tf
 	attrs["credential_name"] = attrs["credential_name"].SetOptional()
 	attrs["external_location_name"] = attrs["external_location_name"].SetOptional()
 	attrs["purpose"] = attrs["purpose"].SetOptional()
+	attrs["purpose"] = attrs["purpose"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("SERVICE", "STORAGE"))
 	attrs["read_only"] = attrs["read_only"].SetOptional()
 	attrs["url"] = attrs["url"].SetOptional()
 
@@ -19684,7 +19749,9 @@ func (newState *ValidationResult) SyncEffectiveFieldsDuringRead(existingState Va
 func (c ValidationResult) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["message"] = attrs["message"].SetOptional()
 	attrs["operation"] = attrs["operation"].SetOptional()
+	attrs["operation"] = attrs["operation"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DELETE", "LIST", "PATH_EXISTS", "READ", "WRITE"))
 	attrs["result"] = attrs["result"].SetOptional()
+	attrs["result"] = attrs["result"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("FAIL", "PASS", "SKIP"))
 
 	return attrs
 }
@@ -19787,6 +19854,7 @@ func (c VolumeInfo) ApplySchemaCustomizations(attrs map[string]tfschema.Attribut
 	attrs["updated_by"] = attrs["updated_by"].SetOptional()
 	attrs["volume_id"] = attrs["volume_id"].SetOptional()
 	attrs["volume_type"] = attrs["volume_type"].SetOptional()
+	attrs["volume_type"] = attrs["volume_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("EXTERNAL", "MANAGED"))
 
 	return attrs
 }
@@ -19898,6 +19966,7 @@ func (newState *WorkspaceBinding) SyncEffectiveFieldsDuringRead(existingState Wo
 
 func (c WorkspaceBinding) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["binding_type"] = attrs["binding_type"].SetOptional()
+	attrs["binding_type"] = attrs["binding_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("BINDING_TYPE_READ_ONLY", "BINDING_TYPE_READ_WRITE"))
 	attrs["workspace_id"] = attrs["workspace_id"].SetOptional()
 
 	return attrs

--- a/internal/service/cleanrooms_tf/legacy_model.go
+++ b/internal/service/cleanrooms_tf/legacy_model.go
@@ -22,6 +22,7 @@ import (
 	"github.com/databricks/terraform-provider-databricks/internal/service/settings_tf"
 	"github.com/databricks/terraform-provider-databricks/internal/service/sharing_tf"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
@@ -68,6 +69,7 @@ func (newState *CleanRoom_SdkV2) SyncEffectiveFieldsDuringRead(existingState Cle
 
 func (c CleanRoom_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["access_restricted"] = attrs["access_restricted"].SetComputed()
+	attrs["access_restricted"] = attrs["access_restricted"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CSP_MISMATCH", "NO_RESTRICTION"))
 	attrs["comment"] = attrs["comment"].SetOptional()
 	attrs["created_at"] = attrs["created_at"].SetComputed()
 	attrs["local_collaborator_alias"] = attrs["local_collaborator_alias"].SetComputed()
@@ -78,6 +80,7 @@ func (c CleanRoom_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.Att
 	attrs["remote_detailed_info"] = attrs["remote_detailed_info"].SetOptional()
 	attrs["remote_detailed_info"] = attrs["remote_detailed_info"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["status"] = attrs["status"].SetComputed()
+	attrs["status"] = attrs["status"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ACTIVE", "DELETED", "FAILED", "PROVISIONING"))
 	attrs["updated_at"] = attrs["updated_at"].SetComputed()
 
 	return attrs
@@ -244,6 +247,7 @@ func (newState *CleanRoomAsset_SdkV2) SyncEffectiveFieldsDuringRead(existingStat
 func (c CleanRoomAsset_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["added_at"] = attrs["added_at"].SetComputed()
 	attrs["asset_type"] = attrs["asset_type"].SetOptional()
+	attrs["asset_type"] = attrs["asset_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("FOREIGN_TABLE", "NOTEBOOK_FILE", "TABLE", "VIEW", "VOLUME"))
 	attrs["foreign_table"] = attrs["foreign_table"].SetOptional()
 	attrs["foreign_table"] = attrs["foreign_table"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["foreign_table_local_details"] = attrs["foreign_table_local_details"].SetOptional()
@@ -253,6 +257,7 @@ func (c CleanRoomAsset_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschem
 	attrs["notebook"] = attrs["notebook"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["owner_collaborator_alias"] = attrs["owner_collaborator_alias"].SetComputed()
 	attrs["status"] = attrs["status"].SetComputed()
+	attrs["status"] = attrs["status"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ACTIVE", "PENDING", "PERMISSION_DENIED"))
 	attrs["table"] = attrs["table"].SetOptional()
 	attrs["table"] = attrs["table"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["table_local_details"] = attrs["table_local_details"].SetOptional()
@@ -706,6 +711,7 @@ func (c CleanRoomAssetNotebook_SdkV2) ApplySchemaCustomizations(attrs map[string
 	attrs["etag"] = attrs["etag"].SetComputed()
 	attrs["notebook_content"] = attrs["notebook_content"].SetOptional()
 	attrs["review_state"] = attrs["review_state"].SetOptional()
+	attrs["review_state"] = attrs["review_state"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("APPROVED", "PENDING", "REJECTED"))
 	attrs["reviews"] = attrs["reviews"].SetOptional()
 	attrs["runner_collaborators"] = attrs["runner_collaborators"].SetOptional()
 
@@ -1260,6 +1266,7 @@ func (c CleanRoomNotebookReview_SdkV2) ApplySchemaCustomizations(attrs map[strin
 	attrs["comment"] = attrs["comment"].SetOptional()
 	attrs["created_at_millis"] = attrs["created_at_millis"].SetOptional()
 	attrs["review_state"] = attrs["review_state"].SetOptional()
+	attrs["review_state"] = attrs["review_state"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("APPROVED", "PENDING", "REJECTED"))
 	attrs["reviewer_collaborator_alias"] = attrs["reviewer_collaborator_alias"].SetOptional()
 
 	return attrs
@@ -1466,6 +1473,7 @@ func (newState *CleanRoomOutputCatalog_SdkV2) SyncEffectiveFieldsDuringRead(exis
 func (c CleanRoomOutputCatalog_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["catalog_name"] = attrs["catalog_name"].SetOptional()
 	attrs["status"] = attrs["status"].SetComputed()
+	attrs["status"] = attrs["status"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CREATED", "NOT_CREATED", "NOT_ELIGIBLE"))
 
 	return attrs
 }

--- a/internal/service/cleanrooms_tf/model.go
+++ b/internal/service/cleanrooms_tf/model.go
@@ -21,6 +21,7 @@ import (
 	"github.com/databricks/terraform-provider-databricks/internal/service/jobs_tf"
 	"github.com/databricks/terraform-provider-databricks/internal/service/settings_tf"
 	"github.com/databricks/terraform-provider-databricks/internal/service/sharing_tf"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
@@ -67,6 +68,7 @@ func (newState *CleanRoom) SyncEffectiveFieldsDuringRead(existingState CleanRoom
 
 func (c CleanRoom) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["access_restricted"] = attrs["access_restricted"].SetComputed()
+	attrs["access_restricted"] = attrs["access_restricted"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CSP_MISMATCH", "NO_RESTRICTION"))
 	attrs["comment"] = attrs["comment"].SetOptional()
 	attrs["created_at"] = attrs["created_at"].SetComputed()
 	attrs["local_collaborator_alias"] = attrs["local_collaborator_alias"].SetComputed()
@@ -75,6 +77,7 @@ func (c CleanRoom) ApplySchemaCustomizations(attrs map[string]tfschema.Attribute
 	attrs["owner"] = attrs["owner"].SetOptional()
 	attrs["remote_detailed_info"] = attrs["remote_detailed_info"].SetOptional()
 	attrs["status"] = attrs["status"].SetComputed()
+	attrs["status"] = attrs["status"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ACTIVE", "DELETED", "FAILED", "PROVISIONING"))
 	attrs["updated_at"] = attrs["updated_at"].SetComputed()
 
 	return attrs
@@ -241,12 +244,14 @@ func (newState *CleanRoomAsset) SyncEffectiveFieldsDuringRead(existingState Clea
 func (c CleanRoomAsset) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["added_at"] = attrs["added_at"].SetComputed()
 	attrs["asset_type"] = attrs["asset_type"].SetOptional()
+	attrs["asset_type"] = attrs["asset_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("FOREIGN_TABLE", "NOTEBOOK_FILE", "TABLE", "VIEW", "VOLUME"))
 	attrs["foreign_table"] = attrs["foreign_table"].SetOptional()
 	attrs["foreign_table_local_details"] = attrs["foreign_table_local_details"].SetOptional()
 	attrs["name"] = attrs["name"].SetOptional()
 	attrs["notebook"] = attrs["notebook"].SetOptional()
 	attrs["owner_collaborator_alias"] = attrs["owner_collaborator_alias"].SetComputed()
 	attrs["status"] = attrs["status"].SetComputed()
+	attrs["status"] = attrs["status"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ACTIVE", "PENDING", "PERMISSION_DENIED"))
 	attrs["table"] = attrs["table"].SetOptional()
 	attrs["table_local_details"] = attrs["table_local_details"].SetOptional()
 	attrs["view"] = attrs["view"].SetOptional()
@@ -695,6 +700,7 @@ func (c CleanRoomAssetNotebook) ApplySchemaCustomizations(attrs map[string]tfsch
 	attrs["etag"] = attrs["etag"].SetComputed()
 	attrs["notebook_content"] = attrs["notebook_content"].SetOptional()
 	attrs["review_state"] = attrs["review_state"].SetOptional()
+	attrs["review_state"] = attrs["review_state"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("APPROVED", "PENDING", "REJECTED"))
 	attrs["reviews"] = attrs["reviews"].SetOptional()
 	attrs["runner_collaborators"] = attrs["runner_collaborators"].SetOptional()
 
@@ -1249,6 +1255,7 @@ func (c CleanRoomNotebookReview) ApplySchemaCustomizations(attrs map[string]tfsc
 	attrs["comment"] = attrs["comment"].SetOptional()
 	attrs["created_at_millis"] = attrs["created_at_millis"].SetOptional()
 	attrs["review_state"] = attrs["review_state"].SetOptional()
+	attrs["review_state"] = attrs["review_state"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("APPROVED", "PENDING", "REJECTED"))
 	attrs["reviewer_collaborator_alias"] = attrs["reviewer_collaborator_alias"].SetOptional()
 
 	return attrs
@@ -1453,6 +1460,7 @@ func (newState *CleanRoomOutputCatalog) SyncEffectiveFieldsDuringRead(existingSt
 func (c CleanRoomOutputCatalog) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["catalog_name"] = attrs["catalog_name"].SetOptional()
 	attrs["status"] = attrs["status"].SetComputed()
+	attrs["status"] = attrs["status"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CREATED", "NOT_CREATED", "NOT_ELIGIBLE"))
 
 	return attrs
 }

--- a/internal/service/compute_tf/legacy_model.go
+++ b/internal/service/compute_tf/legacy_model.go
@@ -18,6 +18,7 @@ import (
 	"github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/tfschema"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
@@ -334,11 +335,13 @@ func (newState *AwsAttributes_SdkV2) SyncEffectiveFieldsDuringRead(existingState
 
 func (c AwsAttributes_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["availability"] = attrs["availability"].SetOptional()
+	attrs["availability"] = attrs["availability"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ON_DEMAND", "SPOT", "SPOT_WITH_FALLBACK"))
 	attrs["ebs_volume_count"] = attrs["ebs_volume_count"].SetOptional()
 	attrs["ebs_volume_iops"] = attrs["ebs_volume_iops"].SetOptional()
 	attrs["ebs_volume_size"] = attrs["ebs_volume_size"].SetOptional()
 	attrs["ebs_volume_throughput"] = attrs["ebs_volume_throughput"].SetOptional()
 	attrs["ebs_volume_type"] = attrs["ebs_volume_type"].SetOptional()
+	attrs["ebs_volume_type"] = attrs["ebs_volume_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("GENERAL_PURPOSE_SSD", "THROUGHPUT_OPTIMIZED_HDD"))
 	attrs["first_on_demand"] = attrs["first_on_demand"].SetOptional()
 	attrs["instance_profile_arn"] = attrs["instance_profile_arn"].SetOptional()
 	attrs["spot_bid_price_percent"] = attrs["spot_bid_price_percent"].SetOptional()
@@ -430,6 +433,7 @@ func (newState *AzureAttributes_SdkV2) SyncEffectiveFieldsDuringRead(existingSta
 
 func (c AzureAttributes_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["availability"] = attrs["availability"].SetOptional()
+	attrs["availability"] = attrs["availability"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ON_DEMAND_AZURE", "SPOT_AZURE", "SPOT_WITH_FALLBACK_AZURE"))
 	attrs["first_on_demand"] = attrs["first_on_demand"].SetOptional()
 	attrs["log_analytics_info"] = attrs["log_analytics_info"].SetOptional()
 	attrs["log_analytics_info"] = attrs["log_analytics_info"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
@@ -884,6 +888,7 @@ func (newState *ClusterAccessControlRequest_SdkV2) SyncEffectiveFieldsDuringRead
 func (c ClusterAccessControlRequest_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["group_name"] = attrs["group_name"].SetOptional()
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_ATTACH_TO", "CAN_MANAGE", "CAN_RESTART"))
 	attrs["service_principal_name"] = attrs["service_principal_name"].SetOptional()
 	attrs["user_name"] = attrs["user_name"].SetOptional()
 
@@ -1201,6 +1206,7 @@ func (c ClusterAttributes_SdkV2) ApplySchemaCustomizations(attrs map[string]tfsc
 	attrs["cluster_name"] = attrs["cluster_name"].SetOptional()
 	attrs["custom_tags"] = attrs["custom_tags"].SetOptional()
 	attrs["data_security_mode"] = attrs["data_security_mode"].SetOptional()
+	attrs["data_security_mode"] = attrs["data_security_mode"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DATA_SECURITY_MODE_AUTO", "DATA_SECURITY_MODE_DEDICATED", "DATA_SECURITY_MODE_STANDARD", "LEGACY_PASSTHROUGH", "LEGACY_SINGLE_USER", "LEGACY_SINGLE_USER_STANDARD", "LEGACY_TABLE_ACL", "NONE", "SINGLE_USER", "USER_ISOLATION"))
 	attrs["docker_image"] = attrs["docker_image"].SetOptional()
 	attrs["docker_image"] = attrs["docker_image"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["driver_instance_pool_id"] = attrs["driver_instance_pool_id"].SetOptional()
@@ -1213,9 +1219,11 @@ func (c ClusterAttributes_SdkV2) ApplySchemaCustomizations(attrs map[string]tfsc
 	attrs["instance_pool_id"] = attrs["instance_pool_id"].SetOptional()
 	attrs["is_single_node"] = attrs["is_single_node"].SetOptional()
 	attrs["kind"] = attrs["kind"].SetOptional()
+	attrs["kind"] = attrs["kind"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CLASSIC_PREVIEW"))
 	attrs["node_type_id"] = attrs["node_type_id"].SetOptional()
 	attrs["policy_id"] = attrs["policy_id"].SetOptional()
 	attrs["runtime_engine"] = attrs["runtime_engine"].SetOptional()
+	attrs["runtime_engine"] = attrs["runtime_engine"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("NULL", "PHOTON", "STANDARD"))
 	attrs["single_user_name"] = attrs["single_user_name"].SetOptional()
 	attrs["spark_conf"] = attrs["spark_conf"].SetOptional()
 	attrs["spark_env_vars"] = attrs["spark_env_vars"].SetOptional()
@@ -1988,9 +1996,11 @@ func (c ClusterDetails_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschem
 	attrs["cluster_memory_mb"] = attrs["cluster_memory_mb"].SetOptional()
 	attrs["cluster_name"] = attrs["cluster_name"].SetOptional()
 	attrs["cluster_source"] = attrs["cluster_source"].SetOptional()
+	attrs["cluster_source"] = attrs["cluster_source"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("API", "JOB", "MODELS", "PIPELINE", "PIPELINE_MAINTENANCE", "SQL", "UI"))
 	attrs["creator_user_name"] = attrs["creator_user_name"].SetOptional()
 	attrs["custom_tags"] = attrs["custom_tags"].SetOptional()
 	attrs["data_security_mode"] = attrs["data_security_mode"].SetOptional()
+	attrs["data_security_mode"] = attrs["data_security_mode"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DATA_SECURITY_MODE_AUTO", "DATA_SECURITY_MODE_DEDICATED", "DATA_SECURITY_MODE_STANDARD", "LEGACY_PASSTHROUGH", "LEGACY_SINGLE_USER", "LEGACY_SINGLE_USER_STANDARD", "LEGACY_TABLE_ACL", "NONE", "SINGLE_USER", "USER_ISOLATION"))
 	attrs["default_tags"] = attrs["default_tags"].SetOptional()
 	attrs["docker_image"] = attrs["docker_image"].SetOptional()
 	attrs["docker_image"] = attrs["docker_image"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
@@ -2008,12 +2018,14 @@ func (c ClusterDetails_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschem
 	attrs["is_single_node"] = attrs["is_single_node"].SetOptional()
 	attrs["jdbc_port"] = attrs["jdbc_port"].SetOptional()
 	attrs["kind"] = attrs["kind"].SetOptional()
+	attrs["kind"] = attrs["kind"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CLASSIC_PREVIEW"))
 	attrs["last_restarted_time"] = attrs["last_restarted_time"].SetOptional()
 	attrs["last_state_loss_time"] = attrs["last_state_loss_time"].SetOptional()
 	attrs["node_type_id"] = attrs["node_type_id"].SetOptional()
 	attrs["num_workers"] = attrs["num_workers"].SetOptional()
 	attrs["policy_id"] = attrs["policy_id"].SetOptional()
 	attrs["runtime_engine"] = attrs["runtime_engine"].SetOptional()
+	attrs["runtime_engine"] = attrs["runtime_engine"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("NULL", "PHOTON", "STANDARD"))
 	attrs["single_user_name"] = attrs["single_user_name"].SetOptional()
 	attrs["spark_conf"] = attrs["spark_conf"].SetOptional()
 	attrs["spark_context_id"] = attrs["spark_context_id"].SetOptional()
@@ -2024,6 +2036,7 @@ func (c ClusterDetails_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschem
 	attrs["ssh_public_keys"] = attrs["ssh_public_keys"].SetOptional()
 	attrs["start_time"] = attrs["start_time"].SetOptional()
 	attrs["state"] = attrs["state"].SetOptional()
+	attrs["state"] = attrs["state"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ERROR", "PENDING", "RESIZING", "RESTARTING", "RUNNING", "TERMINATED", "TERMINATING", "UNKNOWN"))
 	attrs["state_message"] = attrs["state_message"].SetOptional()
 	attrs["terminated_time"] = attrs["terminated_time"].SetOptional()
 	attrs["termination_reason"] = attrs["termination_reason"].SetOptional()
@@ -2712,6 +2725,7 @@ func (c ClusterEvent_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.
 	attrs["details"] = attrs["details"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["timestamp"] = attrs["timestamp"].SetOptional()
 	attrs["type"] = attrs["type"].SetOptional()
+	attrs["type"] = attrs["type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ADD_NODES_FAILED", "AUTOMATIC_CLUSTER_UPDATE", "AUTOSCALING_BACKOFF", "AUTOSCALING_FAILED", "AUTOSCALING_STATS_REPORT", "CREATING", "DBFS_DOWN", "DID_NOT_EXPAND_DISK", "DRIVER_HEALTHY", "DRIVER_NOT_RESPONDING", "DRIVER_UNAVAILABLE", "EDITED", "EXPANDED_DISK", "FAILED_TO_EXPAND_DISK", "INIT_SCRIPTS_FINISHED", "INIT_SCRIPTS_STARTED", "METASTORE_DOWN", "NODES_LOST", "NODE_BLACKLISTED", "NODE_EXCLUDED_DECOMMISSIONED", "PINNED", "RESIZING", "RESTARTING", "RUNNING", "SPARK_EXCEPTION", "STARTING", "TERMINATING", "UNPINNED", "UPSIZE_COMPLETED"))
 
 	return attrs
 }
@@ -3034,6 +3048,7 @@ func (c ClusterPermission_SdkV2) ApplySchemaCustomizations(attrs map[string]tfsc
 	attrs["inherited"] = attrs["inherited"].SetOptional()
 	attrs["inherited_from_object"] = attrs["inherited_from_object"].SetOptional()
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_ATTACH_TO", "CAN_MANAGE", "CAN_RESTART"))
 
 	return attrs
 }
@@ -3205,6 +3220,7 @@ func (newState *ClusterPermissionsDescription_SdkV2) SyncEffectiveFieldsDuringRe
 func (c ClusterPermissionsDescription_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["description"] = attrs["description"].SetOptional()
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_ATTACH_TO", "CAN_MANAGE", "CAN_RESTART"))
 
 	return attrs
 }
@@ -3344,6 +3360,7 @@ func (newState *ClusterPolicyAccessControlRequest_SdkV2) SyncEffectiveFieldsDuri
 func (c ClusterPolicyAccessControlRequest_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["group_name"] = attrs["group_name"].SetOptional()
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_USE"))
 	attrs["service_principal_name"] = attrs["service_principal_name"].SetOptional()
 	attrs["user_name"] = attrs["user_name"].SetOptional()
 
@@ -3503,6 +3520,7 @@ func (c ClusterPolicyPermission_SdkV2) ApplySchemaCustomizations(attrs map[strin
 	attrs["inherited"] = attrs["inherited"].SetOptional()
 	attrs["inherited_from_object"] = attrs["inherited_from_object"].SetOptional()
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_USE"))
 
 	return attrs
 }
@@ -3674,6 +3692,7 @@ func (newState *ClusterPolicyPermissionsDescription_SdkV2) SyncEffectiveFieldsDu
 func (c ClusterPolicyPermissionsDescription_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["description"] = attrs["description"].SetOptional()
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_USE"))
 
 	return attrs
 }
@@ -4152,6 +4171,7 @@ func (c ClusterSpec_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.A
 	attrs["cluster_name"] = attrs["cluster_name"].SetOptional()
 	attrs["custom_tags"] = attrs["custom_tags"].SetOptional()
 	attrs["data_security_mode"] = attrs["data_security_mode"].SetOptional()
+	attrs["data_security_mode"] = attrs["data_security_mode"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DATA_SECURITY_MODE_AUTO", "DATA_SECURITY_MODE_DEDICATED", "DATA_SECURITY_MODE_STANDARD", "LEGACY_PASSTHROUGH", "LEGACY_SINGLE_USER", "LEGACY_SINGLE_USER_STANDARD", "LEGACY_TABLE_ACL", "NONE", "SINGLE_USER", "USER_ISOLATION"))
 	attrs["docker_image"] = attrs["docker_image"].SetOptional()
 	attrs["docker_image"] = attrs["docker_image"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["driver_instance_pool_id"] = attrs["driver_instance_pool_id"].SetOptional()
@@ -4164,10 +4184,12 @@ func (c ClusterSpec_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.A
 	attrs["instance_pool_id"] = attrs["instance_pool_id"].SetOptional()
 	attrs["is_single_node"] = attrs["is_single_node"].SetOptional()
 	attrs["kind"] = attrs["kind"].SetOptional()
+	attrs["kind"] = attrs["kind"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CLASSIC_PREVIEW"))
 	attrs["node_type_id"] = attrs["node_type_id"].SetOptional()
 	attrs["num_workers"] = attrs["num_workers"].SetOptional()
 	attrs["policy_id"] = attrs["policy_id"].SetOptional()
 	attrs["runtime_engine"] = attrs["runtime_engine"].SetOptional()
+	attrs["runtime_engine"] = attrs["runtime_engine"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("NULL", "PHOTON", "STANDARD"))
 	attrs["single_user_name"] = attrs["single_user_name"].SetOptional()
 	attrs["spark_conf"] = attrs["spark_conf"].SetOptional()
 	attrs["spark_env_vars"] = attrs["spark_env_vars"].SetOptional()
@@ -4677,6 +4699,7 @@ func (c Command_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.Attri
 	attrs["command"] = attrs["command"].SetOptional()
 	attrs["contextId"] = attrs["contextId"].SetOptional()
 	attrs["language"] = attrs["language"].SetOptional()
+	attrs["language"] = attrs["language"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("python", "scala", "sql"))
 
 	return attrs
 }
@@ -4781,6 +4804,7 @@ func (c CommandStatusResponse_SdkV2) ApplySchemaCustomizations(attrs map[string]
 	attrs["results"] = attrs["results"].SetOptional()
 	attrs["results"] = attrs["results"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["status"] = attrs["status"].SetOptional()
+	attrs["status"] = attrs["status"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("Cancelled", "Cancelling", "Error", "Finished", "Queued", "Running"))
 
 	return attrs
 }
@@ -4905,6 +4929,7 @@ func (newState *ContextStatusResponse_SdkV2) SyncEffectiveFieldsDuringRead(exist
 func (c ContextStatusResponse_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["id"] = attrs["id"].SetOptional()
 	attrs["status"] = attrs["status"].SetOptional()
+	attrs["status"] = attrs["status"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("Error", "Pending", "Running"))
 
 	return attrs
 }
@@ -5145,6 +5170,7 @@ func (c CreateCluster_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema
 	attrs["cluster_name"] = attrs["cluster_name"].SetOptional()
 	attrs["custom_tags"] = attrs["custom_tags"].SetOptional()
 	attrs["data_security_mode"] = attrs["data_security_mode"].SetOptional()
+	attrs["data_security_mode"] = attrs["data_security_mode"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DATA_SECURITY_MODE_AUTO", "DATA_SECURITY_MODE_DEDICATED", "DATA_SECURITY_MODE_STANDARD", "LEGACY_PASSTHROUGH", "LEGACY_SINGLE_USER", "LEGACY_SINGLE_USER_STANDARD", "LEGACY_TABLE_ACL", "NONE", "SINGLE_USER", "USER_ISOLATION"))
 	attrs["docker_image"] = attrs["docker_image"].SetOptional()
 	attrs["docker_image"] = attrs["docker_image"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["driver_instance_pool_id"] = attrs["driver_instance_pool_id"].SetOptional()
@@ -5157,10 +5183,12 @@ func (c CreateCluster_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema
 	attrs["instance_pool_id"] = attrs["instance_pool_id"].SetOptional()
 	attrs["is_single_node"] = attrs["is_single_node"].SetOptional()
 	attrs["kind"] = attrs["kind"].SetOptional()
+	attrs["kind"] = attrs["kind"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CLASSIC_PREVIEW"))
 	attrs["node_type_id"] = attrs["node_type_id"].SetOptional()
 	attrs["num_workers"] = attrs["num_workers"].SetOptional()
 	attrs["policy_id"] = attrs["policy_id"].SetOptional()
 	attrs["runtime_engine"] = attrs["runtime_engine"].SetOptional()
+	attrs["runtime_engine"] = attrs["runtime_engine"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("NULL", "PHOTON", "STANDARD"))
 	attrs["single_user_name"] = attrs["single_user_name"].SetOptional()
 	attrs["spark_conf"] = attrs["spark_conf"].SetOptional()
 	attrs["spark_env_vars"] = attrs["spark_env_vars"].SetOptional()
@@ -5705,6 +5733,7 @@ func (newState *CreateContext_SdkV2) SyncEffectiveFieldsDuringRead(existingState
 func (c CreateContext_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["clusterId"] = attrs["clusterId"].SetOptional()
 	attrs["language"] = attrs["language"].SetOptional()
+	attrs["language"] = attrs["language"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("python", "scala", "sql"))
 
 	return attrs
 }
@@ -6474,6 +6503,7 @@ func (newState *DataPlaneEventDetails_SdkV2) SyncEffectiveFieldsDuringRead(exist
 
 func (c DataPlaneEventDetails_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["event_type"] = attrs["event_type"].SetOptional()
+	attrs["event_type"] = attrs["event_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("NODE_BLACKLISTED", "NODE_EXCLUDED_DECOMMISSIONED"))
 	attrs["executor_failures"] = attrs["executor_failures"].SetOptional()
 	attrs["host_id"] = attrs["host_id"].SetOptional()
 	attrs["timestamp"] = attrs["timestamp"].SetOptional()
@@ -7117,7 +7147,9 @@ func (newState *DiskType_SdkV2) SyncEffectiveFieldsDuringRead(existingState Disk
 
 func (c DiskType_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["azure_disk_volume_type"] = attrs["azure_disk_volume_type"].SetOptional()
+	attrs["azure_disk_volume_type"] = attrs["azure_disk_volume_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("PREMIUM_LRS", "STANDARD_LRS"))
 	attrs["ebs_volume_type"] = attrs["ebs_volume_type"].SetOptional()
+	attrs["ebs_volume_type"] = attrs["ebs_volume_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("GENERAL_PURPOSE_SSD", "THROUGHPUT_OPTIMIZED_HDD"))
 
 	return attrs
 }
@@ -7492,6 +7524,7 @@ func (c EditCluster_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.A
 	attrs["cluster_name"] = attrs["cluster_name"].SetOptional()
 	attrs["custom_tags"] = attrs["custom_tags"].SetOptional()
 	attrs["data_security_mode"] = attrs["data_security_mode"].SetOptional()
+	attrs["data_security_mode"] = attrs["data_security_mode"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DATA_SECURITY_MODE_AUTO", "DATA_SECURITY_MODE_DEDICATED", "DATA_SECURITY_MODE_STANDARD", "LEGACY_PASSTHROUGH", "LEGACY_SINGLE_USER", "LEGACY_SINGLE_USER_STANDARD", "LEGACY_TABLE_ACL", "NONE", "SINGLE_USER", "USER_ISOLATION"))
 	attrs["docker_image"] = attrs["docker_image"].SetOptional()
 	attrs["docker_image"] = attrs["docker_image"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["driver_instance_pool_id"] = attrs["driver_instance_pool_id"].SetOptional()
@@ -7504,10 +7537,12 @@ func (c EditCluster_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.A
 	attrs["instance_pool_id"] = attrs["instance_pool_id"].SetOptional()
 	attrs["is_single_node"] = attrs["is_single_node"].SetOptional()
 	attrs["kind"] = attrs["kind"].SetOptional()
+	attrs["kind"] = attrs["kind"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CLASSIC_PREVIEW"))
 	attrs["node_type_id"] = attrs["node_type_id"].SetOptional()
 	attrs["num_workers"] = attrs["num_workers"].SetOptional()
 	attrs["policy_id"] = attrs["policy_id"].SetOptional()
 	attrs["runtime_engine"] = attrs["runtime_engine"].SetOptional()
+	attrs["runtime_engine"] = attrs["runtime_engine"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("NULL", "PHOTON", "STANDARD"))
 	attrs["single_user_name"] = attrs["single_user_name"].SetOptional()
 	attrs["spark_conf"] = attrs["spark_conf"].SetOptional()
 	attrs["spark_env_vars"] = attrs["spark_env_vars"].SetOptional()
@@ -8664,6 +8699,7 @@ func (c EventDetails_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.
 	attrs["attributes"] = attrs["attributes"].SetOptional()
 	attrs["attributes"] = attrs["attributes"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["cause"] = attrs["cause"].SetOptional()
+	attrs["cause"] = attrs["cause"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("AUTORECOVERY", "AUTOSCALE", "REPLACE_BAD_NODES", "USER_REQUEST"))
 	attrs["cluster_size"] = attrs["cluster_size"].SetOptional()
 	attrs["cluster_size"] = attrs["cluster_size"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["current_num_vcpus"] = attrs["current_num_vcpus"].SetOptional()
@@ -8977,6 +9013,7 @@ func (newState *GcpAttributes_SdkV2) SyncEffectiveFieldsDuringRead(existingState
 
 func (c GcpAttributes_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["availability"] = attrs["availability"].SetOptional()
+	attrs["availability"] = attrs["availability"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ON_DEMAND_GCP", "PREEMPTIBLE_GCP", "PREEMPTIBLE_WITH_FALLBACK_GCP"))
 	attrs["boot_disk_size"] = attrs["boot_disk_size"].SetOptional()
 	attrs["google_service_account"] = attrs["google_service_account"].SetOptional()
 	attrs["local_ssd_count"] = attrs["local_ssd_count"].SetOptional()
@@ -9614,6 +9651,7 @@ func (c GetEvents_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.Att
 	attrs["limit"] = attrs["limit"].SetOptional()
 	attrs["offset"] = attrs["offset"].SetOptional()
 	attrs["order"] = attrs["order"].SetOptional()
+	attrs["order"] = attrs["order"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ASC", "DESC"))
 	attrs["start_time"] = attrs["start_time"].SetOptional()
 
 	return attrs
@@ -9952,6 +9990,7 @@ func (c GetInstancePool_SdkV2) ApplySchemaCustomizations(attrs map[string]tfsche
 	attrs["preloaded_docker_images"] = attrs["preloaded_docker_images"].SetOptional()
 	attrs["preloaded_spark_versions"] = attrs["preloaded_spark_versions"].SetOptional()
 	attrs["state"] = attrs["state"].SetOptional()
+	attrs["state"] = attrs["state"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ACTIVE", "DELETED", "STOPPED"))
 	attrs["stats"] = attrs["stats"].SetOptional()
 	attrs["stats"] = attrs["stats"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["status"] = attrs["status"].SetOptional()
@@ -11090,6 +11129,7 @@ func (c InitScriptExecutionDetails_SdkV2) ApplySchemaCustomizations(attrs map[st
 	attrs["error_message"] = attrs["error_message"].SetOptional()
 	attrs["execution_duration_seconds"] = attrs["execution_duration_seconds"].SetOptional()
 	attrs["status"] = attrs["status"].SetOptional()
+	attrs["status"] = attrs["status"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("FAILED_EXECUTION", "FAILED_FETCH", "NOT_EXECUTED", "SKIPPED", "SUCCEEDED", "UNKNOWN"))
 
 	return attrs
 }
@@ -11687,6 +11727,7 @@ func (newState *InstancePoolAccessControlRequest_SdkV2) SyncEffectiveFieldsDurin
 func (c InstancePoolAccessControlRequest_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["group_name"] = attrs["group_name"].SetOptional()
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_ATTACH_TO", "CAN_MANAGE"))
 	attrs["service_principal_name"] = attrs["service_principal_name"].SetOptional()
 	attrs["user_name"] = attrs["user_name"].SetOptional()
 
@@ -11931,6 +11972,7 @@ func (c InstancePoolAndStats_SdkV2) ApplySchemaCustomizations(attrs map[string]t
 	attrs["preloaded_docker_images"] = attrs["preloaded_docker_images"].SetOptional()
 	attrs["preloaded_spark_versions"] = attrs["preloaded_spark_versions"].SetOptional()
 	attrs["state"] = attrs["state"].SetOptional()
+	attrs["state"] = attrs["state"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ACTIVE", "DELETED", "STOPPED"))
 	attrs["stats"] = attrs["stats"].SetOptional()
 	attrs["stats"] = attrs["stats"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["status"] = attrs["status"].SetOptional()
@@ -12335,6 +12377,7 @@ func (newState *InstancePoolAwsAttributes_SdkV2) SyncEffectiveFieldsDuringRead(e
 
 func (c InstancePoolAwsAttributes_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["availability"] = attrs["availability"].SetOptional()
+	attrs["availability"] = attrs["availability"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ON_DEMAND", "SPOT"))
 	attrs["spot_bid_price_percent"] = attrs["spot_bid_price_percent"].SetOptional()
 	attrs["zone_id"] = attrs["zone_id"].SetOptional()
 
@@ -12395,6 +12438,7 @@ func (newState *InstancePoolAzureAttributes_SdkV2) SyncEffectiveFieldsDuringRead
 
 func (c InstancePoolAzureAttributes_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["availability"] = attrs["availability"].SetOptional()
+	attrs["availability"] = attrs["availability"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ON_DEMAND_AZURE", "SPOT_AZURE"))
 	attrs["spot_bid_max_price"] = attrs["spot_bid_max_price"].SetOptional()
 
 	return attrs
@@ -12472,6 +12516,7 @@ func (newState *InstancePoolGcpAttributes_SdkV2) SyncEffectiveFieldsDuringRead(e
 
 func (c InstancePoolGcpAttributes_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["gcp_availability"] = attrs["gcp_availability"].SetOptional()
+	attrs["gcp_availability"] = attrs["gcp_availability"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ON_DEMAND_GCP", "PREEMPTIBLE_GCP", "PREEMPTIBLE_WITH_FALLBACK_GCP"))
 	attrs["local_ssd_count"] = attrs["local_ssd_count"].SetOptional()
 	attrs["zone_id"] = attrs["zone_id"].SetOptional()
 
@@ -12531,6 +12576,7 @@ func (c InstancePoolPermission_SdkV2) ApplySchemaCustomizations(attrs map[string
 	attrs["inherited"] = attrs["inherited"].SetOptional()
 	attrs["inherited_from_object"] = attrs["inherited_from_object"].SetOptional()
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_ATTACH_TO", "CAN_MANAGE"))
 
 	return attrs
 }
@@ -12702,6 +12748,7 @@ func (newState *InstancePoolPermissionsDescription_SdkV2) SyncEffectiveFieldsDur
 func (c InstancePoolPermissionsDescription_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["description"] = attrs["description"].SetOptional()
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_ATTACH_TO", "CAN_MANAGE"))
 
 	return attrs
 }
@@ -13249,6 +13296,7 @@ func (c LibraryFullStatus_SdkV2) ApplySchemaCustomizations(attrs map[string]tfsc
 	attrs["library"] = attrs["library"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["messages"] = attrs["messages"].SetOptional()
 	attrs["status"] = attrs["status"].SetOptional()
+	attrs["status"] = attrs["status"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("FAILED", "INSTALLED", "INSTALLING", "PENDING", "RESOLVING", "RESTORED", "SKIPPED", "UNINSTALL_ON_RESTART"))
 
 	return attrs
 }
@@ -14035,7 +14083,9 @@ func (newState *ListClustersSortBy_SdkV2) SyncEffectiveFieldsDuringRead(existing
 
 func (c ListClustersSortBy_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["direction"] = attrs["direction"].SetOptional()
+	attrs["direction"] = attrs["direction"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ASC", "DESC"))
 	attrs["field"] = attrs["field"].SetOptional()
+	attrs["field"] = attrs["field"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CLUSTER_NAME", "DEFAULT"))
 
 	return attrs
 }
@@ -16025,6 +16075,7 @@ func (c Results_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.Attri
 	attrs["isJsonSchema"] = attrs["isJsonSchema"].SetOptional()
 	attrs["pos"] = attrs["pos"].SetOptional()
 	attrs["resultType"] = attrs["resultType"].SetOptional()
+	attrs["resultType"] = attrs["resultType"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("error", "image", "images", "table", "text"))
 	attrs["schema"] = attrs["schema"].SetOptional()
 	attrs["summary"] = attrs["summary"].SetOptional()
 	attrs["truncated"] = attrs["truncated"].SetOptional()
@@ -16568,8 +16619,10 @@ func (newState *TerminationReason_SdkV2) SyncEffectiveFieldsDuringRead(existingS
 
 func (c TerminationReason_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["code"] = attrs["code"].SetOptional()
+	attrs["code"] = attrs["code"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ABUSE_DETECTED", "ATTACH_PROJECT_FAILURE", "AWS_AUTHORIZATION_FAILURE", "AWS_INSUFFICIENT_FREE_ADDRESSES_IN_SUBNET_FAILURE", "AWS_INSUFFICIENT_INSTANCE_CAPACITY_FAILURE", "AWS_MAX_SPOT_INSTANCE_COUNT_EXCEEDED_FAILURE", "AWS_REQUEST_LIMIT_EXCEEDED", "AWS_UNSUPPORTED_FAILURE", "AZURE_BYOK_KEY_PERMISSION_FAILURE", "AZURE_EPHEMERAL_DISK_FAILURE", "AZURE_INVALID_DEPLOYMENT_TEMPLATE", "AZURE_OPERATION_NOT_ALLOWED_EXCEPTION", "AZURE_QUOTA_EXCEEDED_EXCEPTION", "AZURE_RESOURCE_MANAGER_THROTTLING", "AZURE_RESOURCE_PROVIDER_THROTTLING", "AZURE_UNEXPECTED_DEPLOYMENT_TEMPLATE_FAILURE", "AZURE_VM_EXTENSION_FAILURE", "AZURE_VNET_CONFIGURATION_FAILURE", "BOOTSTRAP_TIMEOUT", "BOOTSTRAP_TIMEOUT_CLOUD_PROVIDER_EXCEPTION", "CLOUD_PROVIDER_DISK_SETUP_FAILURE", "CLOUD_PROVIDER_LAUNCH_FAILURE", "CLOUD_PROVIDER_RESOURCE_STOCKOUT", "CLOUD_PROVIDER_SHUTDOWN", "COMMUNICATION_LOST", "CONTAINER_LAUNCH_FAILURE", "CONTROL_PLANE_REQUEST_FAILURE", "DATABASE_CONNECTION_FAILURE", "DBFS_COMPONENT_UNHEALTHY", "DOCKER_IMAGE_PULL_FAILURE", "DRIVER_UNREACHABLE", "DRIVER_UNRESPONSIVE", "EXECUTION_COMPONENT_UNHEALTHY", "GCP_QUOTA_EXCEEDED", "GCP_SERVICE_ACCOUNT_DELETED", "GLOBAL_INIT_SCRIPT_FAILURE", "HIVE_METASTORE_PROVISIONING_FAILURE", "IMAGE_PULL_PERMISSION_DENIED", "INACTIVITY", "INIT_SCRIPT_FAILURE", "INSTANCE_POOL_CLUSTER_FAILURE", "INSTANCE_UNREACHABLE", "INTERNAL_ERROR", "INVALID_ARGUMENT", "INVALID_SPARK_IMAGE", "IP_EXHAUSTION_FAILURE", "JOB_FINISHED", "K8S_AUTOSCALING_FAILURE", "K8S_DBR_CLUSTER_LAUNCH_TIMEOUT", "METASTORE_COMPONENT_UNHEALTHY", "NEPHOS_RESOURCE_MANAGEMENT", "NETWORK_CONFIGURATION_FAILURE", "NFS_MOUNT_FAILURE", "NPIP_TUNNEL_SETUP_FAILURE", "NPIP_TUNNEL_TOKEN_FAILURE", "REQUEST_REJECTED", "REQUEST_THROTTLED", "SECRET_RESOLUTION_ERROR", "SECURITY_DAEMON_REGISTRATION_EXCEPTION", "SELF_BOOTSTRAP_FAILURE", "SKIPPED_SLOW_NODES", "SLOW_IMAGE_DOWNLOAD", "SPARK_ERROR", "SPARK_IMAGE_DOWNLOAD_FAILURE", "SPARK_STARTUP_FAILURE", "SPOT_INSTANCE_TERMINATION", "STORAGE_DOWNLOAD_FAILURE", "STS_CLIENT_SETUP_FAILURE", "SUBNET_EXHAUSTED_FAILURE", "TEMPORARILY_UNAVAILABLE", "TRIAL_EXPIRED", "UNEXPECTED_LAUNCH_FAILURE", "UNKNOWN", "UNSUPPORTED_INSTANCE_TYPE", "UPDATE_INSTANCE_PROFILE_FAILURE", "USER_REQUEST", "WORKER_SETUP_FAILURE", "WORKSPACE_CANCELLED_ERROR", "WORKSPACE_CONFIGURATION_ERROR"))
 	attrs["parameters"] = attrs["parameters"].SetOptional()
 	attrs["type"] = attrs["type"].SetOptional()
+	attrs["type"] = attrs["type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CLIENT_ERROR", "CLOUD_FAILURE", "SERVICE_FAULT", "SUCCESS"))
 
 	return attrs
 }
@@ -17138,6 +17191,7 @@ func (c UpdateClusterResource_SdkV2) ApplySchemaCustomizations(attrs map[string]
 	attrs["cluster_name"] = attrs["cluster_name"].SetOptional()
 	attrs["custom_tags"] = attrs["custom_tags"].SetOptional()
 	attrs["data_security_mode"] = attrs["data_security_mode"].SetOptional()
+	attrs["data_security_mode"] = attrs["data_security_mode"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DATA_SECURITY_MODE_AUTO", "DATA_SECURITY_MODE_DEDICATED", "DATA_SECURITY_MODE_STANDARD", "LEGACY_PASSTHROUGH", "LEGACY_SINGLE_USER", "LEGACY_SINGLE_USER_STANDARD", "LEGACY_TABLE_ACL", "NONE", "SINGLE_USER", "USER_ISOLATION"))
 	attrs["docker_image"] = attrs["docker_image"].SetOptional()
 	attrs["docker_image"] = attrs["docker_image"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["driver_instance_pool_id"] = attrs["driver_instance_pool_id"].SetOptional()
@@ -17150,10 +17204,12 @@ func (c UpdateClusterResource_SdkV2) ApplySchemaCustomizations(attrs map[string]
 	attrs["instance_pool_id"] = attrs["instance_pool_id"].SetOptional()
 	attrs["is_single_node"] = attrs["is_single_node"].SetOptional()
 	attrs["kind"] = attrs["kind"].SetOptional()
+	attrs["kind"] = attrs["kind"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CLASSIC_PREVIEW"))
 	attrs["node_type_id"] = attrs["node_type_id"].SetOptional()
 	attrs["num_workers"] = attrs["num_workers"].SetOptional()
 	attrs["policy_id"] = attrs["policy_id"].SetOptional()
 	attrs["runtime_engine"] = attrs["runtime_engine"].SetOptional()
+	attrs["runtime_engine"] = attrs["runtime_engine"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("NULL", "PHOTON", "STANDARD"))
 	attrs["single_user_name"] = attrs["single_user_name"].SetOptional()
 	attrs["spark_conf"] = attrs["spark_conf"].SetOptional()
 	attrs["spark_env_vars"] = attrs["spark_env_vars"].SetOptional()

--- a/internal/service/compute_tf/model.go
+++ b/internal/service/compute_tf/model.go
@@ -17,6 +17,7 @@ import (
 	pluginfwcommon "github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/common"
 	"github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/tfschema"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
@@ -333,11 +334,13 @@ func (newState *AwsAttributes) SyncEffectiveFieldsDuringRead(existingState AwsAt
 
 func (c AwsAttributes) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["availability"] = attrs["availability"].SetOptional()
+	attrs["availability"] = attrs["availability"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ON_DEMAND", "SPOT", "SPOT_WITH_FALLBACK"))
 	attrs["ebs_volume_count"] = attrs["ebs_volume_count"].SetOptional()
 	attrs["ebs_volume_iops"] = attrs["ebs_volume_iops"].SetOptional()
 	attrs["ebs_volume_size"] = attrs["ebs_volume_size"].SetOptional()
 	attrs["ebs_volume_throughput"] = attrs["ebs_volume_throughput"].SetOptional()
 	attrs["ebs_volume_type"] = attrs["ebs_volume_type"].SetOptional()
+	attrs["ebs_volume_type"] = attrs["ebs_volume_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("GENERAL_PURPOSE_SSD", "THROUGHPUT_OPTIMIZED_HDD"))
 	attrs["first_on_demand"] = attrs["first_on_demand"].SetOptional()
 	attrs["instance_profile_arn"] = attrs["instance_profile_arn"].SetOptional()
 	attrs["spot_bid_price_percent"] = attrs["spot_bid_price_percent"].SetOptional()
@@ -429,6 +432,7 @@ func (newState *AzureAttributes) SyncEffectiveFieldsDuringRead(existingState Azu
 
 func (c AzureAttributes) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["availability"] = attrs["availability"].SetOptional()
+	attrs["availability"] = attrs["availability"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ON_DEMAND_AZURE", "SPOT_AZURE", "SPOT_WITH_FALLBACK_AZURE"))
 	attrs["first_on_demand"] = attrs["first_on_demand"].SetOptional()
 	attrs["log_analytics_info"] = attrs["log_analytics_info"].SetOptional()
 	attrs["spot_bid_max_price"] = attrs["spot_bid_max_price"].SetOptional()
@@ -882,6 +886,7 @@ func (newState *ClusterAccessControlRequest) SyncEffectiveFieldsDuringRead(exist
 func (c ClusterAccessControlRequest) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["group_name"] = attrs["group_name"].SetOptional()
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_ATTACH_TO", "CAN_MANAGE", "CAN_RESTART"))
 	attrs["service_principal_name"] = attrs["service_principal_name"].SetOptional()
 	attrs["user_name"] = attrs["user_name"].SetOptional()
 
@@ -1196,6 +1201,7 @@ func (c ClusterAttributes) ApplySchemaCustomizations(attrs map[string]tfschema.A
 	attrs["cluster_name"] = attrs["cluster_name"].SetOptional()
 	attrs["custom_tags"] = attrs["custom_tags"].SetOptional()
 	attrs["data_security_mode"] = attrs["data_security_mode"].SetOptional()
+	attrs["data_security_mode"] = attrs["data_security_mode"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DATA_SECURITY_MODE_AUTO", "DATA_SECURITY_MODE_DEDICATED", "DATA_SECURITY_MODE_STANDARD", "LEGACY_PASSTHROUGH", "LEGACY_SINGLE_USER", "LEGACY_SINGLE_USER_STANDARD", "LEGACY_TABLE_ACL", "NONE", "SINGLE_USER", "USER_ISOLATION"))
 	attrs["docker_image"] = attrs["docker_image"].SetOptional()
 	attrs["driver_instance_pool_id"] = attrs["driver_instance_pool_id"].SetOptional()
 	attrs["driver_node_type_id"] = attrs["driver_node_type_id"].SetOptional()
@@ -1206,9 +1212,11 @@ func (c ClusterAttributes) ApplySchemaCustomizations(attrs map[string]tfschema.A
 	attrs["instance_pool_id"] = attrs["instance_pool_id"].SetOptional()
 	attrs["is_single_node"] = attrs["is_single_node"].SetOptional()
 	attrs["kind"] = attrs["kind"].SetOptional()
+	attrs["kind"] = attrs["kind"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CLASSIC_PREVIEW"))
 	attrs["node_type_id"] = attrs["node_type_id"].SetOptional()
 	attrs["policy_id"] = attrs["policy_id"].SetOptional()
 	attrs["runtime_engine"] = attrs["runtime_engine"].SetOptional()
+	attrs["runtime_engine"] = attrs["runtime_engine"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("NULL", "PHOTON", "STANDARD"))
 	attrs["single_user_name"] = attrs["single_user_name"].SetOptional()
 	attrs["spark_conf"] = attrs["spark_conf"].SetOptional()
 	attrs["spark_env_vars"] = attrs["spark_env_vars"].SetOptional()
@@ -1975,9 +1983,11 @@ func (c ClusterDetails) ApplySchemaCustomizations(attrs map[string]tfschema.Attr
 	attrs["cluster_memory_mb"] = attrs["cluster_memory_mb"].SetOptional()
 	attrs["cluster_name"] = attrs["cluster_name"].SetOptional()
 	attrs["cluster_source"] = attrs["cluster_source"].SetOptional()
+	attrs["cluster_source"] = attrs["cluster_source"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("API", "JOB", "MODELS", "PIPELINE", "PIPELINE_MAINTENANCE", "SQL", "UI"))
 	attrs["creator_user_name"] = attrs["creator_user_name"].SetOptional()
 	attrs["custom_tags"] = attrs["custom_tags"].SetOptional()
 	attrs["data_security_mode"] = attrs["data_security_mode"].SetOptional()
+	attrs["data_security_mode"] = attrs["data_security_mode"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DATA_SECURITY_MODE_AUTO", "DATA_SECURITY_MODE_DEDICATED", "DATA_SECURITY_MODE_STANDARD", "LEGACY_PASSTHROUGH", "LEGACY_SINGLE_USER", "LEGACY_SINGLE_USER_STANDARD", "LEGACY_TABLE_ACL", "NONE", "SINGLE_USER", "USER_ISOLATION"))
 	attrs["default_tags"] = attrs["default_tags"].SetOptional()
 	attrs["docker_image"] = attrs["docker_image"].SetOptional()
 	attrs["driver"] = attrs["driver"].SetOptional()
@@ -1992,12 +2002,14 @@ func (c ClusterDetails) ApplySchemaCustomizations(attrs map[string]tfschema.Attr
 	attrs["is_single_node"] = attrs["is_single_node"].SetOptional()
 	attrs["jdbc_port"] = attrs["jdbc_port"].SetOptional()
 	attrs["kind"] = attrs["kind"].SetOptional()
+	attrs["kind"] = attrs["kind"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CLASSIC_PREVIEW"))
 	attrs["last_restarted_time"] = attrs["last_restarted_time"].SetOptional()
 	attrs["last_state_loss_time"] = attrs["last_state_loss_time"].SetOptional()
 	attrs["node_type_id"] = attrs["node_type_id"].SetOptional()
 	attrs["num_workers"] = attrs["num_workers"].SetOptional()
 	attrs["policy_id"] = attrs["policy_id"].SetOptional()
 	attrs["runtime_engine"] = attrs["runtime_engine"].SetOptional()
+	attrs["runtime_engine"] = attrs["runtime_engine"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("NULL", "PHOTON", "STANDARD"))
 	attrs["single_user_name"] = attrs["single_user_name"].SetOptional()
 	attrs["spark_conf"] = attrs["spark_conf"].SetOptional()
 	attrs["spark_context_id"] = attrs["spark_context_id"].SetOptional()
@@ -2007,6 +2019,7 @@ func (c ClusterDetails) ApplySchemaCustomizations(attrs map[string]tfschema.Attr
 	attrs["ssh_public_keys"] = attrs["ssh_public_keys"].SetOptional()
 	attrs["start_time"] = attrs["start_time"].SetOptional()
 	attrs["state"] = attrs["state"].SetOptional()
+	attrs["state"] = attrs["state"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ERROR", "PENDING", "RESIZING", "RESTARTING", "RUNNING", "TERMINATED", "TERMINATING", "UNKNOWN"))
 	attrs["state_message"] = attrs["state_message"].SetOptional()
 	attrs["terminated_time"] = attrs["terminated_time"].SetOptional()
 	attrs["termination_reason"] = attrs["termination_reason"].SetOptional()
@@ -2691,6 +2704,7 @@ func (c ClusterEvent) ApplySchemaCustomizations(attrs map[string]tfschema.Attrib
 	attrs["details"] = attrs["details"].SetOptional()
 	attrs["timestamp"] = attrs["timestamp"].SetOptional()
 	attrs["type"] = attrs["type"].SetOptional()
+	attrs["type"] = attrs["type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ADD_NODES_FAILED", "AUTOMATIC_CLUSTER_UPDATE", "AUTOSCALING_BACKOFF", "AUTOSCALING_FAILED", "AUTOSCALING_STATS_REPORT", "CREATING", "DBFS_DOWN", "DID_NOT_EXPAND_DISK", "DRIVER_HEALTHY", "DRIVER_NOT_RESPONDING", "DRIVER_UNAVAILABLE", "EDITED", "EXPANDED_DISK", "FAILED_TO_EXPAND_DISK", "INIT_SCRIPTS_FINISHED", "INIT_SCRIPTS_STARTED", "METASTORE_DOWN", "NODES_LOST", "NODE_BLACKLISTED", "NODE_EXCLUDED_DECOMMISSIONED", "PINNED", "RESIZING", "RESTARTING", "RUNNING", "SPARK_EXCEPTION", "STARTING", "TERMINATING", "UNPINNED", "UPSIZE_COMPLETED"))
 
 	return attrs
 }
@@ -3011,6 +3025,7 @@ func (c ClusterPermission) ApplySchemaCustomizations(attrs map[string]tfschema.A
 	attrs["inherited"] = attrs["inherited"].SetOptional()
 	attrs["inherited_from_object"] = attrs["inherited_from_object"].SetOptional()
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_ATTACH_TO", "CAN_MANAGE", "CAN_RESTART"))
 
 	return attrs
 }
@@ -3182,6 +3197,7 @@ func (newState *ClusterPermissionsDescription) SyncEffectiveFieldsDuringRead(exi
 func (c ClusterPermissionsDescription) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["description"] = attrs["description"].SetOptional()
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_ATTACH_TO", "CAN_MANAGE", "CAN_RESTART"))
 
 	return attrs
 }
@@ -3321,6 +3337,7 @@ func (newState *ClusterPolicyAccessControlRequest) SyncEffectiveFieldsDuringRead
 func (c ClusterPolicyAccessControlRequest) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["group_name"] = attrs["group_name"].SetOptional()
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_USE"))
 	attrs["service_principal_name"] = attrs["service_principal_name"].SetOptional()
 	attrs["user_name"] = attrs["user_name"].SetOptional()
 
@@ -3480,6 +3497,7 @@ func (c ClusterPolicyPermission) ApplySchemaCustomizations(attrs map[string]tfsc
 	attrs["inherited"] = attrs["inherited"].SetOptional()
 	attrs["inherited_from_object"] = attrs["inherited_from_object"].SetOptional()
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_USE"))
 
 	return attrs
 }
@@ -3651,6 +3669,7 @@ func (newState *ClusterPolicyPermissionsDescription) SyncEffectiveFieldsDuringRe
 func (c ClusterPolicyPermissionsDescription) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["description"] = attrs["description"].SetOptional()
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_USE"))
 
 	return attrs
 }
@@ -4124,6 +4143,7 @@ func (c ClusterSpec) ApplySchemaCustomizations(attrs map[string]tfschema.Attribu
 	attrs["cluster_name"] = attrs["cluster_name"].SetOptional()
 	attrs["custom_tags"] = attrs["custom_tags"].SetOptional()
 	attrs["data_security_mode"] = attrs["data_security_mode"].SetOptional()
+	attrs["data_security_mode"] = attrs["data_security_mode"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DATA_SECURITY_MODE_AUTO", "DATA_SECURITY_MODE_DEDICATED", "DATA_SECURITY_MODE_STANDARD", "LEGACY_PASSTHROUGH", "LEGACY_SINGLE_USER", "LEGACY_SINGLE_USER_STANDARD", "LEGACY_TABLE_ACL", "NONE", "SINGLE_USER", "USER_ISOLATION"))
 	attrs["docker_image"] = attrs["docker_image"].SetOptional()
 	attrs["driver_instance_pool_id"] = attrs["driver_instance_pool_id"].SetOptional()
 	attrs["driver_node_type_id"] = attrs["driver_node_type_id"].SetOptional()
@@ -4134,10 +4154,12 @@ func (c ClusterSpec) ApplySchemaCustomizations(attrs map[string]tfschema.Attribu
 	attrs["instance_pool_id"] = attrs["instance_pool_id"].SetOptional()
 	attrs["is_single_node"] = attrs["is_single_node"].SetOptional()
 	attrs["kind"] = attrs["kind"].SetOptional()
+	attrs["kind"] = attrs["kind"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CLASSIC_PREVIEW"))
 	attrs["node_type_id"] = attrs["node_type_id"].SetOptional()
 	attrs["num_workers"] = attrs["num_workers"].SetOptional()
 	attrs["policy_id"] = attrs["policy_id"].SetOptional()
 	attrs["runtime_engine"] = attrs["runtime_engine"].SetOptional()
+	attrs["runtime_engine"] = attrs["runtime_engine"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("NULL", "PHOTON", "STANDARD"))
 	attrs["single_user_name"] = attrs["single_user_name"].SetOptional()
 	attrs["spark_conf"] = attrs["spark_conf"].SetOptional()
 	attrs["spark_env_vars"] = attrs["spark_env_vars"].SetOptional()
@@ -4646,6 +4668,7 @@ func (c Command) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBu
 	attrs["command"] = attrs["command"].SetOptional()
 	attrs["contextId"] = attrs["contextId"].SetOptional()
 	attrs["language"] = attrs["language"].SetOptional()
+	attrs["language"] = attrs["language"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("python", "scala", "sql"))
 
 	return attrs
 }
@@ -4749,6 +4772,7 @@ func (c CommandStatusResponse) ApplySchemaCustomizations(attrs map[string]tfsche
 	attrs["id"] = attrs["id"].SetOptional()
 	attrs["results"] = attrs["results"].SetOptional()
 	attrs["status"] = attrs["status"].SetOptional()
+	attrs["status"] = attrs["status"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("Cancelled", "Cancelling", "Error", "Finished", "Queued", "Running"))
 
 	return attrs
 }
@@ -4873,6 +4897,7 @@ func (newState *ContextStatusResponse) SyncEffectiveFieldsDuringRead(existingSta
 func (c ContextStatusResponse) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["id"] = attrs["id"].SetOptional()
 	attrs["status"] = attrs["status"].SetOptional()
+	attrs["status"] = attrs["status"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("Error", "Pending", "Running"))
 
 	return attrs
 }
@@ -5108,6 +5133,7 @@ func (c CreateCluster) ApplySchemaCustomizations(attrs map[string]tfschema.Attri
 	attrs["cluster_name"] = attrs["cluster_name"].SetOptional()
 	attrs["custom_tags"] = attrs["custom_tags"].SetOptional()
 	attrs["data_security_mode"] = attrs["data_security_mode"].SetOptional()
+	attrs["data_security_mode"] = attrs["data_security_mode"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DATA_SECURITY_MODE_AUTO", "DATA_SECURITY_MODE_DEDICATED", "DATA_SECURITY_MODE_STANDARD", "LEGACY_PASSTHROUGH", "LEGACY_SINGLE_USER", "LEGACY_SINGLE_USER_STANDARD", "LEGACY_TABLE_ACL", "NONE", "SINGLE_USER", "USER_ISOLATION"))
 	attrs["docker_image"] = attrs["docker_image"].SetOptional()
 	attrs["driver_instance_pool_id"] = attrs["driver_instance_pool_id"].SetOptional()
 	attrs["driver_node_type_id"] = attrs["driver_node_type_id"].SetOptional()
@@ -5118,10 +5144,12 @@ func (c CreateCluster) ApplySchemaCustomizations(attrs map[string]tfschema.Attri
 	attrs["instance_pool_id"] = attrs["instance_pool_id"].SetOptional()
 	attrs["is_single_node"] = attrs["is_single_node"].SetOptional()
 	attrs["kind"] = attrs["kind"].SetOptional()
+	attrs["kind"] = attrs["kind"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CLASSIC_PREVIEW"))
 	attrs["node_type_id"] = attrs["node_type_id"].SetOptional()
 	attrs["num_workers"] = attrs["num_workers"].SetOptional()
 	attrs["policy_id"] = attrs["policy_id"].SetOptional()
 	attrs["runtime_engine"] = attrs["runtime_engine"].SetOptional()
+	attrs["runtime_engine"] = attrs["runtime_engine"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("NULL", "PHOTON", "STANDARD"))
 	attrs["single_user_name"] = attrs["single_user_name"].SetOptional()
 	attrs["spark_conf"] = attrs["spark_conf"].SetOptional()
 	attrs["spark_env_vars"] = attrs["spark_env_vars"].SetOptional()
@@ -5665,6 +5693,7 @@ func (newState *CreateContext) SyncEffectiveFieldsDuringRead(existingState Creat
 func (c CreateContext) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["clusterId"] = attrs["clusterId"].SetOptional()
 	attrs["language"] = attrs["language"].SetOptional()
+	attrs["language"] = attrs["language"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("python", "scala", "sql"))
 
 	return attrs
 }
@@ -6430,6 +6459,7 @@ func (newState *DataPlaneEventDetails) SyncEffectiveFieldsDuringRead(existingSta
 
 func (c DataPlaneEventDetails) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["event_type"] = attrs["event_type"].SetOptional()
+	attrs["event_type"] = attrs["event_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("NODE_BLACKLISTED", "NODE_EXCLUDED_DECOMMISSIONED"))
 	attrs["executor_failures"] = attrs["executor_failures"].SetOptional()
 	attrs["host_id"] = attrs["host_id"].SetOptional()
 	attrs["timestamp"] = attrs["timestamp"].SetOptional()
@@ -7072,7 +7102,9 @@ func (newState *DiskType) SyncEffectiveFieldsDuringRead(existingState DiskType) 
 
 func (c DiskType) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["azure_disk_volume_type"] = attrs["azure_disk_volume_type"].SetOptional()
+	attrs["azure_disk_volume_type"] = attrs["azure_disk_volume_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("PREMIUM_LRS", "STANDARD_LRS"))
 	attrs["ebs_volume_type"] = attrs["ebs_volume_type"].SetOptional()
+	attrs["ebs_volume_type"] = attrs["ebs_volume_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("GENERAL_PURPOSE_SSD", "THROUGHPUT_OPTIMIZED_HDD"))
 
 	return attrs
 }
@@ -7442,6 +7474,7 @@ func (c EditCluster) ApplySchemaCustomizations(attrs map[string]tfschema.Attribu
 	attrs["cluster_name"] = attrs["cluster_name"].SetOptional()
 	attrs["custom_tags"] = attrs["custom_tags"].SetOptional()
 	attrs["data_security_mode"] = attrs["data_security_mode"].SetOptional()
+	attrs["data_security_mode"] = attrs["data_security_mode"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DATA_SECURITY_MODE_AUTO", "DATA_SECURITY_MODE_DEDICATED", "DATA_SECURITY_MODE_STANDARD", "LEGACY_PASSTHROUGH", "LEGACY_SINGLE_USER", "LEGACY_SINGLE_USER_STANDARD", "LEGACY_TABLE_ACL", "NONE", "SINGLE_USER", "USER_ISOLATION"))
 	attrs["docker_image"] = attrs["docker_image"].SetOptional()
 	attrs["driver_instance_pool_id"] = attrs["driver_instance_pool_id"].SetOptional()
 	attrs["driver_node_type_id"] = attrs["driver_node_type_id"].SetOptional()
@@ -7452,10 +7485,12 @@ func (c EditCluster) ApplySchemaCustomizations(attrs map[string]tfschema.Attribu
 	attrs["instance_pool_id"] = attrs["instance_pool_id"].SetOptional()
 	attrs["is_single_node"] = attrs["is_single_node"].SetOptional()
 	attrs["kind"] = attrs["kind"].SetOptional()
+	attrs["kind"] = attrs["kind"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CLASSIC_PREVIEW"))
 	attrs["node_type_id"] = attrs["node_type_id"].SetOptional()
 	attrs["num_workers"] = attrs["num_workers"].SetOptional()
 	attrs["policy_id"] = attrs["policy_id"].SetOptional()
 	attrs["runtime_engine"] = attrs["runtime_engine"].SetOptional()
+	attrs["runtime_engine"] = attrs["runtime_engine"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("NULL", "PHOTON", "STANDARD"))
 	attrs["single_user_name"] = attrs["single_user_name"].SetOptional()
 	attrs["spark_conf"] = attrs["spark_conf"].SetOptional()
 	attrs["spark_env_vars"] = attrs["spark_env_vars"].SetOptional()
@@ -8610,6 +8645,7 @@ func (newState *EventDetails) SyncEffectiveFieldsDuringRead(existingState EventD
 func (c EventDetails) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["attributes"] = attrs["attributes"].SetOptional()
 	attrs["cause"] = attrs["cause"].SetOptional()
+	attrs["cause"] = attrs["cause"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("AUTORECOVERY", "AUTOSCALE", "REPLACE_BAD_NODES", "USER_REQUEST"))
 	attrs["cluster_size"] = attrs["cluster_size"].SetOptional()
 	attrs["current_num_vcpus"] = attrs["current_num_vcpus"].SetOptional()
 	attrs["current_num_workers"] = attrs["current_num_workers"].SetOptional()
@@ -8918,6 +8954,7 @@ func (newState *GcpAttributes) SyncEffectiveFieldsDuringRead(existingState GcpAt
 
 func (c GcpAttributes) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["availability"] = attrs["availability"].SetOptional()
+	attrs["availability"] = attrs["availability"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ON_DEMAND_GCP", "PREEMPTIBLE_GCP", "PREEMPTIBLE_WITH_FALLBACK_GCP"))
 	attrs["boot_disk_size"] = attrs["boot_disk_size"].SetOptional()
 	attrs["google_service_account"] = attrs["google_service_account"].SetOptional()
 	attrs["local_ssd_count"] = attrs["local_ssd_count"].SetOptional()
@@ -9555,6 +9592,7 @@ func (c GetEvents) ApplySchemaCustomizations(attrs map[string]tfschema.Attribute
 	attrs["limit"] = attrs["limit"].SetOptional()
 	attrs["offset"] = attrs["offset"].SetOptional()
 	attrs["order"] = attrs["order"].SetOptional()
+	attrs["order"] = attrs["order"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ASC", "DESC"))
 	attrs["start_time"] = attrs["start_time"].SetOptional()
 
 	return attrs
@@ -9888,6 +9926,7 @@ func (c GetInstancePool) ApplySchemaCustomizations(attrs map[string]tfschema.Att
 	attrs["preloaded_docker_images"] = attrs["preloaded_docker_images"].SetOptional()
 	attrs["preloaded_spark_versions"] = attrs["preloaded_spark_versions"].SetOptional()
 	attrs["state"] = attrs["state"].SetOptional()
+	attrs["state"] = attrs["state"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ACTIVE", "DELETED", "STOPPED"))
 	attrs["stats"] = attrs["stats"].SetOptional()
 	attrs["status"] = attrs["status"].SetOptional()
 
@@ -11024,6 +11063,7 @@ func (c InitScriptExecutionDetails) ApplySchemaCustomizations(attrs map[string]t
 	attrs["error_message"] = attrs["error_message"].SetOptional()
 	attrs["execution_duration_seconds"] = attrs["execution_duration_seconds"].SetOptional()
 	attrs["status"] = attrs["status"].SetOptional()
+	attrs["status"] = attrs["status"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("FAILED_EXECUTION", "FAILED_FETCH", "NOT_EXECUTED", "SKIPPED", "SUCCEEDED", "UNKNOWN"))
 
 	return attrs
 }
@@ -11612,6 +11652,7 @@ func (newState *InstancePoolAccessControlRequest) SyncEffectiveFieldsDuringRead(
 func (c InstancePoolAccessControlRequest) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["group_name"] = attrs["group_name"].SetOptional()
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_ATTACH_TO", "CAN_MANAGE"))
 	attrs["service_principal_name"] = attrs["service_principal_name"].SetOptional()
 	attrs["user_name"] = attrs["user_name"].SetOptional()
 
@@ -11852,6 +11893,7 @@ func (c InstancePoolAndStats) ApplySchemaCustomizations(attrs map[string]tfschem
 	attrs["preloaded_docker_images"] = attrs["preloaded_docker_images"].SetOptional()
 	attrs["preloaded_spark_versions"] = attrs["preloaded_spark_versions"].SetOptional()
 	attrs["state"] = attrs["state"].SetOptional()
+	attrs["state"] = attrs["state"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ACTIVE", "DELETED", "STOPPED"))
 	attrs["stats"] = attrs["stats"].SetOptional()
 	attrs["status"] = attrs["status"].SetOptional()
 
@@ -12254,6 +12296,7 @@ func (newState *InstancePoolAwsAttributes) SyncEffectiveFieldsDuringRead(existin
 
 func (c InstancePoolAwsAttributes) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["availability"] = attrs["availability"].SetOptional()
+	attrs["availability"] = attrs["availability"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ON_DEMAND", "SPOT"))
 	attrs["spot_bid_price_percent"] = attrs["spot_bid_price_percent"].SetOptional()
 	attrs["zone_id"] = attrs["zone_id"].SetOptional()
 
@@ -12314,6 +12357,7 @@ func (newState *InstancePoolAzureAttributes) SyncEffectiveFieldsDuringRead(exist
 
 func (c InstancePoolAzureAttributes) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["availability"] = attrs["availability"].SetOptional()
+	attrs["availability"] = attrs["availability"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ON_DEMAND_AZURE", "SPOT_AZURE"))
 	attrs["spot_bid_max_price"] = attrs["spot_bid_max_price"].SetOptional()
 
 	return attrs
@@ -12391,6 +12435,7 @@ func (newState *InstancePoolGcpAttributes) SyncEffectiveFieldsDuringRead(existin
 
 func (c InstancePoolGcpAttributes) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["gcp_availability"] = attrs["gcp_availability"].SetOptional()
+	attrs["gcp_availability"] = attrs["gcp_availability"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ON_DEMAND_GCP", "PREEMPTIBLE_GCP", "PREEMPTIBLE_WITH_FALLBACK_GCP"))
 	attrs["local_ssd_count"] = attrs["local_ssd_count"].SetOptional()
 	attrs["zone_id"] = attrs["zone_id"].SetOptional()
 
@@ -12450,6 +12495,7 @@ func (c InstancePoolPermission) ApplySchemaCustomizations(attrs map[string]tfsch
 	attrs["inherited"] = attrs["inherited"].SetOptional()
 	attrs["inherited_from_object"] = attrs["inherited_from_object"].SetOptional()
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_ATTACH_TO", "CAN_MANAGE"))
 
 	return attrs
 }
@@ -12621,6 +12667,7 @@ func (newState *InstancePoolPermissionsDescription) SyncEffectiveFieldsDuringRea
 func (c InstancePoolPermissionsDescription) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["description"] = attrs["description"].SetOptional()
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_ATTACH_TO", "CAN_MANAGE"))
 
 	return attrs
 }
@@ -13164,6 +13211,7 @@ func (c LibraryFullStatus) ApplySchemaCustomizations(attrs map[string]tfschema.A
 	attrs["library"] = attrs["library"].SetOptional()
 	attrs["messages"] = attrs["messages"].SetOptional()
 	attrs["status"] = attrs["status"].SetOptional()
+	attrs["status"] = attrs["status"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("FAILED", "INSTALLED", "INSTALLING", "PENDING", "RESOLVING", "RESTORED", "SKIPPED", "UNINSTALL_ON_RESTART"))
 
 	return attrs
 }
@@ -13950,7 +13998,9 @@ func (newState *ListClustersSortBy) SyncEffectiveFieldsDuringRead(existingState 
 
 func (c ListClustersSortBy) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["direction"] = attrs["direction"].SetOptional()
+	attrs["direction"] = attrs["direction"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ASC", "DESC"))
 	attrs["field"] = attrs["field"].SetOptional()
+	attrs["field"] = attrs["field"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CLUSTER_NAME", "DEFAULT"))
 
 	return attrs
 }
@@ -15937,6 +15987,7 @@ func (c Results) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBu
 	attrs["isJsonSchema"] = attrs["isJsonSchema"].SetOptional()
 	attrs["pos"] = attrs["pos"].SetOptional()
 	attrs["resultType"] = attrs["resultType"].SetOptional()
+	attrs["resultType"] = attrs["resultType"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("error", "image", "images", "table", "text"))
 	attrs["schema"] = attrs["schema"].SetOptional()
 	attrs["summary"] = attrs["summary"].SetOptional()
 	attrs["truncated"] = attrs["truncated"].SetOptional()
@@ -16479,8 +16530,10 @@ func (newState *TerminationReason) SyncEffectiveFieldsDuringRead(existingState T
 
 func (c TerminationReason) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["code"] = attrs["code"].SetOptional()
+	attrs["code"] = attrs["code"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ABUSE_DETECTED", "ATTACH_PROJECT_FAILURE", "AWS_AUTHORIZATION_FAILURE", "AWS_INSUFFICIENT_FREE_ADDRESSES_IN_SUBNET_FAILURE", "AWS_INSUFFICIENT_INSTANCE_CAPACITY_FAILURE", "AWS_MAX_SPOT_INSTANCE_COUNT_EXCEEDED_FAILURE", "AWS_REQUEST_LIMIT_EXCEEDED", "AWS_UNSUPPORTED_FAILURE", "AZURE_BYOK_KEY_PERMISSION_FAILURE", "AZURE_EPHEMERAL_DISK_FAILURE", "AZURE_INVALID_DEPLOYMENT_TEMPLATE", "AZURE_OPERATION_NOT_ALLOWED_EXCEPTION", "AZURE_QUOTA_EXCEEDED_EXCEPTION", "AZURE_RESOURCE_MANAGER_THROTTLING", "AZURE_RESOURCE_PROVIDER_THROTTLING", "AZURE_UNEXPECTED_DEPLOYMENT_TEMPLATE_FAILURE", "AZURE_VM_EXTENSION_FAILURE", "AZURE_VNET_CONFIGURATION_FAILURE", "BOOTSTRAP_TIMEOUT", "BOOTSTRAP_TIMEOUT_CLOUD_PROVIDER_EXCEPTION", "CLOUD_PROVIDER_DISK_SETUP_FAILURE", "CLOUD_PROVIDER_LAUNCH_FAILURE", "CLOUD_PROVIDER_RESOURCE_STOCKOUT", "CLOUD_PROVIDER_SHUTDOWN", "COMMUNICATION_LOST", "CONTAINER_LAUNCH_FAILURE", "CONTROL_PLANE_REQUEST_FAILURE", "DATABASE_CONNECTION_FAILURE", "DBFS_COMPONENT_UNHEALTHY", "DOCKER_IMAGE_PULL_FAILURE", "DRIVER_UNREACHABLE", "DRIVER_UNRESPONSIVE", "EXECUTION_COMPONENT_UNHEALTHY", "GCP_QUOTA_EXCEEDED", "GCP_SERVICE_ACCOUNT_DELETED", "GLOBAL_INIT_SCRIPT_FAILURE", "HIVE_METASTORE_PROVISIONING_FAILURE", "IMAGE_PULL_PERMISSION_DENIED", "INACTIVITY", "INIT_SCRIPT_FAILURE", "INSTANCE_POOL_CLUSTER_FAILURE", "INSTANCE_UNREACHABLE", "INTERNAL_ERROR", "INVALID_ARGUMENT", "INVALID_SPARK_IMAGE", "IP_EXHAUSTION_FAILURE", "JOB_FINISHED", "K8S_AUTOSCALING_FAILURE", "K8S_DBR_CLUSTER_LAUNCH_TIMEOUT", "METASTORE_COMPONENT_UNHEALTHY", "NEPHOS_RESOURCE_MANAGEMENT", "NETWORK_CONFIGURATION_FAILURE", "NFS_MOUNT_FAILURE", "NPIP_TUNNEL_SETUP_FAILURE", "NPIP_TUNNEL_TOKEN_FAILURE", "REQUEST_REJECTED", "REQUEST_THROTTLED", "SECRET_RESOLUTION_ERROR", "SECURITY_DAEMON_REGISTRATION_EXCEPTION", "SELF_BOOTSTRAP_FAILURE", "SKIPPED_SLOW_NODES", "SLOW_IMAGE_DOWNLOAD", "SPARK_ERROR", "SPARK_IMAGE_DOWNLOAD_FAILURE", "SPARK_STARTUP_FAILURE", "SPOT_INSTANCE_TERMINATION", "STORAGE_DOWNLOAD_FAILURE", "STS_CLIENT_SETUP_FAILURE", "SUBNET_EXHAUSTED_FAILURE", "TEMPORARILY_UNAVAILABLE", "TRIAL_EXPIRED", "UNEXPECTED_LAUNCH_FAILURE", "UNKNOWN", "UNSUPPORTED_INSTANCE_TYPE", "UPDATE_INSTANCE_PROFILE_FAILURE", "USER_REQUEST", "WORKER_SETUP_FAILURE", "WORKSPACE_CANCELLED_ERROR", "WORKSPACE_CONFIGURATION_ERROR"))
 	attrs["parameters"] = attrs["parameters"].SetOptional()
 	attrs["type"] = attrs["type"].SetOptional()
+	attrs["type"] = attrs["type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CLIENT_ERROR", "CLOUD_FAILURE", "SERVICE_FAULT", "SUCCESS"))
 
 	return attrs
 }
@@ -17044,6 +17097,7 @@ func (c UpdateClusterResource) ApplySchemaCustomizations(attrs map[string]tfsche
 	attrs["cluster_name"] = attrs["cluster_name"].SetOptional()
 	attrs["custom_tags"] = attrs["custom_tags"].SetOptional()
 	attrs["data_security_mode"] = attrs["data_security_mode"].SetOptional()
+	attrs["data_security_mode"] = attrs["data_security_mode"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DATA_SECURITY_MODE_AUTO", "DATA_SECURITY_MODE_DEDICATED", "DATA_SECURITY_MODE_STANDARD", "LEGACY_PASSTHROUGH", "LEGACY_SINGLE_USER", "LEGACY_SINGLE_USER_STANDARD", "LEGACY_TABLE_ACL", "NONE", "SINGLE_USER", "USER_ISOLATION"))
 	attrs["docker_image"] = attrs["docker_image"].SetOptional()
 	attrs["driver_instance_pool_id"] = attrs["driver_instance_pool_id"].SetOptional()
 	attrs["driver_node_type_id"] = attrs["driver_node_type_id"].SetOptional()
@@ -17054,10 +17108,12 @@ func (c UpdateClusterResource) ApplySchemaCustomizations(attrs map[string]tfsche
 	attrs["instance_pool_id"] = attrs["instance_pool_id"].SetOptional()
 	attrs["is_single_node"] = attrs["is_single_node"].SetOptional()
 	attrs["kind"] = attrs["kind"].SetOptional()
+	attrs["kind"] = attrs["kind"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CLASSIC_PREVIEW"))
 	attrs["node_type_id"] = attrs["node_type_id"].SetOptional()
 	attrs["num_workers"] = attrs["num_workers"].SetOptional()
 	attrs["policy_id"] = attrs["policy_id"].SetOptional()
 	attrs["runtime_engine"] = attrs["runtime_engine"].SetOptional()
+	attrs["runtime_engine"] = attrs["runtime_engine"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("NULL", "PHOTON", "STANDARD"))
 	attrs["single_user_name"] = attrs["single_user_name"].SetOptional()
 	attrs["spark_conf"] = attrs["spark_conf"].SetOptional()
 	attrs["spark_env_vars"] = attrs["spark_env_vars"].SetOptional()

--- a/internal/service/dashboards_tf/legacy_model.go
+++ b/internal/service/dashboards_tf/legacy_model.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/databricks/terraform-provider-databricks/internal/service/sql_tf"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
@@ -617,6 +618,7 @@ func (c Dashboard_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.Att
 	attrs["display_name"] = attrs["display_name"].SetOptional()
 	attrs["etag"] = attrs["etag"].SetComputed()
 	attrs["lifecycle_state"] = attrs["lifecycle_state"].SetComputed()
+	attrs["lifecycle_state"] = attrs["lifecycle_state"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ACTIVE", "TRASHED"))
 	attrs["parent_path"] = attrs["parent_path"].SetComputed()
 	attrs["path"] = attrs["path"].SetComputed()
 	attrs["serialized_dashboard"] = attrs["serialized_dashboard"].SetOptional()
@@ -1503,6 +1505,7 @@ func (c GenieMessage_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.
 	attrs["query_result"] = attrs["query_result"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["space_id"] = attrs["space_id"].SetRequired()
 	attrs["status"] = attrs["status"].SetOptional()
+	attrs["status"] = attrs["status"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ASKING_AI", "CANCELLED", "COMPLETED", "EXECUTING_QUERY", "FAILED", "FETCHING_METADATA", "FILTERING_CONTEXT", "PENDING_WAREHOUSE", "QUERY_RESULT_EXPIRED", "SUBMITTED"))
 	attrs["user_id"] = attrs["user_id"].SetOptional()
 
 	return attrs
@@ -2477,6 +2480,7 @@ func (newState *MessageError_SdkV2) SyncEffectiveFieldsDuringRead(existingState 
 func (c MessageError_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["error"] = attrs["error"].SetOptional()
 	attrs["type"] = attrs["type"].SetOptional()
+	attrs["type"] = attrs["type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("BLOCK_MULTIPLE_EXECUTIONS_EXCEPTION", "CHAT_COMPLETION_CLIENT_EXCEPTION", "CHAT_COMPLETION_CLIENT_TIMEOUT_EXCEPTION", "CHAT_COMPLETION_NETWORK_EXCEPTION", "CONTENT_FILTER_EXCEPTION", "CONTEXT_EXCEEDED_EXCEPTION", "COULD_NOT_GET_UC_SCHEMA_EXCEPTION", "DEPLOYMENT_NOT_FOUND_EXCEPTION", "FUNCTIONS_NOT_AVAILABLE_EXCEPTION", "FUNCTION_ARGUMENTS_INVALID_EXCEPTION", "FUNCTION_ARGUMENTS_INVALID_JSON_EXCEPTION", "FUNCTION_CALL_MISSING_PARAMETER_EXCEPTION", "GENERIC_CHAT_COMPLETION_EXCEPTION", "GENERIC_CHAT_COMPLETION_SERVICE_EXCEPTION", "GENERIC_SQL_EXEC_API_CALL_EXCEPTION", "ILLEGAL_PARAMETER_DEFINITION_EXCEPTION", "INVALID_CERTIFIED_ANSWER_FUNCTION_EXCEPTION", "INVALID_CERTIFIED_ANSWER_IDENTIFIER_EXCEPTION", "INVALID_CHAT_COMPLETION_JSON_EXCEPTION", "INVALID_COMPLETION_REQUEST_EXCEPTION", "INVALID_FUNCTION_CALL_EXCEPTION", "INVALID_TABLE_IDENTIFIER_EXCEPTION", "LOCAL_CONTEXT_EXCEEDED_EXCEPTION", "MESSAGE_DELETED_WHILE_EXECUTING_EXCEPTION", "MESSAGE_UPDATED_WHILE_EXECUTING_EXCEPTION", "NO_DEPLOYMENTS_AVAILABLE_TO_WORKSPACE", "NO_QUERY_TO_VISUALIZE_EXCEPTION", "NO_TABLES_TO_QUERY_EXCEPTION", "RATE_LIMIT_EXCEEDED_GENERIC_EXCEPTION", "RATE_LIMIT_EXCEEDED_SPECIFIED_WAIT_EXCEPTION", "REPLY_PROCESS_TIMEOUT_EXCEPTION", "RETRYABLE_PROCESSING_EXCEPTION", "SQL_EXECUTION_EXCEPTION", "TABLES_MISSING_EXCEPTION", "TOO_MANY_CERTIFIED_ANSWERS_EXCEPTION", "TOO_MANY_TABLES_EXCEPTION", "UNEXPECTED_REPLY_PROCESS_EXCEPTION", "UNKNOWN_AI_MODEL", "WAREHOUSE_ACCESS_MISSING_EXCEPTION", "WAREHOUSE_NOT_FOUND_EXCEPTION"))
 
 	return attrs
 }
@@ -3399,6 +3403,7 @@ func (newState *QuerySchemaColumn_SdkV2) SyncEffectiveFieldsDuringRead(existingS
 
 func (c QuerySchemaColumn_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["data_type"] = attrs["data_type"].SetRequired()
+	attrs["data_type"] = attrs["data_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DATA_TYPE_ARRAY", "DATA_TYPE_BIG_INT", "DATA_TYPE_BINARY", "DATA_TYPE_BOOLEAN", "DATA_TYPE_DATE", "DATA_TYPE_DECIMAL", "DATA_TYPE_DOUBLE", "DATA_TYPE_FLOAT", "DATA_TYPE_INT", "DATA_TYPE_INTERVAL", "DATA_TYPE_MAP", "DATA_TYPE_SMALL_INT", "DATA_TYPE_STRING", "DATA_TYPE_STRUCT", "DATA_TYPE_TIMESTAMP", "DATA_TYPE_TINY_INT", "DATA_TYPE_VOID"))
 	attrs["name"] = attrs["name"].SetRequired()
 	attrs["type_text"] = attrs["type_text"].SetRequired()
 
@@ -3538,6 +3543,7 @@ func (c Schedule_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.Attr
 	attrs["display_name"] = attrs["display_name"].SetOptional()
 	attrs["etag"] = attrs["etag"].SetComputed()
 	attrs["pause_status"] = attrs["pause_status"].SetOptional()
+	attrs["pause_status"] = attrs["pause_status"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("PAUSED", "UNPAUSED"))
 	attrs["schedule_id"] = attrs["schedule_id"].SetComputed()
 	attrs["update_time"] = attrs["update_time"].SetComputed()
 	attrs["warehouse_id"] = attrs["warehouse_id"].SetOptional()

--- a/internal/service/dashboards_tf/model.go
+++ b/internal/service/dashboards_tf/model.go
@@ -18,6 +18,7 @@ import (
 	"github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/tfschema"
 
 	"github.com/databricks/terraform-provider-databricks/internal/service/sql_tf"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
@@ -614,6 +615,7 @@ func (c Dashboard) ApplySchemaCustomizations(attrs map[string]tfschema.Attribute
 	attrs["display_name"] = attrs["display_name"].SetOptional()
 	attrs["etag"] = attrs["etag"].SetComputed()
 	attrs["lifecycle_state"] = attrs["lifecycle_state"].SetComputed()
+	attrs["lifecycle_state"] = attrs["lifecycle_state"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ACTIVE", "TRASHED"))
 	attrs["parent_path"] = attrs["parent_path"].SetComputed()
 	attrs["path"] = attrs["path"].SetComputed()
 	attrs["serialized_dashboard"] = attrs["serialized_dashboard"].SetOptional()
@@ -1495,6 +1497,7 @@ func (c GenieMessage) ApplySchemaCustomizations(attrs map[string]tfschema.Attrib
 	attrs["query_result"] = attrs["query_result"].SetOptional()
 	attrs["space_id"] = attrs["space_id"].SetRequired()
 	attrs["status"] = attrs["status"].SetOptional()
+	attrs["status"] = attrs["status"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ASKING_AI", "CANCELLED", "COMPLETED", "EXECUTING_QUERY", "FAILED", "FETCHING_METADATA", "FILTERING_CONTEXT", "PENDING_WAREHOUSE", "QUERY_RESULT_EXPIRED", "SUBMITTED"))
 	attrs["user_id"] = attrs["user_id"].SetOptional()
 
 	return attrs
@@ -2467,6 +2470,7 @@ func (newState *MessageError) SyncEffectiveFieldsDuringRead(existingState Messag
 func (c MessageError) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["error"] = attrs["error"].SetOptional()
 	attrs["type"] = attrs["type"].SetOptional()
+	attrs["type"] = attrs["type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("BLOCK_MULTIPLE_EXECUTIONS_EXCEPTION", "CHAT_COMPLETION_CLIENT_EXCEPTION", "CHAT_COMPLETION_CLIENT_TIMEOUT_EXCEPTION", "CHAT_COMPLETION_NETWORK_EXCEPTION", "CONTENT_FILTER_EXCEPTION", "CONTEXT_EXCEEDED_EXCEPTION", "COULD_NOT_GET_UC_SCHEMA_EXCEPTION", "DEPLOYMENT_NOT_FOUND_EXCEPTION", "FUNCTIONS_NOT_AVAILABLE_EXCEPTION", "FUNCTION_ARGUMENTS_INVALID_EXCEPTION", "FUNCTION_ARGUMENTS_INVALID_JSON_EXCEPTION", "FUNCTION_CALL_MISSING_PARAMETER_EXCEPTION", "GENERIC_CHAT_COMPLETION_EXCEPTION", "GENERIC_CHAT_COMPLETION_SERVICE_EXCEPTION", "GENERIC_SQL_EXEC_API_CALL_EXCEPTION", "ILLEGAL_PARAMETER_DEFINITION_EXCEPTION", "INVALID_CERTIFIED_ANSWER_FUNCTION_EXCEPTION", "INVALID_CERTIFIED_ANSWER_IDENTIFIER_EXCEPTION", "INVALID_CHAT_COMPLETION_JSON_EXCEPTION", "INVALID_COMPLETION_REQUEST_EXCEPTION", "INVALID_FUNCTION_CALL_EXCEPTION", "INVALID_TABLE_IDENTIFIER_EXCEPTION", "LOCAL_CONTEXT_EXCEEDED_EXCEPTION", "MESSAGE_DELETED_WHILE_EXECUTING_EXCEPTION", "MESSAGE_UPDATED_WHILE_EXECUTING_EXCEPTION", "NO_DEPLOYMENTS_AVAILABLE_TO_WORKSPACE", "NO_QUERY_TO_VISUALIZE_EXCEPTION", "NO_TABLES_TO_QUERY_EXCEPTION", "RATE_LIMIT_EXCEEDED_GENERIC_EXCEPTION", "RATE_LIMIT_EXCEEDED_SPECIFIED_WAIT_EXCEPTION", "REPLY_PROCESS_TIMEOUT_EXCEPTION", "RETRYABLE_PROCESSING_EXCEPTION", "SQL_EXECUTION_EXCEPTION", "TABLES_MISSING_EXCEPTION", "TOO_MANY_CERTIFIED_ANSWERS_EXCEPTION", "TOO_MANY_TABLES_EXCEPTION", "UNEXPECTED_REPLY_PROCESS_EXCEPTION", "UNKNOWN_AI_MODEL", "WAREHOUSE_ACCESS_MISSING_EXCEPTION", "WAREHOUSE_NOT_FOUND_EXCEPTION"))
 
 	return attrs
 }
@@ -3383,6 +3387,7 @@ func (newState *QuerySchemaColumn) SyncEffectiveFieldsDuringRead(existingState Q
 
 func (c QuerySchemaColumn) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["data_type"] = attrs["data_type"].SetRequired()
+	attrs["data_type"] = attrs["data_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DATA_TYPE_ARRAY", "DATA_TYPE_BIG_INT", "DATA_TYPE_BINARY", "DATA_TYPE_BOOLEAN", "DATA_TYPE_DATE", "DATA_TYPE_DECIMAL", "DATA_TYPE_DOUBLE", "DATA_TYPE_FLOAT", "DATA_TYPE_INT", "DATA_TYPE_INTERVAL", "DATA_TYPE_MAP", "DATA_TYPE_SMALL_INT", "DATA_TYPE_STRING", "DATA_TYPE_STRUCT", "DATA_TYPE_TIMESTAMP", "DATA_TYPE_TINY_INT", "DATA_TYPE_VOID"))
 	attrs["name"] = attrs["name"].SetRequired()
 	attrs["type_text"] = attrs["type_text"].SetRequired()
 
@@ -3521,6 +3526,7 @@ func (c Schedule) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeB
 	attrs["display_name"] = attrs["display_name"].SetOptional()
 	attrs["etag"] = attrs["etag"].SetComputed()
 	attrs["pause_status"] = attrs["pause_status"].SetOptional()
+	attrs["pause_status"] = attrs["pause_status"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("PAUSED", "UNPAUSED"))
 	attrs["schedule_id"] = attrs["schedule_id"].SetComputed()
 	attrs["update_time"] = attrs["update_time"].SetComputed()
 	attrs["warehouse_id"] = attrs["warehouse_id"].SetOptional()

--- a/internal/service/iam_tf/legacy_model.go
+++ b/internal/service/iam_tf/legacy_model.go
@@ -18,6 +18,7 @@ import (
 	"github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/tfschema"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
@@ -43,6 +44,7 @@ func (newState *AccessControlRequest_SdkV2) SyncEffectiveFieldsDuringRead(existi
 func (c AccessControlRequest_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["group_name"] = attrs["group_name"].SetOptional()
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_ATTACH_TO", "CAN_BIND", "CAN_EDIT", "CAN_EDIT_METADATA", "CAN_MANAGE", "CAN_MANAGE_PRODUCTION_VERSIONS", "CAN_MANAGE_RUN", "CAN_MANAGE_STAGING_VERSIONS", "CAN_MONITOR", "CAN_QUERY", "CAN_READ", "CAN_RESTART", "CAN_RUN", "CAN_USE", "CAN_VIEW", "CAN_VIEW_METADATA", "IS_OWNER"))
 	attrs["service_principal_name"] = attrs["service_principal_name"].SetOptional()
 	attrs["user_name"] = attrs["user_name"].SetOptional()
 
@@ -3063,6 +3065,7 @@ func (newState *PasswordAccessControlRequest_SdkV2) SyncEffectiveFieldsDuringRea
 func (c PasswordAccessControlRequest_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["group_name"] = attrs["group_name"].SetOptional()
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_USE"))
 	attrs["service_principal_name"] = attrs["service_principal_name"].SetOptional()
 	attrs["user_name"] = attrs["user_name"].SetOptional()
 
@@ -3222,6 +3225,7 @@ func (c PasswordPermission_SdkV2) ApplySchemaCustomizations(attrs map[string]tfs
 	attrs["inherited"] = attrs["inherited"].SetOptional()
 	attrs["inherited_from_object"] = attrs["inherited_from_object"].SetOptional()
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_USE"))
 
 	return attrs
 }
@@ -3393,6 +3397,7 @@ func (newState *PasswordPermissionsDescription_SdkV2) SyncEffectiveFieldsDuringR
 func (c PasswordPermissionsDescription_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["description"] = attrs["description"].SetOptional()
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_USE"))
 
 	return attrs
 }
@@ -3524,6 +3529,7 @@ func (newState *Patch_SdkV2) SyncEffectiveFieldsDuringRead(existingState Patch_S
 
 func (c Patch_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["op"] = attrs["op"].SetOptional()
+	attrs["op"] = attrs["op"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("add", "remove", "replace"))
 	attrs["path"] = attrs["path"].SetOptional()
 	attrs["value"] = attrs["value"].SetOptional()
 
@@ -3613,6 +3619,7 @@ func (c Permission_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.At
 	attrs["inherited"] = attrs["inherited"].SetOptional()
 	attrs["inherited_from_object"] = attrs["inherited_from_object"].SetOptional()
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_ATTACH_TO", "CAN_BIND", "CAN_EDIT", "CAN_EDIT_METADATA", "CAN_MANAGE", "CAN_MANAGE_PRODUCTION_VERSIONS", "CAN_MANAGE_RUN", "CAN_MANAGE_STAGING_VERSIONS", "CAN_MONITOR", "CAN_QUERY", "CAN_READ", "CAN_RESTART", "CAN_RUN", "CAN_USE", "CAN_VIEW", "CAN_VIEW_METADATA", "IS_OWNER"))
 
 	return attrs
 }
@@ -3896,6 +3903,7 @@ func (newState *PermissionOutput_SdkV2) SyncEffectiveFieldsDuringRead(existingSt
 func (c PermissionOutput_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["description"] = attrs["description"].SetOptional()
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ADMIN", "UNKNOWN", "USER"))
 
 	return attrs
 }
@@ -3948,6 +3956,7 @@ func (newState *PermissionsDescription_SdkV2) SyncEffectiveFieldsDuringRead(exis
 func (c PermissionsDescription_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["description"] = attrs["description"].SetOptional()
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_ATTACH_TO", "CAN_BIND", "CAN_EDIT", "CAN_EDIT_METADATA", "CAN_MANAGE", "CAN_MANAGE_PRODUCTION_VERSIONS", "CAN_MANAGE_RUN", "CAN_MANAGE_STAGING_VERSIONS", "CAN_MONITOR", "CAN_QUERY", "CAN_READ", "CAN_RESTART", "CAN_RUN", "CAN_USE", "CAN_VIEW", "CAN_VIEW_METADATA", "IS_OWNER"))
 
 	return attrs
 }

--- a/internal/service/iam_tf/model.go
+++ b/internal/service/iam_tf/model.go
@@ -17,6 +17,7 @@ import (
 	pluginfwcommon "github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/common"
 	"github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/tfschema"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
@@ -42,6 +43,7 @@ func (newState *AccessControlRequest) SyncEffectiveFieldsDuringRead(existingStat
 func (c AccessControlRequest) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["group_name"] = attrs["group_name"].SetOptional()
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_ATTACH_TO", "CAN_BIND", "CAN_EDIT", "CAN_EDIT_METADATA", "CAN_MANAGE", "CAN_MANAGE_PRODUCTION_VERSIONS", "CAN_MANAGE_RUN", "CAN_MANAGE_STAGING_VERSIONS", "CAN_MONITOR", "CAN_QUERY", "CAN_READ", "CAN_RESTART", "CAN_RUN", "CAN_USE", "CAN_VIEW", "CAN_VIEW_METADATA", "IS_OWNER"))
 	attrs["service_principal_name"] = attrs["service_principal_name"].SetOptional()
 	attrs["user_name"] = attrs["user_name"].SetOptional()
 
@@ -3060,6 +3062,7 @@ func (newState *PasswordAccessControlRequest) SyncEffectiveFieldsDuringRead(exis
 func (c PasswordAccessControlRequest) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["group_name"] = attrs["group_name"].SetOptional()
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_USE"))
 	attrs["service_principal_name"] = attrs["service_principal_name"].SetOptional()
 	attrs["user_name"] = attrs["user_name"].SetOptional()
 
@@ -3219,6 +3222,7 @@ func (c PasswordPermission) ApplySchemaCustomizations(attrs map[string]tfschema.
 	attrs["inherited"] = attrs["inherited"].SetOptional()
 	attrs["inherited_from_object"] = attrs["inherited_from_object"].SetOptional()
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_USE"))
 
 	return attrs
 }
@@ -3390,6 +3394,7 @@ func (newState *PasswordPermissionsDescription) SyncEffectiveFieldsDuringRead(ex
 func (c PasswordPermissionsDescription) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["description"] = attrs["description"].SetOptional()
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_USE"))
 
 	return attrs
 }
@@ -3521,6 +3526,7 @@ func (newState *Patch) SyncEffectiveFieldsDuringRead(existingState Patch) {
 
 func (c Patch) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["op"] = attrs["op"].SetOptional()
+	attrs["op"] = attrs["op"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("add", "remove", "replace"))
 	attrs["path"] = attrs["path"].SetOptional()
 	attrs["value"] = attrs["value"].SetOptional()
 
@@ -3610,6 +3616,7 @@ func (c Permission) ApplySchemaCustomizations(attrs map[string]tfschema.Attribut
 	attrs["inherited"] = attrs["inherited"].SetOptional()
 	attrs["inherited_from_object"] = attrs["inherited_from_object"].SetOptional()
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_ATTACH_TO", "CAN_BIND", "CAN_EDIT", "CAN_EDIT_METADATA", "CAN_MANAGE", "CAN_MANAGE_PRODUCTION_VERSIONS", "CAN_MANAGE_RUN", "CAN_MANAGE_STAGING_VERSIONS", "CAN_MONITOR", "CAN_QUERY", "CAN_READ", "CAN_RESTART", "CAN_RUN", "CAN_USE", "CAN_VIEW", "CAN_VIEW_METADATA", "IS_OWNER"))
 
 	return attrs
 }
@@ -3892,6 +3899,7 @@ func (newState *PermissionOutput) SyncEffectiveFieldsDuringRead(existingState Pe
 func (c PermissionOutput) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["description"] = attrs["description"].SetOptional()
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ADMIN", "UNKNOWN", "USER"))
 
 	return attrs
 }
@@ -3944,6 +3952,7 @@ func (newState *PermissionsDescription) SyncEffectiveFieldsDuringRead(existingSt
 func (c PermissionsDescription) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["description"] = attrs["description"].SetOptional()
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_ATTACH_TO", "CAN_BIND", "CAN_EDIT", "CAN_EDIT_METADATA", "CAN_MANAGE", "CAN_MANAGE_PRODUCTION_VERSIONS", "CAN_MANAGE_RUN", "CAN_MANAGE_STAGING_VERSIONS", "CAN_MONITOR", "CAN_QUERY", "CAN_READ", "CAN_RESTART", "CAN_RUN", "CAN_USE", "CAN_VIEW", "CAN_VIEW_METADATA", "IS_OWNER"))
 
 	return attrs
 }

--- a/internal/service/jobs_tf/legacy_model.go
+++ b/internal/service/jobs_tf/legacy_model.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/databricks/terraform-provider-databricks/internal/service/compute_tf"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
@@ -303,6 +304,7 @@ func (c BaseRun_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.Attri
 	attrs["creator_user_name"] = attrs["creator_user_name"].SetOptional()
 	attrs["description"] = attrs["description"].SetOptional()
 	attrs["effective_performance_target"] = attrs["effective_performance_target"].SetOptional()
+	attrs["effective_performance_target"] = attrs["effective_performance_target"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("COST_OPTIMIZED", "PERFORMANCE_OPTIMIZED"))
 	attrs["end_time"] = attrs["end_time"].SetOptional()
 	attrs["execution_duration"] = attrs["execution_duration"].SetOptional()
 	attrs["git_source"] = attrs["git_source"].SetOptional()
@@ -323,6 +325,7 @@ func (c BaseRun_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.Attri
 	attrs["run_name"] = attrs["run_name"].SetOptional()
 	attrs["run_page_url"] = attrs["run_page_url"].SetOptional()
 	attrs["run_type"] = attrs["run_type"].SetOptional()
+	attrs["run_type"] = attrs["run_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("JOB_RUN", "SUBMIT_RUN", "WORKFLOW_RUN"))
 	attrs["schedule"] = attrs["schedule"].SetOptional()
 	attrs["schedule"] = attrs["schedule"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["setup_duration"] = attrs["setup_duration"].SetOptional()
@@ -333,6 +336,7 @@ func (c BaseRun_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.Attri
 	attrs["status"] = attrs["status"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["tasks"] = attrs["tasks"].SetOptional()
 	attrs["trigger"] = attrs["trigger"].SetOptional()
+	attrs["trigger"] = attrs["trigger"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("FILE_ARRIVAL", "ONE_TIME", "PERIODIC", "RETRY", "RUN_JOB_TASK", "TABLE"))
 	attrs["trigger_info"] = attrs["trigger_info"].SetOptional()
 	attrs["trigger_info"] = attrs["trigger_info"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 
@@ -963,7 +967,9 @@ func (newState *CleanRoomTaskRunState_SdkV2) SyncEffectiveFieldsDuringRead(exist
 
 func (c CleanRoomTaskRunState_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["life_cycle_state"] = attrs["life_cycle_state"].SetOptional()
+	attrs["life_cycle_state"] = attrs["life_cycle_state"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("BLOCKED", "INTERNAL_ERROR", "PENDING", "QUEUED", "RUNNING", "RUN_LIFE_CYCLE_STATE_UNSPECIFIED", "SKIPPED", "TERMINATED", "TERMINATING", "WAITING_FOR_RETRY"))
 	attrs["result_state"] = attrs["result_state"].SetOptional()
+	attrs["result_state"] = attrs["result_state"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CANCELED", "DISABLED", "EVICTED", "EXCLUDED", "FAILED", "MAXIMUM_CONCURRENT_RUNS_REACHED", "RUN_RESULT_STATE_UNSPECIFIED", "SUCCESS", "SUCCESS_WITH_FAILURES", "TIMEDOUT", "UPSTREAM_CANCELED", "UPSTREAM_EVICTED", "UPSTREAM_FAILED"))
 
 	return attrs
 }
@@ -1470,6 +1476,7 @@ func (newState *ConditionTask_SdkV2) SyncEffectiveFieldsDuringRead(existingState
 func (c ConditionTask_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["left"] = attrs["left"].SetRequired()
 	attrs["op"] = attrs["op"].SetRequired()
+	attrs["op"] = attrs["op"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("EQUAL_TO", "GREATER_THAN", "GREATER_THAN_OR_EQUAL", "LESS_THAN", "LESS_THAN_OR_EQUAL", "NOT_EQUAL"))
 	attrs["right"] = attrs["right"].SetRequired()
 
 	return attrs
@@ -1524,6 +1531,7 @@ func (newState *Continuous_SdkV2) SyncEffectiveFieldsDuringRead(existingState Co
 
 func (c Continuous_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["pause_status"] = attrs["pause_status"].SetOptional()
+	attrs["pause_status"] = attrs["pause_status"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("PAUSED", "UNPAUSED"))
 
 	return attrs
 }
@@ -1687,10 +1695,12 @@ func (c CreateJob_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.Att
 	attrs["deployment"] = attrs["deployment"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["description"] = attrs["description"].SetOptional()
 	attrs["edit_mode"] = attrs["edit_mode"].SetOptional()
+	attrs["edit_mode"] = attrs["edit_mode"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("EDITABLE", "UI_LOCKED"))
 	attrs["email_notifications"] = attrs["email_notifications"].SetOptional()
 	attrs["email_notifications"] = attrs["email_notifications"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["environment"] = attrs["environment"].SetOptional()
 	attrs["format"] = attrs["format"].SetOptional()
+	attrs["format"] = attrs["format"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("MULTI_TASK", "SINGLE_TASK"))
 	attrs["git_source"] = attrs["git_source"].SetOptional()
 	attrs["git_source"] = attrs["git_source"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["health"] = attrs["health"].SetOptional()
@@ -1702,6 +1712,7 @@ func (c CreateJob_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.Att
 	attrs["notification_settings"] = attrs["notification_settings"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["parameter"] = attrs["parameter"].SetOptional()
 	attrs["performance_target"] = attrs["performance_target"].SetOptional()
+	attrs["performance_target"] = attrs["performance_target"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("COST_OPTIMIZED", "PERFORMANCE_OPTIMIZED"))
 	attrs["queue"] = attrs["queue"].SetOptional()
 	attrs["queue"] = attrs["queue"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["run_as"] = attrs["run_as"].SetOptional()
@@ -2364,6 +2375,7 @@ func (newState *CronSchedule_SdkV2) SyncEffectiveFieldsDuringRead(existingState 
 
 func (c CronSchedule_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["pause_status"] = attrs["pause_status"].SetOptional()
+	attrs["pause_status"] = attrs["pause_status"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("PAUSED", "UNPAUSED"))
 	attrs["quartz_cron_expression"] = attrs["quartz_cron_expression"].SetRequired()
 	attrs["timezone_id"] = attrs["timezone_id"].SetRequired()
 
@@ -2541,6 +2553,7 @@ func (c DbtTask_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.Attri
 	attrs["project_directory"] = attrs["project_directory"].SetOptional()
 	attrs["schema"] = attrs["schema"].SetOptional()
 	attrs["source"] = attrs["source"].SetOptional()
+	attrs["source"] = attrs["source"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("GIT", "WORKSPACE"))
 	attrs["warehouse_id"] = attrs["warehouse_id"].SetOptional()
 
 	return attrs
@@ -4053,6 +4066,7 @@ func (c GitSource_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.Att
 	attrs["branch"] = attrs["branch"].SetOptional()
 	attrs["commit"] = attrs["commit"].SetOptional()
 	attrs["git_provider"] = attrs["git_provider"].SetRequired()
+	attrs["git_provider"] = attrs["git_provider"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("awsCodeCommit", "azureDevOpsServices", "bitbucketCloud", "bitbucketServer", "gitHub", "gitHubEnterprise", "gitLab", "gitLabEnterpriseEdition"))
 	attrs["git_snapshot"] = attrs["git_snapshot"].SetOptional()
 	attrs["git_snapshot"] = attrs["git_snapshot"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["tag"] = attrs["tag"].SetOptional()
@@ -4317,6 +4331,7 @@ func (newState *JobAccessControlRequest_SdkV2) SyncEffectiveFieldsDuringRead(exi
 func (c JobAccessControlRequest_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["group_name"] = attrs["group_name"].SetOptional()
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_MANAGE", "CAN_MANAGE_RUN", "CAN_VIEW", "IS_OWNER"))
 	attrs["service_principal_name"] = attrs["service_principal_name"].SetOptional()
 	attrs["user_name"] = attrs["user_name"].SetOptional()
 
@@ -4653,6 +4668,7 @@ func (newState *JobDeployment_SdkV2) SyncEffectiveFieldsDuringRead(existingState
 
 func (c JobDeployment_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["kind"] = attrs["kind"].SetRequired()
+	attrs["kind"] = attrs["kind"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("BUNDLE"))
 	attrs["metadata_file_path"] = attrs["metadata_file_path"].SetOptional()
 
 	return attrs
@@ -5202,6 +5218,7 @@ func (c JobPermission_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema
 	attrs["inherited"] = attrs["inherited"].SetOptional()
 	attrs["inherited_from_object"] = attrs["inherited_from_object"].SetOptional()
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_MANAGE", "CAN_MANAGE_RUN", "CAN_VIEW", "IS_OWNER"))
 
 	return attrs
 }
@@ -5373,6 +5390,7 @@ func (newState *JobPermissionsDescription_SdkV2) SyncEffectiveFieldsDuringRead(e
 func (c JobPermissionsDescription_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["description"] = attrs["description"].SetOptional()
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_MANAGE", "CAN_MANAGE_RUN", "CAN_VIEW", "IS_OWNER"))
 
 	return attrs
 }
@@ -5677,10 +5695,12 @@ func (c JobSettings_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.A
 	attrs["deployment"] = attrs["deployment"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["description"] = attrs["description"].SetOptional()
 	attrs["edit_mode"] = attrs["edit_mode"].SetOptional()
+	attrs["edit_mode"] = attrs["edit_mode"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("EDITABLE", "UI_LOCKED"))
 	attrs["email_notifications"] = attrs["email_notifications"].SetOptional()
 	attrs["email_notifications"] = attrs["email_notifications"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["environment"] = attrs["environment"].SetOptional()
 	attrs["format"] = attrs["format"].SetOptional()
+	attrs["format"] = attrs["format"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("MULTI_TASK", "SINGLE_TASK"))
 	attrs["git_source"] = attrs["git_source"].SetOptional()
 	attrs["git_source"] = attrs["git_source"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["health"] = attrs["health"].SetOptional()
@@ -5692,6 +5712,7 @@ func (c JobSettings_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.A
 	attrs["notification_settings"] = attrs["notification_settings"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["parameter"] = attrs["parameter"].SetOptional()
 	attrs["performance_target"] = attrs["performance_target"].SetOptional()
+	attrs["performance_target"] = attrs["performance_target"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("COST_OPTIMIZED", "PERFORMANCE_OPTIMIZED"))
 	attrs["queue"] = attrs["queue"].SetOptional()
 	attrs["queue"] = attrs["queue"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["run_as"] = attrs["run_as"].SetOptional()
@@ -6278,6 +6299,7 @@ func (newState *JobSource_SdkV2) SyncEffectiveFieldsDuringRead(existingState Job
 
 func (c JobSource_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["dirty_state"] = attrs["dirty_state"].SetOptional()
+	attrs["dirty_state"] = attrs["dirty_state"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DISCONNECTED", "NOT_SYNCED"))
 	attrs["import_from_git_branch"] = attrs["import_from_git_branch"].SetRequired()
 	attrs["job_config_path"] = attrs["job_config_path"].SetRequired()
 
@@ -6349,7 +6371,9 @@ func (newState *JobsHealthRule_SdkV2) SyncEffectiveFieldsDuringRead(existingStat
 
 func (c JobsHealthRule_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["metric"] = attrs["metric"].SetRequired()
+	attrs["metric"] = attrs["metric"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("RUN_DURATION_SECONDS", "STREAMING_BACKLOG_BYTES", "STREAMING_BACKLOG_FILES", "STREAMING_BACKLOG_RECORDS", "STREAMING_BACKLOG_SECONDS"))
 	attrs["op"] = attrs["op"].SetRequired()
+	attrs["op"] = attrs["op"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("GREATER_THAN"))
 	attrs["value"] = attrs["value"].SetRequired()
 
 	return attrs
@@ -7061,6 +7085,7 @@ func (c NotebookTask_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.
 	attrs["base_parameters"] = attrs["base_parameters"].SetOptional()
 	attrs["notebook_path"] = attrs["notebook_path"].SetRequired()
 	attrs["source"] = attrs["source"].SetOptional()
+	attrs["source"] = attrs["source"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("GIT", "WORKSPACE"))
 	attrs["warehouse_id"] = attrs["warehouse_id"].SetOptional()
 
 	return attrs
@@ -7209,6 +7234,7 @@ func (newState *PeriodicTriggerConfiguration_SdkV2) SyncEffectiveFieldsDuringRea
 func (c PeriodicTriggerConfiguration_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["interval"] = attrs["interval"].SetRequired()
 	attrs["unit"] = attrs["unit"].SetRequired()
+	attrs["unit"] = attrs["unit"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DAYS", "HOURS", "WEEKS"))
 
 	return attrs
 }
@@ -7495,6 +7521,7 @@ func (newState *QueueDetails_SdkV2) SyncEffectiveFieldsDuringRead(existingState 
 
 func (c QueueDetails_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["code"] = attrs["code"].SetOptional()
+	attrs["code"] = attrs["code"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ACTIVE_RUNS_LIMIT_REACHED", "ACTIVE_RUN_JOB_TASKS_LIMIT_REACHED", "MAX_CONCURRENT_RUNS_REACHED"))
 	attrs["message"] = attrs["message"].SetOptional()
 
 	return attrs
@@ -7617,6 +7644,7 @@ func (c RepairHistoryItem_SdkV2) ApplySchemaCustomizations(attrs map[string]tfsc
 	attrs["status"] = attrs["status"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["task_run_ids"] = attrs["task_run_ids"].SetOptional()
 	attrs["type"] = attrs["type"].SetOptional()
+	attrs["type"] = attrs["type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ORIGINAL", "REPAIR"))
 
 	return attrs
 }
@@ -9542,6 +9570,7 @@ func (c Run_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.Attribute
 	attrs["creator_user_name"] = attrs["creator_user_name"].SetOptional()
 	attrs["description"] = attrs["description"].SetOptional()
 	attrs["effective_performance_target"] = attrs["effective_performance_target"].SetOptional()
+	attrs["effective_performance_target"] = attrs["effective_performance_target"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("COST_OPTIMIZED", "PERFORMANCE_OPTIMIZED"))
 	attrs["end_time"] = attrs["end_time"].SetOptional()
 	attrs["execution_duration"] = attrs["execution_duration"].SetOptional()
 	attrs["git_source"] = attrs["git_source"].SetOptional()
@@ -9564,6 +9593,7 @@ func (c Run_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.Attribute
 	attrs["run_name"] = attrs["run_name"].SetOptional()
 	attrs["run_page_url"] = attrs["run_page_url"].SetOptional()
 	attrs["run_type"] = attrs["run_type"].SetOptional()
+	attrs["run_type"] = attrs["run_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("JOB_RUN", "SUBMIT_RUN", "WORKFLOW_RUN"))
 	attrs["schedule"] = attrs["schedule"].SetOptional()
 	attrs["schedule"] = attrs["schedule"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["setup_duration"] = attrs["setup_duration"].SetOptional()
@@ -9574,6 +9604,7 @@ func (c Run_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.Attribute
 	attrs["status"] = attrs["status"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["tasks"] = attrs["tasks"].SetOptional()
 	attrs["trigger"] = attrs["trigger"].SetOptional()
+	attrs["trigger"] = attrs["trigger"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("FILE_ARRIVAL", "ONE_TIME", "PERIODIC", "RETRY", "RUN_JOB_TASK", "TABLE"))
 	attrs["trigger_info"] = attrs["trigger_info"].SetOptional()
 	attrs["trigger_info"] = attrs["trigger_info"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 
@@ -10089,6 +10120,7 @@ func (newState *RunConditionTask_SdkV2) SyncEffectiveFieldsDuringRead(existingSt
 func (c RunConditionTask_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["left"] = attrs["left"].SetRequired()
 	attrs["op"] = attrs["op"].SetRequired()
+	attrs["op"] = attrs["op"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("EQUAL_TO", "GREATER_THAN", "GREATER_THAN_OR_EQUAL", "LESS_THAN", "LESS_THAN_OR_EQUAL", "NOT_EQUAL"))
 	attrs["outcome"] = attrs["outcome"].SetOptional()
 	attrs["right"] = attrs["right"].SetRequired()
 
@@ -10859,6 +10891,7 @@ func (c RunNow_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.Attrib
 	attrs["notebook_params"] = attrs["notebook_params"].SetOptional()
 	attrs["only"] = attrs["only"].SetOptional()
 	attrs["performance_target"] = attrs["performance_target"].SetOptional()
+	attrs["performance_target"] = attrs["performance_target"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("COST_OPTIMIZED", "PERFORMANCE_OPTIMIZED"))
 	attrs["pipeline_params"] = attrs["pipeline_params"].SetOptional()
 	attrs["pipeline_params"] = attrs["pipeline_params"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["python_named_params"] = attrs["python_named_params"].SetOptional()
@@ -12008,8 +12041,10 @@ func (newState *RunState_SdkV2) SyncEffectiveFieldsDuringRead(existingState RunS
 
 func (c RunState_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["life_cycle_state"] = attrs["life_cycle_state"].SetOptional()
+	attrs["life_cycle_state"] = attrs["life_cycle_state"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("BLOCKED", "INTERNAL_ERROR", "PENDING", "QUEUED", "RUNNING", "SKIPPED", "TERMINATED", "TERMINATING", "WAITING_FOR_RETRY"))
 	attrs["queue_reason"] = attrs["queue_reason"].SetOptional()
 	attrs["result_state"] = attrs["result_state"].SetOptional()
+	attrs["result_state"] = attrs["result_state"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CANCELED", "DISABLED", "EXCLUDED", "FAILED", "MAXIMUM_CONCURRENT_RUNS_REACHED", "SUCCESS", "SUCCESS_WITH_FAILURES", "TIMEDOUT", "UPSTREAM_CANCELED", "UPSTREAM_FAILED"))
 	attrs["state_message"] = attrs["state_message"].SetOptional()
 	attrs["user_cancelled_or_timedout"] = attrs["user_cancelled_or_timedout"].SetOptional()
 
@@ -12076,6 +12111,7 @@ func (c RunStatus_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.Att
 	attrs["queue_details"] = attrs["queue_details"].SetOptional()
 	attrs["queue_details"] = attrs["queue_details"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["state"] = attrs["state"].SetOptional()
+	attrs["state"] = attrs["state"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("BLOCKED", "PENDING", "QUEUED", "RUNNING", "TERMINATED", "TERMINATING"))
 	attrs["termination_details"] = attrs["termination_details"].SetOptional()
 	attrs["termination_details"] = attrs["termination_details"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 
@@ -12379,6 +12415,7 @@ func (c RunTask_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.Attri
 	attrs["description"] = attrs["description"].SetOptional()
 	attrs["disabled"] = attrs["disabled"].SetComputed()
 	attrs["effective_performance_target"] = attrs["effective_performance_target"].SetComputed()
+	attrs["effective_performance_target"] = attrs["effective_performance_target"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("COST_OPTIMIZED", "PERFORMANCE_OPTIMIZED"))
 	attrs["email_notifications"] = attrs["email_notifications"].SetOptional()
 	attrs["email_notifications"] = attrs["email_notifications"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["end_time"] = attrs["end_time"].SetOptional()
@@ -12407,6 +12444,7 @@ func (c RunTask_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.Attri
 	attrs["run_duration"] = attrs["run_duration"].SetOptional()
 	attrs["run_id"] = attrs["run_id"].SetOptional()
 	attrs["run_if"] = attrs["run_if"].SetOptional()
+	attrs["run_if"] = attrs["run_if"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ALL_DONE", "ALL_FAILED", "ALL_SUCCESS", "AT_LEAST_ONE_FAILED", "AT_LEAST_ONE_SUCCESS", "NONE_FAILED"))
 	attrs["run_job_task"] = attrs["run_job_task"].SetOptional()
 	attrs["run_job_task"] = attrs["run_job_task"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["run_page_url"] = attrs["run_page_url"].SetOptional()
@@ -13352,6 +13390,7 @@ func (c SparkPythonTask_SdkV2) ApplySchemaCustomizations(attrs map[string]tfsche
 	attrs["parameters"] = attrs["parameters"].SetOptional()
 	attrs["python_file"] = attrs["python_file"].SetRequired()
 	attrs["source"] = attrs["source"].SetOptional()
+	attrs["source"] = attrs["source"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("GIT", "WORKSPACE"))
 
 	return attrs
 }
@@ -13530,6 +13569,7 @@ func (newState *SqlAlertOutput_SdkV2) SyncEffectiveFieldsDuringRead(existingStat
 
 func (c SqlAlertOutput_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["alert_state"] = attrs["alert_state"].SetOptional()
+	attrs["alert_state"] = attrs["alert_state"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("OK", "TRIGGERED", "UNKNOWN"))
 	attrs["output_link"] = attrs["output_link"].SetOptional()
 	attrs["query_text"] = attrs["query_text"].SetOptional()
 	attrs["sql_statements"] = attrs["sql_statements"].SetOptional()
@@ -13720,6 +13760,7 @@ func (c SqlDashboardWidgetOutput_SdkV2) ApplySchemaCustomizations(attrs map[stri
 	attrs["output_link"] = attrs["output_link"].SetOptional()
 	attrs["start_time"] = attrs["start_time"].SetOptional()
 	attrs["status"] = attrs["status"].SetOptional()
+	attrs["status"] = attrs["status"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CANCELLED", "FAILED", "PENDING", "RUNNING", "SUCCESS"))
 	attrs["widget_id"] = attrs["widget_id"].SetOptional()
 	attrs["widget_title"] = attrs["widget_title"].SetOptional()
 
@@ -14576,6 +14617,7 @@ func (newState *SqlTaskFile_SdkV2) SyncEffectiveFieldsDuringRead(existingState S
 func (c SqlTaskFile_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["path"] = attrs["path"].SetRequired()
 	attrs["source"] = attrs["source"].SetOptional()
+	attrs["source"] = attrs["source"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("GIT", "WORKSPACE"))
 
 	return attrs
 }
@@ -15350,6 +15392,7 @@ func (c SubmitTask_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.At
 	attrs["python_wheel_task"] = attrs["python_wheel_task"].SetOptional()
 	attrs["python_wheel_task"] = attrs["python_wheel_task"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["run_if"] = attrs["run_if"].SetOptional()
+	attrs["run_if"] = attrs["run_if"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ALL_DONE", "ALL_FAILED", "ALL_SUCCESS", "AT_LEAST_ONE_FAILED", "AT_LEAST_ONE_SUCCESS", "NONE_FAILED"))
 	attrs["run_job_task"] = attrs["run_job_task"].SetOptional()
 	attrs["run_job_task"] = attrs["run_job_task"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["spark_jar_task"] = attrs["spark_jar_task"].SetOptional()
@@ -16024,6 +16067,7 @@ func (newState *TableUpdateTriggerConfiguration_SdkV2) SyncEffectiveFieldsDuring
 
 func (c TableUpdateTriggerConfiguration_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["condition"] = attrs["condition"].SetOptional()
+	attrs["condition"] = attrs["condition"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ALL_UPDATED", "ANY_UPDATED"))
 	attrs["min_time_between_triggers_seconds"] = attrs["min_time_between_triggers_seconds"].SetOptional()
 	attrs["table_names"] = attrs["table_names"].SetOptional()
 	attrs["wait_after_last_change_seconds"] = attrs["wait_after_last_change_seconds"].SetOptional()
@@ -16266,6 +16310,7 @@ func (c Task_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.Attribut
 	attrs["python_wheel_task"] = attrs["python_wheel_task"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["retry_on_timeout"] = attrs["retry_on_timeout"].SetOptional()
 	attrs["run_if"] = attrs["run_if"].SetOptional()
+	attrs["run_if"] = attrs["run_if"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ALL_DONE", "ALL_FAILED", "ALL_SUCCESS", "AT_LEAST_ONE_FAILED", "AT_LEAST_ONE_SUCCESS", "NONE_FAILED"))
 	attrs["run_job_task"] = attrs["run_job_task"].SetOptional()
 	attrs["run_job_task"] = attrs["run_job_task"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["spark_jar_task"] = attrs["spark_jar_task"].SetOptional()
@@ -17350,8 +17395,10 @@ func (newState *TerminationDetails_SdkV2) SyncEffectiveFieldsDuringRead(existing
 
 func (c TerminationDetails_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["code"] = attrs["code"].SetOptional()
+	attrs["code"] = attrs["code"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("BUDGET_POLICY_LIMIT_EXCEEDED", "CANCELED", "CLOUD_FAILURE", "CLUSTER_ERROR", "CLUSTER_REQUEST_LIMIT_EXCEEDED", "DRIVER_ERROR", "FEATURE_DISABLED", "INTERNAL_ERROR", "INVALID_CLUSTER_REQUEST", "INVALID_RUN_CONFIGURATION", "LIBRARY_INSTALLATION_ERROR", "MAX_CONCURRENT_RUNS_EXCEEDED", "MAX_JOB_QUEUE_SIZE_EXCEEDED", "MAX_SPARK_CONTEXTS_EXCEEDED", "REPOSITORY_CHECKOUT_FAILED", "RESOURCE_NOT_FOUND", "RUN_EXECUTION_ERROR", "SKIPPED", "STORAGE_ACCESS_ERROR", "SUCCESS", "UNAUTHORIZED_ERROR", "USER_CANCELED", "WORKSPACE_RUN_LIMIT_EXCEEDED"))
 	attrs["message"] = attrs["message"].SetOptional()
 	attrs["type"] = attrs["type"].SetOptional()
+	attrs["type"] = attrs["type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CLIENT_ERROR", "CLOUD_FAILURE", "INTERNAL_ERROR", "SUCCESS"))
 
 	return attrs
 }
@@ -17463,6 +17510,7 @@ func (c TriggerSettings_SdkV2) ApplySchemaCustomizations(attrs map[string]tfsche
 	attrs["file_arrival"] = attrs["file_arrival"].SetOptional()
 	attrs["file_arrival"] = attrs["file_arrival"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["pause_status"] = attrs["pause_status"].SetOptional()
+	attrs["pause_status"] = attrs["pause_status"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("PAUSED", "UNPAUSED"))
 	attrs["periodic"] = attrs["periodic"].SetOptional()
 	attrs["periodic"] = attrs["periodic"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["table"] = attrs["table"].SetOptional()
@@ -17810,6 +17858,7 @@ func (c ViewItem_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.Attr
 	attrs["content"] = attrs["content"].SetOptional()
 	attrs["name"] = attrs["name"].SetOptional()
 	attrs["type"] = attrs["type"].SetOptional()
+	attrs["type"] = attrs["type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DASHBOARD", "NOTEBOOK"))
 
 	return attrs
 }

--- a/internal/service/jobs_tf/model.go
+++ b/internal/service/jobs_tf/model.go
@@ -18,6 +18,7 @@ import (
 	"github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/tfschema"
 
 	"github.com/databricks/terraform-provider-databricks/internal/service/compute_tf"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
@@ -299,6 +300,7 @@ func (c BaseRun) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBu
 	attrs["creator_user_name"] = attrs["creator_user_name"].SetOptional()
 	attrs["description"] = attrs["description"].SetOptional()
 	attrs["effective_performance_target"] = attrs["effective_performance_target"].SetOptional()
+	attrs["effective_performance_target"] = attrs["effective_performance_target"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("COST_OPTIMIZED", "PERFORMANCE_OPTIMIZED"))
 	attrs["end_time"] = attrs["end_time"].SetOptional()
 	attrs["execution_duration"] = attrs["execution_duration"].SetOptional()
 	attrs["git_source"] = attrs["git_source"].SetOptional()
@@ -317,6 +319,7 @@ func (c BaseRun) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBu
 	attrs["run_name"] = attrs["run_name"].SetOptional()
 	attrs["run_page_url"] = attrs["run_page_url"].SetOptional()
 	attrs["run_type"] = attrs["run_type"].SetOptional()
+	attrs["run_type"] = attrs["run_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("JOB_RUN", "SUBMIT_RUN", "WORKFLOW_RUN"))
 	attrs["schedule"] = attrs["schedule"].SetOptional()
 	attrs["setup_duration"] = attrs["setup_duration"].SetOptional()
 	attrs["start_time"] = attrs["start_time"].SetOptional()
@@ -324,6 +327,7 @@ func (c BaseRun) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBu
 	attrs["status"] = attrs["status"].SetOptional()
 	attrs["tasks"] = attrs["tasks"].SetOptional()
 	attrs["trigger"] = attrs["trigger"].SetOptional()
+	attrs["trigger"] = attrs["trigger"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("FILE_ARRIVAL", "ONE_TIME", "PERIODIC", "RETRY", "RUN_JOB_TASK", "TABLE"))
 	attrs["trigger_info"] = attrs["trigger_info"].SetOptional()
 
 	return attrs
@@ -953,7 +957,9 @@ func (newState *CleanRoomTaskRunState) SyncEffectiveFieldsDuringRead(existingSta
 
 func (c CleanRoomTaskRunState) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["life_cycle_state"] = attrs["life_cycle_state"].SetOptional()
+	attrs["life_cycle_state"] = attrs["life_cycle_state"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("BLOCKED", "INTERNAL_ERROR", "PENDING", "QUEUED", "RUNNING", "RUN_LIFE_CYCLE_STATE_UNSPECIFIED", "SKIPPED", "TERMINATED", "TERMINATING", "WAITING_FOR_RETRY"))
 	attrs["result_state"] = attrs["result_state"].SetOptional()
+	attrs["result_state"] = attrs["result_state"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CANCELED", "DISABLED", "EVICTED", "EXCLUDED", "FAILED", "MAXIMUM_CONCURRENT_RUNS_REACHED", "RUN_RESULT_STATE_UNSPECIFIED", "SUCCESS", "SUCCESS_WITH_FAILURES", "TIMEDOUT", "UPSTREAM_CANCELED", "UPSTREAM_EVICTED", "UPSTREAM_FAILED"))
 
 	return attrs
 }
@@ -1456,6 +1462,7 @@ func (newState *ConditionTask) SyncEffectiveFieldsDuringRead(existingState Condi
 func (c ConditionTask) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["left"] = attrs["left"].SetRequired()
 	attrs["op"] = attrs["op"].SetRequired()
+	attrs["op"] = attrs["op"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("EQUAL_TO", "GREATER_THAN", "GREATER_THAN_OR_EQUAL", "LESS_THAN", "LESS_THAN_OR_EQUAL", "NOT_EQUAL"))
 	attrs["right"] = attrs["right"].SetRequired()
 
 	return attrs
@@ -1510,6 +1517,7 @@ func (newState *Continuous) SyncEffectiveFieldsDuringRead(existingState Continuo
 
 func (c Continuous) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["pause_status"] = attrs["pause_status"].SetOptional()
+	attrs["pause_status"] = attrs["pause_status"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("PAUSED", "UNPAUSED"))
 
 	return attrs
 }
@@ -1671,9 +1679,11 @@ func (c CreateJob) ApplySchemaCustomizations(attrs map[string]tfschema.Attribute
 	attrs["deployment"] = attrs["deployment"].SetOptional()
 	attrs["description"] = attrs["description"].SetOptional()
 	attrs["edit_mode"] = attrs["edit_mode"].SetOptional()
+	attrs["edit_mode"] = attrs["edit_mode"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("EDITABLE", "UI_LOCKED"))
 	attrs["email_notifications"] = attrs["email_notifications"].SetOptional()
 	attrs["environment"] = attrs["environment"].SetOptional()
 	attrs["format"] = attrs["format"].SetOptional()
+	attrs["format"] = attrs["format"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("MULTI_TASK", "SINGLE_TASK"))
 	attrs["git_source"] = attrs["git_source"].SetOptional()
 	attrs["health"] = attrs["health"].SetOptional()
 	attrs["job_cluster"] = attrs["job_cluster"].SetOptional()
@@ -1682,6 +1692,7 @@ func (c CreateJob) ApplySchemaCustomizations(attrs map[string]tfschema.Attribute
 	attrs["notification_settings"] = attrs["notification_settings"].SetOptional()
 	attrs["parameter"] = attrs["parameter"].SetOptional()
 	attrs["performance_target"] = attrs["performance_target"].SetOptional()
+	attrs["performance_target"] = attrs["performance_target"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("COST_OPTIMIZED", "PERFORMANCE_OPTIMIZED"))
 	attrs["queue"] = attrs["queue"].SetOptional()
 	attrs["run_as"] = attrs["run_as"].SetOptional()
 	attrs["schedule"] = attrs["schedule"].SetOptional()
@@ -2339,6 +2350,7 @@ func (newState *CronSchedule) SyncEffectiveFieldsDuringRead(existingState CronSc
 
 func (c CronSchedule) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["pause_status"] = attrs["pause_status"].SetOptional()
+	attrs["pause_status"] = attrs["pause_status"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("PAUSED", "UNPAUSED"))
 	attrs["quartz_cron_expression"] = attrs["quartz_cron_expression"].SetRequired()
 	attrs["timezone_id"] = attrs["timezone_id"].SetRequired()
 
@@ -2516,6 +2528,7 @@ func (c DbtTask) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBu
 	attrs["project_directory"] = attrs["project_directory"].SetOptional()
 	attrs["schema"] = attrs["schema"].SetOptional()
 	attrs["source"] = attrs["source"].SetOptional()
+	attrs["source"] = attrs["source"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("GIT", "WORKSPACE"))
 	attrs["warehouse_id"] = attrs["warehouse_id"].SetOptional()
 
 	return attrs
@@ -4025,6 +4038,7 @@ func (c GitSource) ApplySchemaCustomizations(attrs map[string]tfschema.Attribute
 	attrs["branch"] = attrs["branch"].SetOptional()
 	attrs["commit"] = attrs["commit"].SetOptional()
 	attrs["git_provider"] = attrs["git_provider"].SetRequired()
+	attrs["git_provider"] = attrs["git_provider"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("awsCodeCommit", "azureDevOpsServices", "bitbucketCloud", "bitbucketServer", "gitHub", "gitHubEnterprise", "gitLab", "gitLabEnterpriseEdition"))
 	attrs["git_snapshot"] = attrs["git_snapshot"].SetOptional()
 	attrs["tag"] = attrs["tag"].SetOptional()
 	attrs["url"] = attrs["url"].SetRequired()
@@ -4286,6 +4300,7 @@ func (newState *JobAccessControlRequest) SyncEffectiveFieldsDuringRead(existingS
 func (c JobAccessControlRequest) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["group_name"] = attrs["group_name"].SetOptional()
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_MANAGE", "CAN_MANAGE_RUN", "CAN_VIEW", "IS_OWNER"))
 	attrs["service_principal_name"] = attrs["service_principal_name"].SetOptional()
 	attrs["user_name"] = attrs["user_name"].SetOptional()
 
@@ -4621,6 +4636,7 @@ func (newState *JobDeployment) SyncEffectiveFieldsDuringRead(existingState JobDe
 
 func (c JobDeployment) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["kind"] = attrs["kind"].SetRequired()
+	attrs["kind"] = attrs["kind"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("BUNDLE"))
 	attrs["metadata_file_path"] = attrs["metadata_file_path"].SetOptional()
 
 	return attrs
@@ -5169,6 +5185,7 @@ func (c JobPermission) ApplySchemaCustomizations(attrs map[string]tfschema.Attri
 	attrs["inherited"] = attrs["inherited"].SetOptional()
 	attrs["inherited_from_object"] = attrs["inherited_from_object"].SetOptional()
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_MANAGE", "CAN_MANAGE_RUN", "CAN_VIEW", "IS_OWNER"))
 
 	return attrs
 }
@@ -5340,6 +5357,7 @@ func (newState *JobPermissionsDescription) SyncEffectiveFieldsDuringRead(existin
 func (c JobPermissionsDescription) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["description"] = attrs["description"].SetOptional()
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_MANAGE", "CAN_MANAGE_RUN", "CAN_VIEW", "IS_OWNER"))
 
 	return attrs
 }
@@ -5642,9 +5660,11 @@ func (c JobSettings) ApplySchemaCustomizations(attrs map[string]tfschema.Attribu
 	attrs["deployment"] = attrs["deployment"].SetOptional()
 	attrs["description"] = attrs["description"].SetOptional()
 	attrs["edit_mode"] = attrs["edit_mode"].SetOptional()
+	attrs["edit_mode"] = attrs["edit_mode"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("EDITABLE", "UI_LOCKED"))
 	attrs["email_notifications"] = attrs["email_notifications"].SetOptional()
 	attrs["environment"] = attrs["environment"].SetOptional()
 	attrs["format"] = attrs["format"].SetOptional()
+	attrs["format"] = attrs["format"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("MULTI_TASK", "SINGLE_TASK"))
 	attrs["git_source"] = attrs["git_source"].SetOptional()
 	attrs["health"] = attrs["health"].SetOptional()
 	attrs["job_cluster"] = attrs["job_cluster"].SetOptional()
@@ -5653,6 +5673,7 @@ func (c JobSettings) ApplySchemaCustomizations(attrs map[string]tfschema.Attribu
 	attrs["notification_settings"] = attrs["notification_settings"].SetOptional()
 	attrs["parameter"] = attrs["parameter"].SetOptional()
 	attrs["performance_target"] = attrs["performance_target"].SetOptional()
+	attrs["performance_target"] = attrs["performance_target"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("COST_OPTIMIZED", "PERFORMANCE_OPTIMIZED"))
 	attrs["queue"] = attrs["queue"].SetOptional()
 	attrs["run_as"] = attrs["run_as"].SetOptional()
 	attrs["schedule"] = attrs["schedule"].SetOptional()
@@ -6234,6 +6255,7 @@ func (newState *JobSource) SyncEffectiveFieldsDuringRead(existingState JobSource
 
 func (c JobSource) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["dirty_state"] = attrs["dirty_state"].SetOptional()
+	attrs["dirty_state"] = attrs["dirty_state"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DISCONNECTED", "NOT_SYNCED"))
 	attrs["import_from_git_branch"] = attrs["import_from_git_branch"].SetRequired()
 	attrs["job_config_path"] = attrs["job_config_path"].SetRequired()
 
@@ -6305,7 +6327,9 @@ func (newState *JobsHealthRule) SyncEffectiveFieldsDuringRead(existingState Jobs
 
 func (c JobsHealthRule) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["metric"] = attrs["metric"].SetRequired()
+	attrs["metric"] = attrs["metric"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("RUN_DURATION_SECONDS", "STREAMING_BACKLOG_BYTES", "STREAMING_BACKLOG_FILES", "STREAMING_BACKLOG_RECORDS", "STREAMING_BACKLOG_SECONDS"))
 	attrs["op"] = attrs["op"].SetRequired()
+	attrs["op"] = attrs["op"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("GREATER_THAN"))
 	attrs["value"] = attrs["value"].SetRequired()
 
 	return attrs
@@ -7017,6 +7041,7 @@ func (c NotebookTask) ApplySchemaCustomizations(attrs map[string]tfschema.Attrib
 	attrs["base_parameters"] = attrs["base_parameters"].SetOptional()
 	attrs["notebook_path"] = attrs["notebook_path"].SetRequired()
 	attrs["source"] = attrs["source"].SetOptional()
+	attrs["source"] = attrs["source"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("GIT", "WORKSPACE"))
 	attrs["warehouse_id"] = attrs["warehouse_id"].SetOptional()
 
 	return attrs
@@ -7165,6 +7190,7 @@ func (newState *PeriodicTriggerConfiguration) SyncEffectiveFieldsDuringRead(exis
 func (c PeriodicTriggerConfiguration) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["interval"] = attrs["interval"].SetRequired()
 	attrs["unit"] = attrs["unit"].SetRequired()
+	attrs["unit"] = attrs["unit"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DAYS", "HOURS", "WEEKS"))
 
 	return attrs
 }
@@ -7451,6 +7477,7 @@ func (newState *QueueDetails) SyncEffectiveFieldsDuringRead(existingState QueueD
 
 func (c QueueDetails) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["code"] = attrs["code"].SetOptional()
+	attrs["code"] = attrs["code"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ACTIVE_RUNS_LIMIT_REACHED", "ACTIVE_RUN_JOB_TASKS_LIMIT_REACHED", "MAX_CONCURRENT_RUNS_REACHED"))
 	attrs["message"] = attrs["message"].SetOptional()
 
 	return attrs
@@ -7571,6 +7598,7 @@ func (c RepairHistoryItem) ApplySchemaCustomizations(attrs map[string]tfschema.A
 	attrs["status"] = attrs["status"].SetOptional()
 	attrs["task_run_ids"] = attrs["task_run_ids"].SetOptional()
 	attrs["type"] = attrs["type"].SetOptional()
+	attrs["type"] = attrs["type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ORIGINAL", "REPAIR"))
 
 	return attrs
 }
@@ -9482,6 +9510,7 @@ func (c Run) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilde
 	attrs["creator_user_name"] = attrs["creator_user_name"].SetOptional()
 	attrs["description"] = attrs["description"].SetOptional()
 	attrs["effective_performance_target"] = attrs["effective_performance_target"].SetOptional()
+	attrs["effective_performance_target"] = attrs["effective_performance_target"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("COST_OPTIMIZED", "PERFORMANCE_OPTIMIZED"))
 	attrs["end_time"] = attrs["end_time"].SetOptional()
 	attrs["execution_duration"] = attrs["execution_duration"].SetOptional()
 	attrs["git_source"] = attrs["git_source"].SetOptional()
@@ -9502,6 +9531,7 @@ func (c Run) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilde
 	attrs["run_name"] = attrs["run_name"].SetOptional()
 	attrs["run_page_url"] = attrs["run_page_url"].SetOptional()
 	attrs["run_type"] = attrs["run_type"].SetOptional()
+	attrs["run_type"] = attrs["run_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("JOB_RUN", "SUBMIT_RUN", "WORKFLOW_RUN"))
 	attrs["schedule"] = attrs["schedule"].SetOptional()
 	attrs["setup_duration"] = attrs["setup_duration"].SetOptional()
 	attrs["start_time"] = attrs["start_time"].SetOptional()
@@ -9509,6 +9539,7 @@ func (c Run) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilde
 	attrs["status"] = attrs["status"].SetOptional()
 	attrs["tasks"] = attrs["tasks"].SetOptional()
 	attrs["trigger"] = attrs["trigger"].SetOptional()
+	attrs["trigger"] = attrs["trigger"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("FILE_ARRIVAL", "ONE_TIME", "PERIODIC", "RETRY", "RUN_JOB_TASK", "TABLE"))
 	attrs["trigger_info"] = attrs["trigger_info"].SetOptional()
 
 	return attrs
@@ -10023,6 +10054,7 @@ func (newState *RunConditionTask) SyncEffectiveFieldsDuringRead(existingState Ru
 func (c RunConditionTask) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["left"] = attrs["left"].SetRequired()
 	attrs["op"] = attrs["op"].SetRequired()
+	attrs["op"] = attrs["op"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("EQUAL_TO", "GREATER_THAN", "GREATER_THAN_OR_EQUAL", "LESS_THAN", "LESS_THAN_OR_EQUAL", "NOT_EQUAL"))
 	attrs["outcome"] = attrs["outcome"].SetOptional()
 	attrs["right"] = attrs["right"].SetRequired()
 
@@ -10790,6 +10822,7 @@ func (c RunNow) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBui
 	attrs["notebook_params"] = attrs["notebook_params"].SetOptional()
 	attrs["only"] = attrs["only"].SetOptional()
 	attrs["performance_target"] = attrs["performance_target"].SetOptional()
+	attrs["performance_target"] = attrs["performance_target"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("COST_OPTIMIZED", "PERFORMANCE_OPTIMIZED"))
 	attrs["pipeline_params"] = attrs["pipeline_params"].SetOptional()
 	attrs["python_named_params"] = attrs["python_named_params"].SetOptional()
 	attrs["python_params"] = attrs["python_params"].SetOptional()
@@ -11930,8 +11963,10 @@ func (newState *RunState) SyncEffectiveFieldsDuringRead(existingState RunState) 
 
 func (c RunState) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["life_cycle_state"] = attrs["life_cycle_state"].SetOptional()
+	attrs["life_cycle_state"] = attrs["life_cycle_state"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("BLOCKED", "INTERNAL_ERROR", "PENDING", "QUEUED", "RUNNING", "SKIPPED", "TERMINATED", "TERMINATING", "WAITING_FOR_RETRY"))
 	attrs["queue_reason"] = attrs["queue_reason"].SetOptional()
 	attrs["result_state"] = attrs["result_state"].SetOptional()
+	attrs["result_state"] = attrs["result_state"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CANCELED", "DISABLED", "EXCLUDED", "FAILED", "MAXIMUM_CONCURRENT_RUNS_REACHED", "SUCCESS", "SUCCESS_WITH_FAILURES", "TIMEDOUT", "UPSTREAM_CANCELED", "UPSTREAM_FAILED"))
 	attrs["state_message"] = attrs["state_message"].SetOptional()
 	attrs["user_cancelled_or_timedout"] = attrs["user_cancelled_or_timedout"].SetOptional()
 
@@ -11997,6 +12032,7 @@ func (newState *RunStatus) SyncEffectiveFieldsDuringRead(existingState RunStatus
 func (c RunStatus) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["queue_details"] = attrs["queue_details"].SetOptional()
 	attrs["state"] = attrs["state"].SetOptional()
+	attrs["state"] = attrs["state"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("BLOCKED", "PENDING", "QUEUED", "RUNNING", "TERMINATED", "TERMINATING"))
 	attrs["termination_details"] = attrs["termination_details"].SetOptional()
 
 	return attrs
@@ -12295,6 +12331,7 @@ func (c RunTask) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBu
 	attrs["description"] = attrs["description"].SetOptional()
 	attrs["disabled"] = attrs["disabled"].SetComputed()
 	attrs["effective_performance_target"] = attrs["effective_performance_target"].SetComputed()
+	attrs["effective_performance_target"] = attrs["effective_performance_target"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("COST_OPTIMIZED", "PERFORMANCE_OPTIMIZED"))
 	attrs["email_notifications"] = attrs["email_notifications"].SetOptional()
 	attrs["end_time"] = attrs["end_time"].SetOptional()
 	attrs["environment_key"] = attrs["environment_key"].SetOptional()
@@ -12314,6 +12351,7 @@ func (c RunTask) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBu
 	attrs["run_duration"] = attrs["run_duration"].SetOptional()
 	attrs["run_id"] = attrs["run_id"].SetOptional()
 	attrs["run_if"] = attrs["run_if"].SetOptional()
+	attrs["run_if"] = attrs["run_if"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ALL_DONE", "ALL_FAILED", "ALL_SUCCESS", "AT_LEAST_ONE_FAILED", "AT_LEAST_ONE_SUCCESS", "NONE_FAILED"))
 	attrs["run_job_task"] = attrs["run_job_task"].SetOptional()
 	attrs["run_page_url"] = attrs["run_page_url"].SetOptional()
 	attrs["setup_duration"] = attrs["setup_duration"].SetOptional()
@@ -13251,6 +13289,7 @@ func (c SparkPythonTask) ApplySchemaCustomizations(attrs map[string]tfschema.Att
 	attrs["parameters"] = attrs["parameters"].SetOptional()
 	attrs["python_file"] = attrs["python_file"].SetRequired()
 	attrs["source"] = attrs["source"].SetOptional()
+	attrs["source"] = attrs["source"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("GIT", "WORKSPACE"))
 
 	return attrs
 }
@@ -13429,6 +13468,7 @@ func (newState *SqlAlertOutput) SyncEffectiveFieldsDuringRead(existingState SqlA
 
 func (c SqlAlertOutput) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["alert_state"] = attrs["alert_state"].SetOptional()
+	attrs["alert_state"] = attrs["alert_state"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("OK", "TRIGGERED", "UNKNOWN"))
 	attrs["output_link"] = attrs["output_link"].SetOptional()
 	attrs["query_text"] = attrs["query_text"].SetOptional()
 	attrs["sql_statements"] = attrs["sql_statements"].SetOptional()
@@ -13618,6 +13658,7 @@ func (c SqlDashboardWidgetOutput) ApplySchemaCustomizations(attrs map[string]tfs
 	attrs["output_link"] = attrs["output_link"].SetOptional()
 	attrs["start_time"] = attrs["start_time"].SetOptional()
 	attrs["status"] = attrs["status"].SetOptional()
+	attrs["status"] = attrs["status"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CANCELLED", "FAILED", "PENDING", "RUNNING", "SUCCESS"))
 	attrs["widget_id"] = attrs["widget_id"].SetOptional()
 	attrs["widget_title"] = attrs["widget_title"].SetOptional()
 
@@ -14467,6 +14508,7 @@ func (newState *SqlTaskFile) SyncEffectiveFieldsDuringRead(existingState SqlTask
 func (c SqlTaskFile) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["path"] = attrs["path"].SetRequired()
 	attrs["source"] = attrs["source"].SetOptional()
+	attrs["source"] = attrs["source"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("GIT", "WORKSPACE"))
 
 	return attrs
 }
@@ -15223,6 +15265,7 @@ func (c SubmitTask) ApplySchemaCustomizations(attrs map[string]tfschema.Attribut
 	attrs["pipeline_task"] = attrs["pipeline_task"].SetOptional()
 	attrs["python_wheel_task"] = attrs["python_wheel_task"].SetOptional()
 	attrs["run_if"] = attrs["run_if"].SetOptional()
+	attrs["run_if"] = attrs["run_if"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ALL_DONE", "ALL_FAILED", "ALL_SUCCESS", "AT_LEAST_ONE_FAILED", "AT_LEAST_ONE_SUCCESS", "NONE_FAILED"))
 	attrs["run_job_task"] = attrs["run_job_task"].SetOptional()
 	attrs["spark_jar_task"] = attrs["spark_jar_task"].SetOptional()
 	attrs["spark_python_task"] = attrs["spark_python_task"].SetOptional()
@@ -15891,6 +15934,7 @@ func (newState *TableUpdateTriggerConfiguration) SyncEffectiveFieldsDuringRead(e
 
 func (c TableUpdateTriggerConfiguration) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["condition"] = attrs["condition"].SetOptional()
+	attrs["condition"] = attrs["condition"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ALL_UPDATED", "ANY_UPDATED"))
 	attrs["min_time_between_triggers_seconds"] = attrs["min_time_between_triggers_seconds"].SetOptional()
 	attrs["table_names"] = attrs["table_names"].SetOptional()
 	attrs["wait_after_last_change_seconds"] = attrs["wait_after_last_change_seconds"].SetOptional()
@@ -16122,6 +16166,7 @@ func (c Task) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuild
 	attrs["python_wheel_task"] = attrs["python_wheel_task"].SetOptional()
 	attrs["retry_on_timeout"] = attrs["retry_on_timeout"].SetOptional()
 	attrs["run_if"] = attrs["run_if"].SetOptional()
+	attrs["run_if"] = attrs["run_if"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ALL_DONE", "ALL_FAILED", "ALL_SUCCESS", "AT_LEAST_ONE_FAILED", "AT_LEAST_ONE_SUCCESS", "NONE_FAILED"))
 	attrs["run_job_task"] = attrs["run_job_task"].SetOptional()
 	attrs["spark_jar_task"] = attrs["spark_jar_task"].SetOptional()
 	attrs["spark_python_task"] = attrs["spark_python_task"].SetOptional()
@@ -17200,8 +17245,10 @@ func (newState *TerminationDetails) SyncEffectiveFieldsDuringRead(existingState 
 
 func (c TerminationDetails) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["code"] = attrs["code"].SetOptional()
+	attrs["code"] = attrs["code"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("BUDGET_POLICY_LIMIT_EXCEEDED", "CANCELED", "CLOUD_FAILURE", "CLUSTER_ERROR", "CLUSTER_REQUEST_LIMIT_EXCEEDED", "DRIVER_ERROR", "FEATURE_DISABLED", "INTERNAL_ERROR", "INVALID_CLUSTER_REQUEST", "INVALID_RUN_CONFIGURATION", "LIBRARY_INSTALLATION_ERROR", "MAX_CONCURRENT_RUNS_EXCEEDED", "MAX_JOB_QUEUE_SIZE_EXCEEDED", "MAX_SPARK_CONTEXTS_EXCEEDED", "REPOSITORY_CHECKOUT_FAILED", "RESOURCE_NOT_FOUND", "RUN_EXECUTION_ERROR", "SKIPPED", "STORAGE_ACCESS_ERROR", "SUCCESS", "UNAUTHORIZED_ERROR", "USER_CANCELED", "WORKSPACE_RUN_LIMIT_EXCEEDED"))
 	attrs["message"] = attrs["message"].SetOptional()
 	attrs["type"] = attrs["type"].SetOptional()
+	attrs["type"] = attrs["type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CLIENT_ERROR", "CLOUD_FAILURE", "INTERNAL_ERROR", "SUCCESS"))
 
 	return attrs
 }
@@ -17312,6 +17359,7 @@ func (newState *TriggerSettings) SyncEffectiveFieldsDuringRead(existingState Tri
 func (c TriggerSettings) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["file_arrival"] = attrs["file_arrival"].SetOptional()
 	attrs["pause_status"] = attrs["pause_status"].SetOptional()
+	attrs["pause_status"] = attrs["pause_status"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("PAUSED", "UNPAUSED"))
 	attrs["periodic"] = attrs["periodic"].SetOptional()
 	attrs["table"] = attrs["table"].SetOptional()
 	attrs["table_update"] = attrs["table_update"].SetOptional()
@@ -17655,6 +17703,7 @@ func (c ViewItem) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeB
 	attrs["content"] = attrs["content"].SetOptional()
 	attrs["name"] = attrs["name"].SetOptional()
 	attrs["type"] = attrs["type"].SetOptional()
+	attrs["type"] = attrs["type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DASHBOARD", "NOTEBOOK"))
 
 	return attrs
 }

--- a/internal/service/marketplace_tf/legacy_model.go
+++ b/internal/service/marketplace_tf/legacy_model.go
@@ -18,6 +18,7 @@ import (
 	"github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/tfschema"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
@@ -821,6 +822,7 @@ func (c CreateFileRequest_SdkV2) ApplySchemaCustomizations(attrs map[string]tfsc
 	attrs["file_parent"] = attrs["file_parent"].SetRequired()
 	attrs["file_parent"] = attrs["file_parent"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["marketplace_file_type"] = attrs["marketplace_file_type"].SetRequired()
+	attrs["marketplace_file_type"] = attrs["marketplace_file_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("EMBEDDED_NOTEBOOK", "PROVIDER_ICON"))
 	attrs["mime_type"] = attrs["mime_type"].SetRequired()
 
 	return attrs
@@ -1002,6 +1004,7 @@ func (c CreateInstallationRequest_SdkV2) ApplySchemaCustomizations(attrs map[str
 	attrs["catalog_name"] = attrs["catalog_name"].SetOptional()
 	attrs["listing_id"] = attrs["listing_id"].SetRequired()
 	attrs["recipient_type"] = attrs["recipient_type"].SetOptional()
+	attrs["recipient_type"] = attrs["recipient_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DELTA_SHARING_RECIPIENT_TYPE_DATABRICKS", "DELTA_SHARING_RECIPIENT_TYPE_OPEN"))
 	attrs["repo_detail"] = attrs["repo_detail"].SetOptional()
 	attrs["repo_detail"] = attrs["repo_detail"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["share_name"] = attrs["share_name"].SetOptional()
@@ -1272,6 +1275,7 @@ func (c CreatePersonalizationRequest_SdkV2) ApplySchemaCustomizations(attrs map[
 	attrs["last_name"] = attrs["last_name"].SetOptional()
 	attrs["listing_id"] = attrs["listing_id"].SetRequired()
 	attrs["recipient_type"] = attrs["recipient_type"].SetOptional()
+	attrs["recipient_type"] = attrs["recipient_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DELTA_SHARING_RECIPIENT_TYPE_DATABRICKS", "DELTA_SHARING_RECIPIENT_TYPE_OPEN"))
 
 	return attrs
 }
@@ -1540,6 +1544,7 @@ func (newState *DataRefreshInfo_SdkV2) SyncEffectiveFieldsDuringRead(existingSta
 func (c DataRefreshInfo_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["interval"] = attrs["interval"].SetRequired()
 	attrs["unit"] = attrs["unit"].SetRequired()
+	attrs["unit"] = attrs["unit"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DAILY", "HOURLY", "MINUTE", "MONTHLY", "NONE", "QUARTERLY", "SECOND", "WEEKLY", "YEARLY"))
 
 	return attrs
 }
@@ -2220,6 +2225,7 @@ func (c ExchangeFilter_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschem
 	attrs["created_by"] = attrs["created_by"].SetOptional()
 	attrs["exchange_id"] = attrs["exchange_id"].SetRequired()
 	attrs["filter_type"] = attrs["filter_type"].SetRequired()
+	attrs["filter_type"] = attrs["filter_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("GLOBAL_METASTORE_ID"))
 	attrs["filter_value"] = attrs["filter_value"].SetRequired()
 	attrs["id"] = attrs["id"].SetOptional()
 	attrs["name"] = attrs["name"].SetOptional()
@@ -2390,8 +2396,10 @@ func (c FileInfo_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.Attr
 	attrs["file_parent"] = attrs["file_parent"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["id"] = attrs["id"].SetOptional()
 	attrs["marketplace_file_type"] = attrs["marketplace_file_type"].SetOptional()
+	attrs["marketplace_file_type"] = attrs["marketplace_file_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("EMBEDDED_NOTEBOOK", "PROVIDER_ICON"))
 	attrs["mime_type"] = attrs["mime_type"].SetOptional()
 	attrs["status"] = attrs["status"].SetOptional()
+	attrs["status"] = attrs["status"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("FILE_STATUS_PUBLISHED", "FILE_STATUS_SANITIZATION_FAILED", "FILE_STATUS_SANITIZING", "FILE_STATUS_STAGING"))
 	attrs["status_message"] = attrs["status_message"].SetOptional()
 	attrs["updated_at"] = attrs["updated_at"].SetOptional()
 
@@ -2491,6 +2499,7 @@ func (newState *FileParent_SdkV2) SyncEffectiveFieldsDuringRead(existingState Fi
 
 func (c FileParent_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["file_parent_type"] = attrs["file_parent_type"].SetOptional()
+	attrs["file_parent_type"] = attrs["file_parent_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("LISTING", "PROVIDER"))
 	attrs["parent_id"] = attrs["parent_id"].SetOptional()
 
 	return attrs
@@ -3514,10 +3523,12 @@ func (c InstallationDetail_SdkV2) ApplySchemaCustomizations(attrs map[string]tfs
 	attrs["listing_id"] = attrs["listing_id"].SetOptional()
 	attrs["listing_name"] = attrs["listing_name"].SetOptional()
 	attrs["recipient_type"] = attrs["recipient_type"].SetOptional()
+	attrs["recipient_type"] = attrs["recipient_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DELTA_SHARING_RECIPIENT_TYPE_DATABRICKS", "DELTA_SHARING_RECIPIENT_TYPE_OPEN"))
 	attrs["repo_name"] = attrs["repo_name"].SetOptional()
 	attrs["repo_path"] = attrs["repo_path"].SetOptional()
 	attrs["share_name"] = attrs["share_name"].SetOptional()
 	attrs["status"] = attrs["status"].SetOptional()
+	attrs["status"] = attrs["status"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("FAILED", "INSTALLED"))
 	attrs["token_detail"] = attrs["token_detail"].SetOptional()
 	attrs["token_detail"] = attrs["token_detail"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["tokens"] = attrs["tokens"].SetOptional()
@@ -5425,6 +5436,7 @@ func (c ListingDetail_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema
 	attrs["collection_granularity"] = attrs["collection_granularity"].SetOptional()
 	attrs["collection_granularity"] = attrs["collection_granularity"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["cost"] = attrs["cost"].SetOptional()
+	attrs["cost"] = attrs["cost"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("FREE", "PAID"))
 	attrs["data_source"] = attrs["data_source"].SetOptional()
 	attrs["description"] = attrs["description"].SetOptional()
 	attrs["documentation_link"] = attrs["documentation_link"].SetOptional()
@@ -5706,8 +5718,10 @@ func (newState *ListingFulfillment_SdkV2) SyncEffectiveFieldsDuringRead(existing
 
 func (c ListingFulfillment_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["fulfillment_type"] = attrs["fulfillment_type"].SetOptional()
+	attrs["fulfillment_type"] = attrs["fulfillment_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("INSTALL", "REQUEST_ACCESS"))
 	attrs["listing_id"] = attrs["listing_id"].SetRequired()
 	attrs["recipient_type"] = attrs["recipient_type"].SetOptional()
+	attrs["recipient_type"] = attrs["recipient_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DELTA_SHARING_RECIPIENT_TYPE_DATABRICKS", "DELTA_SHARING_RECIPIENT_TYPE_OPEN"))
 	attrs["repo_info"] = attrs["repo_info"].SetOptional()
 	attrs["repo_info"] = attrs["repo_info"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["share_info"] = attrs["share_info"].SetOptional()
@@ -5826,6 +5840,7 @@ func (newState *ListingSetting_SdkV2) SyncEffectiveFieldsDuringRead(existingStat
 
 func (c ListingSetting_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["visibility"] = attrs["visibility"].SetOptional()
+	attrs["visibility"] = attrs["visibility"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("PRIVATE", "PUBLIC"))
 
 	return attrs
 }
@@ -5918,6 +5933,7 @@ func (c ListingSummary_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschem
 	attrs["git_repo"] = attrs["git_repo"].SetOptional()
 	attrs["git_repo"] = attrs["git_repo"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["listingType"] = attrs["listingType"].SetRequired()
+	attrs["listingType"] = attrs["listingType"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("PERSONALIZED", "STANDARD"))
 	attrs["name"] = attrs["name"].SetRequired()
 	attrs["provider_id"] = attrs["provider_id"].SetOptional()
 	attrs["provider_region"] = attrs["provider_region"].SetOptional()
@@ -5929,6 +5945,7 @@ func (c ListingSummary_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschem
 	attrs["share"] = attrs["share"].SetOptional()
 	attrs["share"] = attrs["share"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["status"] = attrs["status"].SetOptional()
+	attrs["status"] = attrs["status"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DRAFT", "PENDING", "PUBLISHED", "SUSPENDED"))
 	attrs["subtitle"] = attrs["subtitle"].SetOptional()
 	attrs["updated_at"] = attrs["updated_at"].SetOptional()
 	attrs["updated_by"] = attrs["updated_by"].SetOptional()
@@ -6195,6 +6212,7 @@ func (newState *ListingTag_SdkV2) SyncEffectiveFieldsDuringRead(existingState Li
 
 func (c ListingTag_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["tag_name"] = attrs["tag_name"].SetOptional()
+	attrs["tag_name"] = attrs["tag_name"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("LISTING_TAG_TYPE_LANGUAGE", "LISTING_TAG_TYPE_TASK"))
 	attrs["tag_values"] = attrs["tag_values"].SetOptional()
 
 	return attrs
@@ -6319,9 +6337,11 @@ func (c PersonalizationRequest_SdkV2) ApplySchemaCustomizations(attrs map[string
 	attrs["metastore_id"] = attrs["metastore_id"].SetOptional()
 	attrs["provider_id"] = attrs["provider_id"].SetOptional()
 	attrs["recipient_type"] = attrs["recipient_type"].SetOptional()
+	attrs["recipient_type"] = attrs["recipient_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DELTA_SHARING_RECIPIENT_TYPE_DATABRICKS", "DELTA_SHARING_RECIPIENT_TYPE_OPEN"))
 	attrs["share"] = attrs["share"].SetOptional()
 	attrs["share"] = attrs["share"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["status"] = attrs["status"].SetOptional()
+	attrs["status"] = attrs["status"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DENIED", "FULFILLED", "NEW", "REQUEST_PENDING"))
 	attrs["status_message"] = attrs["status_message"].SetOptional()
 	attrs["updated_at"] = attrs["updated_at"].SetOptional()
 
@@ -7118,6 +7138,7 @@ func (newState *ShareInfo_SdkV2) SyncEffectiveFieldsDuringRead(existingState Sha
 func (c ShareInfo_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["name"] = attrs["name"].SetRequired()
 	attrs["type"] = attrs["type"].SetRequired()
+	attrs["type"] = attrs["type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("FULL", "SAMPLE"))
 
 	return attrs
 }
@@ -8031,6 +8052,7 @@ func (c UpdatePersonalizationRequestRequest_SdkV2) ApplySchemaCustomizations(att
 	attrs["share"] = attrs["share"].SetOptional()
 	attrs["share"] = attrs["share"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["status"] = attrs["status"].SetRequired()
+	attrs["status"] = attrs["status"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DENIED", "FULFILLED", "NEW", "REQUEST_PENDING"))
 
 	return attrs
 }

--- a/internal/service/marketplace_tf/model.go
+++ b/internal/service/marketplace_tf/model.go
@@ -17,6 +17,7 @@ import (
 	pluginfwcommon "github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/common"
 	"github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/tfschema"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
@@ -816,6 +817,7 @@ func (c CreateFileRequest) ApplySchemaCustomizations(attrs map[string]tfschema.A
 	attrs["display_name"] = attrs["display_name"].SetOptional()
 	attrs["file_parent"] = attrs["file_parent"].SetRequired()
 	attrs["marketplace_file_type"] = attrs["marketplace_file_type"].SetRequired()
+	attrs["marketplace_file_type"] = attrs["marketplace_file_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("EMBEDDED_NOTEBOOK", "PROVIDER_ICON"))
 	attrs["mime_type"] = attrs["mime_type"].SetRequired()
 
 	return attrs
@@ -995,6 +997,7 @@ func (c CreateInstallationRequest) ApplySchemaCustomizations(attrs map[string]tf
 	attrs["catalog_name"] = attrs["catalog_name"].SetOptional()
 	attrs["listing_id"] = attrs["listing_id"].SetRequired()
 	attrs["recipient_type"] = attrs["recipient_type"].SetOptional()
+	attrs["recipient_type"] = attrs["recipient_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DELTA_SHARING_RECIPIENT_TYPE_DATABRICKS", "DELTA_SHARING_RECIPIENT_TYPE_OPEN"))
 	attrs["repo_detail"] = attrs["repo_detail"].SetOptional()
 	attrs["share_name"] = attrs["share_name"].SetOptional()
 
@@ -1262,6 +1265,7 @@ func (c CreatePersonalizationRequest) ApplySchemaCustomizations(attrs map[string
 	attrs["last_name"] = attrs["last_name"].SetOptional()
 	attrs["listing_id"] = attrs["listing_id"].SetRequired()
 	attrs["recipient_type"] = attrs["recipient_type"].SetOptional()
+	attrs["recipient_type"] = attrs["recipient_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DELTA_SHARING_RECIPIENT_TYPE_DATABRICKS", "DELTA_SHARING_RECIPIENT_TYPE_OPEN"))
 
 	return attrs
 }
@@ -1529,6 +1533,7 @@ func (newState *DataRefreshInfo) SyncEffectiveFieldsDuringRead(existingState Dat
 func (c DataRefreshInfo) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["interval"] = attrs["interval"].SetRequired()
 	attrs["unit"] = attrs["unit"].SetRequired()
+	attrs["unit"] = attrs["unit"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DAILY", "HOURLY", "MINUTE", "MONTHLY", "NONE", "QUARTERLY", "SECOND", "WEEKLY", "YEARLY"))
 
 	return attrs
 }
@@ -2209,6 +2214,7 @@ func (c ExchangeFilter) ApplySchemaCustomizations(attrs map[string]tfschema.Attr
 	attrs["created_by"] = attrs["created_by"].SetOptional()
 	attrs["exchange_id"] = attrs["exchange_id"].SetRequired()
 	attrs["filter_type"] = attrs["filter_type"].SetRequired()
+	attrs["filter_type"] = attrs["filter_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("GLOBAL_METASTORE_ID"))
 	attrs["filter_value"] = attrs["filter_value"].SetRequired()
 	attrs["id"] = attrs["id"].SetOptional()
 	attrs["name"] = attrs["name"].SetOptional()
@@ -2378,8 +2384,10 @@ func (c FileInfo) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeB
 	attrs["file_parent"] = attrs["file_parent"].SetOptional()
 	attrs["id"] = attrs["id"].SetOptional()
 	attrs["marketplace_file_type"] = attrs["marketplace_file_type"].SetOptional()
+	attrs["marketplace_file_type"] = attrs["marketplace_file_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("EMBEDDED_NOTEBOOK", "PROVIDER_ICON"))
 	attrs["mime_type"] = attrs["mime_type"].SetOptional()
 	attrs["status"] = attrs["status"].SetOptional()
+	attrs["status"] = attrs["status"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("FILE_STATUS_PUBLISHED", "FILE_STATUS_SANITIZATION_FAILED", "FILE_STATUS_SANITIZING", "FILE_STATUS_STAGING"))
 	attrs["status_message"] = attrs["status_message"].SetOptional()
 	attrs["updated_at"] = attrs["updated_at"].SetOptional()
 
@@ -2479,6 +2487,7 @@ func (newState *FileParent) SyncEffectiveFieldsDuringRead(existingState FilePare
 
 func (c FileParent) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["file_parent_type"] = attrs["file_parent_type"].SetOptional()
+	attrs["file_parent_type"] = attrs["file_parent_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("LISTING", "PROVIDER"))
 	attrs["parent_id"] = attrs["parent_id"].SetOptional()
 
 	return attrs
@@ -3497,10 +3506,12 @@ func (c InstallationDetail) ApplySchemaCustomizations(attrs map[string]tfschema.
 	attrs["listing_id"] = attrs["listing_id"].SetOptional()
 	attrs["listing_name"] = attrs["listing_name"].SetOptional()
 	attrs["recipient_type"] = attrs["recipient_type"].SetOptional()
+	attrs["recipient_type"] = attrs["recipient_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DELTA_SHARING_RECIPIENT_TYPE_DATABRICKS", "DELTA_SHARING_RECIPIENT_TYPE_OPEN"))
 	attrs["repo_name"] = attrs["repo_name"].SetOptional()
 	attrs["repo_path"] = attrs["repo_path"].SetOptional()
 	attrs["share_name"] = attrs["share_name"].SetOptional()
 	attrs["status"] = attrs["status"].SetOptional()
+	attrs["status"] = attrs["status"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("FAILED", "INSTALLED"))
 	attrs["token_detail"] = attrs["token_detail"].SetOptional()
 	attrs["tokens"] = attrs["tokens"].SetOptional()
 
@@ -5404,6 +5415,7 @@ func (c ListingDetail) ApplySchemaCustomizations(attrs map[string]tfschema.Attri
 	attrs["collection_date_start"] = attrs["collection_date_start"].SetOptional()
 	attrs["collection_granularity"] = attrs["collection_granularity"].SetOptional()
 	attrs["cost"] = attrs["cost"].SetOptional()
+	attrs["cost"] = attrs["cost"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("FREE", "PAID"))
 	attrs["data_source"] = attrs["data_source"].SetOptional()
 	attrs["description"] = attrs["description"].SetOptional()
 	attrs["documentation_link"] = attrs["documentation_link"].SetOptional()
@@ -5684,8 +5696,10 @@ func (newState *ListingFulfillment) SyncEffectiveFieldsDuringRead(existingState 
 
 func (c ListingFulfillment) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["fulfillment_type"] = attrs["fulfillment_type"].SetOptional()
+	attrs["fulfillment_type"] = attrs["fulfillment_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("INSTALL", "REQUEST_ACCESS"))
 	attrs["listing_id"] = attrs["listing_id"].SetRequired()
 	attrs["recipient_type"] = attrs["recipient_type"].SetOptional()
+	attrs["recipient_type"] = attrs["recipient_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DELTA_SHARING_RECIPIENT_TYPE_DATABRICKS", "DELTA_SHARING_RECIPIENT_TYPE_OPEN"))
 	attrs["repo_info"] = attrs["repo_info"].SetOptional()
 	attrs["share_info"] = attrs["share_info"].SetOptional()
 
@@ -5802,6 +5816,7 @@ func (newState *ListingSetting) SyncEffectiveFieldsDuringRead(existingState List
 
 func (c ListingSetting) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["visibility"] = attrs["visibility"].SetOptional()
+	attrs["visibility"] = attrs["visibility"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("PRIVATE", "PUBLIC"))
 
 	return attrs
 }
@@ -5893,6 +5908,7 @@ func (c ListingSummary) ApplySchemaCustomizations(attrs map[string]tfschema.Attr
 	attrs["exchange_ids"] = attrs["exchange_ids"].SetOptional()
 	attrs["git_repo"] = attrs["git_repo"].SetOptional()
 	attrs["listingType"] = attrs["listingType"].SetRequired()
+	attrs["listingType"] = attrs["listingType"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("PERSONALIZED", "STANDARD"))
 	attrs["name"] = attrs["name"].SetRequired()
 	attrs["provider_id"] = attrs["provider_id"].SetOptional()
 	attrs["provider_region"] = attrs["provider_region"].SetOptional()
@@ -5901,6 +5917,7 @@ func (c ListingSummary) ApplySchemaCustomizations(attrs map[string]tfschema.Attr
 	attrs["setting"] = attrs["setting"].SetOptional()
 	attrs["share"] = attrs["share"].SetOptional()
 	attrs["status"] = attrs["status"].SetOptional()
+	attrs["status"] = attrs["status"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DRAFT", "PENDING", "PUBLISHED", "SUSPENDED"))
 	attrs["subtitle"] = attrs["subtitle"].SetOptional()
 	attrs["updated_at"] = attrs["updated_at"].SetOptional()
 	attrs["updated_by"] = attrs["updated_by"].SetOptional()
@@ -6167,6 +6184,7 @@ func (newState *ListingTag) SyncEffectiveFieldsDuringRead(existingState ListingT
 
 func (c ListingTag) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["tag_name"] = attrs["tag_name"].SetOptional()
+	attrs["tag_name"] = attrs["tag_name"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("LISTING_TAG_TYPE_LANGUAGE", "LISTING_TAG_TYPE_TASK"))
 	attrs["tag_values"] = attrs["tag_values"].SetOptional()
 
 	return attrs
@@ -6289,8 +6307,10 @@ func (c PersonalizationRequest) ApplySchemaCustomizations(attrs map[string]tfsch
 	attrs["metastore_id"] = attrs["metastore_id"].SetOptional()
 	attrs["provider_id"] = attrs["provider_id"].SetOptional()
 	attrs["recipient_type"] = attrs["recipient_type"].SetOptional()
+	attrs["recipient_type"] = attrs["recipient_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DELTA_SHARING_RECIPIENT_TYPE_DATABRICKS", "DELTA_SHARING_RECIPIENT_TYPE_OPEN"))
 	attrs["share"] = attrs["share"].SetOptional()
 	attrs["status"] = attrs["status"].SetOptional()
+	attrs["status"] = attrs["status"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DENIED", "FULFILLED", "NEW", "REQUEST_PENDING"))
 	attrs["status_message"] = attrs["status_message"].SetOptional()
 	attrs["updated_at"] = attrs["updated_at"].SetOptional()
 
@@ -7087,6 +7107,7 @@ func (newState *ShareInfo) SyncEffectiveFieldsDuringRead(existingState ShareInfo
 func (c ShareInfo) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["name"] = attrs["name"].SetRequired()
 	attrs["type"] = attrs["type"].SetRequired()
+	attrs["type"] = attrs["type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("FULL", "SAMPLE"))
 
 	return attrs
 }
@@ -7991,6 +8012,7 @@ func (c UpdatePersonalizationRequestRequest) ApplySchemaCustomizations(attrs map
 	attrs["request_id"] = attrs["request_id"].SetRequired()
 	attrs["share"] = attrs["share"].SetOptional()
 	attrs["status"] = attrs["status"].SetRequired()
+	attrs["status"] = attrs["status"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DENIED", "FULFILLED", "NEW", "REQUEST_PENDING"))
 
 	return attrs
 }

--- a/internal/service/ml_tf/legacy_model.go
+++ b/internal/service/ml_tf/legacy_model.go
@@ -18,6 +18,7 @@ import (
 	"github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/tfschema"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
@@ -87,13 +88,16 @@ func (newState *Activity_SdkV2) SyncEffectiveFieldsDuringRead(existingState Acti
 
 func (c Activity_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["activity_type"] = attrs["activity_type"].SetOptional()
+	attrs["activity_type"] = attrs["activity_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("APPLIED_TRANSITION", "APPROVED_REQUEST", "CANCELLED_REQUEST", "NEW_COMMENT", "REJECTED_REQUEST", "REQUESTED_TRANSITION", "SYSTEM_TRANSITION"))
 	attrs["comment"] = attrs["comment"].SetOptional()
 	attrs["creation_timestamp"] = attrs["creation_timestamp"].SetOptional()
 	attrs["from_stage"] = attrs["from_stage"].SetOptional()
+	attrs["from_stage"] = attrs["from_stage"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("Archived", "None", "Production", "Staging"))
 	attrs["id"] = attrs["id"].SetOptional()
 	attrs["last_updated_timestamp"] = attrs["last_updated_timestamp"].SetOptional()
 	attrs["system_comment"] = attrs["system_comment"].SetOptional()
 	attrs["to_stage"] = attrs["to_stage"].SetOptional()
+	attrs["to_stage"] = attrs["to_stage"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("Archived", "None", "Production", "Staging"))
 	attrs["user_id"] = attrs["user_id"].SetOptional()
 
 	return attrs
@@ -179,6 +183,7 @@ func (c ApproveTransitionRequest_SdkV2) ApplySchemaCustomizations(attrs map[stri
 	attrs["comment"] = attrs["comment"].SetOptional()
 	attrs["name"] = attrs["name"].SetRequired()
 	attrs["stage"] = attrs["stage"].SetRequired()
+	attrs["stage"] = attrs["stage"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("Archived", "None", "Production", "Staging"))
 	attrs["version"] = attrs["version"].SetRequired()
 
 	return attrs
@@ -1077,6 +1082,7 @@ func (c CreateRegistryWebhook_SdkV2) ApplySchemaCustomizations(attrs map[string]
 	attrs["job_spec"] = attrs["job_spec"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["model_name"] = attrs["model_name"].SetOptional()
 	attrs["status"] = attrs["status"].SetOptional()
+	attrs["status"] = attrs["status"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ACTIVE", "DISABLED", "TEST_MODE"))
 
 	return attrs
 }
@@ -1413,6 +1419,7 @@ func (c CreateTransitionRequest_SdkV2) ApplySchemaCustomizations(attrs map[strin
 	attrs["comment"] = attrs["comment"].SetOptional()
 	attrs["name"] = attrs["name"].SetRequired()
 	attrs["stage"] = attrs["stage"].SetRequired()
+	attrs["stage"] = attrs["stage"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("Archived", "None", "Production", "Staging"))
 	attrs["version"] = attrs["version"].SetRequired()
 
 	return attrs
@@ -2803,6 +2810,7 @@ func (newState *ExperimentAccessControlRequest_SdkV2) SyncEffectiveFieldsDuringR
 func (c ExperimentAccessControlRequest_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["group_name"] = attrs["group_name"].SetOptional()
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_EDIT", "CAN_MANAGE", "CAN_READ"))
 	attrs["service_principal_name"] = attrs["service_principal_name"].SetOptional()
 	attrs["user_name"] = attrs["user_name"].SetOptional()
 
@@ -2962,6 +2970,7 @@ func (c ExperimentPermission_SdkV2) ApplySchemaCustomizations(attrs map[string]t
 	attrs["inherited"] = attrs["inherited"].SetOptional()
 	attrs["inherited_from_object"] = attrs["inherited_from_object"].SetOptional()
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_EDIT", "CAN_MANAGE", "CAN_READ"))
 
 	return attrs
 }
@@ -3133,6 +3142,7 @@ func (newState *ExperimentPermissionsDescription_SdkV2) SyncEffectiveFieldsDurin
 func (c ExperimentPermissionsDescription_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["description"] = attrs["description"].SetOptional()
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_EDIT", "CAN_MANAGE", "CAN_READ"))
 
 	return attrs
 }
@@ -6398,6 +6408,7 @@ func (c ModelDatabricks_SdkV2) ApplySchemaCustomizations(attrs map[string]tfsche
 	attrs["latest_versions"] = attrs["latest_versions"].SetOptional()
 	attrs["name"] = attrs["name"].SetOptional()
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_EDIT", "CAN_MANAGE", "CAN_MANAGE_PRODUCTION_VERSIONS", "CAN_MANAGE_STAGING_VERSIONS", "CAN_READ"))
 	attrs["tags"] = attrs["tags"].SetOptional()
 	attrs["user_id"] = attrs["user_id"].SetOptional()
 
@@ -6611,6 +6622,7 @@ func (c ModelVersion_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.
 	attrs["run_link"] = attrs["run_link"].SetOptional()
 	attrs["source"] = attrs["source"].SetOptional()
 	attrs["status"] = attrs["status"].SetOptional()
+	attrs["status"] = attrs["status"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("FAILED_REGISTRATION", "PENDING_REGISTRATION", "READY"))
 	attrs["status_message"] = attrs["status_message"].SetOptional()
 	attrs["tags"] = attrs["tags"].SetOptional()
 	attrs["user_id"] = attrs["user_id"].SetOptional()
@@ -6764,14 +6776,17 @@ func (newState *ModelVersionDatabricks_SdkV2) SyncEffectiveFieldsDuringRead(exis
 func (c ModelVersionDatabricks_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["creation_timestamp"] = attrs["creation_timestamp"].SetOptional()
 	attrs["current_stage"] = attrs["current_stage"].SetOptional()
+	attrs["current_stage"] = attrs["current_stage"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("Archived", "None", "Production", "Staging"))
 	attrs["description"] = attrs["description"].SetOptional()
 	attrs["last_updated_timestamp"] = attrs["last_updated_timestamp"].SetOptional()
 	attrs["name"] = attrs["name"].SetOptional()
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_EDIT", "CAN_MANAGE", "CAN_MANAGE_PRODUCTION_VERSIONS", "CAN_MANAGE_STAGING_VERSIONS", "CAN_READ"))
 	attrs["run_id"] = attrs["run_id"].SetOptional()
 	attrs["run_link"] = attrs["run_link"].SetOptional()
 	attrs["source"] = attrs["source"].SetOptional()
 	attrs["status"] = attrs["status"].SetOptional()
+	attrs["status"] = attrs["status"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("FAILED_REGISTRATION", "PENDING_REGISTRATION", "READY"))
 	attrs["status_message"] = attrs["status_message"].SetOptional()
 	attrs["tags"] = attrs["tags"].SetOptional()
 	attrs["user_id"] = attrs["user_id"].SetOptional()
@@ -6993,6 +7008,7 @@ func (newState *RegisteredModelAccessControlRequest_SdkV2) SyncEffectiveFieldsDu
 func (c RegisteredModelAccessControlRequest_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["group_name"] = attrs["group_name"].SetOptional()
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_EDIT", "CAN_MANAGE", "CAN_MANAGE_PRODUCTION_VERSIONS", "CAN_MANAGE_STAGING_VERSIONS", "CAN_READ"))
 	attrs["service_principal_name"] = attrs["service_principal_name"].SetOptional()
 	attrs["user_name"] = attrs["user_name"].SetOptional()
 
@@ -7152,6 +7168,7 @@ func (c RegisteredModelPermission_SdkV2) ApplySchemaCustomizations(attrs map[str
 	attrs["inherited"] = attrs["inherited"].SetOptional()
 	attrs["inherited_from_object"] = attrs["inherited_from_object"].SetOptional()
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_EDIT", "CAN_MANAGE", "CAN_MANAGE_PRODUCTION_VERSIONS", "CAN_MANAGE_STAGING_VERSIONS", "CAN_READ"))
 
 	return attrs
 }
@@ -7323,6 +7340,7 @@ func (newState *RegisteredModelPermissionsDescription_SdkV2) SyncEffectiveFields
 func (c RegisteredModelPermissionsDescription_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["description"] = attrs["description"].SetOptional()
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_EDIT", "CAN_MANAGE", "CAN_MANAGE_PRODUCTION_VERSIONS", "CAN_MANAGE_STAGING_VERSIONS", "CAN_READ"))
 
 	return attrs
 }
@@ -7520,6 +7538,7 @@ func (c RegistryWebhook_SdkV2) ApplySchemaCustomizations(attrs map[string]tfsche
 	attrs["last_updated_timestamp"] = attrs["last_updated_timestamp"].SetOptional()
 	attrs["model_name"] = attrs["model_name"].SetOptional()
 	attrs["status"] = attrs["status"].SetOptional()
+	attrs["status"] = attrs["status"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ACTIVE", "DISABLED", "TEST_MODE"))
 
 	return attrs
 }
@@ -7688,6 +7707,7 @@ func (c RejectTransitionRequest_SdkV2) ApplySchemaCustomizations(attrs map[strin
 	attrs["comment"] = attrs["comment"].SetOptional()
 	attrs["name"] = attrs["name"].SetRequired()
 	attrs["stage"] = attrs["stage"].SetRequired()
+	attrs["stage"] = attrs["stage"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("Archived", "None", "Production", "Staging"))
 	attrs["version"] = attrs["version"].SetRequired()
 
 	return attrs
@@ -8551,6 +8571,7 @@ func (c RunInfo_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.Attri
 	attrs["run_uuid"] = attrs["run_uuid"].SetOptional()
 	attrs["start_time"] = attrs["start_time"].SetOptional()
 	attrs["status"] = attrs["status"].SetOptional()
+	attrs["status"] = attrs["status"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("FAILED", "FINISHED", "KILLED", "RUNNING", "SCHEDULED"))
 	attrs["user_id"] = attrs["user_id"].SetOptional()
 
 	return attrs
@@ -8764,6 +8785,7 @@ func (c SearchExperiments_SdkV2) ApplySchemaCustomizations(attrs map[string]tfsc
 	attrs["order_by"] = attrs["order_by"].SetOptional()
 	attrs["page_token"] = attrs["page_token"].SetOptional()
 	attrs["view_type"] = attrs["view_type"].SetOptional()
+	attrs["view_type"] = attrs["view_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ACTIVE_ONLY", "ALL", "DELETED_ONLY"))
 
 	return attrs
 }
@@ -9299,6 +9321,7 @@ func (c SearchRuns_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.At
 	attrs["order_by"] = attrs["order_by"].SetOptional()
 	attrs["page_token"] = attrs["page_token"].SetOptional()
 	attrs["run_view_type"] = attrs["run_view_type"].SetOptional()
+	attrs["run_view_type"] = attrs["run_view_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ACTIVE_ONLY", "ALL", "DELETED_ONLY"))
 
 	return attrs
 }
@@ -9980,6 +10003,7 @@ func (newState *TestRegistryWebhookRequest_SdkV2) SyncEffectiveFieldsDuringRead(
 
 func (c TestRegistryWebhookRequest_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["event"] = attrs["event"].SetOptional()
+	attrs["event"] = attrs["event"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("COMMENT_CREATED", "MODEL_VERSION_CREATED", "MODEL_VERSION_TAG_SET", "MODEL_VERSION_TRANSITIONED_STAGE", "MODEL_VERSION_TRANSITIONED_TO_ARCHIVED", "MODEL_VERSION_TRANSITIONED_TO_PRODUCTION", "MODEL_VERSION_TRANSITIONED_TO_STAGING", "REGISTERED_MODEL_CREATED", "TRANSITION_REQUEST_CREATED", "TRANSITION_REQUEST_TO_ARCHIVED_CREATED", "TRANSITION_REQUEST_TO_PRODUCTION_CREATED", "TRANSITION_REQUEST_TO_STAGING_CREATED"))
 	attrs["id"] = attrs["id"].SetRequired()
 
 	return attrs
@@ -10117,6 +10141,7 @@ func (c TransitionModelVersionStageDatabricks_SdkV2) ApplySchemaCustomizations(a
 	attrs["comment"] = attrs["comment"].SetOptional()
 	attrs["name"] = attrs["name"].SetRequired()
 	attrs["stage"] = attrs["stage"].SetRequired()
+	attrs["stage"] = attrs["stage"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("Archived", "None", "Production", "Staging"))
 	attrs["version"] = attrs["version"].SetRequired()
 
 	return attrs
@@ -10195,6 +10220,7 @@ func (c TransitionRequest_SdkV2) ApplySchemaCustomizations(attrs map[string]tfsc
 	attrs["comment"] = attrs["comment"].SetOptional()
 	attrs["creation_timestamp"] = attrs["creation_timestamp"].SetOptional()
 	attrs["to_stage"] = attrs["to_stage"].SetOptional()
+	attrs["to_stage"] = attrs["to_stage"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("Archived", "None", "Production", "Staging"))
 	attrs["user_id"] = attrs["user_id"].SetOptional()
 
 	return attrs
@@ -10788,6 +10814,7 @@ func (c UpdateRegistryWebhook_SdkV2) ApplySchemaCustomizations(attrs map[string]
 	attrs["job_spec"] = attrs["job_spec"].SetOptional()
 	attrs["job_spec"] = attrs["job_spec"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["status"] = attrs["status"].SetOptional()
+	attrs["status"] = attrs["status"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ACTIVE", "DISABLED", "TEST_MODE"))
 
 	return attrs
 }
@@ -10944,6 +10971,7 @@ func (c UpdateRun_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.Att
 	attrs["run_id"] = attrs["run_id"].SetOptional()
 	attrs["run_uuid"] = attrs["run_uuid"].SetOptional()
 	attrs["status"] = attrs["status"].SetOptional()
+	attrs["status"] = attrs["status"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("FAILED", "FINISHED", "KILLED", "RUNNING", "SCHEDULED"))
 
 	return attrs
 }

--- a/internal/service/ml_tf/model.go
+++ b/internal/service/ml_tf/model.go
@@ -17,6 +17,7 @@ import (
 	pluginfwcommon "github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/common"
 	"github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/tfschema"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
@@ -86,13 +87,16 @@ func (newState *Activity) SyncEffectiveFieldsDuringRead(existingState Activity) 
 
 func (c Activity) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["activity_type"] = attrs["activity_type"].SetOptional()
+	attrs["activity_type"] = attrs["activity_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("APPLIED_TRANSITION", "APPROVED_REQUEST", "CANCELLED_REQUEST", "NEW_COMMENT", "REJECTED_REQUEST", "REQUESTED_TRANSITION", "SYSTEM_TRANSITION"))
 	attrs["comment"] = attrs["comment"].SetOptional()
 	attrs["creation_timestamp"] = attrs["creation_timestamp"].SetOptional()
 	attrs["from_stage"] = attrs["from_stage"].SetOptional()
+	attrs["from_stage"] = attrs["from_stage"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("Archived", "None", "Production", "Staging"))
 	attrs["id"] = attrs["id"].SetOptional()
 	attrs["last_updated_timestamp"] = attrs["last_updated_timestamp"].SetOptional()
 	attrs["system_comment"] = attrs["system_comment"].SetOptional()
 	attrs["to_stage"] = attrs["to_stage"].SetOptional()
+	attrs["to_stage"] = attrs["to_stage"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("Archived", "None", "Production", "Staging"))
 	attrs["user_id"] = attrs["user_id"].SetOptional()
 
 	return attrs
@@ -178,6 +182,7 @@ func (c ApproveTransitionRequest) ApplySchemaCustomizations(attrs map[string]tfs
 	attrs["comment"] = attrs["comment"].SetOptional()
 	attrs["name"] = attrs["name"].SetRequired()
 	attrs["stage"] = attrs["stage"].SetRequired()
+	attrs["stage"] = attrs["stage"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("Archived", "None", "Production", "Staging"))
 	attrs["version"] = attrs["version"].SetRequired()
 
 	return attrs
@@ -1072,6 +1077,7 @@ func (c CreateRegistryWebhook) ApplySchemaCustomizations(attrs map[string]tfsche
 	attrs["job_spec"] = attrs["job_spec"].SetOptional()
 	attrs["model_name"] = attrs["model_name"].SetOptional()
 	attrs["status"] = attrs["status"].SetOptional()
+	attrs["status"] = attrs["status"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ACTIVE", "DISABLED", "TEST_MODE"))
 
 	return attrs
 }
@@ -1407,6 +1413,7 @@ func (c CreateTransitionRequest) ApplySchemaCustomizations(attrs map[string]tfsc
 	attrs["comment"] = attrs["comment"].SetOptional()
 	attrs["name"] = attrs["name"].SetRequired()
 	attrs["stage"] = attrs["stage"].SetRequired()
+	attrs["stage"] = attrs["stage"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("Archived", "None", "Production", "Staging"))
 	attrs["version"] = attrs["version"].SetRequired()
 
 	return attrs
@@ -2796,6 +2803,7 @@ func (newState *ExperimentAccessControlRequest) SyncEffectiveFieldsDuringRead(ex
 func (c ExperimentAccessControlRequest) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["group_name"] = attrs["group_name"].SetOptional()
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_EDIT", "CAN_MANAGE", "CAN_READ"))
 	attrs["service_principal_name"] = attrs["service_principal_name"].SetOptional()
 	attrs["user_name"] = attrs["user_name"].SetOptional()
 
@@ -2955,6 +2963,7 @@ func (c ExperimentPermission) ApplySchemaCustomizations(attrs map[string]tfschem
 	attrs["inherited"] = attrs["inherited"].SetOptional()
 	attrs["inherited_from_object"] = attrs["inherited_from_object"].SetOptional()
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_EDIT", "CAN_MANAGE", "CAN_READ"))
 
 	return attrs
 }
@@ -3126,6 +3135,7 @@ func (newState *ExperimentPermissionsDescription) SyncEffectiveFieldsDuringRead(
 func (c ExperimentPermissionsDescription) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["description"] = attrs["description"].SetOptional()
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_EDIT", "CAN_MANAGE", "CAN_READ"))
 
 	return attrs
 }
@@ -6388,6 +6398,7 @@ func (c ModelDatabricks) ApplySchemaCustomizations(attrs map[string]tfschema.Att
 	attrs["latest_versions"] = attrs["latest_versions"].SetOptional()
 	attrs["name"] = attrs["name"].SetOptional()
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_EDIT", "CAN_MANAGE", "CAN_MANAGE_PRODUCTION_VERSIONS", "CAN_MANAGE_STAGING_VERSIONS", "CAN_READ"))
 	attrs["tags"] = attrs["tags"].SetOptional()
 	attrs["user_id"] = attrs["user_id"].SetOptional()
 
@@ -6601,6 +6612,7 @@ func (c ModelVersion) ApplySchemaCustomizations(attrs map[string]tfschema.Attrib
 	attrs["run_link"] = attrs["run_link"].SetOptional()
 	attrs["source"] = attrs["source"].SetOptional()
 	attrs["status"] = attrs["status"].SetOptional()
+	attrs["status"] = attrs["status"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("FAILED_REGISTRATION", "PENDING_REGISTRATION", "READY"))
 	attrs["status_message"] = attrs["status_message"].SetOptional()
 	attrs["tags"] = attrs["tags"].SetOptional()
 	attrs["user_id"] = attrs["user_id"].SetOptional()
@@ -6754,14 +6766,17 @@ func (newState *ModelVersionDatabricks) SyncEffectiveFieldsDuringRead(existingSt
 func (c ModelVersionDatabricks) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["creation_timestamp"] = attrs["creation_timestamp"].SetOptional()
 	attrs["current_stage"] = attrs["current_stage"].SetOptional()
+	attrs["current_stage"] = attrs["current_stage"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("Archived", "None", "Production", "Staging"))
 	attrs["description"] = attrs["description"].SetOptional()
 	attrs["last_updated_timestamp"] = attrs["last_updated_timestamp"].SetOptional()
 	attrs["name"] = attrs["name"].SetOptional()
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_EDIT", "CAN_MANAGE", "CAN_MANAGE_PRODUCTION_VERSIONS", "CAN_MANAGE_STAGING_VERSIONS", "CAN_READ"))
 	attrs["run_id"] = attrs["run_id"].SetOptional()
 	attrs["run_link"] = attrs["run_link"].SetOptional()
 	attrs["source"] = attrs["source"].SetOptional()
 	attrs["status"] = attrs["status"].SetOptional()
+	attrs["status"] = attrs["status"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("FAILED_REGISTRATION", "PENDING_REGISTRATION", "READY"))
 	attrs["status_message"] = attrs["status_message"].SetOptional()
 	attrs["tags"] = attrs["tags"].SetOptional()
 	attrs["user_id"] = attrs["user_id"].SetOptional()
@@ -6983,6 +6998,7 @@ func (newState *RegisteredModelAccessControlRequest) SyncEffectiveFieldsDuringRe
 func (c RegisteredModelAccessControlRequest) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["group_name"] = attrs["group_name"].SetOptional()
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_EDIT", "CAN_MANAGE", "CAN_MANAGE_PRODUCTION_VERSIONS", "CAN_MANAGE_STAGING_VERSIONS", "CAN_READ"))
 	attrs["service_principal_name"] = attrs["service_principal_name"].SetOptional()
 	attrs["user_name"] = attrs["user_name"].SetOptional()
 
@@ -7142,6 +7158,7 @@ func (c RegisteredModelPermission) ApplySchemaCustomizations(attrs map[string]tf
 	attrs["inherited"] = attrs["inherited"].SetOptional()
 	attrs["inherited_from_object"] = attrs["inherited_from_object"].SetOptional()
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_EDIT", "CAN_MANAGE", "CAN_MANAGE_PRODUCTION_VERSIONS", "CAN_MANAGE_STAGING_VERSIONS", "CAN_READ"))
 
 	return attrs
 }
@@ -7313,6 +7330,7 @@ func (newState *RegisteredModelPermissionsDescription) SyncEffectiveFieldsDuring
 func (c RegisteredModelPermissionsDescription) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["description"] = attrs["description"].SetOptional()
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_EDIT", "CAN_MANAGE", "CAN_MANAGE_PRODUCTION_VERSIONS", "CAN_MANAGE_STAGING_VERSIONS", "CAN_READ"))
 
 	return attrs
 }
@@ -7508,6 +7526,7 @@ func (c RegistryWebhook) ApplySchemaCustomizations(attrs map[string]tfschema.Att
 	attrs["last_updated_timestamp"] = attrs["last_updated_timestamp"].SetOptional()
 	attrs["model_name"] = attrs["model_name"].SetOptional()
 	attrs["status"] = attrs["status"].SetOptional()
+	attrs["status"] = attrs["status"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ACTIVE", "DISABLED", "TEST_MODE"))
 
 	return attrs
 }
@@ -7676,6 +7695,7 @@ func (c RejectTransitionRequest) ApplySchemaCustomizations(attrs map[string]tfsc
 	attrs["comment"] = attrs["comment"].SetOptional()
 	attrs["name"] = attrs["name"].SetRequired()
 	attrs["stage"] = attrs["stage"].SetRequired()
+	attrs["stage"] = attrs["stage"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("Archived", "None", "Production", "Staging"))
 	attrs["version"] = attrs["version"].SetRequired()
 
 	return attrs
@@ -8535,6 +8555,7 @@ func (c RunInfo) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBu
 	attrs["run_uuid"] = attrs["run_uuid"].SetOptional()
 	attrs["start_time"] = attrs["start_time"].SetOptional()
 	attrs["status"] = attrs["status"].SetOptional()
+	attrs["status"] = attrs["status"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("FAILED", "FINISHED", "KILLED", "RUNNING", "SCHEDULED"))
 	attrs["user_id"] = attrs["user_id"].SetOptional()
 
 	return attrs
@@ -8748,6 +8769,7 @@ func (c SearchExperiments) ApplySchemaCustomizations(attrs map[string]tfschema.A
 	attrs["order_by"] = attrs["order_by"].SetOptional()
 	attrs["page_token"] = attrs["page_token"].SetOptional()
 	attrs["view_type"] = attrs["view_type"].SetOptional()
+	attrs["view_type"] = attrs["view_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ACTIVE_ONLY", "ALL", "DELETED_ONLY"))
 
 	return attrs
 }
@@ -9283,6 +9305,7 @@ func (c SearchRuns) ApplySchemaCustomizations(attrs map[string]tfschema.Attribut
 	attrs["order_by"] = attrs["order_by"].SetOptional()
 	attrs["page_token"] = attrs["page_token"].SetOptional()
 	attrs["run_view_type"] = attrs["run_view_type"].SetOptional()
+	attrs["run_view_type"] = attrs["run_view_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ACTIVE_ONLY", "ALL", "DELETED_ONLY"))
 
 	return attrs
 }
@@ -9964,6 +9987,7 @@ func (newState *TestRegistryWebhookRequest) SyncEffectiveFieldsDuringRead(existi
 
 func (c TestRegistryWebhookRequest) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["event"] = attrs["event"].SetOptional()
+	attrs["event"] = attrs["event"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("COMMENT_CREATED", "MODEL_VERSION_CREATED", "MODEL_VERSION_TAG_SET", "MODEL_VERSION_TRANSITIONED_STAGE", "MODEL_VERSION_TRANSITIONED_TO_ARCHIVED", "MODEL_VERSION_TRANSITIONED_TO_PRODUCTION", "MODEL_VERSION_TRANSITIONED_TO_STAGING", "REGISTERED_MODEL_CREATED", "TRANSITION_REQUEST_CREATED", "TRANSITION_REQUEST_TO_ARCHIVED_CREATED", "TRANSITION_REQUEST_TO_PRODUCTION_CREATED", "TRANSITION_REQUEST_TO_STAGING_CREATED"))
 	attrs["id"] = attrs["id"].SetRequired()
 
 	return attrs
@@ -10101,6 +10125,7 @@ func (c TransitionModelVersionStageDatabricks) ApplySchemaCustomizations(attrs m
 	attrs["comment"] = attrs["comment"].SetOptional()
 	attrs["name"] = attrs["name"].SetRequired()
 	attrs["stage"] = attrs["stage"].SetRequired()
+	attrs["stage"] = attrs["stage"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("Archived", "None", "Production", "Staging"))
 	attrs["version"] = attrs["version"].SetRequired()
 
 	return attrs
@@ -10179,6 +10204,7 @@ func (c TransitionRequest) ApplySchemaCustomizations(attrs map[string]tfschema.A
 	attrs["comment"] = attrs["comment"].SetOptional()
 	attrs["creation_timestamp"] = attrs["creation_timestamp"].SetOptional()
 	attrs["to_stage"] = attrs["to_stage"].SetOptional()
+	attrs["to_stage"] = attrs["to_stage"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("Archived", "None", "Production", "Staging"))
 	attrs["user_id"] = attrs["user_id"].SetOptional()
 
 	return attrs
@@ -10770,6 +10796,7 @@ func (c UpdateRegistryWebhook) ApplySchemaCustomizations(attrs map[string]tfsche
 	attrs["id"] = attrs["id"].SetRequired()
 	attrs["job_spec"] = attrs["job_spec"].SetOptional()
 	attrs["status"] = attrs["status"].SetOptional()
+	attrs["status"] = attrs["status"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ACTIVE", "DISABLED", "TEST_MODE"))
 
 	return attrs
 }
@@ -10926,6 +10953,7 @@ func (c UpdateRun) ApplySchemaCustomizations(attrs map[string]tfschema.Attribute
 	attrs["run_id"] = attrs["run_id"].SetOptional()
 	attrs["run_uuid"] = attrs["run_uuid"].SetOptional()
 	attrs["status"] = attrs["status"].SetOptional()
+	attrs["status"] = attrs["status"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("FAILED", "FINISHED", "KILLED", "RUNNING", "SCHEDULED"))
 
 	return attrs
 }

--- a/internal/service/pipelines_tf/legacy_model.go
+++ b/internal/service/pipelines_tf/legacy_model.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/databricks/terraform-provider-databricks/internal/service/compute_tf"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
@@ -1841,6 +1842,7 @@ func (c GetPipelineResponse_SdkV2) ApplySchemaCustomizations(attrs map[string]tf
 	attrs["creator_user_name"] = attrs["creator_user_name"].SetOptional()
 	attrs["effective_budget_policy_id"] = attrs["effective_budget_policy_id"].SetOptional()
 	attrs["health"] = attrs["health"].SetOptional()
+	attrs["health"] = attrs["health"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("HEALTHY", "UNHEALTHY"))
 	attrs["last_modified"] = attrs["last_modified"].SetOptional()
 	attrs["latest_updates"] = attrs["latest_updates"].SetOptional()
 	attrs["name"] = attrs["name"].SetOptional()
@@ -1849,6 +1851,7 @@ func (c GetPipelineResponse_SdkV2) ApplySchemaCustomizations(attrs map[string]tf
 	attrs["spec"] = attrs["spec"].SetOptional()
 	attrs["spec"] = attrs["spec"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["state"] = attrs["state"].SetOptional()
+	attrs["state"] = attrs["state"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DELETED", "DEPLOYING", "FAILED", "IDLE", "RECOVERING", "RESETTING", "RUNNING", "STARTING", "STOPPING"))
 
 	return attrs
 }
@@ -3293,6 +3296,7 @@ func (newState *PipelineAccessControlRequest_SdkV2) SyncEffectiveFieldsDuringRea
 func (c PipelineAccessControlRequest_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["group_name"] = attrs["group_name"].SetOptional()
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_MANAGE", "CAN_RUN", "CAN_VIEW", "IS_OWNER"))
 	attrs["service_principal_name"] = attrs["service_principal_name"].SetOptional()
 	attrs["user_name"] = attrs["user_name"].SetOptional()
 
@@ -3950,6 +3954,7 @@ func (c PipelineClusterAutoscale_SdkV2) ApplySchemaCustomizations(attrs map[stri
 	attrs["max_workers"] = attrs["max_workers"].SetRequired()
 	attrs["min_workers"] = attrs["min_workers"].SetRequired()
 	attrs["mode"] = attrs["mode"].SetOptional()
+	attrs["mode"] = attrs["mode"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ENHANCED", "LEGACY"))
 
 	return attrs
 }
@@ -4004,6 +4009,7 @@ func (newState *PipelineDeployment_SdkV2) SyncEffectiveFieldsDuringRead(existing
 
 func (c PipelineDeployment_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["kind"] = attrs["kind"].SetOptional()
+	attrs["kind"] = attrs["kind"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("BUNDLE"))
 	attrs["metadata_file_path"] = attrs["metadata_file_path"].SetOptional()
 
 	return attrs
@@ -4075,7 +4081,9 @@ func (c PipelineEvent_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema
 	attrs["event_type"] = attrs["event_type"].SetOptional()
 	attrs["id"] = attrs["id"].SetOptional()
 	attrs["level"] = attrs["level"].SetOptional()
+	attrs["level"] = attrs["level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ERROR", "INFO", "METRICS", "WARN"))
 	attrs["maturity_level"] = attrs["maturity_level"].SetOptional()
+	attrs["maturity_level"] = attrs["maturity_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DEPRECATED", "EVOLVING", "STABLE"))
 	attrs["message"] = attrs["message"].SetOptional()
 	attrs["origin"] = attrs["origin"].SetOptional()
 	attrs["origin"] = attrs["origin"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
@@ -4400,6 +4408,7 @@ func (c PipelinePermission_SdkV2) ApplySchemaCustomizations(attrs map[string]tfs
 	attrs["inherited"] = attrs["inherited"].SetOptional()
 	attrs["inherited_from_object"] = attrs["inherited_from_object"].SetOptional()
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_MANAGE", "CAN_RUN", "CAN_VIEW", "IS_OWNER"))
 
 	return attrs
 }
@@ -4571,6 +4580,7 @@ func (newState *PipelinePermissionsDescription_SdkV2) SyncEffectiveFieldsDuringR
 func (c PipelinePermissionsDescription_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["description"] = attrs["description"].SetOptional()
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_MANAGE", "CAN_RUN", "CAN_VIEW", "IS_OWNER"))
 
 	return attrs
 }
@@ -5185,11 +5195,13 @@ func (c PipelineStateInfo_SdkV2) ApplySchemaCustomizations(attrs map[string]tfsc
 	attrs["cluster_id"] = attrs["cluster_id"].SetOptional()
 	attrs["creator_user_name"] = attrs["creator_user_name"].SetOptional()
 	attrs["health"] = attrs["health"].SetOptional()
+	attrs["health"] = attrs["health"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("HEALTHY", "UNHEALTHY"))
 	attrs["latest_updates"] = attrs["latest_updates"].SetOptional()
 	attrs["name"] = attrs["name"].SetOptional()
 	attrs["pipeline_id"] = attrs["pipeline_id"].SetOptional()
 	attrs["run_as_user_name"] = attrs["run_as_user_name"].SetOptional()
 	attrs["state"] = attrs["state"].SetOptional()
+	attrs["state"] = attrs["state"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DELETED", "DEPLOYING", "FAILED", "IDLE", "RECOVERING", "RESETTING", "RUNNING", "STARTING", "STOPPING"))
 
 	return attrs
 }
@@ -6007,6 +6019,7 @@ func (newState *StartUpdate_SdkV2) SyncEffectiveFieldsDuringRead(existingState S
 
 func (c StartUpdate_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["cause"] = attrs["cause"].SetOptional()
+	attrs["cause"] = attrs["cause"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("API_CALL", "JOB_TASK", "RETRY_ON_FAILURE", "SCHEMA_CHANGE", "SERVICE_UPGRADE", "USER_ACTION"))
 	attrs["full_refresh"] = attrs["full_refresh"].SetOptional()
 	attrs["full_refresh_selection"] = attrs["full_refresh_selection"].SetOptional()
 	attrs["pipeline_id"] = attrs["pipeline_id"].SetRequired()
@@ -6377,6 +6390,7 @@ func (c TableSpecificConfig_SdkV2) ApplySchemaCustomizations(attrs map[string]tf
 	attrs["primary_keys"] = attrs["primary_keys"].SetOptional()
 	attrs["salesforce_include_formula_fields"] = attrs["salesforce_include_formula_fields"].SetOptional()
 	attrs["scd_type"] = attrs["scd_type"].SetOptional()
+	attrs["scd_type"] = attrs["scd_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("SCD_TYPE_1", "SCD_TYPE_2"))
 	attrs["sequence_by"] = attrs["sequence_by"].SetOptional()
 
 	return attrs
@@ -6519,6 +6533,7 @@ func (newState *UpdateInfo_SdkV2) SyncEffectiveFieldsDuringRead(existingState Up
 
 func (c UpdateInfo_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["cause"] = attrs["cause"].SetOptional()
+	attrs["cause"] = attrs["cause"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("API_CALL", "JOB_TASK", "RETRY_ON_FAILURE", "SCHEMA_CHANGE", "SERVICE_UPGRADE", "USER_ACTION"))
 	attrs["cluster_id"] = attrs["cluster_id"].SetOptional()
 	attrs["config"] = attrs["config"].SetOptional()
 	attrs["config"] = attrs["config"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
@@ -6528,6 +6543,7 @@ func (c UpdateInfo_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.At
 	attrs["pipeline_id"] = attrs["pipeline_id"].SetOptional()
 	attrs["refresh_selection"] = attrs["refresh_selection"].SetOptional()
 	attrs["state"] = attrs["state"].SetOptional()
+	attrs["state"] = attrs["state"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CANCELED", "COMPLETED", "CREATED", "FAILED", "INITIALIZING", "QUEUED", "RESETTING", "RUNNING", "SETTING_UP_TABLES", "STOPPING", "WAITING_FOR_RESOURCES"))
 	attrs["update_id"] = attrs["update_id"].SetOptional()
 	attrs["validate_only"] = attrs["validate_only"].SetOptional()
 
@@ -6690,6 +6706,7 @@ func (newState *UpdateStateInfo_SdkV2) SyncEffectiveFieldsDuringRead(existingSta
 func (c UpdateStateInfo_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["creation_time"] = attrs["creation_time"].SetOptional()
 	attrs["state"] = attrs["state"].SetOptional()
+	attrs["state"] = attrs["state"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CANCELED", "COMPLETED", "CREATED", "FAILED", "INITIALIZING", "QUEUED", "RESETTING", "RUNNING", "SETTING_UP_TABLES", "STOPPING", "WAITING_FOR_RESOURCES"))
 	attrs["update_id"] = attrs["update_id"].SetOptional()
 
 	return attrs

--- a/internal/service/pipelines_tf/model.go
+++ b/internal/service/pipelines_tf/model.go
@@ -18,6 +18,7 @@ import (
 	"github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/tfschema"
 
 	"github.com/databricks/terraform-provider-databricks/internal/service/compute_tf"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
@@ -1825,6 +1826,7 @@ func (c GetPipelineResponse) ApplySchemaCustomizations(attrs map[string]tfschema
 	attrs["creator_user_name"] = attrs["creator_user_name"].SetOptional()
 	attrs["effective_budget_policy_id"] = attrs["effective_budget_policy_id"].SetOptional()
 	attrs["health"] = attrs["health"].SetOptional()
+	attrs["health"] = attrs["health"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("HEALTHY", "UNHEALTHY"))
 	attrs["last_modified"] = attrs["last_modified"].SetOptional()
 	attrs["latest_updates"] = attrs["latest_updates"].SetOptional()
 	attrs["name"] = attrs["name"].SetOptional()
@@ -1832,6 +1834,7 @@ func (c GetPipelineResponse) ApplySchemaCustomizations(attrs map[string]tfschema
 	attrs["run_as_user_name"] = attrs["run_as_user_name"].SetOptional()
 	attrs["spec"] = attrs["spec"].SetOptional()
 	attrs["state"] = attrs["state"].SetOptional()
+	attrs["state"] = attrs["state"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DELETED", "DEPLOYING", "FAILED", "IDLE", "RECOVERING", "RESETTING", "RUNNING", "STARTING", "STOPPING"))
 
 	return attrs
 }
@@ -3271,6 +3274,7 @@ func (newState *PipelineAccessControlRequest) SyncEffectiveFieldsDuringRead(exis
 func (c PipelineAccessControlRequest) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["group_name"] = attrs["group_name"].SetOptional()
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_MANAGE", "CAN_RUN", "CAN_VIEW", "IS_OWNER"))
 	attrs["service_principal_name"] = attrs["service_principal_name"].SetOptional()
 	attrs["user_name"] = attrs["user_name"].SetOptional()
 
@@ -3923,6 +3927,7 @@ func (c PipelineClusterAutoscale) ApplySchemaCustomizations(attrs map[string]tfs
 	attrs["max_workers"] = attrs["max_workers"].SetRequired()
 	attrs["min_workers"] = attrs["min_workers"].SetRequired()
 	attrs["mode"] = attrs["mode"].SetOptional()
+	attrs["mode"] = attrs["mode"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ENHANCED", "LEGACY"))
 
 	return attrs
 }
@@ -3977,6 +3982,7 @@ func (newState *PipelineDeployment) SyncEffectiveFieldsDuringRead(existingState 
 
 func (c PipelineDeployment) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["kind"] = attrs["kind"].SetOptional()
+	attrs["kind"] = attrs["kind"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("BUNDLE"))
 	attrs["metadata_file_path"] = attrs["metadata_file_path"].SetOptional()
 
 	return attrs
@@ -4047,7 +4053,9 @@ func (c PipelineEvent) ApplySchemaCustomizations(attrs map[string]tfschema.Attri
 	attrs["event_type"] = attrs["event_type"].SetOptional()
 	attrs["id"] = attrs["id"].SetOptional()
 	attrs["level"] = attrs["level"].SetOptional()
+	attrs["level"] = attrs["level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ERROR", "INFO", "METRICS", "WARN"))
 	attrs["maturity_level"] = attrs["maturity_level"].SetOptional()
+	attrs["maturity_level"] = attrs["maturity_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DEPRECATED", "EVOLVING", "STABLE"))
 	attrs["message"] = attrs["message"].SetOptional()
 	attrs["origin"] = attrs["origin"].SetOptional()
 	attrs["sequence"] = attrs["sequence"].SetOptional()
@@ -4367,6 +4375,7 @@ func (c PipelinePermission) ApplySchemaCustomizations(attrs map[string]tfschema.
 	attrs["inherited"] = attrs["inherited"].SetOptional()
 	attrs["inherited_from_object"] = attrs["inherited_from_object"].SetOptional()
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_MANAGE", "CAN_RUN", "CAN_VIEW", "IS_OWNER"))
 
 	return attrs
 }
@@ -4538,6 +4547,7 @@ func (newState *PipelinePermissionsDescription) SyncEffectiveFieldsDuringRead(ex
 func (c PipelinePermissionsDescription) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["description"] = attrs["description"].SetOptional()
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_MANAGE", "CAN_RUN", "CAN_VIEW", "IS_OWNER"))
 
 	return attrs
 }
@@ -5146,11 +5156,13 @@ func (c PipelineStateInfo) ApplySchemaCustomizations(attrs map[string]tfschema.A
 	attrs["cluster_id"] = attrs["cluster_id"].SetOptional()
 	attrs["creator_user_name"] = attrs["creator_user_name"].SetOptional()
 	attrs["health"] = attrs["health"].SetOptional()
+	attrs["health"] = attrs["health"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("HEALTHY", "UNHEALTHY"))
 	attrs["latest_updates"] = attrs["latest_updates"].SetOptional()
 	attrs["name"] = attrs["name"].SetOptional()
 	attrs["pipeline_id"] = attrs["pipeline_id"].SetOptional()
 	attrs["run_as_user_name"] = attrs["run_as_user_name"].SetOptional()
 	attrs["state"] = attrs["state"].SetOptional()
+	attrs["state"] = attrs["state"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DELETED", "DEPLOYING", "FAILED", "IDLE", "RECOVERING", "RESETTING", "RUNNING", "STARTING", "STOPPING"))
 
 	return attrs
 }
@@ -5963,6 +5975,7 @@ func (newState *StartUpdate) SyncEffectiveFieldsDuringRead(existingState StartUp
 
 func (c StartUpdate) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["cause"] = attrs["cause"].SetOptional()
+	attrs["cause"] = attrs["cause"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("API_CALL", "JOB_TASK", "RETRY_ON_FAILURE", "SCHEMA_CHANGE", "SERVICE_UPGRADE", "USER_ACTION"))
 	attrs["full_refresh"] = attrs["full_refresh"].SetOptional()
 	attrs["full_refresh_selection"] = attrs["full_refresh_selection"].SetOptional()
 	attrs["pipeline_id"] = attrs["pipeline_id"].SetRequired()
@@ -6332,6 +6345,7 @@ func (c TableSpecificConfig) ApplySchemaCustomizations(attrs map[string]tfschema
 	attrs["primary_keys"] = attrs["primary_keys"].SetOptional()
 	attrs["salesforce_include_formula_fields"] = attrs["salesforce_include_formula_fields"].SetOptional()
 	attrs["scd_type"] = attrs["scd_type"].SetOptional()
+	attrs["scd_type"] = attrs["scd_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("SCD_TYPE_1", "SCD_TYPE_2"))
 	attrs["sequence_by"] = attrs["sequence_by"].SetOptional()
 
 	return attrs
@@ -6474,6 +6488,7 @@ func (newState *UpdateInfo) SyncEffectiveFieldsDuringRead(existingState UpdateIn
 
 func (c UpdateInfo) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["cause"] = attrs["cause"].SetOptional()
+	attrs["cause"] = attrs["cause"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("API_CALL", "JOB_TASK", "RETRY_ON_FAILURE", "SCHEMA_CHANGE", "SERVICE_UPGRADE", "USER_ACTION"))
 	attrs["cluster_id"] = attrs["cluster_id"].SetOptional()
 	attrs["config"] = attrs["config"].SetOptional()
 	attrs["creation_time"] = attrs["creation_time"].SetOptional()
@@ -6482,6 +6497,7 @@ func (c UpdateInfo) ApplySchemaCustomizations(attrs map[string]tfschema.Attribut
 	attrs["pipeline_id"] = attrs["pipeline_id"].SetOptional()
 	attrs["refresh_selection"] = attrs["refresh_selection"].SetOptional()
 	attrs["state"] = attrs["state"].SetOptional()
+	attrs["state"] = attrs["state"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CANCELED", "COMPLETED", "CREATED", "FAILED", "INITIALIZING", "QUEUED", "RESETTING", "RUNNING", "SETTING_UP_TABLES", "STOPPING", "WAITING_FOR_RESOURCES"))
 	attrs["update_id"] = attrs["update_id"].SetOptional()
 	attrs["validate_only"] = attrs["validate_only"].SetOptional()
 
@@ -6644,6 +6660,7 @@ func (newState *UpdateStateInfo) SyncEffectiveFieldsDuringRead(existingState Upd
 func (c UpdateStateInfo) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["creation_time"] = attrs["creation_time"].SetOptional()
 	attrs["state"] = attrs["state"].SetOptional()
+	attrs["state"] = attrs["state"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CANCELED", "COMPLETED", "CREATED", "FAILED", "INITIALIZING", "QUEUED", "RESETTING", "RUNNING", "SETTING_UP_TABLES", "STOPPING", "WAITING_FOR_RESOURCES"))
 	attrs["update_id"] = attrs["update_id"].SetOptional()
 
 	return attrs

--- a/internal/service/provisioning_tf/legacy_model.go
+++ b/internal/service/provisioning_tf/legacy_model.go
@@ -18,6 +18,7 @@ import (
 	"github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/tfschema"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
@@ -1280,6 +1281,7 @@ func (c CreateWorkspaceRequest_SdkV2) ApplySchemaCustomizations(attrs map[string
 	attrs["managed_services_customer_managed_key_id"] = attrs["managed_services_customer_managed_key_id"].SetOptional()
 	attrs["network_id"] = attrs["network_id"].SetOptional()
 	attrs["pricing_tier"] = attrs["pricing_tier"].SetOptional()
+	attrs["pricing_tier"] = attrs["pricing_tier"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("COMMUNITY_EDITION", "DEDICATED", "ENTERPRISE", "PREMIUM", "STANDARD", "UNKNOWN"))
 	attrs["private_access_settings_id"] = attrs["private_access_settings_id"].SetOptional()
 	attrs["storage_configuration_id"] = attrs["storage_configuration_id"].SetOptional()
 	attrs["storage_customer_managed_key_id"] = attrs["storage_customer_managed_key_id"].SetOptional()
@@ -2696,6 +2698,7 @@ func (newState *GkeConfig_SdkV2) SyncEffectiveFieldsDuringRead(existingState Gke
 
 func (c GkeConfig_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["connectivity_type"] = attrs["connectivity_type"].SetOptional()
+	attrs["connectivity_type"] = attrs["connectivity_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("PRIVATE_NODE_PUBLIC_MASTER", "PUBLIC_NODE_PUBLIC_MASTER"))
 	attrs["master_ip_range"] = attrs["master_ip_range"].SetOptional()
 
 	return attrs
@@ -2790,6 +2793,7 @@ func (c Network_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.Attri
 	attrs["vpc_endpoints"] = attrs["vpc_endpoints"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["vpc_id"] = attrs["vpc_id"].SetOptional()
 	attrs["vpc_status"] = attrs["vpc_status"].SetComputed()
+	attrs["vpc_status"] = attrs["vpc_status"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("BROKEN", "UNATTACHED", "VALID", "WARNED"))
 	attrs["warning_messages"] = attrs["warning_messages"].SetComputed()
 	attrs["workspace_id"] = attrs["workspace_id"].SetOptional()
 
@@ -3043,6 +3047,7 @@ func (newState *NetworkHealth_SdkV2) SyncEffectiveFieldsDuringRead(existingState
 func (c NetworkHealth_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["error_message"] = attrs["error_message"].SetOptional()
 	attrs["error_type"] = attrs["error_type"].SetOptional()
+	attrs["error_type"] = attrs["error_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("credentials", "networkAcl", "securityGroup", "subnet", "vpc"))
 
 	return attrs
 }
@@ -3215,6 +3220,7 @@ func (newState *NetworkWarning_SdkV2) SyncEffectiveFieldsDuringRead(existingStat
 func (c NetworkWarning_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["warning_message"] = attrs["warning_message"].SetOptional()
 	attrs["warning_type"] = attrs["warning_type"].SetOptional()
+	attrs["warning_type"] = attrs["warning_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("securityGroup", "subnet"))
 
 	return attrs
 }
@@ -3289,6 +3295,7 @@ func (c PrivateAccessSettings_SdkV2) ApplySchemaCustomizations(attrs map[string]
 	attrs["account_id"] = attrs["account_id"].SetOptional()
 	attrs["allowed_vpc_endpoint_ids"] = attrs["allowed_vpc_endpoint_ids"].SetOptional()
 	attrs["private_access_level"] = attrs["private_access_level"].SetOptional()
+	attrs["private_access_level"] = attrs["private_access_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ACCOUNT", "ENDPOINT"))
 	attrs["private_access_settings_id"] = attrs["private_access_settings_id"].SetOptional()
 	attrs["private_access_settings_name"] = attrs["private_access_settings_name"].SetOptional()
 	attrs["public_access_enabled"] = attrs["public_access_enabled"].SetOptional()
@@ -3814,6 +3821,7 @@ func (newState *UpsertPrivateAccessSettingsRequest_SdkV2) SyncEffectiveFieldsDur
 func (c UpsertPrivateAccessSettingsRequest_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["allowed_vpc_endpoint_ids"] = attrs["allowed_vpc_endpoint_ids"].SetOptional()
 	attrs["private_access_level"] = attrs["private_access_level"].SetOptional()
+	attrs["private_access_level"] = attrs["private_access_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ACCOUNT", "ENDPOINT"))
 	attrs["private_access_settings_id"] = attrs["private_access_settings_id"].SetRequired()
 	attrs["private_access_settings_name"] = attrs["private_access_settings_name"].SetRequired()
 	attrs["public_access_enabled"] = attrs["public_access_enabled"].SetOptional()
@@ -3947,6 +3955,7 @@ func (c VpcEndpoint_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.A
 	attrs["region"] = attrs["region"].SetOptional()
 	attrs["state"] = attrs["state"].SetOptional()
 	attrs["use_case"] = attrs["use_case"].SetOptional()
+	attrs["use_case"] = attrs["use_case"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DATAPLANE_RELAY_ACCESS", "WORKSPACE_ACCESS"))
 	attrs["vpc_endpoint_id"] = attrs["vpc_endpoint_id"].SetOptional()
 	attrs["vpc_endpoint_name"] = attrs["vpc_endpoint_name"].SetOptional()
 
@@ -4161,12 +4170,14 @@ func (c Workspace_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.Att
 	attrs["managed_services_customer_managed_key_id"] = attrs["managed_services_customer_managed_key_id"].SetOptional()
 	attrs["network_id"] = attrs["network_id"].SetOptional()
 	attrs["pricing_tier"] = attrs["pricing_tier"].SetOptional()
+	attrs["pricing_tier"] = attrs["pricing_tier"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("COMMUNITY_EDITION", "DEDICATED", "ENTERPRISE", "PREMIUM", "STANDARD", "UNKNOWN"))
 	attrs["private_access_settings_id"] = attrs["private_access_settings_id"].SetOptional()
 	attrs["storage_configuration_id"] = attrs["storage_configuration_id"].SetOptional()
 	attrs["storage_customer_managed_key_id"] = attrs["storage_customer_managed_key_id"].SetOptional()
 	attrs["workspace_id"] = attrs["workspace_id"].SetOptional()
 	attrs["workspace_name"] = attrs["workspace_name"].SetOptional()
 	attrs["workspace_status"] = attrs["workspace_status"].SetComputed()
+	attrs["workspace_status"] = attrs["workspace_status"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("BANNED", "CANCELLING", "FAILED", "NOT_PROVISIONED", "PROVISIONING", "RUNNING"))
 	attrs["workspace_status_message"] = attrs["workspace_status_message"].SetComputed()
 
 	return attrs

--- a/internal/service/provisioning_tf/model.go
+++ b/internal/service/provisioning_tf/model.go
@@ -17,6 +17,7 @@ import (
 	pluginfwcommon "github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/common"
 	"github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/tfschema"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
@@ -1266,6 +1267,7 @@ func (c CreateWorkspaceRequest) ApplySchemaCustomizations(attrs map[string]tfsch
 	attrs["managed_services_customer_managed_key_id"] = attrs["managed_services_customer_managed_key_id"].SetOptional()
 	attrs["network_id"] = attrs["network_id"].SetOptional()
 	attrs["pricing_tier"] = attrs["pricing_tier"].SetOptional()
+	attrs["pricing_tier"] = attrs["pricing_tier"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("COMMUNITY_EDITION", "DEDICATED", "ENTERPRISE", "PREMIUM", "STANDARD", "UNKNOWN"))
 	attrs["private_access_settings_id"] = attrs["private_access_settings_id"].SetOptional()
 	attrs["storage_configuration_id"] = attrs["storage_configuration_id"].SetOptional()
 	attrs["storage_customer_managed_key_id"] = attrs["storage_customer_managed_key_id"].SetOptional()
@@ -2679,6 +2681,7 @@ func (newState *GkeConfig) SyncEffectiveFieldsDuringRead(existingState GkeConfig
 
 func (c GkeConfig) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["connectivity_type"] = attrs["connectivity_type"].SetOptional()
+	attrs["connectivity_type"] = attrs["connectivity_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("PRIVATE_NODE_PUBLIC_MASTER", "PUBLIC_NODE_PUBLIC_MASTER"))
 	attrs["master_ip_range"] = attrs["master_ip_range"].SetOptional()
 
 	return attrs
@@ -2771,6 +2774,7 @@ func (c Network) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBu
 	attrs["vpc_endpoints"] = attrs["vpc_endpoints"].SetOptional()
 	attrs["vpc_id"] = attrs["vpc_id"].SetOptional()
 	attrs["vpc_status"] = attrs["vpc_status"].SetComputed()
+	attrs["vpc_status"] = attrs["vpc_status"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("BROKEN", "UNATTACHED", "VALID", "WARNED"))
 	attrs["warning_messages"] = attrs["warning_messages"].SetComputed()
 	attrs["workspace_id"] = attrs["workspace_id"].SetOptional()
 
@@ -3024,6 +3028,7 @@ func (newState *NetworkHealth) SyncEffectiveFieldsDuringRead(existingState Netwo
 func (c NetworkHealth) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["error_message"] = attrs["error_message"].SetOptional()
 	attrs["error_type"] = attrs["error_type"].SetOptional()
+	attrs["error_type"] = attrs["error_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("credentials", "networkAcl", "securityGroup", "subnet", "vpc"))
 
 	return attrs
 }
@@ -3196,6 +3201,7 @@ func (newState *NetworkWarning) SyncEffectiveFieldsDuringRead(existingState Netw
 func (c NetworkWarning) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["warning_message"] = attrs["warning_message"].SetOptional()
 	attrs["warning_type"] = attrs["warning_type"].SetOptional()
+	attrs["warning_type"] = attrs["warning_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("securityGroup", "subnet"))
 
 	return attrs
 }
@@ -3270,6 +3276,7 @@ func (c PrivateAccessSettings) ApplySchemaCustomizations(attrs map[string]tfsche
 	attrs["account_id"] = attrs["account_id"].SetOptional()
 	attrs["allowed_vpc_endpoint_ids"] = attrs["allowed_vpc_endpoint_ids"].SetOptional()
 	attrs["private_access_level"] = attrs["private_access_level"].SetOptional()
+	attrs["private_access_level"] = attrs["private_access_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ACCOUNT", "ENDPOINT"))
 	attrs["private_access_settings_id"] = attrs["private_access_settings_id"].SetOptional()
 	attrs["private_access_settings_name"] = attrs["private_access_settings_name"].SetOptional()
 	attrs["public_access_enabled"] = attrs["public_access_enabled"].SetOptional()
@@ -3794,6 +3801,7 @@ func (newState *UpsertPrivateAccessSettingsRequest) SyncEffectiveFieldsDuringRea
 func (c UpsertPrivateAccessSettingsRequest) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["allowed_vpc_endpoint_ids"] = attrs["allowed_vpc_endpoint_ids"].SetOptional()
 	attrs["private_access_level"] = attrs["private_access_level"].SetOptional()
+	attrs["private_access_level"] = attrs["private_access_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ACCOUNT", "ENDPOINT"))
 	attrs["private_access_settings_id"] = attrs["private_access_settings_id"].SetRequired()
 	attrs["private_access_settings_name"] = attrs["private_access_settings_name"].SetRequired()
 	attrs["public_access_enabled"] = attrs["public_access_enabled"].SetOptional()
@@ -3926,6 +3934,7 @@ func (c VpcEndpoint) ApplySchemaCustomizations(attrs map[string]tfschema.Attribu
 	attrs["region"] = attrs["region"].SetOptional()
 	attrs["state"] = attrs["state"].SetOptional()
 	attrs["use_case"] = attrs["use_case"].SetOptional()
+	attrs["use_case"] = attrs["use_case"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DATAPLANE_RELAY_ACCESS", "WORKSPACE_ACCESS"))
 	attrs["vpc_endpoint_id"] = attrs["vpc_endpoint_id"].SetOptional()
 	attrs["vpc_endpoint_name"] = attrs["vpc_endpoint_name"].SetOptional()
 
@@ -4135,12 +4144,14 @@ func (c Workspace) ApplySchemaCustomizations(attrs map[string]tfschema.Attribute
 	attrs["managed_services_customer_managed_key_id"] = attrs["managed_services_customer_managed_key_id"].SetOptional()
 	attrs["network_id"] = attrs["network_id"].SetOptional()
 	attrs["pricing_tier"] = attrs["pricing_tier"].SetOptional()
+	attrs["pricing_tier"] = attrs["pricing_tier"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("COMMUNITY_EDITION", "DEDICATED", "ENTERPRISE", "PREMIUM", "STANDARD", "UNKNOWN"))
 	attrs["private_access_settings_id"] = attrs["private_access_settings_id"].SetOptional()
 	attrs["storage_configuration_id"] = attrs["storage_configuration_id"].SetOptional()
 	attrs["storage_customer_managed_key_id"] = attrs["storage_customer_managed_key_id"].SetOptional()
 	attrs["workspace_id"] = attrs["workspace_id"].SetOptional()
 	attrs["workspace_name"] = attrs["workspace_name"].SetOptional()
 	attrs["workspace_status"] = attrs["workspace_status"].SetComputed()
+	attrs["workspace_status"] = attrs["workspace_status"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("BANNED", "CANCELLING", "FAILED", "NOT_PROVISIONED", "PROVISIONING", "RUNNING"))
 	attrs["workspace_status_message"] = attrs["workspace_status_message"].SetComputed()
 
 	return attrs

--- a/internal/service/serving_tf/legacy_model.go
+++ b/internal/service/serving_tf/legacy_model.go
@@ -18,6 +18,7 @@ import (
 	"github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/tfschema"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
@@ -437,6 +438,7 @@ func (newState *AiGatewayGuardrailPiiBehavior_SdkV2) SyncEffectiveFieldsDuringRe
 
 func (c AiGatewayGuardrailPiiBehavior_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["behavior"] = attrs["behavior"].SetOptional()
+	attrs["behavior"] = attrs["behavior"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("BLOCK", "NONE"))
 
 	return attrs
 }
@@ -675,7 +677,9 @@ func (newState *AiGatewayRateLimit_SdkV2) SyncEffectiveFieldsDuringRead(existing
 func (c AiGatewayRateLimit_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["calls"] = attrs["calls"].SetRequired()
 	attrs["key"] = attrs["key"].SetOptional()
+	attrs["key"] = attrs["key"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("endpoint", "user"))
 	attrs["renewal_period"] = attrs["renewal_period"].SetRequired()
+	attrs["renewal_period"] = attrs["renewal_period"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("minute"))
 
 	return attrs
 }
@@ -810,6 +814,7 @@ func (c AmazonBedrockConfig_SdkV2) ApplySchemaCustomizations(attrs map[string]tf
 	attrs["aws_secret_access_key"] = attrs["aws_secret_access_key"].SetOptional()
 	attrs["aws_secret_access_key_plaintext"] = attrs["aws_secret_access_key_plaintext"].SetOptional()
 	attrs["bedrock_provider"] = attrs["bedrock_provider"].SetRequired()
+	attrs["bedrock_provider"] = attrs["bedrock_provider"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ai21labs", "amazon", "anthropic", "cohere"))
 
 	return attrs
 }
@@ -1267,6 +1272,7 @@ func (newState *ChatMessage_SdkV2) SyncEffectiveFieldsDuringRead(existingState C
 func (c ChatMessage_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["content"] = attrs["content"].SetOptional()
 	attrs["role"] = attrs["role"].SetOptional()
+	attrs["role"] = attrs["role"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("assistant", "system", "user"))
 
 	return attrs
 }
@@ -1919,6 +1925,7 @@ func (c EmbeddingsV1ResponseEmbeddingElement_SdkV2) ApplySchemaCustomizations(at
 	attrs["embedding"] = attrs["embedding"].SetOptional()
 	attrs["index"] = attrs["index"].SetOptional()
 	attrs["object"] = attrs["object"].SetOptional()
+	attrs["object"] = attrs["object"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("embedding"))
 
 	return attrs
 }
@@ -2706,7 +2713,9 @@ func (newState *EndpointState_SdkV2) SyncEffectiveFieldsDuringRead(existingState
 
 func (c EndpointState_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["config_update"] = attrs["config_update"].SetOptional()
+	attrs["config_update"] = attrs["config_update"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("IN_PROGRESS", "NOT_UPDATING", "UPDATE_CANCELED", "UPDATE_FAILED"))
 	attrs["ready"] = attrs["ready"].SetOptional()
+	attrs["ready"] = attrs["ready"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("NOT_READY", "READY"))
 
 	return attrs
 }
@@ -2976,6 +2985,7 @@ func (c ExternalFunctionRequest_SdkV2) ApplySchemaCustomizations(attrs map[strin
 	attrs["headers"] = attrs["headers"].SetOptional()
 	attrs["json"] = attrs["json"].SetOptional()
 	attrs["method"] = attrs["method"].SetRequired()
+	attrs["method"] = attrs["method"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DELETE", "GET", "PATCH", "POST", "PUT"))
 	attrs["params"] = attrs["params"].SetOptional()
 	attrs["path"] = attrs["path"].SetRequired()
 
@@ -3078,6 +3088,7 @@ func (c ExternalModel_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema
 	attrs["palm_config"] = attrs["palm_config"].SetOptional()
 	attrs["palm_config"] = attrs["palm_config"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["provider"] = attrs["provider"].SetRequired()
+	attrs["provider"] = attrs["provider"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ai21labs", "amazon-bedrock", "anthropic", "cohere", "databricks-model-serving", "google-cloud-vertex-ai", "openai", "palm"))
 	attrs["task"] = attrs["task"].SetRequired()
 
 	return attrs
@@ -5333,6 +5344,7 @@ func (c QueryEndpointResponse_SdkV2) ApplySchemaCustomizations(attrs map[string]
 	attrs["id"] = attrs["id"].SetOptional()
 	attrs["model"] = attrs["model"].SetOptional()
 	attrs["object"] = attrs["object"].SetOptional()
+	attrs["object"] = attrs["object"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("chat.completion", "list", "text_completion"))
 	attrs["predictions"] = attrs["predictions"].SetOptional()
 	attrs["served-model-name"] = attrs["served-model-name"].SetOptional()
 	attrs["usage"] = attrs["usage"].SetOptional()
@@ -5527,7 +5539,9 @@ func (newState *RateLimit_SdkV2) SyncEffectiveFieldsDuringRead(existingState Rat
 func (c RateLimit_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["calls"] = attrs["calls"].SetRequired()
 	attrs["key"] = attrs["key"].SetOptional()
+	attrs["key"] = attrs["key"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("endpoint", "user"))
 	attrs["renewal_period"] = attrs["renewal_period"].SetRequired()
+	attrs["renewal_period"] = attrs["renewal_period"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("minute"))
 
 	return attrs
 }
@@ -5699,6 +5713,7 @@ func (c ServedEntityInput_SdkV2) ApplySchemaCustomizations(attrs map[string]tfsc
 	attrs["scale_to_zero_enabled"] = attrs["scale_to_zero_enabled"].SetOptional()
 	attrs["workload_size"] = attrs["workload_size"].SetOptional()
 	attrs["workload_type"] = attrs["workload_type"].SetOptional()
+	attrs["workload_type"] = attrs["workload_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CPU", "GPU_LARGE", "GPU_MEDIUM", "GPU_SMALL", "MULTIGPU_MEDIUM"))
 
 	return attrs
 }
@@ -5905,6 +5920,7 @@ func (c ServedEntityOutput_SdkV2) ApplySchemaCustomizations(attrs map[string]tfs
 	attrs["state"] = attrs["state"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["workload_size"] = attrs["workload_size"].SetOptional()
 	attrs["workload_type"] = attrs["workload_type"].SetOptional()
+	attrs["workload_type"] = attrs["workload_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CPU", "GPU_LARGE", "GPU_MEDIUM", "GPU_SMALL", "MULTIGPU_MEDIUM"))
 
 	return attrs
 }
@@ -6276,7 +6292,9 @@ func (c ServedModelInput_SdkV2) ApplySchemaCustomizations(attrs map[string]tfsch
 	attrs["name"] = attrs["name"].SetOptional()
 	attrs["scale_to_zero_enabled"] = attrs["scale_to_zero_enabled"].SetRequired()
 	attrs["workload_size"] = attrs["workload_size"].SetOptional()
+	attrs["workload_size"] = attrs["workload_size"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("Large", "Medium", "Small"))
 	attrs["workload_type"] = attrs["workload_type"].SetOptional()
+	attrs["workload_type"] = attrs["workload_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CPU", "GPU_LARGE", "GPU_MEDIUM", "GPU_SMALL", "MULTIGPU_MEDIUM"))
 
 	return attrs
 }
@@ -6426,6 +6444,7 @@ func (c ServedModelOutput_SdkV2) ApplySchemaCustomizations(attrs map[string]tfsc
 	attrs["state"] = attrs["state"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["workload_size"] = attrs["workload_size"].SetOptional()
 	attrs["workload_type"] = attrs["workload_type"].SetOptional()
+	attrs["workload_type"] = attrs["workload_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CPU", "GPU_LARGE", "GPU_MEDIUM", "GPU_SMALL", "MULTIGPU_MEDIUM"))
 
 	return attrs
 }
@@ -6612,6 +6631,7 @@ func (newState *ServedModelState_SdkV2) SyncEffectiveFieldsDuringRead(existingSt
 
 func (c ServedModelState_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["deployment"] = attrs["deployment"].SetOptional()
+	attrs["deployment"] = attrs["deployment"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DEPLOYMENT_ABORTED", "DEPLOYMENT_CREATING", "DEPLOYMENT_FAILED", "DEPLOYMENT_READY", "DEPLOYMENT_RECOVERING"))
 	attrs["deployment_state_message"] = attrs["deployment_state_message"].SetOptional()
 
 	return attrs
@@ -6935,6 +6955,7 @@ func (newState *ServingEndpointAccessControlRequest_SdkV2) SyncEffectiveFieldsDu
 func (c ServingEndpointAccessControlRequest_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["group_name"] = attrs["group_name"].SetOptional()
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_MANAGE", "CAN_QUERY", "CAN_VIEW"))
 	attrs["service_principal_name"] = attrs["service_principal_name"].SetOptional()
 	attrs["user_name"] = attrs["user_name"].SetOptional()
 
@@ -7135,6 +7156,7 @@ func (c ServingEndpointDetailed_SdkV2) ApplySchemaCustomizations(attrs map[strin
 	attrs["pending_config"] = attrs["pending_config"].SetOptional()
 	attrs["pending_config"] = attrs["pending_config"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_MANAGE", "CAN_QUERY", "CAN_VIEW"))
 	attrs["route_optimized"] = attrs["route_optimized"].SetOptional()
 	attrs["state"] = attrs["state"].SetOptional()
 	attrs["state"] = attrs["state"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
@@ -7396,6 +7418,7 @@ func (c ServingEndpointPermission_SdkV2) ApplySchemaCustomizations(attrs map[str
 	attrs["inherited"] = attrs["inherited"].SetOptional()
 	attrs["inherited_from_object"] = attrs["inherited_from_object"].SetOptional()
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_MANAGE", "CAN_QUERY", "CAN_VIEW"))
 
 	return attrs
 }
@@ -7567,6 +7590,7 @@ func (newState *ServingEndpointPermissionsDescription_SdkV2) SyncEffectiveFields
 func (c ServingEndpointPermissionsDescription_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["description"] = attrs["description"].SetOptional()
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_MANAGE", "CAN_QUERY", "CAN_VIEW"))
 
 	return attrs
 }

--- a/internal/service/serving_tf/model.go
+++ b/internal/service/serving_tf/model.go
@@ -17,6 +17,7 @@ import (
 	pluginfwcommon "github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/common"
 	"github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/tfschema"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
@@ -432,6 +433,7 @@ func (newState *AiGatewayGuardrailPiiBehavior) SyncEffectiveFieldsDuringRead(exi
 
 func (c AiGatewayGuardrailPiiBehavior) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["behavior"] = attrs["behavior"].SetOptional()
+	attrs["behavior"] = attrs["behavior"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("BLOCK", "NONE"))
 
 	return attrs
 }
@@ -668,7 +670,9 @@ func (newState *AiGatewayRateLimit) SyncEffectiveFieldsDuringRead(existingState 
 func (c AiGatewayRateLimit) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["calls"] = attrs["calls"].SetRequired()
 	attrs["key"] = attrs["key"].SetOptional()
+	attrs["key"] = attrs["key"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("endpoint", "user"))
 	attrs["renewal_period"] = attrs["renewal_period"].SetRequired()
+	attrs["renewal_period"] = attrs["renewal_period"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("minute"))
 
 	return attrs
 }
@@ -803,6 +807,7 @@ func (c AmazonBedrockConfig) ApplySchemaCustomizations(attrs map[string]tfschema
 	attrs["aws_secret_access_key"] = attrs["aws_secret_access_key"].SetOptional()
 	attrs["aws_secret_access_key_plaintext"] = attrs["aws_secret_access_key_plaintext"].SetOptional()
 	attrs["bedrock_provider"] = attrs["bedrock_provider"].SetRequired()
+	attrs["bedrock_provider"] = attrs["bedrock_provider"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ai21labs", "amazon", "anthropic", "cohere"))
 
 	return attrs
 }
@@ -1258,6 +1263,7 @@ func (newState *ChatMessage) SyncEffectiveFieldsDuringRead(existingState ChatMes
 func (c ChatMessage) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["content"] = attrs["content"].SetOptional()
 	attrs["role"] = attrs["role"].SetOptional()
+	attrs["role"] = attrs["role"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("assistant", "system", "user"))
 
 	return attrs
 }
@@ -1908,6 +1914,7 @@ func (c EmbeddingsV1ResponseEmbeddingElement) ApplySchemaCustomizations(attrs ma
 	attrs["embedding"] = attrs["embedding"].SetOptional()
 	attrs["index"] = attrs["index"].SetOptional()
 	attrs["object"] = attrs["object"].SetOptional()
+	attrs["object"] = attrs["object"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("embedding"))
 
 	return attrs
 }
@@ -2689,7 +2696,9 @@ func (newState *EndpointState) SyncEffectiveFieldsDuringRead(existingState Endpo
 
 func (c EndpointState) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["config_update"] = attrs["config_update"].SetOptional()
+	attrs["config_update"] = attrs["config_update"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("IN_PROGRESS", "NOT_UPDATING", "UPDATE_CANCELED", "UPDATE_FAILED"))
 	attrs["ready"] = attrs["ready"].SetOptional()
+	attrs["ready"] = attrs["ready"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("NOT_READY", "READY"))
 
 	return attrs
 }
@@ -2959,6 +2968,7 @@ func (c ExternalFunctionRequest) ApplySchemaCustomizations(attrs map[string]tfsc
 	attrs["headers"] = attrs["headers"].SetOptional()
 	attrs["json"] = attrs["json"].SetOptional()
 	attrs["method"] = attrs["method"].SetRequired()
+	attrs["method"] = attrs["method"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DELETE", "GET", "PATCH", "POST", "PUT"))
 	attrs["params"] = attrs["params"].SetOptional()
 	attrs["path"] = attrs["path"].SetRequired()
 
@@ -3053,6 +3063,7 @@ func (c ExternalModel) ApplySchemaCustomizations(attrs map[string]tfschema.Attri
 	attrs["openai_config"] = attrs["openai_config"].SetOptional()
 	attrs["palm_config"] = attrs["palm_config"].SetOptional()
 	attrs["provider"] = attrs["provider"].SetRequired()
+	attrs["provider"] = attrs["provider"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ai21labs", "amazon-bedrock", "anthropic", "cohere", "databricks-model-serving", "google-cloud-vertex-ai", "openai", "palm"))
 	attrs["task"] = attrs["task"].SetRequired()
 
 	return attrs
@@ -5300,6 +5311,7 @@ func (c QueryEndpointResponse) ApplySchemaCustomizations(attrs map[string]tfsche
 	attrs["id"] = attrs["id"].SetOptional()
 	attrs["model"] = attrs["model"].SetOptional()
 	attrs["object"] = attrs["object"].SetOptional()
+	attrs["object"] = attrs["object"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("chat.completion", "list", "text_completion"))
 	attrs["predictions"] = attrs["predictions"].SetOptional()
 	attrs["served-model-name"] = attrs["served-model-name"].SetOptional()
 	attrs["usage"] = attrs["usage"].SetOptional()
@@ -5493,7 +5505,9 @@ func (newState *RateLimit) SyncEffectiveFieldsDuringRead(existingState RateLimit
 func (c RateLimit) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["calls"] = attrs["calls"].SetRequired()
 	attrs["key"] = attrs["key"].SetOptional()
+	attrs["key"] = attrs["key"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("endpoint", "user"))
 	attrs["renewal_period"] = attrs["renewal_period"].SetRequired()
+	attrs["renewal_period"] = attrs["renewal_period"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("minute"))
 
 	return attrs
 }
@@ -5664,6 +5678,7 @@ func (c ServedEntityInput) ApplySchemaCustomizations(attrs map[string]tfschema.A
 	attrs["scale_to_zero_enabled"] = attrs["scale_to_zero_enabled"].SetOptional()
 	attrs["workload_size"] = attrs["workload_size"].SetOptional()
 	attrs["workload_type"] = attrs["workload_type"].SetOptional()
+	attrs["workload_type"] = attrs["workload_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CPU", "GPU_LARGE", "GPU_MEDIUM", "GPU_SMALL", "MULTIGPU_MEDIUM"))
 
 	return attrs
 }
@@ -5867,6 +5882,7 @@ func (c ServedEntityOutput) ApplySchemaCustomizations(attrs map[string]tfschema.
 	attrs["state"] = attrs["state"].SetOptional()
 	attrs["workload_size"] = attrs["workload_size"].SetOptional()
 	attrs["workload_type"] = attrs["workload_type"].SetOptional()
+	attrs["workload_type"] = attrs["workload_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CPU", "GPU_LARGE", "GPU_MEDIUM", "GPU_SMALL", "MULTIGPU_MEDIUM"))
 
 	return attrs
 }
@@ -6236,7 +6252,9 @@ func (c ServedModelInput) ApplySchemaCustomizations(attrs map[string]tfschema.At
 	attrs["name"] = attrs["name"].SetOptional()
 	attrs["scale_to_zero_enabled"] = attrs["scale_to_zero_enabled"].SetRequired()
 	attrs["workload_size"] = attrs["workload_size"].SetOptional()
+	attrs["workload_size"] = attrs["workload_size"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("Large", "Medium", "Small"))
 	attrs["workload_type"] = attrs["workload_type"].SetOptional()
+	attrs["workload_type"] = attrs["workload_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CPU", "GPU_LARGE", "GPU_MEDIUM", "GPU_SMALL", "MULTIGPU_MEDIUM"))
 
 	return attrs
 }
@@ -6385,6 +6403,7 @@ func (c ServedModelOutput) ApplySchemaCustomizations(attrs map[string]tfschema.A
 	attrs["state"] = attrs["state"].SetOptional()
 	attrs["workload_size"] = attrs["workload_size"].SetOptional()
 	attrs["workload_type"] = attrs["workload_type"].SetOptional()
+	attrs["workload_type"] = attrs["workload_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CPU", "GPU_LARGE", "GPU_MEDIUM", "GPU_SMALL", "MULTIGPU_MEDIUM"))
 
 	return attrs
 }
@@ -6571,6 +6590,7 @@ func (newState *ServedModelState) SyncEffectiveFieldsDuringRead(existingState Se
 
 func (c ServedModelState) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["deployment"] = attrs["deployment"].SetOptional()
+	attrs["deployment"] = attrs["deployment"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DEPLOYMENT_ABORTED", "DEPLOYMENT_CREATING", "DEPLOYMENT_FAILED", "DEPLOYMENT_READY", "DEPLOYMENT_RECOVERING"))
 	attrs["deployment_state_message"] = attrs["deployment_state_message"].SetOptional()
 
 	return attrs
@@ -6891,6 +6911,7 @@ func (newState *ServingEndpointAccessControlRequest) SyncEffectiveFieldsDuringRe
 func (c ServingEndpointAccessControlRequest) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["group_name"] = attrs["group_name"].SetOptional()
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_MANAGE", "CAN_QUERY", "CAN_VIEW"))
 	attrs["service_principal_name"] = attrs["service_principal_name"].SetOptional()
 	attrs["user_name"] = attrs["user_name"].SetOptional()
 
@@ -7087,6 +7108,7 @@ func (c ServingEndpointDetailed) ApplySchemaCustomizations(attrs map[string]tfsc
 	attrs["name"] = attrs["name"].SetOptional()
 	attrs["pending_config"] = attrs["pending_config"].SetOptional()
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_MANAGE", "CAN_QUERY", "CAN_VIEW"))
 	attrs["route_optimized"] = attrs["route_optimized"].SetOptional()
 	attrs["state"] = attrs["state"].SetOptional()
 	attrs["tags"] = attrs["tags"].SetOptional()
@@ -7347,6 +7369,7 @@ func (c ServingEndpointPermission) ApplySchemaCustomizations(attrs map[string]tf
 	attrs["inherited"] = attrs["inherited"].SetOptional()
 	attrs["inherited_from_object"] = attrs["inherited_from_object"].SetOptional()
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_MANAGE", "CAN_QUERY", "CAN_VIEW"))
 
 	return attrs
 }
@@ -7518,6 +7541,7 @@ func (newState *ServingEndpointPermissionsDescription) SyncEffectiveFieldsDuring
 func (c ServingEndpointPermissionsDescription) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["description"] = attrs["description"].SetOptional()
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_MANAGE", "CAN_QUERY", "CAN_VIEW"))
 
 	return attrs
 }

--- a/internal/service/settings_tf/legacy_model.go
+++ b/internal/service/settings_tf/legacy_model.go
@@ -18,6 +18,7 @@ import (
 	"github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/tfschema"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
@@ -133,6 +134,7 @@ func (newState *AibiDashboardEmbeddingAccessPolicy_SdkV2) SyncEffectiveFieldsDur
 
 func (c AibiDashboardEmbeddingAccessPolicy_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["access_policy_type"] = attrs["access_policy_type"].SetRequired()
+	attrs["access_policy_type"] = attrs["access_policy_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ALLOW_ALL_DOMAINS", "ALLOW_APPROVED_DOMAINS", "DENY_ALL_DOMAINS"))
 
 	return attrs
 }
@@ -878,7 +880,9 @@ func (newState *ClusterAutoRestartMessageMaintenanceWindowWeekDayBasedSchedule_S
 
 func (c ClusterAutoRestartMessageMaintenanceWindowWeekDayBasedSchedule_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["day_of_week"] = attrs["day_of_week"].SetOptional()
+	attrs["day_of_week"] = attrs["day_of_week"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("FRIDAY", "MONDAY", "SATURDAY", "SUNDAY", "THURSDAY", "TUESDAY", "WEDNESDAY"))
 	attrs["frequency"] = attrs["frequency"].SetOptional()
+	attrs["frequency"] = attrs["frequency"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("EVERY_WEEK", "FIRST_AND_THIRD_OF_MONTH", "FIRST_OF_MONTH", "FOURTH_OF_MONTH", "SECOND_AND_FOURTH_OF_MONTH", "SECOND_OF_MONTH", "THIRD_OF_MONTH"))
 	attrs["window_start_time"] = attrs["window_start_time"].SetOptional()
 	attrs["window_start_time"] = attrs["window_start_time"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 
@@ -1427,6 +1431,7 @@ func (c CreateIpAccessList_SdkV2) ApplySchemaCustomizations(attrs map[string]tfs
 	attrs["ip_addresses"] = attrs["ip_addresses"].SetOptional()
 	attrs["label"] = attrs["label"].SetRequired()
 	attrs["list_type"] = attrs["list_type"].SetRequired()
+	attrs["list_type"] = attrs["list_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ALLOW", "BLOCK"))
 
 	return attrs
 }
@@ -1881,6 +1886,7 @@ func (newState *CreatePrivateEndpointRuleRequest_SdkV2) SyncEffectiveFieldsDurin
 
 func (c CreatePrivateEndpointRuleRequest_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["group_id"] = attrs["group_id"].SetRequired()
+	attrs["group_id"] = attrs["group_id"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("blob", "dfs", "mysqlServer", "sqlServer"))
 	attrs["network_connectivity_config_id"] = attrs["network_connectivity_config_id"].SetRequired()
 	attrs["resource_id"] = attrs["resource_id"].SetRequired()
 
@@ -3925,6 +3931,7 @@ func (c EgressNetworkPolicyInternetAccessPolicy_SdkV2) ApplySchemaCustomizations
 	attrs["log_only_mode"] = attrs["log_only_mode"].SetOptional()
 	attrs["log_only_mode"] = attrs["log_only_mode"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["restriction_mode"] = attrs["restriction_mode"].SetOptional()
+	attrs["restriction_mode"] = attrs["restriction_mode"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("FULL_ACCESS", "PRIVATE_ACCESS_ONLY", "RESTRICTED_ACCESS"))
 
 	return attrs
 }
@@ -4078,7 +4085,9 @@ func (newState *EgressNetworkPolicyInternetAccessPolicyInternetDestination_SdkV2
 func (c EgressNetworkPolicyInternetAccessPolicyInternetDestination_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["destination"] = attrs["destination"].SetOptional()
 	attrs["protocol"] = attrs["protocol"].SetOptional()
+	attrs["protocol"] = attrs["protocol"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("TCP"))
 	attrs["type"] = attrs["type"].SetOptional()
+	attrs["type"] = attrs["type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("FQDN"))
 
 	return attrs
 }
@@ -4132,6 +4141,7 @@ func (newState *EgressNetworkPolicyInternetAccessPolicyLogOnlyMode_SdkV2) SyncEf
 
 func (c EgressNetworkPolicyInternetAccessPolicyLogOnlyMode_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["log_only_mode_type"] = attrs["log_only_mode_type"].SetOptional()
+	attrs["log_only_mode_type"] = attrs["log_only_mode_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ALL_SERVICES", "SELECTED_SERVICES"))
 	attrs["workloads"] = attrs["workloads"].SetOptional()
 
 	return attrs
@@ -4234,6 +4244,7 @@ func (c EgressNetworkPolicyInternetAccessPolicyStorageDestination_SdkV2) ApplySc
 	attrs["bucket_name"] = attrs["bucket_name"].SetOptional()
 	attrs["region"] = attrs["region"].SetOptional()
 	attrs["type"] = attrs["type"].SetOptional()
+	attrs["type"] = attrs["type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("AWS_S3", "AZURE_STORAGE", "CLOUDFLARE_R2", "GOOGLE_CLOUD_STORAGE"))
 
 	return attrs
 }
@@ -4753,6 +4764,7 @@ func (c ExchangeToken_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema
 	attrs["ownerId"] = attrs["ownerId"].SetOptional()
 	attrs["scopes"] = attrs["scopes"].SetOptional()
 	attrs["tokenType"] = attrs["tokenType"].SetOptional()
+	attrs["tokenType"] = attrs["tokenType"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ARCLIGHT_AZURE_EXCHANGE_TOKEN", "ARCLIGHT_AZURE_EXCHANGE_TOKEN_WITH_USER_DELEGATION_KEY", "AZURE_ACTIVE_DIRECTORY_TOKEN"))
 
 	return attrs
 }
@@ -6426,6 +6438,7 @@ func (c IpAccessListInfo_SdkV2) ApplySchemaCustomizations(attrs map[string]tfsch
 	attrs["label"] = attrs["label"].SetOptional()
 	attrs["list_id"] = attrs["list_id"].SetOptional()
 	attrs["list_type"] = attrs["list_type"].SetOptional()
+	attrs["list_type"] = attrs["list_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ALLOW", "BLOCK"))
 	attrs["updated_at"] = attrs["updated_at"].SetOptional()
 	attrs["updated_by"] = attrs["updated_by"].SetOptional()
 
@@ -6933,6 +6946,7 @@ func (newState *ListNotificationDestinationsResult_SdkV2) SyncEffectiveFieldsDur
 
 func (c ListNotificationDestinationsResult_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["destination_type"] = attrs["destination_type"].SetOptional()
+	attrs["destination_type"] = attrs["destination_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("EMAIL", "MICROSOFT_TEAMS", "PAGERDUTY", "SLACK", "WEBHOOK"))
 	attrs["display_name"] = attrs["display_name"].SetOptional()
 	attrs["id"] = attrs["id"].SetOptional()
 
@@ -7393,11 +7407,13 @@ func (newState *NccAzurePrivateEndpointRule_SdkV2) SyncEffectiveFieldsDuringRead
 
 func (c NccAzurePrivateEndpointRule_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["connection_state"] = attrs["connection_state"].SetOptional()
+	attrs["connection_state"] = attrs["connection_state"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DISCONNECTED", "ESTABLISHED", "INIT", "PENDING", "REJECTED"))
 	attrs["creation_time"] = attrs["creation_time"].SetComputed()
 	attrs["deactivated"] = attrs["deactivated"].SetComputed()
 	attrs["deactivated_at"] = attrs["deactivated_at"].SetComputed()
 	attrs["endpoint_name"] = attrs["endpoint_name"].SetComputed()
 	attrs["group_id"] = attrs["group_id"].SetOptional()
+	attrs["group_id"] = attrs["group_id"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("blob", "dfs", "mysqlServer", "sqlServer"))
 	attrs["network_connectivity_config_id"] = attrs["network_connectivity_config_id"].SetOptional()
 	attrs["resource_id"] = attrs["resource_id"].SetOptional()
 	attrs["rule_id"] = attrs["rule_id"].SetComputed()
@@ -8034,6 +8050,7 @@ func (c NotificationDestination_SdkV2) ApplySchemaCustomizations(attrs map[strin
 	attrs["config"] = attrs["config"].SetOptional()
 	attrs["config"] = attrs["config"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["destination_type"] = attrs["destination_type"].SetOptional()
+	attrs["destination_type"] = attrs["destination_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("EMAIL", "MICROSOFT_TEAMS", "PAGERDUTY", "SLACK", "WEBHOOK"))
 	attrs["display_name"] = attrs["display_name"].SetOptional()
 	attrs["id"] = attrs["id"].SetOptional()
 
@@ -8228,6 +8245,7 @@ func (newState *PersonalComputeMessage_SdkV2) SyncEffectiveFieldsDuringRead(exis
 
 func (c PersonalComputeMessage_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["value"] = attrs["value"].SetRequired()
+	attrs["value"] = attrs["value"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DELEGATE", "ON"))
 
 	return attrs
 }
@@ -8457,6 +8475,7 @@ func (c ReplaceIpAccessList_SdkV2) ApplySchemaCustomizations(attrs map[string]tf
 	attrs["ip_addresses"] = attrs["ip_addresses"].SetOptional()
 	attrs["label"] = attrs["label"].SetRequired()
 	attrs["list_type"] = attrs["list_type"].SetRequired()
+	attrs["list_type"] = attrs["list_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ALLOW", "BLOCK"))
 
 	return attrs
 }
@@ -8572,6 +8591,7 @@ func (newState *RestrictWorkspaceAdminsMessage_SdkV2) SyncEffectiveFieldsDuringR
 
 func (c RestrictWorkspaceAdminsMessage_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["status"] = attrs["status"].SetRequired()
+	attrs["status"] = attrs["status"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ALLOW_ALL", "RESTRICT_TOKENS_AND_JOB_RUN_AS"))
 
 	return attrs
 }
@@ -8946,6 +8966,7 @@ func (newState *TokenAccessControlRequest_SdkV2) SyncEffectiveFieldsDuringRead(e
 func (c TokenAccessControlRequest_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["group_name"] = attrs["group_name"].SetOptional()
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_USE"))
 	attrs["service_principal_name"] = attrs["service_principal_name"].SetOptional()
 	attrs["user_name"] = attrs["user_name"].SetOptional()
 
@@ -9195,6 +9216,7 @@ func (c TokenPermission_SdkV2) ApplySchemaCustomizations(attrs map[string]tfsche
 	attrs["inherited"] = attrs["inherited"].SetOptional()
 	attrs["inherited_from_object"] = attrs["inherited_from_object"].SetOptional()
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_USE"))
 
 	return attrs
 }
@@ -9366,6 +9388,7 @@ func (newState *TokenPermissionsDescription_SdkV2) SyncEffectiveFieldsDuringRead
 func (c TokenPermissionsDescription_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["description"] = attrs["description"].SetOptional()
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_USE"))
 
 	return attrs
 }
@@ -10731,6 +10754,7 @@ func (c UpdateIpAccessList_SdkV2) ApplySchemaCustomizations(attrs map[string]tfs
 	attrs["ip_addresses"] = attrs["ip_addresses"].SetOptional()
 	attrs["label"] = attrs["label"].SetOptional()
 	attrs["list_type"] = attrs["list_type"].SetOptional()
+	attrs["list_type"] = attrs["list_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ALLOW", "BLOCK"))
 
 	return attrs
 }

--- a/internal/service/settings_tf/model.go
+++ b/internal/service/settings_tf/model.go
@@ -17,6 +17,7 @@ import (
 	pluginfwcommon "github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/common"
 	"github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/tfschema"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
@@ -131,6 +132,7 @@ func (newState *AibiDashboardEmbeddingAccessPolicy) SyncEffectiveFieldsDuringRea
 
 func (c AibiDashboardEmbeddingAccessPolicy) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["access_policy_type"] = attrs["access_policy_type"].SetRequired()
+	attrs["access_policy_type"] = attrs["access_policy_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ALLOW_ALL_DOMAINS", "ALLOW_APPROVED_DOMAINS", "DENY_ALL_DOMAINS"))
 
 	return attrs
 }
@@ -870,7 +872,9 @@ func (newState *ClusterAutoRestartMessageMaintenanceWindowWeekDayBasedSchedule) 
 
 func (c ClusterAutoRestartMessageMaintenanceWindowWeekDayBasedSchedule) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["day_of_week"] = attrs["day_of_week"].SetOptional()
+	attrs["day_of_week"] = attrs["day_of_week"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("FRIDAY", "MONDAY", "SATURDAY", "SUNDAY", "THURSDAY", "TUESDAY", "WEDNESDAY"))
 	attrs["frequency"] = attrs["frequency"].SetOptional()
+	attrs["frequency"] = attrs["frequency"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("EVERY_WEEK", "FIRST_AND_THIRD_OF_MONTH", "FIRST_OF_MONTH", "FOURTH_OF_MONTH", "SECOND_AND_FOURTH_OF_MONTH", "SECOND_OF_MONTH", "THIRD_OF_MONTH"))
 	attrs["window_start_time"] = attrs["window_start_time"].SetOptional()
 
 	return attrs
@@ -1412,6 +1416,7 @@ func (c CreateIpAccessList) ApplySchemaCustomizations(attrs map[string]tfschema.
 	attrs["ip_addresses"] = attrs["ip_addresses"].SetOptional()
 	attrs["label"] = attrs["label"].SetRequired()
 	attrs["list_type"] = attrs["list_type"].SetRequired()
+	attrs["list_type"] = attrs["list_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ALLOW", "BLOCK"))
 
 	return attrs
 }
@@ -1863,6 +1868,7 @@ func (newState *CreatePrivateEndpointRuleRequest) SyncEffectiveFieldsDuringRead(
 
 func (c CreatePrivateEndpointRuleRequest) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["group_id"] = attrs["group_id"].SetRequired()
+	attrs["group_id"] = attrs["group_id"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("blob", "dfs", "mysqlServer", "sqlServer"))
 	attrs["network_connectivity_config_id"] = attrs["network_connectivity_config_id"].SetRequired()
 	attrs["resource_id"] = attrs["resource_id"].SetRequired()
 
@@ -3899,6 +3905,7 @@ func (c EgressNetworkPolicyInternetAccessPolicy) ApplySchemaCustomizations(attrs
 	attrs["allowed_storage_destinations"] = attrs["allowed_storage_destinations"].SetOptional()
 	attrs["log_only_mode"] = attrs["log_only_mode"].SetOptional()
 	attrs["restriction_mode"] = attrs["restriction_mode"].SetOptional()
+	attrs["restriction_mode"] = attrs["restriction_mode"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("FULL_ACCESS", "PRIVATE_ACCESS_ONLY", "RESTRICTED_ACCESS"))
 
 	return attrs
 }
@@ -4052,7 +4059,9 @@ func (newState *EgressNetworkPolicyInternetAccessPolicyInternetDestination) Sync
 func (c EgressNetworkPolicyInternetAccessPolicyInternetDestination) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["destination"] = attrs["destination"].SetOptional()
 	attrs["protocol"] = attrs["protocol"].SetOptional()
+	attrs["protocol"] = attrs["protocol"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("TCP"))
 	attrs["type"] = attrs["type"].SetOptional()
+	attrs["type"] = attrs["type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("FQDN"))
 
 	return attrs
 }
@@ -4106,6 +4115,7 @@ func (newState *EgressNetworkPolicyInternetAccessPolicyLogOnlyMode) SyncEffectiv
 
 func (c EgressNetworkPolicyInternetAccessPolicyLogOnlyMode) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["log_only_mode_type"] = attrs["log_only_mode_type"].SetOptional()
+	attrs["log_only_mode_type"] = attrs["log_only_mode_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ALL_SERVICES", "SELECTED_SERVICES"))
 	attrs["workloads"] = attrs["workloads"].SetOptional()
 
 	return attrs
@@ -4208,6 +4218,7 @@ func (c EgressNetworkPolicyInternetAccessPolicyStorageDestination) ApplySchemaCu
 	attrs["bucket_name"] = attrs["bucket_name"].SetOptional()
 	attrs["region"] = attrs["region"].SetOptional()
 	attrs["type"] = attrs["type"].SetOptional()
+	attrs["type"] = attrs["type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("AWS_S3", "AZURE_STORAGE", "CLOUDFLARE_R2", "GOOGLE_CLOUD_STORAGE"))
 
 	return attrs
 }
@@ -4725,6 +4736,7 @@ func (c ExchangeToken) ApplySchemaCustomizations(attrs map[string]tfschema.Attri
 	attrs["ownerId"] = attrs["ownerId"].SetOptional()
 	attrs["scopes"] = attrs["scopes"].SetOptional()
 	attrs["tokenType"] = attrs["tokenType"].SetOptional()
+	attrs["tokenType"] = attrs["tokenType"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ARCLIGHT_AZURE_EXCHANGE_TOKEN", "ARCLIGHT_AZURE_EXCHANGE_TOKEN_WITH_USER_DELEGATION_KEY", "AZURE_ACTIVE_DIRECTORY_TOKEN"))
 
 	return attrs
 }
@@ -6394,6 +6406,7 @@ func (c IpAccessListInfo) ApplySchemaCustomizations(attrs map[string]tfschema.At
 	attrs["label"] = attrs["label"].SetOptional()
 	attrs["list_id"] = attrs["list_id"].SetOptional()
 	attrs["list_type"] = attrs["list_type"].SetOptional()
+	attrs["list_type"] = attrs["list_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ALLOW", "BLOCK"))
 	attrs["updated_at"] = attrs["updated_at"].SetOptional()
 	attrs["updated_by"] = attrs["updated_by"].SetOptional()
 
@@ -6901,6 +6914,7 @@ func (newState *ListNotificationDestinationsResult) SyncEffectiveFieldsDuringRea
 
 func (c ListNotificationDestinationsResult) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["destination_type"] = attrs["destination_type"].SetOptional()
+	attrs["destination_type"] = attrs["destination_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("EMAIL", "MICROSOFT_TEAMS", "PAGERDUTY", "SLACK", "WEBHOOK"))
 	attrs["display_name"] = attrs["display_name"].SetOptional()
 	attrs["id"] = attrs["id"].SetOptional()
 
@@ -7361,11 +7375,13 @@ func (newState *NccAzurePrivateEndpointRule) SyncEffectiveFieldsDuringRead(exist
 
 func (c NccAzurePrivateEndpointRule) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["connection_state"] = attrs["connection_state"].SetOptional()
+	attrs["connection_state"] = attrs["connection_state"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DISCONNECTED", "ESTABLISHED", "INIT", "PENDING", "REJECTED"))
 	attrs["creation_time"] = attrs["creation_time"].SetComputed()
 	attrs["deactivated"] = attrs["deactivated"].SetComputed()
 	attrs["deactivated_at"] = attrs["deactivated_at"].SetComputed()
 	attrs["endpoint_name"] = attrs["endpoint_name"].SetComputed()
 	attrs["group_id"] = attrs["group_id"].SetOptional()
+	attrs["group_id"] = attrs["group_id"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("blob", "dfs", "mysqlServer", "sqlServer"))
 	attrs["network_connectivity_config_id"] = attrs["network_connectivity_config_id"].SetOptional()
 	attrs["resource_id"] = attrs["resource_id"].SetOptional()
 	attrs["rule_id"] = attrs["rule_id"].SetComputed()
@@ -7996,6 +8012,7 @@ func (newState *NotificationDestination) SyncEffectiveFieldsDuringRead(existingS
 func (c NotificationDestination) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["config"] = attrs["config"].SetOptional()
 	attrs["destination_type"] = attrs["destination_type"].SetOptional()
+	attrs["destination_type"] = attrs["destination_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("EMAIL", "MICROSOFT_TEAMS", "PAGERDUTY", "SLACK", "WEBHOOK"))
 	attrs["display_name"] = attrs["display_name"].SetOptional()
 	attrs["id"] = attrs["id"].SetOptional()
 
@@ -8190,6 +8207,7 @@ func (newState *PersonalComputeMessage) SyncEffectiveFieldsDuringRead(existingSt
 
 func (c PersonalComputeMessage) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["value"] = attrs["value"].SetRequired()
+	attrs["value"] = attrs["value"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DELEGATE", "ON"))
 
 	return attrs
 }
@@ -8418,6 +8436,7 @@ func (c ReplaceIpAccessList) ApplySchemaCustomizations(attrs map[string]tfschema
 	attrs["ip_addresses"] = attrs["ip_addresses"].SetOptional()
 	attrs["label"] = attrs["label"].SetRequired()
 	attrs["list_type"] = attrs["list_type"].SetRequired()
+	attrs["list_type"] = attrs["list_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ALLOW", "BLOCK"))
 
 	return attrs
 }
@@ -8533,6 +8552,7 @@ func (newState *RestrictWorkspaceAdminsMessage) SyncEffectiveFieldsDuringRead(ex
 
 func (c RestrictWorkspaceAdminsMessage) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["status"] = attrs["status"].SetRequired()
+	attrs["status"] = attrs["status"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ALLOW_ALL", "RESTRICT_TOKENS_AND_JOB_RUN_AS"))
 
 	return attrs
 }
@@ -8906,6 +8926,7 @@ func (newState *TokenAccessControlRequest) SyncEffectiveFieldsDuringRead(existin
 func (c TokenAccessControlRequest) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["group_name"] = attrs["group_name"].SetOptional()
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_USE"))
 	attrs["service_principal_name"] = attrs["service_principal_name"].SetOptional()
 	attrs["user_name"] = attrs["user_name"].SetOptional()
 
@@ -9155,6 +9176,7 @@ func (c TokenPermission) ApplySchemaCustomizations(attrs map[string]tfschema.Att
 	attrs["inherited"] = attrs["inherited"].SetOptional()
 	attrs["inherited_from_object"] = attrs["inherited_from_object"].SetOptional()
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_USE"))
 
 	return attrs
 }
@@ -9326,6 +9348,7 @@ func (newState *TokenPermissionsDescription) SyncEffectiveFieldsDuringRead(exist
 func (c TokenPermissionsDescription) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["description"] = attrs["description"].SetOptional()
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_USE"))
 
 	return attrs
 }
@@ -10679,6 +10702,7 @@ func (c UpdateIpAccessList) ApplySchemaCustomizations(attrs map[string]tfschema.
 	attrs["ip_addresses"] = attrs["ip_addresses"].SetOptional()
 	attrs["label"] = attrs["label"].SetOptional()
 	attrs["list_type"] = attrs["list_type"].SetOptional()
+	attrs["list_type"] = attrs["list_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ALLOW", "BLOCK"))
 
 	return attrs
 }

--- a/internal/service/sharing_tf/legacy_model.go
+++ b/internal/service/sharing_tf/legacy_model.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/databricks/terraform-provider-databricks/internal/service/catalog_tf"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
@@ -44,6 +45,7 @@ func (newState *CreateProvider_SdkV2) SyncEffectiveFieldsDuringRead(existingStat
 
 func (c CreateProvider_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["authentication_type"] = attrs["authentication_type"].SetRequired()
+	attrs["authentication_type"] = attrs["authentication_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DATABRICKS", "TOKEN"))
 	attrs["comment"] = attrs["comment"].SetOptional()
 	attrs["name"] = attrs["name"].SetRequired()
 	attrs["recipient_profile_str"] = attrs["recipient_profile_str"].SetOptional()
@@ -124,6 +126,7 @@ func (newState *CreateRecipient_SdkV2) SyncEffectiveFieldsDuringRead(existingSta
 
 func (c CreateRecipient_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["authentication_type"] = attrs["authentication_type"].SetRequired()
+	attrs["authentication_type"] = attrs["authentication_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DATABRICKS", "TOKEN"))
 	attrs["comment"] = attrs["comment"].SetOptional()
 	attrs["data_recipient_global_metastore_id"] = attrs["data_recipient_global_metastore_id"].SetOptional()
 	attrs["expiration_time"] = attrs["expiration_time"].SetOptional()
@@ -1480,6 +1483,7 @@ func (newState *PartitionValue_SdkV2) SyncEffectiveFieldsDuringRead(existingStat
 func (c PartitionValue_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["name"] = attrs["name"].SetOptional()
 	attrs["op"] = attrs["op"].SetOptional()
+	attrs["op"] = attrs["op"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("EQUAL", "LIKE"))
 	attrs["recipient_property_key"] = attrs["recipient_property_key"].SetOptional()
 	attrs["value"] = attrs["value"].SetOptional()
 
@@ -1652,6 +1656,7 @@ func (newState *ProviderInfo_SdkV2) SyncEffectiveFieldsDuringRead(existingState 
 
 func (c ProviderInfo_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["authentication_type"] = attrs["authentication_type"].SetOptional()
+	attrs["authentication_type"] = attrs["authentication_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DATABRICKS", "TOKEN"))
 	attrs["cloud"] = attrs["cloud"].SetComputed()
 	attrs["comment"] = attrs["comment"].SetOptional()
 	attrs["created_at"] = attrs["created_at"].SetComputed()
@@ -1868,6 +1873,7 @@ func (c RecipientInfo_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema
 	attrs["activated"] = attrs["activated"].SetComputed()
 	attrs["activation_url"] = attrs["activation_url"].SetComputed()
 	attrs["authentication_type"] = attrs["authentication_type"].SetOptional()
+	attrs["authentication_type"] = attrs["authentication_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DATABRICKS", "TOKEN"))
 	attrs["cloud"] = attrs["cloud"].SetComputed()
 	attrs["comment"] = attrs["comment"].SetOptional()
 	attrs["created_at"] = attrs["created_at"].SetComputed()
@@ -2779,8 +2785,10 @@ func (c SharedDataObject_SdkV2) ApplySchemaCustomizations(attrs map[string]tfsch
 	attrs["comment"] = attrs["comment"].SetOptional()
 	attrs["content"] = attrs["content"].SetOptional()
 	attrs["data_object_type"] = attrs["data_object_type"].SetOptional()
+	attrs["data_object_type"] = attrs["data_object_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("FEATURE_SPEC", "FUNCTION", "MATERIALIZED_VIEW", "MODEL", "NOTEBOOK_FILE", "SCHEMA", "STREAMING_TABLE", "TABLE", "VIEW"))
 	attrs["effective_history_data_sharing_status"] = attrs["effective_history_data_sharing_status"].SetComputed()
 	attrs["history_data_sharing_status"] = attrs["history_data_sharing_status"].SetOptional()
+	attrs["history_data_sharing_status"] = attrs["history_data_sharing_status"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DISABLED", "ENABLED"))
 	attrs["name"] = attrs["name"].SetRequired()
 	attrs["partition"] = attrs["partition"].SetOptional()
 	attrs["effective_shared_as"] = attrs["effective_shared_as"].SetComputed()
@@ -2788,6 +2796,7 @@ func (c SharedDataObject_SdkV2) ApplySchemaCustomizations(attrs map[string]tfsch
 	attrs["effective_start_version"] = attrs["effective_start_version"].SetComputed()
 	attrs["start_version"] = attrs["start_version"].SetOptional()
 	attrs["status"] = attrs["status"].SetComputed()
+	attrs["status"] = attrs["status"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ACTIVE", "PERMISSION_DENIED"))
 	attrs["string_shared_as"] = attrs["string_shared_as"].SetOptional()
 
 	return attrs
@@ -2901,6 +2910,7 @@ func (newState *SharedDataObjectUpdate_SdkV2) SyncEffectiveFieldsDuringRead(exis
 
 func (c SharedDataObjectUpdate_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["action"] = attrs["action"].SetOptional()
+	attrs["action"] = attrs["action"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ADD", "REMOVE", "UPDATE"))
 	attrs["data_object"] = attrs["data_object"].SetOptional()
 	attrs["data_object"] = attrs["data_object"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 

--- a/internal/service/sharing_tf/model.go
+++ b/internal/service/sharing_tf/model.go
@@ -18,6 +18,7 @@ import (
 	"github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/tfschema"
 
 	"github.com/databricks/terraform-provider-databricks/internal/service/catalog_tf"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
@@ -43,6 +44,7 @@ func (newState *CreateProvider) SyncEffectiveFieldsDuringRead(existingState Crea
 
 func (c CreateProvider) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["authentication_type"] = attrs["authentication_type"].SetRequired()
+	attrs["authentication_type"] = attrs["authentication_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DATABRICKS", "TOKEN"))
 	attrs["comment"] = attrs["comment"].SetOptional()
 	attrs["name"] = attrs["name"].SetRequired()
 	attrs["recipient_profile_str"] = attrs["recipient_profile_str"].SetOptional()
@@ -123,6 +125,7 @@ func (newState *CreateRecipient) SyncEffectiveFieldsDuringRead(existingState Cre
 
 func (c CreateRecipient) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["authentication_type"] = attrs["authentication_type"].SetRequired()
+	attrs["authentication_type"] = attrs["authentication_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DATABRICKS", "TOKEN"))
 	attrs["comment"] = attrs["comment"].SetOptional()
 	attrs["data_recipient_global_metastore_id"] = attrs["data_recipient_global_metastore_id"].SetOptional()
 	attrs["expiration_time"] = attrs["expiration_time"].SetOptional()
@@ -1477,6 +1480,7 @@ func (newState *PartitionValue) SyncEffectiveFieldsDuringRead(existingState Part
 func (c PartitionValue) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["name"] = attrs["name"].SetOptional()
 	attrs["op"] = attrs["op"].SetOptional()
+	attrs["op"] = attrs["op"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("EQUAL", "LIKE"))
 	attrs["recipient_property_key"] = attrs["recipient_property_key"].SetOptional()
 	attrs["value"] = attrs["value"].SetOptional()
 
@@ -1649,6 +1653,7 @@ func (newState *ProviderInfo) SyncEffectiveFieldsDuringRead(existingState Provid
 
 func (c ProviderInfo) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["authentication_type"] = attrs["authentication_type"].SetOptional()
+	attrs["authentication_type"] = attrs["authentication_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DATABRICKS", "TOKEN"))
 	attrs["cloud"] = attrs["cloud"].SetComputed()
 	attrs["comment"] = attrs["comment"].SetOptional()
 	attrs["created_at"] = attrs["created_at"].SetComputed()
@@ -1864,6 +1869,7 @@ func (c RecipientInfo) ApplySchemaCustomizations(attrs map[string]tfschema.Attri
 	attrs["activated"] = attrs["activated"].SetComputed()
 	attrs["activation_url"] = attrs["activation_url"].SetComputed()
 	attrs["authentication_type"] = attrs["authentication_type"].SetOptional()
+	attrs["authentication_type"] = attrs["authentication_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DATABRICKS", "TOKEN"))
 	attrs["cloud"] = attrs["cloud"].SetComputed()
 	attrs["comment"] = attrs["comment"].SetOptional()
 	attrs["created_at"] = attrs["created_at"].SetComputed()
@@ -2773,8 +2779,10 @@ func (c SharedDataObject) ApplySchemaCustomizations(attrs map[string]tfschema.At
 	attrs["comment"] = attrs["comment"].SetOptional()
 	attrs["content"] = attrs["content"].SetOptional()
 	attrs["data_object_type"] = attrs["data_object_type"].SetOptional()
+	attrs["data_object_type"] = attrs["data_object_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("FEATURE_SPEC", "FUNCTION", "MATERIALIZED_VIEW", "MODEL", "NOTEBOOK_FILE", "SCHEMA", "STREAMING_TABLE", "TABLE", "VIEW"))
 	attrs["effective_history_data_sharing_status"] = attrs["effective_history_data_sharing_status"].SetComputed()
 	attrs["history_data_sharing_status"] = attrs["history_data_sharing_status"].SetOptional()
+	attrs["history_data_sharing_status"] = attrs["history_data_sharing_status"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DISABLED", "ENABLED"))
 	attrs["name"] = attrs["name"].SetRequired()
 	attrs["partition"] = attrs["partition"].SetOptional()
 	attrs["effective_shared_as"] = attrs["effective_shared_as"].SetComputed()
@@ -2782,6 +2790,7 @@ func (c SharedDataObject) ApplySchemaCustomizations(attrs map[string]tfschema.At
 	attrs["effective_start_version"] = attrs["effective_start_version"].SetComputed()
 	attrs["start_version"] = attrs["start_version"].SetOptional()
 	attrs["status"] = attrs["status"].SetComputed()
+	attrs["status"] = attrs["status"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ACTIVE", "PERMISSION_DENIED"))
 	attrs["string_shared_as"] = attrs["string_shared_as"].SetOptional()
 
 	return attrs
@@ -2895,6 +2904,7 @@ func (newState *SharedDataObjectUpdate) SyncEffectiveFieldsDuringRead(existingSt
 
 func (c SharedDataObjectUpdate) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["action"] = attrs["action"].SetOptional()
+	attrs["action"] = attrs["action"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ADD", "REMOVE", "UPDATE"))
 	attrs["data_object"] = attrs["data_object"].SetOptional()
 
 	return attrs

--- a/internal/service/sql_tf/legacy_model.go
+++ b/internal/service/sql_tf/legacy_model.go
@@ -18,6 +18,7 @@ import (
 	"github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/tfschema"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
@@ -41,6 +42,7 @@ func (newState *AccessControl_SdkV2) SyncEffectiveFieldsDuringRead(existingState
 func (c AccessControl_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["group_name"] = attrs["group_name"].SetOptional()
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_EDIT", "CAN_MANAGE", "CAN_RUN", "CAN_VIEW"))
 	attrs["user_name"] = attrs["user_name"].SetOptional()
 
 	return attrs
@@ -142,12 +144,14 @@ func (c Alert_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.Attribu
 	attrs["display_name"] = attrs["display_name"].SetOptional()
 	attrs["id"] = attrs["id"].SetOptional()
 	attrs["lifecycle_state"] = attrs["lifecycle_state"].SetOptional()
+	attrs["lifecycle_state"] = attrs["lifecycle_state"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ACTIVE", "TRASHED"))
 	attrs["notify_on_ok"] = attrs["notify_on_ok"].SetOptional()
 	attrs["owner_user_name"] = attrs["owner_user_name"].SetOptional()
 	attrs["parent_path"] = attrs["parent_path"].SetOptional()
 	attrs["query_id"] = attrs["query_id"].SetOptional()
 	attrs["seconds_to_retrigger"] = attrs["seconds_to_retrigger"].SetOptional()
 	attrs["state"] = attrs["state"].SetOptional()
+	attrs["state"] = attrs["state"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("OK", "TRIGGERED", "UNKNOWN"))
 	attrs["trigger_time"] = attrs["trigger_time"].SetOptional()
 	attrs["update_time"] = attrs["update_time"].SetOptional()
 
@@ -263,7 +267,9 @@ func (newState *AlertCondition_SdkV2) SyncEffectiveFieldsDuringRead(existingStat
 
 func (c AlertCondition_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["empty_result_state"] = attrs["empty_result_state"].SetOptional()
+	attrs["empty_result_state"] = attrs["empty_result_state"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("OK", "TRIGGERED", "UNKNOWN"))
 	attrs["op"] = attrs["op"].SetOptional()
+	attrs["op"] = attrs["op"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("EQUAL", "GREATER_THAN", "GREATER_THAN_OR_EQUAL", "IS_NULL", "LESS_THAN", "LESS_THAN_OR_EQUAL", "NOT_EQUAL"))
 	attrs["operand"] = attrs["operand"].SetOptional()
 	attrs["operand"] = attrs["operand"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["threshold"] = attrs["threshold"].SetOptional()
@@ -667,6 +673,7 @@ func (c AlertOptions_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.
 	attrs["custom_body"] = attrs["custom_body"].SetOptional()
 	attrs["custom_subject"] = attrs["custom_subject"].SetOptional()
 	attrs["empty_result_state"] = attrs["empty_result_state"].SetOptional()
+	attrs["empty_result_state"] = attrs["empty_result_state"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ok", "triggered", "unknown"))
 	attrs["muted"] = attrs["muted"].SetOptional()
 	attrs["op"] = attrs["op"].SetRequired()
 	attrs["value"] = attrs["value"].SetRequired()
@@ -1050,6 +1057,7 @@ func (newState *Channel_SdkV2) SyncEffectiveFieldsDuringRead(existingState Chann
 func (c Channel_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["dbsql_version"] = attrs["dbsql_version"].SetOptional()
 	attrs["name"] = attrs["name"].SetOptional()
+	attrs["name"] = attrs["name"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CHANNEL_NAME_CURRENT", "CHANNEL_NAME_CUSTOM", "CHANNEL_NAME_PREVIEW", "CHANNEL_NAME_PREVIOUS"))
 
 	return attrs
 }
@@ -1104,6 +1112,7 @@ func (newState *ChannelInfo_SdkV2) SyncEffectiveFieldsDuringRead(existingState C
 func (c ChannelInfo_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["dbsql_version"] = attrs["dbsql_version"].SetOptional()
 	attrs["name"] = attrs["name"].SetOptional()
+	attrs["name"] = attrs["name"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CHANNEL_NAME_CURRENT", "CHANNEL_NAME_CUSTOM", "CHANNEL_NAME_PREVIEW", "CHANNEL_NAME_PREVIOUS"))
 
 	return attrs
 }
@@ -1264,6 +1273,7 @@ func (c ColumnInfo_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.At
 	attrs["position"] = attrs["position"].SetOptional()
 	attrs["type_interval_type"] = attrs["type_interval_type"].SetOptional()
 	attrs["type_name"] = attrs["type_name"].SetOptional()
+	attrs["type_name"] = attrs["type_name"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ARRAY", "BINARY", "BOOLEAN", "BYTE", "CHAR", "DATE", "DECIMAL", "DOUBLE", "FLOAT", "INT", "INTERVAL", "LONG", "MAP", "NULL", "SHORT", "STRING", "STRUCT", "TIMESTAMP", "USER_DEFINED_TYPE"))
 	attrs["type_precision"] = attrs["type_precision"].SetOptional()
 	attrs["type_scale"] = attrs["type_scale"].SetOptional()
 	attrs["type_text"] = attrs["type_text"].SetOptional()
@@ -1736,6 +1746,7 @@ func (c CreateQueryRequestQuery_SdkV2) ApplySchemaCustomizations(attrs map[strin
 	attrs["parent_path"] = attrs["parent_path"].SetOptional()
 	attrs["query_text"] = attrs["query_text"].SetOptional()
 	attrs["run_as_mode"] = attrs["run_as_mode"].SetOptional()
+	attrs["run_as_mode"] = attrs["run_as_mode"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("OWNER", "VIEWER"))
 	attrs["schema"] = attrs["schema"].SetOptional()
 	attrs["tags"] = attrs["tags"].SetOptional()
 	attrs["warehouse_id"] = attrs["warehouse_id"].SetOptional()
@@ -2143,9 +2154,11 @@ func (c CreateWarehouseRequest_SdkV2) ApplySchemaCustomizations(attrs map[string
 	attrs["min_num_clusters"] = attrs["min_num_clusters"].SetOptional()
 	attrs["name"] = attrs["name"].SetOptional()
 	attrs["spot_instance_policy"] = attrs["spot_instance_policy"].SetOptional()
+	attrs["spot_instance_policy"] = attrs["spot_instance_policy"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("COST_OPTIMIZED", "POLICY_UNSPECIFIED", "RELIABILITY_OPTIMIZED"))
 	attrs["tags"] = attrs["tags"].SetOptional()
 	attrs["tags"] = attrs["tags"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["warehouse_type"] = attrs["warehouse_type"].SetOptional()
+	attrs["warehouse_type"] = attrs["warehouse_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CLASSIC", "PRO", "TYPE_UNSPECIFIED"))
 
 	return attrs
 }
@@ -2486,6 +2499,7 @@ func (c Dashboard_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.Att
 	attrs["options"] = attrs["options"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["parent"] = attrs["parent"].SetOptional()
 	attrs["permission_tier"] = attrs["permission_tier"].SetOptional()
+	attrs["permission_tier"] = attrs["permission_tier"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_EDIT", "CAN_MANAGE", "CAN_RUN", "CAN_VIEW"))
 	attrs["slug"] = attrs["slug"].SetOptional()
 	attrs["tags"] = attrs["tags"].SetOptional()
 	attrs["updated_at"] = attrs["updated_at"].SetOptional()
@@ -2700,6 +2714,7 @@ func (c DashboardEditContent_SdkV2) ApplySchemaCustomizations(attrs map[string]t
 	attrs["dashboard_id"] = attrs["dashboard_id"].SetRequired()
 	attrs["name"] = attrs["name"].SetOptional()
 	attrs["run_as_role"] = attrs["run_as_role"].SetOptional()
+	attrs["run_as_role"] = attrs["run_as_role"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("owner", "viewer"))
 	attrs["tags"] = attrs["tags"].SetOptional()
 
 	return attrs
@@ -2853,6 +2868,7 @@ func (c DashboardPostContent_SdkV2) ApplySchemaCustomizations(attrs map[string]t
 	attrs["name"] = attrs["name"].SetRequired()
 	attrs["parent"] = attrs["parent"].SetOptional()
 	attrs["run_as_role"] = attrs["run_as_role"].SetOptional()
+	attrs["run_as_role"] = attrs["run_as_role"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("owner", "viewer"))
 	attrs["tags"] = attrs["tags"].SetOptional()
 
 	return attrs
@@ -3098,7 +3114,9 @@ func (c DateRangeValue_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschem
 	attrs["date_range_value"] = attrs["date_range_value"].SetOptional()
 	attrs["date_range_value"] = attrs["date_range_value"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["dynamic_date_range_value"] = attrs["dynamic_date_range_value"].SetOptional()
+	attrs["dynamic_date_range_value"] = attrs["dynamic_date_range_value"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("LAST_12_MONTHS", "LAST_14_DAYS", "LAST_24_HOURS", "LAST_30_DAYS", "LAST_60_DAYS", "LAST_7_DAYS", "LAST_8_HOURS", "LAST_90_DAYS", "LAST_HOUR", "LAST_MONTH", "LAST_WEEK", "LAST_YEAR", "THIS_MONTH", "THIS_WEEK", "THIS_YEAR", "TODAY", "YESTERDAY"))
 	attrs["precision"] = attrs["precision"].SetOptional()
+	attrs["precision"] = attrs["precision"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DAY_PRECISION", "MINUTE_PRECISION", "SECOND_PRECISION"))
 	attrs["start_day_of_week"] = attrs["start_day_of_week"].SetOptional()
 
 	return attrs
@@ -3190,7 +3208,9 @@ func (newState *DateValue_SdkV2) SyncEffectiveFieldsDuringRead(existingState Dat
 func (c DateValue_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["date_value"] = attrs["date_value"].SetOptional()
 	attrs["dynamic_date_value"] = attrs["dynamic_date_value"].SetOptional()
+	attrs["dynamic_date_value"] = attrs["dynamic_date_value"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("NOW", "YESTERDAY"))
 	attrs["precision"] = attrs["precision"].SetOptional()
+	attrs["precision"] = attrs["precision"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DAY_PRECISION", "MINUTE_PRECISION", "SECOND_PRECISION"))
 
 	return attrs
 }
@@ -3740,9 +3760,11 @@ func (c EditWarehouseRequest_SdkV2) ApplySchemaCustomizations(attrs map[string]t
 	attrs["min_num_clusters"] = attrs["min_num_clusters"].SetOptional()
 	attrs["name"] = attrs["name"].SetOptional()
 	attrs["spot_instance_policy"] = attrs["spot_instance_policy"].SetOptional()
+	attrs["spot_instance_policy"] = attrs["spot_instance_policy"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("COST_OPTIMIZED", "POLICY_UNSPECIFIED", "RELIABILITY_OPTIMIZED"))
 	attrs["tags"] = attrs["tags"].SetOptional()
 	attrs["tags"] = attrs["tags"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["warehouse_type"] = attrs["warehouse_type"].SetOptional()
+	attrs["warehouse_type"] = attrs["warehouse_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CLASSIC", "PRO", "TYPE_UNSPECIFIED"))
 
 	return attrs
 }
@@ -4026,6 +4048,7 @@ func (c EndpointHealth_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschem
 	attrs["failure_reason"] = attrs["failure_reason"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["message"] = attrs["message"].SetOptional()
 	attrs["status"] = attrs["status"].SetOptional()
+	attrs["status"] = attrs["status"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DEGRADED", "FAILED", "HEALTHY", "STATUS_UNSPECIFIED"))
 	attrs["summary"] = attrs["summary"].SetOptional()
 
 	return attrs
@@ -4204,10 +4227,13 @@ func (c EndpointInfo_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.
 	attrs["odbc_params"] = attrs["odbc_params"].SetOptional()
 	attrs["odbc_params"] = attrs["odbc_params"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["spot_instance_policy"] = attrs["spot_instance_policy"].SetOptional()
+	attrs["spot_instance_policy"] = attrs["spot_instance_policy"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("COST_OPTIMIZED", "POLICY_UNSPECIFIED", "RELIABILITY_OPTIMIZED"))
 	attrs["state"] = attrs["state"].SetOptional()
+	attrs["state"] = attrs["state"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DELETED", "DELETING", "RUNNING", "STARTING", "STOPPED", "STOPPING"))
 	attrs["tags"] = attrs["tags"].SetOptional()
 	attrs["tags"] = attrs["tags"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["warehouse_type"] = attrs["warehouse_type"].SetOptional()
+	attrs["warehouse_type"] = attrs["warehouse_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CLASSIC", "PRO", "TYPE_UNSPECIFIED"))
 
 	return attrs
 }
@@ -4781,8 +4807,11 @@ func (c ExecuteStatementRequest_SdkV2) ApplySchemaCustomizations(attrs map[strin
 	attrs["byte_limit"] = attrs["byte_limit"].SetOptional()
 	attrs["catalog"] = attrs["catalog"].SetOptional()
 	attrs["disposition"] = attrs["disposition"].SetOptional()
+	attrs["disposition"] = attrs["disposition"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("EXTERNAL_LINKS", "INLINE"))
 	attrs["format"] = attrs["format"].SetOptional()
+	attrs["format"] = attrs["format"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ARROW_STREAM", "CSV", "JSON_ARRAY"))
 	attrs["on_wait_timeout"] = attrs["on_wait_timeout"].SetOptional()
+	attrs["on_wait_timeout"] = attrs["on_wait_timeout"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CANCEL", "CONTINUE"))
 	attrs["parameters"] = attrs["parameters"].SetOptional()
 	attrs["row_limit"] = attrs["row_limit"].SetOptional()
 	attrs["schema"] = attrs["schema"].SetOptional()
@@ -5670,10 +5699,13 @@ func (c GetWarehouseResponse_SdkV2) ApplySchemaCustomizations(attrs map[string]t
 	attrs["odbc_params"] = attrs["odbc_params"].SetOptional()
 	attrs["odbc_params"] = attrs["odbc_params"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["spot_instance_policy"] = attrs["spot_instance_policy"].SetOptional()
+	attrs["spot_instance_policy"] = attrs["spot_instance_policy"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("COST_OPTIMIZED", "POLICY_UNSPECIFIED", "RELIABILITY_OPTIMIZED"))
 	attrs["state"] = attrs["state"].SetOptional()
+	attrs["state"] = attrs["state"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DELETED", "DELETING", "RUNNING", "STARTING", "STOPPED", "STOPPING"))
 	attrs["tags"] = attrs["tags"].SetOptional()
 	attrs["tags"] = attrs["tags"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["warehouse_type"] = attrs["warehouse_type"].SetOptional()
+	attrs["warehouse_type"] = attrs["warehouse_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CLASSIC", "PRO", "TYPE_UNSPECIFIED"))
 
 	return attrs
 }
@@ -5910,6 +5942,7 @@ func (c GetWorkspaceWarehouseConfigResponse_SdkV2) ApplySchemaCustomizations(att
 	attrs["google_service_account"] = attrs["google_service_account"].SetOptional()
 	attrs["instance_profile_arn"] = attrs["instance_profile_arn"].SetOptional()
 	attrs["security_policy"] = attrs["security_policy"].SetOptional()
+	attrs["security_policy"] = attrs["security_policy"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DATA_ACCESS_CONTROL", "NONE", "PASSTHROUGH"))
 	attrs["sql_configuration_parameters"] = attrs["sql_configuration_parameters"].SetOptional()
 	attrs["sql_configuration_parameters"] = attrs["sql_configuration_parameters"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 
@@ -6185,6 +6218,7 @@ func (c LegacyAlert_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.A
 	attrs["query"] = attrs["query"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["rearm"] = attrs["rearm"].SetOptional()
 	attrs["state"] = attrs["state"].SetOptional()
+	attrs["state"] = attrs["state"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ok", "triggered", "unknown"))
 	attrs["updated_at"] = attrs["updated_at"].SetOptional()
 	attrs["user"] = attrs["user"].SetOptional()
 	attrs["user"] = attrs["user"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
@@ -6427,9 +6461,11 @@ func (c LegacyQuery_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.A
 	attrs["options"] = attrs["options"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["parent"] = attrs["parent"].SetOptional()
 	attrs["permission_tier"] = attrs["permission_tier"].SetOptional()
+	attrs["permission_tier"] = attrs["permission_tier"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_EDIT", "CAN_MANAGE", "CAN_RUN", "CAN_VIEW"))
 	attrs["query"] = attrs["query"].SetOptional()
 	attrs["query_hash"] = attrs["query_hash"].SetOptional()
 	attrs["run_as_role"] = attrs["run_as_role"].SetOptional()
+	attrs["run_as_role"] = attrs["run_as_role"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("owner", "viewer"))
 	attrs["tags"] = attrs["tags"].SetOptional()
 	attrs["updated_at"] = attrs["updated_at"].SetOptional()
 	attrs["user"] = attrs["user"].SetOptional()
@@ -6966,11 +7002,13 @@ func (c ListAlertsResponseAlert_SdkV2) ApplySchemaCustomizations(attrs map[strin
 	attrs["display_name"] = attrs["display_name"].SetOptional()
 	attrs["id"] = attrs["id"].SetOptional()
 	attrs["lifecycle_state"] = attrs["lifecycle_state"].SetOptional()
+	attrs["lifecycle_state"] = attrs["lifecycle_state"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ACTIVE", "TRASHED"))
 	attrs["notify_on_ok"] = attrs["notify_on_ok"].SetOptional()
 	attrs["owner_user_name"] = attrs["owner_user_name"].SetOptional()
 	attrs["query_id"] = attrs["query_id"].SetOptional()
 	attrs["seconds_to_retrigger"] = attrs["seconds_to_retrigger"].SetOptional()
 	attrs["state"] = attrs["state"].SetOptional()
+	attrs["state"] = attrs["state"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("OK", "TRIGGERED", "UNKNOWN"))
 	attrs["trigger_time"] = attrs["trigger_time"].SetOptional()
 	attrs["update_time"] = attrs["update_time"].SetOptional()
 
@@ -7521,10 +7559,12 @@ func (c ListQueryObjectsResponseQuery_SdkV2) ApplySchemaCustomizations(attrs map
 	attrs["id"] = attrs["id"].SetOptional()
 	attrs["last_modifier_user_name"] = attrs["last_modifier_user_name"].SetOptional()
 	attrs["lifecycle_state"] = attrs["lifecycle_state"].SetOptional()
+	attrs["lifecycle_state"] = attrs["lifecycle_state"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ACTIVE", "TRASHED"))
 	attrs["owner_user_name"] = attrs["owner_user_name"].SetOptional()
 	attrs["parameters"] = attrs["parameters"].SetOptional()
 	attrs["query_text"] = attrs["query_text"].SetOptional()
 	attrs["run_as_mode"] = attrs["run_as_mode"].SetOptional()
+	attrs["run_as_mode"] = attrs["run_as_mode"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("OWNER", "VIEWER"))
 	attrs["schema"] = attrs["schema"].SetOptional()
 	attrs["tags"] = attrs["tags"].SetOptional()
 	attrs["update_time"] = attrs["update_time"].SetOptional()
@@ -8176,6 +8216,7 @@ func (c Parameter_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.Att
 	attrs["queryId"] = attrs["queryId"].SetOptional()
 	attrs["title"] = attrs["title"].SetOptional()
 	attrs["type"] = attrs["type"].SetOptional()
+	attrs["type"] = attrs["type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("datetime", "enum", "number", "query", "text"))
 	attrs["value"] = attrs["value"].SetOptional()
 
 	return attrs
@@ -8308,11 +8349,13 @@ func (c Query_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.Attribu
 	attrs["id"] = attrs["id"].SetOptional()
 	attrs["last_modifier_user_name"] = attrs["last_modifier_user_name"].SetOptional()
 	attrs["lifecycle_state"] = attrs["lifecycle_state"].SetOptional()
+	attrs["lifecycle_state"] = attrs["lifecycle_state"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ACTIVE", "TRASHED"))
 	attrs["owner_user_name"] = attrs["owner_user_name"].SetOptional()
 	attrs["parameters"] = attrs["parameters"].SetOptional()
 	attrs["parent_path"] = attrs["parent_path"].SetOptional()
 	attrs["query_text"] = attrs["query_text"].SetOptional()
 	attrs["run_as_mode"] = attrs["run_as_mode"].SetOptional()
+	attrs["run_as_mode"] = attrs["run_as_mode"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("OWNER", "VIEWER"))
 	attrs["schema"] = attrs["schema"].SetOptional()
 	attrs["tags"] = attrs["tags"].SetOptional()
 	attrs["update_time"] = attrs["update_time"].SetOptional()
@@ -8603,6 +8646,7 @@ func (c QueryEditContent_SdkV2) ApplySchemaCustomizations(attrs map[string]tfsch
 	attrs["query"] = attrs["query"].SetOptional()
 	attrs["query_id"] = attrs["query_id"].SetRequired()
 	attrs["run_as_role"] = attrs["run_as_role"].SetOptional()
+	attrs["run_as_role"] = attrs["run_as_role"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("owner", "viewer"))
 	attrs["tags"] = attrs["tags"].SetOptional()
 
 	return attrs
@@ -8971,6 +9015,7 @@ func (c QueryInfo_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.Att
 	attrs["metrics"] = attrs["metrics"].SetOptional()
 	attrs["metrics"] = attrs["metrics"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["plans_state"] = attrs["plans_state"].SetOptional()
+	attrs["plans_state"] = attrs["plans_state"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("EMPTY", "EXISTS", "IGNORED_LARGE_PLANS_SIZE", "IGNORED_SMALL_DURATION", "IGNORED_SPARK_PLAN_TYPE", "UNKNOWN"))
 	attrs["query_end_time_ms"] = attrs["query_end_time_ms"].SetOptional()
 	attrs["query_id"] = attrs["query_id"].SetOptional()
 	attrs["query_start_time_ms"] = attrs["query_start_time_ms"].SetOptional()
@@ -8978,7 +9023,9 @@ func (c QueryInfo_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.Att
 	attrs["rows_produced"] = attrs["rows_produced"].SetOptional()
 	attrs["spark_ui_url"] = attrs["spark_ui_url"].SetOptional()
 	attrs["statement_type"] = attrs["statement_type"].SetOptional()
+	attrs["statement_type"] = attrs["statement_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ALTER", "ANALYZE", "COPY", "CREATE", "DELETE", "DESCRIBE", "DROP", "EXPLAIN", "GRANT", "INSERT", "MERGE", "OPTIMIZE", "OTHER", "REFRESH", "REPLACE", "REVOKE", "SELECT", "SET", "SHOW", "TRUNCATE", "UPDATE", "USE"))
 	attrs["status"] = attrs["status"].SetOptional()
+	attrs["status"] = attrs["status"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CANCELED", "COMPILED", "COMPILING", "FAILED", "FINISHED", "QUEUED", "RUNNING", "STARTED"))
 	attrs["user_id"] = attrs["user_id"].SetOptional()
 	attrs["user_name"] = attrs["user_name"].SetOptional()
 	attrs["warehouse_id"] = attrs["warehouse_id"].SetOptional()
@@ -9782,6 +9829,7 @@ func (c QueryPostContent_SdkV2) ApplySchemaCustomizations(attrs map[string]tfsch
 	attrs["parent"] = attrs["parent"].SetOptional()
 	attrs["query"] = attrs["query"].SetOptional()
 	attrs["run_as_role"] = attrs["run_as_role"].SetOptional()
+	attrs["run_as_role"] = attrs["run_as_role"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("owner", "viewer"))
 	attrs["tags"] = attrs["tags"].SetOptional()
 
 	return attrs
@@ -10257,6 +10305,7 @@ func (newState *ResultManifest_SdkV2) SyncEffectiveFieldsDuringRead(existingStat
 func (c ResultManifest_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["chunks"] = attrs["chunks"].SetOptional()
 	attrs["format"] = attrs["format"].SetOptional()
+	attrs["format"] = attrs["format"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ARROW_STREAM", "CSV", "JSON_ARRAY"))
 	attrs["schema"] = attrs["schema"].SetOptional()
 	attrs["schema"] = attrs["schema"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["total_byte_count"] = attrs["total_byte_count"].SetOptional()
@@ -10466,6 +10515,7 @@ func (newState *ServiceError_SdkV2) SyncEffectiveFieldsDuringRead(existingState 
 
 func (c ServiceError_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["error_code"] = attrs["error_code"].SetOptional()
+	attrs["error_code"] = attrs["error_code"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ABORTED", "ALREADY_EXISTS", "BAD_REQUEST", "CANCELLED", "DEADLINE_EXCEEDED", "INTERNAL_ERROR", "IO_ERROR", "NOT_FOUND", "RESOURCE_EXHAUSTED", "SERVICE_UNDER_MAINTENANCE", "TEMPORARILY_UNAVAILABLE", "UNAUTHENTICATED", "UNKNOWN", "WORKSPACE_TEMPORARILY_UNAVAILABLE"))
 	attrs["message"] = attrs["message"].SetOptional()
 
 	return attrs
@@ -10698,6 +10748,7 @@ func (c SetWorkspaceWarehouseConfigRequest_SdkV2) ApplySchemaCustomizations(attr
 	attrs["google_service_account"] = attrs["google_service_account"].SetOptional()
 	attrs["instance_profile_arn"] = attrs["instance_profile_arn"].SetOptional()
 	attrs["security_policy"] = attrs["security_policy"].SetOptional()
+	attrs["security_policy"] = attrs["security_policy"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DATA_ACCESS_CONTROL", "NONE", "PASSTHROUGH"))
 	attrs["sql_configuration_parameters"] = attrs["sql_configuration_parameters"].SetOptional()
 	attrs["sql_configuration_parameters"] = attrs["sql_configuration_parameters"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 
@@ -11290,6 +11341,7 @@ func (c StatementStatus_SdkV2) ApplySchemaCustomizations(attrs map[string]tfsche
 	attrs["error"] = attrs["error"].SetOptional()
 	attrs["error"] = attrs["error"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["state"] = attrs["state"].SetOptional()
+	attrs["state"] = attrs["state"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CANCELED", "CLOSED", "FAILED", "PENDING", "RUNNING", "SUCCEEDED"))
 
 	return attrs
 }
@@ -11447,6 +11499,7 @@ func (newState *Success_SdkV2) SyncEffectiveFieldsDuringRead(existingState Succe
 
 func (c Success_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["message"] = attrs["message"].SetOptional()
+	attrs["message"] = attrs["message"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("Success"))
 
 	return attrs
 }
@@ -11500,8 +11553,10 @@ func (newState *TerminationReason_SdkV2) SyncEffectiveFieldsDuringRead(existingS
 
 func (c TerminationReason_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["code"] = attrs["code"].SetOptional()
+	attrs["code"] = attrs["code"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ABUSE_DETECTED", "ATTACH_PROJECT_FAILURE", "AWS_AUTHORIZATION_FAILURE", "AWS_INSUFFICIENT_FREE_ADDRESSES_IN_SUBNET_FAILURE", "AWS_INSUFFICIENT_INSTANCE_CAPACITY_FAILURE", "AWS_MAX_SPOT_INSTANCE_COUNT_EXCEEDED_FAILURE", "AWS_REQUEST_LIMIT_EXCEEDED", "AWS_UNSUPPORTED_FAILURE", "AZURE_BYOK_KEY_PERMISSION_FAILURE", "AZURE_EPHEMERAL_DISK_FAILURE", "AZURE_INVALID_DEPLOYMENT_TEMPLATE", "AZURE_OPERATION_NOT_ALLOWED_EXCEPTION", "AZURE_QUOTA_EXCEEDED_EXCEPTION", "AZURE_RESOURCE_MANAGER_THROTTLING", "AZURE_RESOURCE_PROVIDER_THROTTLING", "AZURE_UNEXPECTED_DEPLOYMENT_TEMPLATE_FAILURE", "AZURE_VM_EXTENSION_FAILURE", "AZURE_VNET_CONFIGURATION_FAILURE", "BOOTSTRAP_TIMEOUT", "BOOTSTRAP_TIMEOUT_CLOUD_PROVIDER_EXCEPTION", "CLOUD_PROVIDER_DISK_SETUP_FAILURE", "CLOUD_PROVIDER_LAUNCH_FAILURE", "CLOUD_PROVIDER_RESOURCE_STOCKOUT", "CLOUD_PROVIDER_SHUTDOWN", "COMMUNICATION_LOST", "CONTAINER_LAUNCH_FAILURE", "CONTROL_PLANE_REQUEST_FAILURE", "DATABASE_CONNECTION_FAILURE", "DBFS_COMPONENT_UNHEALTHY", "DOCKER_IMAGE_PULL_FAILURE", "DRIVER_UNREACHABLE", "DRIVER_UNRESPONSIVE", "EXECUTION_COMPONENT_UNHEALTHY", "GCP_QUOTA_EXCEEDED", "GCP_SERVICE_ACCOUNT_DELETED", "GLOBAL_INIT_SCRIPT_FAILURE", "HIVE_METASTORE_PROVISIONING_FAILURE", "IMAGE_PULL_PERMISSION_DENIED", "INACTIVITY", "INIT_SCRIPT_FAILURE", "INSTANCE_POOL_CLUSTER_FAILURE", "INSTANCE_UNREACHABLE", "INTERNAL_ERROR", "INVALID_ARGUMENT", "INVALID_SPARK_IMAGE", "IP_EXHAUSTION_FAILURE", "JOB_FINISHED", "K8S_AUTOSCALING_FAILURE", "K8S_DBR_CLUSTER_LAUNCH_TIMEOUT", "METASTORE_COMPONENT_UNHEALTHY", "NEPHOS_RESOURCE_MANAGEMENT", "NETWORK_CONFIGURATION_FAILURE", "NFS_MOUNT_FAILURE", "NPIP_TUNNEL_SETUP_FAILURE", "NPIP_TUNNEL_TOKEN_FAILURE", "REQUEST_REJECTED", "REQUEST_THROTTLED", "SECRET_RESOLUTION_ERROR", "SECURITY_DAEMON_REGISTRATION_EXCEPTION", "SELF_BOOTSTRAP_FAILURE", "SKIPPED_SLOW_NODES", "SLOW_IMAGE_DOWNLOAD", "SPARK_ERROR", "SPARK_IMAGE_DOWNLOAD_FAILURE", "SPARK_STARTUP_FAILURE", "SPOT_INSTANCE_TERMINATION", "STORAGE_DOWNLOAD_FAILURE", "STS_CLIENT_SETUP_FAILURE", "SUBNET_EXHAUSTED_FAILURE", "TEMPORARILY_UNAVAILABLE", "TRIAL_EXPIRED", "UNEXPECTED_LAUNCH_FAILURE", "UNKNOWN", "UNSUPPORTED_INSTANCE_TYPE", "UPDATE_INSTANCE_PROFILE_FAILURE", "USER_REQUEST", "WORKER_SETUP_FAILURE", "WORKSPACE_CANCELLED_ERROR", "WORKSPACE_CONFIGURATION_ERROR"))
 	attrs["parameters"] = attrs["parameters"].SetOptional()
 	attrs["type"] = attrs["type"].SetOptional()
+	attrs["type"] = attrs["type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CLIENT_ERROR", "CLOUD_FAILURE", "SERVICE_FAULT", "SUCCESS"))
 
 	return attrs
 }
@@ -12228,6 +12283,7 @@ func (c UpdateQueryRequestQuery_SdkV2) ApplySchemaCustomizations(attrs map[strin
 	attrs["parameters"] = attrs["parameters"].SetOptional()
 	attrs["query_text"] = attrs["query_text"].SetOptional()
 	attrs["run_as_mode"] = attrs["run_as_mode"].SetOptional()
+	attrs["run_as_mode"] = attrs["run_as_mode"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("OWNER", "VIEWER"))
 	attrs["schema"] = attrs["schema"].SetOptional()
 	attrs["tags"] = attrs["tags"].SetOptional()
 	attrs["warehouse_id"] = attrs["warehouse_id"].SetOptional()
@@ -12704,6 +12760,7 @@ func (newState *WarehouseAccessControlRequest_SdkV2) SyncEffectiveFieldsDuringRe
 func (c WarehouseAccessControlRequest_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["group_name"] = attrs["group_name"].SetOptional()
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_MANAGE", "CAN_MONITOR", "CAN_USE", "IS_OWNER"))
 	attrs["service_principal_name"] = attrs["service_principal_name"].SetOptional()
 	attrs["user_name"] = attrs["user_name"].SetOptional()
 
@@ -12863,6 +12920,7 @@ func (c WarehousePermission_SdkV2) ApplySchemaCustomizations(attrs map[string]tf
 	attrs["inherited"] = attrs["inherited"].SetOptional()
 	attrs["inherited_from_object"] = attrs["inherited_from_object"].SetOptional()
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_MANAGE", "CAN_MONITOR", "CAN_USE", "IS_OWNER"))
 
 	return attrs
 }
@@ -13034,6 +13092,7 @@ func (newState *WarehousePermissionsDescription_SdkV2) SyncEffectiveFieldsDuring
 func (c WarehousePermissionsDescription_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["description"] = attrs["description"].SetOptional()
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_MANAGE", "CAN_MONITOR", "CAN_USE", "IS_OWNER"))
 
 	return attrs
 }
@@ -13170,6 +13229,7 @@ func (newState *WarehouseTypePair_SdkV2) SyncEffectiveFieldsDuringRead(existingS
 func (c WarehouseTypePair_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["enabled"] = attrs["enabled"].SetOptional()
 	attrs["warehouse_type"] = attrs["warehouse_type"].SetOptional()
+	attrs["warehouse_type"] = attrs["warehouse_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CLASSIC", "PRO", "TYPE_UNSPECIFIED"))
 
 	return attrs
 }

--- a/internal/service/sql_tf/model.go
+++ b/internal/service/sql_tf/model.go
@@ -17,6 +17,7 @@ import (
 	pluginfwcommon "github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/common"
 	"github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/tfschema"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
@@ -40,6 +41,7 @@ func (newState *AccessControl) SyncEffectiveFieldsDuringRead(existingState Acces
 func (c AccessControl) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["group_name"] = attrs["group_name"].SetOptional()
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_EDIT", "CAN_MANAGE", "CAN_RUN", "CAN_VIEW"))
 	attrs["user_name"] = attrs["user_name"].SetOptional()
 
 	return attrs
@@ -140,12 +142,14 @@ func (c Alert) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuil
 	attrs["display_name"] = attrs["display_name"].SetOptional()
 	attrs["id"] = attrs["id"].SetOptional()
 	attrs["lifecycle_state"] = attrs["lifecycle_state"].SetOptional()
+	attrs["lifecycle_state"] = attrs["lifecycle_state"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ACTIVE", "TRASHED"))
 	attrs["notify_on_ok"] = attrs["notify_on_ok"].SetOptional()
 	attrs["owner_user_name"] = attrs["owner_user_name"].SetOptional()
 	attrs["parent_path"] = attrs["parent_path"].SetOptional()
 	attrs["query_id"] = attrs["query_id"].SetOptional()
 	attrs["seconds_to_retrigger"] = attrs["seconds_to_retrigger"].SetOptional()
 	attrs["state"] = attrs["state"].SetOptional()
+	attrs["state"] = attrs["state"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("OK", "TRIGGERED", "UNKNOWN"))
 	attrs["trigger_time"] = attrs["trigger_time"].SetOptional()
 	attrs["update_time"] = attrs["update_time"].SetOptional()
 
@@ -261,7 +265,9 @@ func (newState *AlertCondition) SyncEffectiveFieldsDuringRead(existingState Aler
 
 func (c AlertCondition) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["empty_result_state"] = attrs["empty_result_state"].SetOptional()
+	attrs["empty_result_state"] = attrs["empty_result_state"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("OK", "TRIGGERED", "UNKNOWN"))
 	attrs["op"] = attrs["op"].SetOptional()
+	attrs["op"] = attrs["op"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("EQUAL", "GREATER_THAN", "GREATER_THAN_OR_EQUAL", "IS_NULL", "LESS_THAN", "LESS_THAN_OR_EQUAL", "NOT_EQUAL"))
 	attrs["operand"] = attrs["operand"].SetOptional()
 	attrs["threshold"] = attrs["threshold"].SetOptional()
 
@@ -661,6 +667,7 @@ func (c AlertOptions) ApplySchemaCustomizations(attrs map[string]tfschema.Attrib
 	attrs["custom_body"] = attrs["custom_body"].SetOptional()
 	attrs["custom_subject"] = attrs["custom_subject"].SetOptional()
 	attrs["empty_result_state"] = attrs["empty_result_state"].SetOptional()
+	attrs["empty_result_state"] = attrs["empty_result_state"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ok", "triggered", "unknown"))
 	attrs["muted"] = attrs["muted"].SetOptional()
 	attrs["op"] = attrs["op"].SetRequired()
 	attrs["value"] = attrs["value"].SetRequired()
@@ -1043,6 +1050,7 @@ func (newState *Channel) SyncEffectiveFieldsDuringRead(existingState Channel) {
 func (c Channel) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["dbsql_version"] = attrs["dbsql_version"].SetOptional()
 	attrs["name"] = attrs["name"].SetOptional()
+	attrs["name"] = attrs["name"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CHANNEL_NAME_CURRENT", "CHANNEL_NAME_CUSTOM", "CHANNEL_NAME_PREVIEW", "CHANNEL_NAME_PREVIOUS"))
 
 	return attrs
 }
@@ -1097,6 +1105,7 @@ func (newState *ChannelInfo) SyncEffectiveFieldsDuringRead(existingState Channel
 func (c ChannelInfo) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["dbsql_version"] = attrs["dbsql_version"].SetOptional()
 	attrs["name"] = attrs["name"].SetOptional()
+	attrs["name"] = attrs["name"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CHANNEL_NAME_CURRENT", "CHANNEL_NAME_CUSTOM", "CHANNEL_NAME_PREVIEW", "CHANNEL_NAME_PREVIOUS"))
 
 	return attrs
 }
@@ -1257,6 +1266,7 @@ func (c ColumnInfo) ApplySchemaCustomizations(attrs map[string]tfschema.Attribut
 	attrs["position"] = attrs["position"].SetOptional()
 	attrs["type_interval_type"] = attrs["type_interval_type"].SetOptional()
 	attrs["type_name"] = attrs["type_name"].SetOptional()
+	attrs["type_name"] = attrs["type_name"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ARRAY", "BINARY", "BOOLEAN", "BYTE", "CHAR", "DATE", "DECIMAL", "DOUBLE", "FLOAT", "INT", "INTERVAL", "LONG", "MAP", "NULL", "SHORT", "STRING", "STRUCT", "TIMESTAMP", "USER_DEFINED_TYPE"))
 	attrs["type_precision"] = attrs["type_precision"].SetOptional()
 	attrs["type_scale"] = attrs["type_scale"].SetOptional()
 	attrs["type_text"] = attrs["type_text"].SetOptional()
@@ -1725,6 +1735,7 @@ func (c CreateQueryRequestQuery) ApplySchemaCustomizations(attrs map[string]tfsc
 	attrs["parent_path"] = attrs["parent_path"].SetOptional()
 	attrs["query_text"] = attrs["query_text"].SetOptional()
 	attrs["run_as_mode"] = attrs["run_as_mode"].SetOptional()
+	attrs["run_as_mode"] = attrs["run_as_mode"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("OWNER", "VIEWER"))
 	attrs["schema"] = attrs["schema"].SetOptional()
 	attrs["tags"] = attrs["tags"].SetOptional()
 	attrs["warehouse_id"] = attrs["warehouse_id"].SetOptional()
@@ -2130,8 +2141,10 @@ func (c CreateWarehouseRequest) ApplySchemaCustomizations(attrs map[string]tfsch
 	attrs["min_num_clusters"] = attrs["min_num_clusters"].SetOptional()
 	attrs["name"] = attrs["name"].SetOptional()
 	attrs["spot_instance_policy"] = attrs["spot_instance_policy"].SetOptional()
+	attrs["spot_instance_policy"] = attrs["spot_instance_policy"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("COST_OPTIMIZED", "POLICY_UNSPECIFIED", "RELIABILITY_OPTIMIZED"))
 	attrs["tags"] = attrs["tags"].SetOptional()
 	attrs["warehouse_type"] = attrs["warehouse_type"].SetOptional()
+	attrs["warehouse_type"] = attrs["warehouse_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CLASSIC", "PRO", "TYPE_UNSPECIFIED"))
 
 	return attrs
 }
@@ -2470,6 +2483,7 @@ func (c Dashboard) ApplySchemaCustomizations(attrs map[string]tfschema.Attribute
 	attrs["options"] = attrs["options"].SetOptional()
 	attrs["parent"] = attrs["parent"].SetOptional()
 	attrs["permission_tier"] = attrs["permission_tier"].SetOptional()
+	attrs["permission_tier"] = attrs["permission_tier"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_EDIT", "CAN_MANAGE", "CAN_RUN", "CAN_VIEW"))
 	attrs["slug"] = attrs["slug"].SetOptional()
 	attrs["tags"] = attrs["tags"].SetOptional()
 	attrs["updated_at"] = attrs["updated_at"].SetOptional()
@@ -2683,6 +2697,7 @@ func (c DashboardEditContent) ApplySchemaCustomizations(attrs map[string]tfschem
 	attrs["dashboard_id"] = attrs["dashboard_id"].SetRequired()
 	attrs["name"] = attrs["name"].SetOptional()
 	attrs["run_as_role"] = attrs["run_as_role"].SetOptional()
+	attrs["run_as_role"] = attrs["run_as_role"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("owner", "viewer"))
 	attrs["tags"] = attrs["tags"].SetOptional()
 
 	return attrs
@@ -2836,6 +2851,7 @@ func (c DashboardPostContent) ApplySchemaCustomizations(attrs map[string]tfschem
 	attrs["name"] = attrs["name"].SetRequired()
 	attrs["parent"] = attrs["parent"].SetOptional()
 	attrs["run_as_role"] = attrs["run_as_role"].SetOptional()
+	attrs["run_as_role"] = attrs["run_as_role"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("owner", "viewer"))
 	attrs["tags"] = attrs["tags"].SetOptional()
 
 	return attrs
@@ -3080,7 +3096,9 @@ func (newState *DateRangeValue) SyncEffectiveFieldsDuringRead(existingState Date
 func (c DateRangeValue) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["date_range_value"] = attrs["date_range_value"].SetOptional()
 	attrs["dynamic_date_range_value"] = attrs["dynamic_date_range_value"].SetOptional()
+	attrs["dynamic_date_range_value"] = attrs["dynamic_date_range_value"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("LAST_12_MONTHS", "LAST_14_DAYS", "LAST_24_HOURS", "LAST_30_DAYS", "LAST_60_DAYS", "LAST_7_DAYS", "LAST_8_HOURS", "LAST_90_DAYS", "LAST_HOUR", "LAST_MONTH", "LAST_WEEK", "LAST_YEAR", "THIS_MONTH", "THIS_WEEK", "THIS_YEAR", "TODAY", "YESTERDAY"))
 	attrs["precision"] = attrs["precision"].SetOptional()
+	attrs["precision"] = attrs["precision"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DAY_PRECISION", "MINUTE_PRECISION", "SECOND_PRECISION"))
 	attrs["start_day_of_week"] = attrs["start_day_of_week"].SetOptional()
 
 	return attrs
@@ -3172,7 +3190,9 @@ func (newState *DateValue) SyncEffectiveFieldsDuringRead(existingState DateValue
 func (c DateValue) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["date_value"] = attrs["date_value"].SetOptional()
 	attrs["dynamic_date_value"] = attrs["dynamic_date_value"].SetOptional()
+	attrs["dynamic_date_value"] = attrs["dynamic_date_value"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("NOW", "YESTERDAY"))
 	attrs["precision"] = attrs["precision"].SetOptional()
+	attrs["precision"] = attrs["precision"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DAY_PRECISION", "MINUTE_PRECISION", "SECOND_PRECISION"))
 
 	return attrs
 }
@@ -3720,8 +3740,10 @@ func (c EditWarehouseRequest) ApplySchemaCustomizations(attrs map[string]tfschem
 	attrs["min_num_clusters"] = attrs["min_num_clusters"].SetOptional()
 	attrs["name"] = attrs["name"].SetOptional()
 	attrs["spot_instance_policy"] = attrs["spot_instance_policy"].SetOptional()
+	attrs["spot_instance_policy"] = attrs["spot_instance_policy"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("COST_OPTIMIZED", "POLICY_UNSPECIFIED", "RELIABILITY_OPTIMIZED"))
 	attrs["tags"] = attrs["tags"].SetOptional()
 	attrs["warehouse_type"] = attrs["warehouse_type"].SetOptional()
+	attrs["warehouse_type"] = attrs["warehouse_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CLASSIC", "PRO", "TYPE_UNSPECIFIED"))
 
 	return attrs
 }
@@ -4004,6 +4026,7 @@ func (c EndpointHealth) ApplySchemaCustomizations(attrs map[string]tfschema.Attr
 	attrs["failure_reason"] = attrs["failure_reason"].SetOptional()
 	attrs["message"] = attrs["message"].SetOptional()
 	attrs["status"] = attrs["status"].SetOptional()
+	attrs["status"] = attrs["status"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DEGRADED", "FAILED", "HEALTHY", "STATUS_UNSPECIFIED"))
 	attrs["summary"] = attrs["summary"].SetOptional()
 
 	return attrs
@@ -4179,9 +4202,12 @@ func (c EndpointInfo) ApplySchemaCustomizations(attrs map[string]tfschema.Attrib
 	attrs["num_clusters"] = attrs["num_clusters"].SetOptional()
 	attrs["odbc_params"] = attrs["odbc_params"].SetOptional()
 	attrs["spot_instance_policy"] = attrs["spot_instance_policy"].SetOptional()
+	attrs["spot_instance_policy"] = attrs["spot_instance_policy"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("COST_OPTIMIZED", "POLICY_UNSPECIFIED", "RELIABILITY_OPTIMIZED"))
 	attrs["state"] = attrs["state"].SetOptional()
+	attrs["state"] = attrs["state"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DELETED", "DELETING", "RUNNING", "STARTING", "STOPPED", "STOPPING"))
 	attrs["tags"] = attrs["tags"].SetOptional()
 	attrs["warehouse_type"] = attrs["warehouse_type"].SetOptional()
+	attrs["warehouse_type"] = attrs["warehouse_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CLASSIC", "PRO", "TYPE_UNSPECIFIED"))
 
 	return attrs
 }
@@ -4754,8 +4780,11 @@ func (c ExecuteStatementRequest) ApplySchemaCustomizations(attrs map[string]tfsc
 	attrs["byte_limit"] = attrs["byte_limit"].SetOptional()
 	attrs["catalog"] = attrs["catalog"].SetOptional()
 	attrs["disposition"] = attrs["disposition"].SetOptional()
+	attrs["disposition"] = attrs["disposition"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("EXTERNAL_LINKS", "INLINE"))
 	attrs["format"] = attrs["format"].SetOptional()
+	attrs["format"] = attrs["format"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ARROW_STREAM", "CSV", "JSON_ARRAY"))
 	attrs["on_wait_timeout"] = attrs["on_wait_timeout"].SetOptional()
+	attrs["on_wait_timeout"] = attrs["on_wait_timeout"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CANCEL", "CONTINUE"))
 	attrs["parameters"] = attrs["parameters"].SetOptional()
 	attrs["row_limit"] = attrs["row_limit"].SetOptional()
 	attrs["schema"] = attrs["schema"].SetOptional()
@@ -5640,9 +5669,12 @@ func (c GetWarehouseResponse) ApplySchemaCustomizations(attrs map[string]tfschem
 	attrs["num_clusters"] = attrs["num_clusters"].SetOptional()
 	attrs["odbc_params"] = attrs["odbc_params"].SetOptional()
 	attrs["spot_instance_policy"] = attrs["spot_instance_policy"].SetOptional()
+	attrs["spot_instance_policy"] = attrs["spot_instance_policy"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("COST_OPTIMIZED", "POLICY_UNSPECIFIED", "RELIABILITY_OPTIMIZED"))
 	attrs["state"] = attrs["state"].SetOptional()
+	attrs["state"] = attrs["state"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DELETED", "DELETING", "RUNNING", "STARTING", "STOPPED", "STOPPING"))
 	attrs["tags"] = attrs["tags"].SetOptional()
 	attrs["warehouse_type"] = attrs["warehouse_type"].SetOptional()
+	attrs["warehouse_type"] = attrs["warehouse_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CLASSIC", "PRO", "TYPE_UNSPECIFIED"))
 
 	return attrs
 }
@@ -5876,6 +5908,7 @@ func (c GetWorkspaceWarehouseConfigResponse) ApplySchemaCustomizations(attrs map
 	attrs["google_service_account"] = attrs["google_service_account"].SetOptional()
 	attrs["instance_profile_arn"] = attrs["instance_profile_arn"].SetOptional()
 	attrs["security_policy"] = attrs["security_policy"].SetOptional()
+	attrs["security_policy"] = attrs["security_policy"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DATA_ACCESS_CONTROL", "NONE", "PASSTHROUGH"))
 	attrs["sql_configuration_parameters"] = attrs["sql_configuration_parameters"].SetOptional()
 
 	return attrs
@@ -6148,6 +6181,7 @@ func (c LegacyAlert) ApplySchemaCustomizations(attrs map[string]tfschema.Attribu
 	attrs["query"] = attrs["query"].SetOptional()
 	attrs["rearm"] = attrs["rearm"].SetOptional()
 	attrs["state"] = attrs["state"].SetOptional()
+	attrs["state"] = attrs["state"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ok", "triggered", "unknown"))
 	attrs["updated_at"] = attrs["updated_at"].SetOptional()
 	attrs["user"] = attrs["user"].SetOptional()
 
@@ -6387,9 +6421,11 @@ func (c LegacyQuery) ApplySchemaCustomizations(attrs map[string]tfschema.Attribu
 	attrs["options"] = attrs["options"].SetOptional()
 	attrs["parent"] = attrs["parent"].SetOptional()
 	attrs["permission_tier"] = attrs["permission_tier"].SetOptional()
+	attrs["permission_tier"] = attrs["permission_tier"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_EDIT", "CAN_MANAGE", "CAN_RUN", "CAN_VIEW"))
 	attrs["query"] = attrs["query"].SetOptional()
 	attrs["query_hash"] = attrs["query_hash"].SetOptional()
 	attrs["run_as_role"] = attrs["run_as_role"].SetOptional()
+	attrs["run_as_role"] = attrs["run_as_role"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("owner", "viewer"))
 	attrs["tags"] = attrs["tags"].SetOptional()
 	attrs["updated_at"] = attrs["updated_at"].SetOptional()
 	attrs["user"] = attrs["user"].SetOptional()
@@ -6923,11 +6959,13 @@ func (c ListAlertsResponseAlert) ApplySchemaCustomizations(attrs map[string]tfsc
 	attrs["display_name"] = attrs["display_name"].SetOptional()
 	attrs["id"] = attrs["id"].SetOptional()
 	attrs["lifecycle_state"] = attrs["lifecycle_state"].SetOptional()
+	attrs["lifecycle_state"] = attrs["lifecycle_state"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ACTIVE", "TRASHED"))
 	attrs["notify_on_ok"] = attrs["notify_on_ok"].SetOptional()
 	attrs["owner_user_name"] = attrs["owner_user_name"].SetOptional()
 	attrs["query_id"] = attrs["query_id"].SetOptional()
 	attrs["seconds_to_retrigger"] = attrs["seconds_to_retrigger"].SetOptional()
 	attrs["state"] = attrs["state"].SetOptional()
+	attrs["state"] = attrs["state"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("OK", "TRIGGERED", "UNKNOWN"))
 	attrs["trigger_time"] = attrs["trigger_time"].SetOptional()
 	attrs["update_time"] = attrs["update_time"].SetOptional()
 
@@ -7478,10 +7516,12 @@ func (c ListQueryObjectsResponseQuery) ApplySchemaCustomizations(attrs map[strin
 	attrs["id"] = attrs["id"].SetOptional()
 	attrs["last_modifier_user_name"] = attrs["last_modifier_user_name"].SetOptional()
 	attrs["lifecycle_state"] = attrs["lifecycle_state"].SetOptional()
+	attrs["lifecycle_state"] = attrs["lifecycle_state"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ACTIVE", "TRASHED"))
 	attrs["owner_user_name"] = attrs["owner_user_name"].SetOptional()
 	attrs["parameters"] = attrs["parameters"].SetOptional()
 	attrs["query_text"] = attrs["query_text"].SetOptional()
 	attrs["run_as_mode"] = attrs["run_as_mode"].SetOptional()
+	attrs["run_as_mode"] = attrs["run_as_mode"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("OWNER", "VIEWER"))
 	attrs["schema"] = attrs["schema"].SetOptional()
 	attrs["tags"] = attrs["tags"].SetOptional()
 	attrs["update_time"] = attrs["update_time"].SetOptional()
@@ -8132,6 +8172,7 @@ func (c Parameter) ApplySchemaCustomizations(attrs map[string]tfschema.Attribute
 	attrs["queryId"] = attrs["queryId"].SetOptional()
 	attrs["title"] = attrs["title"].SetOptional()
 	attrs["type"] = attrs["type"].SetOptional()
+	attrs["type"] = attrs["type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("datetime", "enum", "number", "query", "text"))
 	attrs["value"] = attrs["value"].SetOptional()
 
 	return attrs
@@ -8264,11 +8305,13 @@ func (c Query) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuil
 	attrs["id"] = attrs["id"].SetOptional()
 	attrs["last_modifier_user_name"] = attrs["last_modifier_user_name"].SetOptional()
 	attrs["lifecycle_state"] = attrs["lifecycle_state"].SetOptional()
+	attrs["lifecycle_state"] = attrs["lifecycle_state"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ACTIVE", "TRASHED"))
 	attrs["owner_user_name"] = attrs["owner_user_name"].SetOptional()
 	attrs["parameters"] = attrs["parameters"].SetOptional()
 	attrs["parent_path"] = attrs["parent_path"].SetOptional()
 	attrs["query_text"] = attrs["query_text"].SetOptional()
 	attrs["run_as_mode"] = attrs["run_as_mode"].SetOptional()
+	attrs["run_as_mode"] = attrs["run_as_mode"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("OWNER", "VIEWER"))
 	attrs["schema"] = attrs["schema"].SetOptional()
 	attrs["tags"] = attrs["tags"].SetOptional()
 	attrs["update_time"] = attrs["update_time"].SetOptional()
@@ -8558,6 +8601,7 @@ func (c QueryEditContent) ApplySchemaCustomizations(attrs map[string]tfschema.At
 	attrs["query"] = attrs["query"].SetOptional()
 	attrs["query_id"] = attrs["query_id"].SetRequired()
 	attrs["run_as_role"] = attrs["run_as_role"].SetOptional()
+	attrs["run_as_role"] = attrs["run_as_role"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("owner", "viewer"))
 	attrs["tags"] = attrs["tags"].SetOptional()
 
 	return attrs
@@ -8923,6 +8967,7 @@ func (c QueryInfo) ApplySchemaCustomizations(attrs map[string]tfschema.Attribute
 	attrs["lookup_key"] = attrs["lookup_key"].SetOptional()
 	attrs["metrics"] = attrs["metrics"].SetOptional()
 	attrs["plans_state"] = attrs["plans_state"].SetOptional()
+	attrs["plans_state"] = attrs["plans_state"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("EMPTY", "EXISTS", "IGNORED_LARGE_PLANS_SIZE", "IGNORED_SMALL_DURATION", "IGNORED_SPARK_PLAN_TYPE", "UNKNOWN"))
 	attrs["query_end_time_ms"] = attrs["query_end_time_ms"].SetOptional()
 	attrs["query_id"] = attrs["query_id"].SetOptional()
 	attrs["query_start_time_ms"] = attrs["query_start_time_ms"].SetOptional()
@@ -8930,7 +8975,9 @@ func (c QueryInfo) ApplySchemaCustomizations(attrs map[string]tfschema.Attribute
 	attrs["rows_produced"] = attrs["rows_produced"].SetOptional()
 	attrs["spark_ui_url"] = attrs["spark_ui_url"].SetOptional()
 	attrs["statement_type"] = attrs["statement_type"].SetOptional()
+	attrs["statement_type"] = attrs["statement_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ALTER", "ANALYZE", "COPY", "CREATE", "DELETE", "DESCRIBE", "DROP", "EXPLAIN", "GRANT", "INSERT", "MERGE", "OPTIMIZE", "OTHER", "REFRESH", "REPLACE", "REVOKE", "SELECT", "SET", "SHOW", "TRUNCATE", "UPDATE", "USE"))
 	attrs["status"] = attrs["status"].SetOptional()
+	attrs["status"] = attrs["status"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CANCELED", "COMPILED", "COMPILING", "FAILED", "FINISHED", "QUEUED", "RUNNING", "STARTED"))
 	attrs["user_id"] = attrs["user_id"].SetOptional()
 	attrs["user_name"] = attrs["user_name"].SetOptional()
 	attrs["warehouse_id"] = attrs["warehouse_id"].SetOptional()
@@ -9728,6 +9775,7 @@ func (c QueryPostContent) ApplySchemaCustomizations(attrs map[string]tfschema.At
 	attrs["parent"] = attrs["parent"].SetOptional()
 	attrs["query"] = attrs["query"].SetOptional()
 	attrs["run_as_role"] = attrs["run_as_role"].SetOptional()
+	attrs["run_as_role"] = attrs["run_as_role"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("owner", "viewer"))
 	attrs["tags"] = attrs["tags"].SetOptional()
 
 	return attrs
@@ -10203,6 +10251,7 @@ func (newState *ResultManifest) SyncEffectiveFieldsDuringRead(existingState Resu
 func (c ResultManifest) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["chunks"] = attrs["chunks"].SetOptional()
 	attrs["format"] = attrs["format"].SetOptional()
+	attrs["format"] = attrs["format"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ARROW_STREAM", "CSV", "JSON_ARRAY"))
 	attrs["schema"] = attrs["schema"].SetOptional()
 	attrs["total_byte_count"] = attrs["total_byte_count"].SetOptional()
 	attrs["total_chunk_count"] = attrs["total_chunk_count"].SetOptional()
@@ -10411,6 +10460,7 @@ func (newState *ServiceError) SyncEffectiveFieldsDuringRead(existingState Servic
 
 func (c ServiceError) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["error_code"] = attrs["error_code"].SetOptional()
+	attrs["error_code"] = attrs["error_code"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ABORTED", "ALREADY_EXISTS", "BAD_REQUEST", "CANCELLED", "DEADLINE_EXCEEDED", "INTERNAL_ERROR", "IO_ERROR", "NOT_FOUND", "RESOURCE_EXHAUSTED", "SERVICE_UNDER_MAINTENANCE", "TEMPORARILY_UNAVAILABLE", "UNAUTHENTICATED", "UNKNOWN", "WORKSPACE_TEMPORARILY_UNAVAILABLE"))
 	attrs["message"] = attrs["message"].SetOptional()
 
 	return attrs
@@ -10640,6 +10690,7 @@ func (c SetWorkspaceWarehouseConfigRequest) ApplySchemaCustomizations(attrs map[
 	attrs["google_service_account"] = attrs["google_service_account"].SetOptional()
 	attrs["instance_profile_arn"] = attrs["instance_profile_arn"].SetOptional()
 	attrs["security_policy"] = attrs["security_policy"].SetOptional()
+	attrs["security_policy"] = attrs["security_policy"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DATA_ACCESS_CONTROL", "NONE", "PASSTHROUGH"))
 	attrs["sql_configuration_parameters"] = attrs["sql_configuration_parameters"].SetOptional()
 
 	return attrs
@@ -11227,6 +11278,7 @@ func (newState *StatementStatus) SyncEffectiveFieldsDuringRead(existingState Sta
 func (c StatementStatus) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["error"] = attrs["error"].SetOptional()
 	attrs["state"] = attrs["state"].SetOptional()
+	attrs["state"] = attrs["state"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CANCELED", "CLOSED", "FAILED", "PENDING", "RUNNING", "SUCCEEDED"))
 
 	return attrs
 }
@@ -11384,6 +11436,7 @@ func (newState *Success) SyncEffectiveFieldsDuringRead(existingState Success) {
 
 func (c Success) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["message"] = attrs["message"].SetOptional()
+	attrs["message"] = attrs["message"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("Success"))
 
 	return attrs
 }
@@ -11437,8 +11490,10 @@ func (newState *TerminationReason) SyncEffectiveFieldsDuringRead(existingState T
 
 func (c TerminationReason) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["code"] = attrs["code"].SetOptional()
+	attrs["code"] = attrs["code"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("ABUSE_DETECTED", "ATTACH_PROJECT_FAILURE", "AWS_AUTHORIZATION_FAILURE", "AWS_INSUFFICIENT_FREE_ADDRESSES_IN_SUBNET_FAILURE", "AWS_INSUFFICIENT_INSTANCE_CAPACITY_FAILURE", "AWS_MAX_SPOT_INSTANCE_COUNT_EXCEEDED_FAILURE", "AWS_REQUEST_LIMIT_EXCEEDED", "AWS_UNSUPPORTED_FAILURE", "AZURE_BYOK_KEY_PERMISSION_FAILURE", "AZURE_EPHEMERAL_DISK_FAILURE", "AZURE_INVALID_DEPLOYMENT_TEMPLATE", "AZURE_OPERATION_NOT_ALLOWED_EXCEPTION", "AZURE_QUOTA_EXCEEDED_EXCEPTION", "AZURE_RESOURCE_MANAGER_THROTTLING", "AZURE_RESOURCE_PROVIDER_THROTTLING", "AZURE_UNEXPECTED_DEPLOYMENT_TEMPLATE_FAILURE", "AZURE_VM_EXTENSION_FAILURE", "AZURE_VNET_CONFIGURATION_FAILURE", "BOOTSTRAP_TIMEOUT", "BOOTSTRAP_TIMEOUT_CLOUD_PROVIDER_EXCEPTION", "CLOUD_PROVIDER_DISK_SETUP_FAILURE", "CLOUD_PROVIDER_LAUNCH_FAILURE", "CLOUD_PROVIDER_RESOURCE_STOCKOUT", "CLOUD_PROVIDER_SHUTDOWN", "COMMUNICATION_LOST", "CONTAINER_LAUNCH_FAILURE", "CONTROL_PLANE_REQUEST_FAILURE", "DATABASE_CONNECTION_FAILURE", "DBFS_COMPONENT_UNHEALTHY", "DOCKER_IMAGE_PULL_FAILURE", "DRIVER_UNREACHABLE", "DRIVER_UNRESPONSIVE", "EXECUTION_COMPONENT_UNHEALTHY", "GCP_QUOTA_EXCEEDED", "GCP_SERVICE_ACCOUNT_DELETED", "GLOBAL_INIT_SCRIPT_FAILURE", "HIVE_METASTORE_PROVISIONING_FAILURE", "IMAGE_PULL_PERMISSION_DENIED", "INACTIVITY", "INIT_SCRIPT_FAILURE", "INSTANCE_POOL_CLUSTER_FAILURE", "INSTANCE_UNREACHABLE", "INTERNAL_ERROR", "INVALID_ARGUMENT", "INVALID_SPARK_IMAGE", "IP_EXHAUSTION_FAILURE", "JOB_FINISHED", "K8S_AUTOSCALING_FAILURE", "K8S_DBR_CLUSTER_LAUNCH_TIMEOUT", "METASTORE_COMPONENT_UNHEALTHY", "NEPHOS_RESOURCE_MANAGEMENT", "NETWORK_CONFIGURATION_FAILURE", "NFS_MOUNT_FAILURE", "NPIP_TUNNEL_SETUP_FAILURE", "NPIP_TUNNEL_TOKEN_FAILURE", "REQUEST_REJECTED", "REQUEST_THROTTLED", "SECRET_RESOLUTION_ERROR", "SECURITY_DAEMON_REGISTRATION_EXCEPTION", "SELF_BOOTSTRAP_FAILURE", "SKIPPED_SLOW_NODES", "SLOW_IMAGE_DOWNLOAD", "SPARK_ERROR", "SPARK_IMAGE_DOWNLOAD_FAILURE", "SPARK_STARTUP_FAILURE", "SPOT_INSTANCE_TERMINATION", "STORAGE_DOWNLOAD_FAILURE", "STS_CLIENT_SETUP_FAILURE", "SUBNET_EXHAUSTED_FAILURE", "TEMPORARILY_UNAVAILABLE", "TRIAL_EXPIRED", "UNEXPECTED_LAUNCH_FAILURE", "UNKNOWN", "UNSUPPORTED_INSTANCE_TYPE", "UPDATE_INSTANCE_PROFILE_FAILURE", "USER_REQUEST", "WORKER_SETUP_FAILURE", "WORKSPACE_CANCELLED_ERROR", "WORKSPACE_CONFIGURATION_ERROR"))
 	attrs["parameters"] = attrs["parameters"].SetOptional()
 	attrs["type"] = attrs["type"].SetOptional()
+	attrs["type"] = attrs["type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CLIENT_ERROR", "CLOUD_FAILURE", "SERVICE_FAULT", "SUCCESS"))
 
 	return attrs
 }
@@ -12162,6 +12217,7 @@ func (c UpdateQueryRequestQuery) ApplySchemaCustomizations(attrs map[string]tfsc
 	attrs["parameters"] = attrs["parameters"].SetOptional()
 	attrs["query_text"] = attrs["query_text"].SetOptional()
 	attrs["run_as_mode"] = attrs["run_as_mode"].SetOptional()
+	attrs["run_as_mode"] = attrs["run_as_mode"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("OWNER", "VIEWER"))
 	attrs["schema"] = attrs["schema"].SetOptional()
 	attrs["tags"] = attrs["tags"].SetOptional()
 	attrs["warehouse_id"] = attrs["warehouse_id"].SetOptional()
@@ -12637,6 +12693,7 @@ func (newState *WarehouseAccessControlRequest) SyncEffectiveFieldsDuringRead(exi
 func (c WarehouseAccessControlRequest) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["group_name"] = attrs["group_name"].SetOptional()
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_MANAGE", "CAN_MONITOR", "CAN_USE", "IS_OWNER"))
 	attrs["service_principal_name"] = attrs["service_principal_name"].SetOptional()
 	attrs["user_name"] = attrs["user_name"].SetOptional()
 
@@ -12796,6 +12853,7 @@ func (c WarehousePermission) ApplySchemaCustomizations(attrs map[string]tfschema
 	attrs["inherited"] = attrs["inherited"].SetOptional()
 	attrs["inherited_from_object"] = attrs["inherited_from_object"].SetOptional()
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_MANAGE", "CAN_MONITOR", "CAN_USE", "IS_OWNER"))
 
 	return attrs
 }
@@ -12967,6 +13025,7 @@ func (newState *WarehousePermissionsDescription) SyncEffectiveFieldsDuringRead(e
 func (c WarehousePermissionsDescription) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["description"] = attrs["description"].SetOptional()
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_MANAGE", "CAN_MONITOR", "CAN_USE", "IS_OWNER"))
 
 	return attrs
 }
@@ -13103,6 +13162,7 @@ func (newState *WarehouseTypePair) SyncEffectiveFieldsDuringRead(existingState W
 func (c WarehouseTypePair) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["enabled"] = attrs["enabled"].SetOptional()
 	attrs["warehouse_type"] = attrs["warehouse_type"].SetOptional()
+	attrs["warehouse_type"] = attrs["warehouse_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CLASSIC", "PRO", "TYPE_UNSPECIFIED"))
 
 	return attrs
 }

--- a/internal/service/vectorsearch_tf/legacy_model.go
+++ b/internal/service/vectorsearch_tf/legacy_model.go
@@ -18,6 +18,7 @@ import (
 	"github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/tfschema"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
@@ -86,6 +87,7 @@ func (newState *CreateEndpoint_SdkV2) SyncEffectiveFieldsDuringRead(existingStat
 
 func (c CreateEndpoint_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["endpoint_type"] = attrs["endpoint_type"].SetRequired()
+	attrs["endpoint_type"] = attrs["endpoint_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("STANDARD"))
 	attrs["name"] = attrs["name"].SetRequired()
 
 	return attrs
@@ -160,6 +162,7 @@ func (c CreateVectorIndexRequest_SdkV2) ApplySchemaCustomizations(attrs map[stri
 	attrs["direct_access_index_spec"] = attrs["direct_access_index_spec"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["endpoint_name"] = attrs["endpoint_name"].SetRequired()
 	attrs["index_type"] = attrs["index_type"].SetRequired()
+	attrs["index_type"] = attrs["index_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DELTA_SYNC", "DIRECT_ACCESS"))
 	attrs["name"] = attrs["name"].SetRequired()
 	attrs["primary_key"] = attrs["primary_key"].SetRequired()
 
@@ -531,6 +534,7 @@ func (c DeleteDataVectorIndexResponse_SdkV2) ApplySchemaCustomizations(attrs map
 	attrs["result"] = attrs["result"].SetOptional()
 	attrs["result"] = attrs["result"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["status"] = attrs["status"].SetOptional()
+	attrs["status"] = attrs["status"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("FAILURE", "PARTIAL_SUCCESS", "SUCCESS"))
 
 	return attrs
 }
@@ -772,6 +776,7 @@ func (c DeltaSyncVectorIndexSpecRequest_SdkV2) ApplySchemaCustomizations(attrs m
 	attrs["embedding_vector_columns"] = attrs["embedding_vector_columns"].SetOptional()
 	attrs["embedding_writeback_table"] = attrs["embedding_writeback_table"].SetOptional()
 	attrs["pipeline_type"] = attrs["pipeline_type"].SetOptional()
+	attrs["pipeline_type"] = attrs["pipeline_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CONTINUOUS", "TRIGGERED"))
 	attrs["source_table"] = attrs["source_table"].SetOptional()
 
 	return attrs
@@ -941,6 +946,7 @@ func (c DeltaSyncVectorIndexSpecResponse_SdkV2) ApplySchemaCustomizations(attrs 
 	attrs["embedding_writeback_table"] = attrs["embedding_writeback_table"].SetOptional()
 	attrs["pipeline_id"] = attrs["pipeline_id"].SetOptional()
 	attrs["pipeline_type"] = attrs["pipeline_type"].SetOptional()
+	attrs["pipeline_type"] = attrs["pipeline_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CONTINUOUS", "TRIGGERED"))
 	attrs["source_table"] = attrs["source_table"].SetOptional()
 
 	return attrs
@@ -1307,6 +1313,7 @@ func (c EndpointInfo_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.
 	attrs["endpoint_status"] = attrs["endpoint_status"].SetOptional()
 	attrs["endpoint_status"] = attrs["endpoint_status"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["endpoint_type"] = attrs["endpoint_type"].SetOptional()
+	attrs["endpoint_type"] = attrs["endpoint_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("STANDARD"))
 	attrs["id"] = attrs["id"].SetOptional()
 	attrs["last_updated_timestamp"] = attrs["last_updated_timestamp"].SetOptional()
 	attrs["last_updated_user"] = attrs["last_updated_user"].SetOptional()
@@ -1410,6 +1417,7 @@ func (newState *EndpointStatus_SdkV2) SyncEffectiveFieldsDuringRead(existingStat
 func (c EndpointStatus_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["message"] = attrs["message"].SetOptional()
 	attrs["state"] = attrs["state"].SetOptional()
+	attrs["state"] = attrs["state"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("OFFLINE", "ONLINE", "PROVISIONING"))
 
 	return attrs
 }
@@ -1958,6 +1966,7 @@ func (c MiniVectorIndex_SdkV2) ApplySchemaCustomizations(attrs map[string]tfsche
 	attrs["creator"] = attrs["creator"].SetOptional()
 	attrs["endpoint_name"] = attrs["endpoint_name"].SetOptional()
 	attrs["index_type"] = attrs["index_type"].SetOptional()
+	attrs["index_type"] = attrs["index_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DELTA_SYNC", "DIRECT_ACCESS"))
 	attrs["name"] = attrs["name"].SetOptional()
 	attrs["primary_key"] = attrs["primary_key"].SetOptional()
 
@@ -2947,6 +2956,7 @@ func (c UpsertDataVectorIndexResponse_SdkV2) ApplySchemaCustomizations(attrs map
 	attrs["result"] = attrs["result"].SetOptional()
 	attrs["result"] = attrs["result"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["status"] = attrs["status"].SetOptional()
+	attrs["status"] = attrs["status"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("FAILURE", "PARTIAL_SUCCESS", "SUCCESS"))
 
 	return attrs
 }
@@ -3186,6 +3196,7 @@ func (c VectorIndex_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.A
 	attrs["direct_access_index_spec"] = attrs["direct_access_index_spec"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["endpoint_name"] = attrs["endpoint_name"].SetOptional()
 	attrs["index_type"] = attrs["index_type"].SetOptional()
+	attrs["index_type"] = attrs["index_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DELTA_SYNC", "DIRECT_ACCESS"))
 	attrs["name"] = attrs["name"].SetOptional()
 	attrs["primary_key"] = attrs["primary_key"].SetOptional()
 	attrs["status"] = attrs["status"].SetOptional()

--- a/internal/service/vectorsearch_tf/model.go
+++ b/internal/service/vectorsearch_tf/model.go
@@ -17,6 +17,7 @@ import (
 	pluginfwcommon "github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/common"
 	"github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/tfschema"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
@@ -85,6 +86,7 @@ func (newState *CreateEndpoint) SyncEffectiveFieldsDuringRead(existingState Crea
 
 func (c CreateEndpoint) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["endpoint_type"] = attrs["endpoint_type"].SetRequired()
+	attrs["endpoint_type"] = attrs["endpoint_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("STANDARD"))
 	attrs["name"] = attrs["name"].SetRequired()
 
 	return attrs
@@ -157,6 +159,7 @@ func (c CreateVectorIndexRequest) ApplySchemaCustomizations(attrs map[string]tfs
 	attrs["direct_access_index_spec"] = attrs["direct_access_index_spec"].SetOptional()
 	attrs["endpoint_name"] = attrs["endpoint_name"].SetRequired()
 	attrs["index_type"] = attrs["index_type"].SetRequired()
+	attrs["index_type"] = attrs["index_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DELTA_SYNC", "DIRECT_ACCESS"))
 	attrs["name"] = attrs["name"].SetRequired()
 	attrs["primary_key"] = attrs["primary_key"].SetRequired()
 
@@ -526,6 +529,7 @@ func (newState *DeleteDataVectorIndexResponse) SyncEffectiveFieldsDuringRead(exi
 func (c DeleteDataVectorIndexResponse) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["result"] = attrs["result"].SetOptional()
 	attrs["status"] = attrs["status"].SetOptional()
+	attrs["status"] = attrs["status"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("FAILURE", "PARTIAL_SUCCESS", "SUCCESS"))
 
 	return attrs
 }
@@ -767,6 +771,7 @@ func (c DeltaSyncVectorIndexSpecRequest) ApplySchemaCustomizations(attrs map[str
 	attrs["embedding_vector_columns"] = attrs["embedding_vector_columns"].SetOptional()
 	attrs["embedding_writeback_table"] = attrs["embedding_writeback_table"].SetOptional()
 	attrs["pipeline_type"] = attrs["pipeline_type"].SetOptional()
+	attrs["pipeline_type"] = attrs["pipeline_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CONTINUOUS", "TRIGGERED"))
 	attrs["source_table"] = attrs["source_table"].SetOptional()
 
 	return attrs
@@ -936,6 +941,7 @@ func (c DeltaSyncVectorIndexSpecResponse) ApplySchemaCustomizations(attrs map[st
 	attrs["embedding_writeback_table"] = attrs["embedding_writeback_table"].SetOptional()
 	attrs["pipeline_id"] = attrs["pipeline_id"].SetOptional()
 	attrs["pipeline_type"] = attrs["pipeline_type"].SetOptional()
+	attrs["pipeline_type"] = attrs["pipeline_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CONTINUOUS", "TRIGGERED"))
 	attrs["source_table"] = attrs["source_table"].SetOptional()
 
 	return attrs
@@ -1301,6 +1307,7 @@ func (c EndpointInfo) ApplySchemaCustomizations(attrs map[string]tfschema.Attrib
 	attrs["creator"] = attrs["creator"].SetOptional()
 	attrs["endpoint_status"] = attrs["endpoint_status"].SetOptional()
 	attrs["endpoint_type"] = attrs["endpoint_type"].SetOptional()
+	attrs["endpoint_type"] = attrs["endpoint_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("STANDARD"))
 	attrs["id"] = attrs["id"].SetOptional()
 	attrs["last_updated_timestamp"] = attrs["last_updated_timestamp"].SetOptional()
 	attrs["last_updated_user"] = attrs["last_updated_user"].SetOptional()
@@ -1404,6 +1411,7 @@ func (newState *EndpointStatus) SyncEffectiveFieldsDuringRead(existingState Endp
 func (c EndpointStatus) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["message"] = attrs["message"].SetOptional()
 	attrs["state"] = attrs["state"].SetOptional()
+	attrs["state"] = attrs["state"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("OFFLINE", "ONLINE", "PROVISIONING"))
 
 	return attrs
 }
@@ -1951,6 +1959,7 @@ func (c MiniVectorIndex) ApplySchemaCustomizations(attrs map[string]tfschema.Att
 	attrs["creator"] = attrs["creator"].SetOptional()
 	attrs["endpoint_name"] = attrs["endpoint_name"].SetOptional()
 	attrs["index_type"] = attrs["index_type"].SetOptional()
+	attrs["index_type"] = attrs["index_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DELTA_SYNC", "DIRECT_ACCESS"))
 	attrs["name"] = attrs["name"].SetOptional()
 	attrs["primary_key"] = attrs["primary_key"].SetOptional()
 
@@ -2937,6 +2946,7 @@ func (newState *UpsertDataVectorIndexResponse) SyncEffectiveFieldsDuringRead(exi
 func (c UpsertDataVectorIndexResponse) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["result"] = attrs["result"].SetOptional()
 	attrs["status"] = attrs["status"].SetOptional()
+	attrs["status"] = attrs["status"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("FAILURE", "PARTIAL_SUCCESS", "SUCCESS"))
 
 	return attrs
 }
@@ -3172,6 +3182,7 @@ func (c VectorIndex) ApplySchemaCustomizations(attrs map[string]tfschema.Attribu
 	attrs["direct_access_index_spec"] = attrs["direct_access_index_spec"].SetOptional()
 	attrs["endpoint_name"] = attrs["endpoint_name"].SetOptional()
 	attrs["index_type"] = attrs["index_type"].SetOptional()
+	attrs["index_type"] = attrs["index_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DELTA_SYNC", "DIRECT_ACCESS"))
 	attrs["name"] = attrs["name"].SetOptional()
 	attrs["primary_key"] = attrs["primary_key"].SetOptional()
 	attrs["status"] = attrs["status"].SetOptional()

--- a/internal/service/workspace_tf/legacy_model.go
+++ b/internal/service/workspace_tf/legacy_model.go
@@ -18,6 +18,7 @@ import (
 	"github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/tfschema"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
@@ -38,6 +39,7 @@ func (newState *AclItem_SdkV2) SyncEffectiveFieldsDuringRead(existingState AclIt
 
 func (c AclItem_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["permission"] = attrs["permission"].SetRequired()
+	attrs["permission"] = attrs["permission"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("MANAGE", "READ", "WRITE"))
 	attrs["principal"] = attrs["principal"].SetRequired()
 
 	return attrs
@@ -495,6 +497,7 @@ func (c CreateScope_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.A
 	attrs["initial_manage_principal"] = attrs["initial_manage_principal"].SetOptional()
 	attrs["scope"] = attrs["scope"].SetRequired()
 	attrs["scope_backend_type"] = attrs["scope_backend_type"].SetOptional()
+	attrs["scope_backend_type"] = attrs["scope_backend_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("AZURE_KEYVAULT", "DATABRICKS"))
 
 	return attrs
 }
@@ -2040,7 +2043,9 @@ func (newState *Import_SdkV2) SyncEffectiveFieldsDuringRead(existingState Import
 func (c Import_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["content"] = attrs["content"].SetOptional()
 	attrs["format"] = attrs["format"].SetOptional()
+	attrs["format"] = attrs["format"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("AUTO", "DBC", "HTML", "JUPYTER", "RAW", "R_MARKDOWN", "SOURCE"))
 	attrs["language"] = attrs["language"].SetOptional()
+	attrs["language"] = attrs["language"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("PYTHON", "R", "SCALA", "SQL"))
 	attrs["overwrite"] = attrs["overwrite"].SetOptional()
 	attrs["path"] = attrs["path"].SetRequired()
 
@@ -2886,9 +2891,11 @@ func (newState *ObjectInfo_SdkV2) SyncEffectiveFieldsDuringRead(existingState Ob
 func (c ObjectInfo_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["created_at"] = attrs["created_at"].SetOptional()
 	attrs["language"] = attrs["language"].SetOptional()
+	attrs["language"] = attrs["language"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("PYTHON", "R", "SCALA", "SQL"))
 	attrs["modified_at"] = attrs["modified_at"].SetOptional()
 	attrs["object_id"] = attrs["object_id"].SetOptional()
 	attrs["object_type"] = attrs["object_type"].SetOptional()
+	attrs["object_type"] = attrs["object_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DASHBOARD", "DIRECTORY", "FILE", "LIBRARY", "NOTEBOOK", "REPO"))
 	attrs["path"] = attrs["path"].SetOptional()
 	attrs["resource_id"] = attrs["resource_id"].SetOptional()
 	attrs["size"] = attrs["size"].SetOptional()
@@ -2958,6 +2965,7 @@ func (newState *PutAcl_SdkV2) SyncEffectiveFieldsDuringRead(existingState PutAcl
 
 func (c PutAcl_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["permission"] = attrs["permission"].SetRequired()
+	attrs["permission"] = attrs["permission"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("MANAGE", "READ", "WRITE"))
 	attrs["principal"] = attrs["principal"].SetRequired()
 	attrs["scope"] = attrs["scope"].SetRequired()
 
@@ -3142,6 +3150,7 @@ func (newState *RepoAccessControlRequest_SdkV2) SyncEffectiveFieldsDuringRead(ex
 func (c RepoAccessControlRequest_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["group_name"] = attrs["group_name"].SetOptional()
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_EDIT", "CAN_MANAGE", "CAN_READ", "CAN_RUN"))
 	attrs["service_principal_name"] = attrs["service_principal_name"].SetOptional()
 	attrs["user_name"] = attrs["user_name"].SetOptional()
 
@@ -3411,6 +3420,7 @@ func (c RepoPermission_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschem
 	attrs["inherited"] = attrs["inherited"].SetOptional()
 	attrs["inherited_from_object"] = attrs["inherited_from_object"].SetOptional()
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_EDIT", "CAN_MANAGE", "CAN_READ", "CAN_RUN"))
 
 	return attrs
 }
@@ -3582,6 +3592,7 @@ func (newState *RepoPermissionsDescription_SdkV2) SyncEffectiveFieldsDuringRead(
 func (c RepoPermissionsDescription_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["description"] = attrs["description"].SetOptional()
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_EDIT", "CAN_MANAGE", "CAN_READ", "CAN_RUN"))
 
 	return attrs
 }
@@ -3771,6 +3782,7 @@ func (newState *SecretScope_SdkV2) SyncEffectiveFieldsDuringRead(existingState S
 
 func (c SecretScope_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["backend_type"] = attrs["backend_type"].SetOptional()
+	attrs["backend_type"] = attrs["backend_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("AZURE_KEYVAULT", "DATABRICKS"))
 	attrs["keyvault_metadata"] = attrs["keyvault_metadata"].SetOptional()
 	attrs["keyvault_metadata"] = attrs["keyvault_metadata"].(tfschema.ListNestedAttributeBuilder).AddValidator(listvalidator.SizeAtMost(1)).(tfschema.AttributeBuilder)
 	attrs["name"] = attrs["name"].SetOptional()
@@ -4283,6 +4295,7 @@ func (newState *WorkspaceObjectAccessControlRequest_SdkV2) SyncEffectiveFieldsDu
 func (c WorkspaceObjectAccessControlRequest_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["group_name"] = attrs["group_name"].SetOptional()
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_EDIT", "CAN_MANAGE", "CAN_READ", "CAN_RUN"))
 	attrs["service_principal_name"] = attrs["service_principal_name"].SetOptional()
 	attrs["user_name"] = attrs["user_name"].SetOptional()
 
@@ -4442,6 +4455,7 @@ func (c WorkspaceObjectPermission_SdkV2) ApplySchemaCustomizations(attrs map[str
 	attrs["inherited"] = attrs["inherited"].SetOptional()
 	attrs["inherited_from_object"] = attrs["inherited_from_object"].SetOptional()
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_EDIT", "CAN_MANAGE", "CAN_READ", "CAN_RUN"))
 
 	return attrs
 }
@@ -4613,6 +4627,7 @@ func (newState *WorkspaceObjectPermissionsDescription_SdkV2) SyncEffectiveFields
 func (c WorkspaceObjectPermissionsDescription_SdkV2) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["description"] = attrs["description"].SetOptional()
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_EDIT", "CAN_MANAGE", "CAN_READ", "CAN_RUN"))
 
 	return attrs
 }

--- a/internal/service/workspace_tf/model.go
+++ b/internal/service/workspace_tf/model.go
@@ -17,6 +17,7 @@ import (
 	pluginfwcommon "github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/common"
 	"github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/tfschema"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
@@ -37,6 +38,7 @@ func (newState *AclItem) SyncEffectiveFieldsDuringRead(existingState AclItem) {
 
 func (c AclItem) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["permission"] = attrs["permission"].SetRequired()
+	attrs["permission"] = attrs["permission"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("MANAGE", "READ", "WRITE"))
 	attrs["principal"] = attrs["principal"].SetRequired()
 
 	return attrs
@@ -491,6 +493,7 @@ func (c CreateScope) ApplySchemaCustomizations(attrs map[string]tfschema.Attribu
 	attrs["initial_manage_principal"] = attrs["initial_manage_principal"].SetOptional()
 	attrs["scope"] = attrs["scope"].SetRequired()
 	attrs["scope_backend_type"] = attrs["scope_backend_type"].SetOptional()
+	attrs["scope_backend_type"] = attrs["scope_backend_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("AZURE_KEYVAULT", "DATABRICKS"))
 
 	return attrs
 }
@@ -2035,7 +2038,9 @@ func (newState *Import) SyncEffectiveFieldsDuringRead(existingState Import) {
 func (c Import) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["content"] = attrs["content"].SetOptional()
 	attrs["format"] = attrs["format"].SetOptional()
+	attrs["format"] = attrs["format"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("AUTO", "DBC", "HTML", "JUPYTER", "RAW", "R_MARKDOWN", "SOURCE"))
 	attrs["language"] = attrs["language"].SetOptional()
+	attrs["language"] = attrs["language"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("PYTHON", "R", "SCALA", "SQL"))
 	attrs["overwrite"] = attrs["overwrite"].SetOptional()
 	attrs["path"] = attrs["path"].SetRequired()
 
@@ -2881,9 +2886,11 @@ func (newState *ObjectInfo) SyncEffectiveFieldsDuringRead(existingState ObjectIn
 func (c ObjectInfo) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["created_at"] = attrs["created_at"].SetOptional()
 	attrs["language"] = attrs["language"].SetOptional()
+	attrs["language"] = attrs["language"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("PYTHON", "R", "SCALA", "SQL"))
 	attrs["modified_at"] = attrs["modified_at"].SetOptional()
 	attrs["object_id"] = attrs["object_id"].SetOptional()
 	attrs["object_type"] = attrs["object_type"].SetOptional()
+	attrs["object_type"] = attrs["object_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("DASHBOARD", "DIRECTORY", "FILE", "LIBRARY", "NOTEBOOK", "REPO"))
 	attrs["path"] = attrs["path"].SetOptional()
 	attrs["resource_id"] = attrs["resource_id"].SetOptional()
 	attrs["size"] = attrs["size"].SetOptional()
@@ -2953,6 +2960,7 @@ func (newState *PutAcl) SyncEffectiveFieldsDuringRead(existingState PutAcl) {
 
 func (c PutAcl) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["permission"] = attrs["permission"].SetRequired()
+	attrs["permission"] = attrs["permission"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("MANAGE", "READ", "WRITE"))
 	attrs["principal"] = attrs["principal"].SetRequired()
 	attrs["scope"] = attrs["scope"].SetRequired()
 
@@ -3137,6 +3145,7 @@ func (newState *RepoAccessControlRequest) SyncEffectiveFieldsDuringRead(existing
 func (c RepoAccessControlRequest) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["group_name"] = attrs["group_name"].SetOptional()
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_EDIT", "CAN_MANAGE", "CAN_READ", "CAN_RUN"))
 	attrs["service_principal_name"] = attrs["service_principal_name"].SetOptional()
 	attrs["user_name"] = attrs["user_name"].SetOptional()
 
@@ -3405,6 +3414,7 @@ func (c RepoPermission) ApplySchemaCustomizations(attrs map[string]tfschema.Attr
 	attrs["inherited"] = attrs["inherited"].SetOptional()
 	attrs["inherited_from_object"] = attrs["inherited_from_object"].SetOptional()
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_EDIT", "CAN_MANAGE", "CAN_READ", "CAN_RUN"))
 
 	return attrs
 }
@@ -3576,6 +3586,7 @@ func (newState *RepoPermissionsDescription) SyncEffectiveFieldsDuringRead(existi
 func (c RepoPermissionsDescription) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["description"] = attrs["description"].SetOptional()
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_EDIT", "CAN_MANAGE", "CAN_READ", "CAN_RUN"))
 
 	return attrs
 }
@@ -3765,6 +3776,7 @@ func (newState *SecretScope) SyncEffectiveFieldsDuringRead(existingState SecretS
 
 func (c SecretScope) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["backend_type"] = attrs["backend_type"].SetOptional()
+	attrs["backend_type"] = attrs["backend_type"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("AZURE_KEYVAULT", "DATABRICKS"))
 	attrs["keyvault_metadata"] = attrs["keyvault_metadata"].SetOptional()
 	attrs["name"] = attrs["name"].SetOptional()
 
@@ -4275,6 +4287,7 @@ func (newState *WorkspaceObjectAccessControlRequest) SyncEffectiveFieldsDuringRe
 func (c WorkspaceObjectAccessControlRequest) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["group_name"] = attrs["group_name"].SetOptional()
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_EDIT", "CAN_MANAGE", "CAN_READ", "CAN_RUN"))
 	attrs["service_principal_name"] = attrs["service_principal_name"].SetOptional()
 	attrs["user_name"] = attrs["user_name"].SetOptional()
 
@@ -4434,6 +4447,7 @@ func (c WorkspaceObjectPermission) ApplySchemaCustomizations(attrs map[string]tf
 	attrs["inherited"] = attrs["inherited"].SetOptional()
 	attrs["inherited_from_object"] = attrs["inherited_from_object"].SetOptional()
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_EDIT", "CAN_MANAGE", "CAN_READ", "CAN_RUN"))
 
 	return attrs
 }
@@ -4605,6 +4619,7 @@ func (newState *WorkspaceObjectPermissionsDescription) SyncEffectiveFieldsDuring
 func (c WorkspaceObjectPermissionsDescription) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
 	attrs["description"] = attrs["description"].SetOptional()
 	attrs["permission_level"] = attrs["permission_level"].SetOptional()
+	attrs["permission_level"] = attrs["permission_level"].(tfschema.StringAttributeBuilder).AddValidator(stringvalidator.OneOf("CAN_EDIT", "CAN_MANAGE", "CAN_READ", "CAN_RUN"))
 
 	return attrs
 }


### PR DESCRIPTION
## Changes
Many fields in the various requests and responses of the Databricks REST API are enums. Attributes in the TF provider corresponding to enums are string types, and users enter the string value of the enum value that they want to specify. Today, there is no validation that the specified attribute value is actually one of the allowed enum values. This could result in confusing behavior: in SDKv2-based resources, the enum value is likely passed through to the REST API, where it would be considered "UNKNOWN" and likely rejected; and in plugin framework-based resources, the enum value will fail to be converted from the TFSDK structure to the Go SDK.

To provide a better experience, we can validate upfront that the plan only contains valid enum values for such attributes. This way, the failure is much more user-friendly and it happens earlier in the cycle (plan, as opposed to apply).

One key point is that as the API supports new enum values, existing provider versions will no longer be able to use them without upgrading. This may present friction in adoption of new enum values for users. My hypothesis is that this slightly increased friction may be worth the improved user experience.

One point we will also need to verify is that output-only fields (i.e. computed, non-optional, non-required) are still allowed to take on any value (e.g. a `state` attribute if a new state is introduced). There is no point in validating these fields, since users cannot specify them in Terraform, and they are not included in any requests to the REST API.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] using Go SDK
- [ ] using TF Plugin Framework
