### PR TITLE
[Fix] Share Reordering Issue

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -8,6 +8,7 @@
  * Increase `databricks_library` timeout from 15m to 30m.
 
 ### Bug Fixes
+ * Fixed an issue where reordering objects in a (pluginfw) Share wouldn’t update properly unless other changes were made ([#4481](https://github.com/databricks/terraform-provider-databricks/pull/4481)).
 
 ### Documentation
 

--- a/internal/providers/pluginfw/products/sharing/resource_acc_test.go
+++ b/internal/providers/pluginfw/products/sharing/resource_acc_test.go
@@ -202,3 +202,35 @@ func TestUcAccUpdateShareAddObject(t *testing.T) {
 		}`,
 	})
 }
+
+func TestUcAccUpdateShareReorderObject(t *testing.T) {
+	acceptance.UnityWorkspaceLevel(t, acceptance.Step{
+		Template: preTestTemplate + preTestTemplateUpdate +
+			`resource "databricks_share_pluginframework" "myshare" {
+			name  = "{var.STICKY_RANDOM}-terraform-delta-share"
+			owner = "account users"
+			object {
+				name = databricks_table.mytable.id
+				data_object_type = "TABLE"
+			}
+			object {
+				name = databricks_table.mytable_3.id
+				data_object_type = "TABLE"
+			}
+		}`,
+	}, acceptance.Step{
+		Template: preTestTemplate + preTestTemplateUpdate +
+			`resource "databricks_share_pluginframework" "myshare" {
+			name  = "{var.STICKY_RANDOM}-terraform-delta-share"
+			owner = "account users"
+			object {
+				name = databricks_table.mytable_3.id
+				data_object_type = "TABLE"
+			}
+			object {
+				name = databricks_table.mytable.id
+				data_object_type = "TABLE"
+			}
+		}`,
+	})
+}

--- a/internal/providers/pluginfw/products/sharing/resource_share.go
+++ b/internal/providers/pluginfw/products/sharing/resource_share.go
@@ -346,9 +346,10 @@ func (r *ShareResource) Update(ctx context.Context, req resource.UpdateRequest, 
 		}
 	}
 
+	upToDateShareInfo := currentShareInfo
 	if len(changes) > 0 {
 		// if there are any other changes, update the share with the changes
-		updatedShareInfo, err := client.Shares.Update(ctx, sharing.UpdateShare{
+		upToDateShareInfo, err = client.Shares.Update(ctx, sharing.UpdateShare{
 			Name:    plan.Name.ValueString(),
 			Updates: changes,
 		})
@@ -371,11 +372,12 @@ func (r *ShareResource) Update(ctx context.Context, req resource.UpdateRequest, 
 			}
 		}
 
-		matchOrder(updatedShareInfo.Objects, planGoSDK.Objects, func(obj sharing.SharedDataObject) string { return obj.Name })
-		resp.Diagnostics.Append(converters.GoSdkToTfSdkStruct(ctx, updatedShareInfo, &state)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
+	}
+
+	matchOrder(upToDateShareInfo.Objects, planGoSDK.Objects, func(obj sharing.SharedDataObject) string { return obj.Name })
+	resp.Diagnostics.Append(converters.GoSdkToTfSdkStruct(ctx, upToDateShareInfo, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
 	state, d := r.syncEffectiveFields(ctx, plan, state, effectiveFieldsActionCreateOrUpdate{})


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
This PR fixes an issue where reordering objects in a (pluginfw) Share would fail unless other changes were made to the objects. The bug caused the new order to be ignored if no additional modifications were present. With this fix, reordering now correctly updates the Share, whether or not other changes are made.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] using Go SDK
- [ ] using TF Plugin Framework
