### PR TITLE
[Fix] Increase `databricks_library` installation timeout from 15m to 30m

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New Features and Improvements
 
  * Support updating `options` in `databricks_catalog` ([#4476](https://github.com/databricks/terraform-provider-databricks/pull/4476)).
+ * Increase `databricks_library` timeout from 15m to 30m.
 
 ### Bug Fixes
 

--- a/internal/providers/pluginfw/products/library/resource_library.go
+++ b/internal/providers/pluginfw/products/library/resource_library.go
@@ -29,7 +29,7 @@ import (
 )
 
 const resourceName = "library"
-const libraryDefaultInstallationTimeout = 15 * time.Minute
+const libraryDefaultInstallationTimeout = 30 * time.Minute
 
 var _ resource.ResourceWithConfigure = &LibraryResource{}
 


### PR DESCRIPTION
## Changes
Currently, `databricks_library` waits for 15m for libraries to install. We received a report that this was a bit too short for some use cases. For now, I'll bump this up to 30m to mitigate the issue faced by this customer.

The long-term plan to fix this should be based on adopting https://developer.hashicorp.com/terraform/plugin/framework/resources/timeouts in our provider.

## Tests

I did not do any tests for this change.
