### PR TITLE
[Internal] Fix relative path for tagging workflow

### DIFF
--- a/tagging.py
+++ b/tagging.py
@@ -37,7 +37,8 @@ class GitHubRepo:
 
     # Replaces "git add file"
     def add_file(self, loc: str, content: str):
-        local_path = os.path.relpath(os.getcwd(), loc)
+        local_path = os.path.relpath(loc, os.getcwd())
+        print(f"Adding file {local_path}")
         blob = self.repo.create_git_blob(content=content, encoding="utf-8")
         element = InputGitTreeElement(path=local_path, mode="100644", type="blob", sha=blob.sha)
         self.changed_files.append(element)


### PR DESCRIPTION
## Changes
Fix relative path for tagging workflow

## Tests
Run script locally (commenting the API calls)
```
Processing package 
adding file CHANGELOG.md
adding file NEXT_CHANGELOG.md
adding file common/version.go
adding file .release_metadata.json
```

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] using Go SDK
- [ ] using TF Plugin Framework

NO_CHANGELOG=true
