### PR TITLE
[Internal] Remove prefix from github reference

### DIFF
--- a/tagging.py
+++ b/tagging.py
@@ -31,7 +31,7 @@ class GitHubRepo:
     def __init__(self, repo: Repository):
         self.repo = repo
         self.changed_files: list[InputGitTreeElement] = []
-        self.ref = "refs/heads/main"
+        self.ref = "heads/main"
         head_ref = self.repo.get_git_ref(self.ref)
         self.sha = head_ref.object.sha
 


### PR DESCRIPTION
## Changes
Remove prefix from github reference. 
GitHub API requires the full reference, but the PyGitHub library adds it automatically.


## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] using Go SDK
- [ ] using TF Plugin Framework

NO_CHANGELOG=true

