### PR TITLE
[Exporter] Fix matching on `workspace_path` and refactoring

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -11,5 +11,6 @@
 ### Exporter
 
  * Explicitly abort execution via `panic` if list of users can't be fetched ([#4500](https://github.com/databricks/terraform-provider-databricks/pull/4500)).
+ * Fix matching on `workspace_path` and refactoring ([#4504](https://github.com/databricks/terraform-provider-databricks/pull/4504)).
 
 ### Internal Changes

--- a/exporter/impl_jobs.go
+++ b/exporter/impl_jobs.go
@@ -148,13 +148,7 @@ func importTask(ic *importContext, task sdk_jobs.Task, jobName, rID string) {
 	}
 	ic.emitLibraries(task.Libraries)
 
-	if task.WebhookNotifications != nil {
-		ic.emitJobsDestinationNotifications(task.WebhookNotifications.OnFailure)
-		ic.emitJobsDestinationNotifications(task.WebhookNotifications.OnSuccess)
-		ic.emitJobsDestinationNotifications(task.WebhookNotifications.OnDurationWarningThresholdExceeded)
-		ic.emitJobsDestinationNotifications(task.WebhookNotifications.OnStart)
-		ic.emitJobsDestinationNotifications(task.WebhookNotifications.OnStreamingBacklogExceeded)
-	}
+	emitWebhookNotifications(ic, task.WebhookNotifications)
 	if task.EmailNotifications != nil {
 		ic.emitListOfUsers(task.EmailNotifications.OnDurationWarningThresholdExceeded)
 		ic.emitListOfUsers(task.EmailNotifications.OnFailure)
@@ -199,19 +193,23 @@ func importJob(ic *importContext, r *resource) error {
 		ic.emitListOfUsers(job.EmailNotifications.OnSuccess)
 		ic.emitListOfUsers(job.EmailNotifications.OnStreamingBacklogExceeded)
 	}
-	if job.WebhookNotifications != nil {
-		ic.emitJobsDestinationNotifications(job.WebhookNotifications.OnFailure)
-		ic.emitJobsDestinationNotifications(job.WebhookNotifications.OnSuccess)
-		ic.emitJobsDestinationNotifications(job.WebhookNotifications.OnDurationWarningThresholdExceeded)
-		ic.emitJobsDestinationNotifications(job.WebhookNotifications.OnStart)
-		ic.emitJobsDestinationNotifications(job.WebhookNotifications.OnStreamingBacklogExceeded)
-	}
+	emitWebhookNotifications(ic, job.WebhookNotifications)
 	for _, param := range job.Parameters {
 		ic.emitIfWsfsFile(param.Default)
 		ic.emitIfVolumeFile(param.Default)
 	}
 
 	return ic.importLibraries(r.Data, s)
+}
+
+func emitWebhookNotifications(ic *importContext, notifications *sdk_jobs.WebhookNotifications) {
+	if notifications != nil {
+		ic.emitJobsDestinationNotifications(notifications.OnFailure)
+		ic.emitJobsDestinationNotifications(notifications.OnSuccess)
+		ic.emitJobsDestinationNotifications(notifications.OnDurationWarningThresholdExceeded)
+		ic.emitJobsDestinationNotifications(notifications.OnStart)
+		ic.emitJobsDestinationNotifications(notifications.OnStreamingBacklogExceeded)
+	}
 }
 
 func listJobs(ic *importContext) error {

--- a/exporter/importables.go
+++ b/exporter/importables.go
@@ -328,7 +328,7 @@ var resourcesMap map[string]importable = map[string]importable{
 			ic.importCluster(&c)
 			ic.emitPermissionsIfNotIgnored(r, fmt.Sprintf("/clusters/%s", r.ID),
 				"cluster_"+ic.Importables["databricks_cluster"].Name(ic, r.Data))
-			return ic.importClusterLibraries(r.Data, s)
+			return ic.importClusterLibraries(r.Data)
 		},
 		ShouldOmitField: makeShouldOmitFieldForCluster(nil),
 	},
@@ -1369,15 +1369,17 @@ var resourcesMap map[string]importable = map[string]importable{
 		Depends: []reference{
 			{Path: "warehouse_id", Resource: "databricks_sql_endpoint"},
 			{Path: "parameter.query_backed_value.query_id", Resource: "databricks_query", Match: "id"},
-			{Path: "owner_user_name", Resource: "databricks_user", Match: "user_name", MatchType: MatchCaseInsensitive},
-			{Path: "owner_user_name", Resource: "databricks_service_principal", Match: "application_id"},
 			{Path: "catalog", Resource: "databricks_catalog"},
 			{Path: "schema", Resource: "databricks_schema", Match: "name",
 				IsValidApproximation: createIsMatchingCatalogAndSchema("catalog", "schema"),
 				SkipDirectLookup:     true},
 			// TODO: add match like for workspace files?
+			{Path: "parent_path", Resource: "databricks_user", Match: "home"},
+			{Path: "parent_path", Resource: "databricks_service_principal", Match: "home"},
 			{Path: "parent_path", Resource: "databricks_directory"},
 			{Path: "parent_path", Resource: "databricks_directory", Match: "workspace_path"},
+			{Path: "owner_user_name", Resource: "databricks_service_principal", Match: "application_id"},
+			{Path: "owner_user_name", Resource: "databricks_user", Match: "user_name", MatchType: MatchCaseInsensitive},
 			// TODO: add support for Repos?
 		},
 	},
@@ -1496,11 +1498,13 @@ var resourcesMap map[string]importable = map[string]importable{
 		Ignore: generateIgnoreObjectWithEmptyAttributeValue("databricks_alert", "display_name"),
 		Depends: []reference{
 			{Path: "query_id", Resource: "databricks_query"},
-			{Path: "owner_user_name", Resource: "databricks_user", Match: "user_name", MatchType: MatchCaseInsensitive},
-			{Path: "owner_user_name", Resource: "databricks_service_principal", Match: "application_id"},
 			// TODO: add match like for workspace files?
+			{Path: "parent_path", Resource: "databricks_user", Match: "home"},
+			{Path: "parent_path", Resource: "databricks_service_principal", Match: "home"},
 			{Path: "parent_path", Resource: "databricks_directory"},
 			{Path: "parent_path", Resource: "databricks_directory", Match: "workspace_path"},
+			{Path: "owner_user_name", Resource: "databricks_service_principal", Match: "application_id"},
+			{Path: "owner_user_name", Resource: "databricks_user", Match: "user_name", MatchType: MatchCaseInsensitive},
 		},
 	},
 	"databricks_pipeline": {
@@ -2482,9 +2486,10 @@ var resourcesMap map[string]importable = map[string]importable{
 		Depends: []reference{
 			{Path: "file_path", File: true},
 			{Path: "warehouse_id", Resource: "databricks_sql_endpoint"},
-			{Path: "parent_path", Resource: "databricks_directory"},
 			{Path: "parent_path", Resource: "databricks_user", Match: "home"},
-			{Path: "parent_path", Resource: "databricks_service_principal"},
+			{Path: "parent_path", Resource: "databricks_service_principal", Match: "home"},
+			{Path: "parent_path", Resource: "databricks_directory"},
+			{Path: "parent_path", Resource: "databricks_directory", Match: "workspace_path"},
 		},
 	},
 	"databricks_notification_destination": {

--- a/exporter/util.go
+++ b/exporter/util.go
@@ -484,7 +484,7 @@ func makeNamePlusIdFunc(nm string) func(ic *importContext, d *schema.ResourceDat
 
 func makeNameOrIdFunc(nm string) func(ic *importContext, d *schema.ResourceData) string {
 	return func(ic *importContext, d *schema.ResourceData) string {
-		name := d.Get("name").(string)
+		name := d.Get(nm).(string)
 		if name == "" {
 			return d.Id()
 		}

--- a/exporter/util_compute.go
+++ b/exporter/util_compute.go
@@ -47,21 +47,25 @@ func (ic *importContext) emitSecretsFromSecretsPathMap(m map[string]string) {
 
 func (ic *importContext) emitLibraries(libs []compute.Library) {
 	for _, lib := range libs {
-		// Files on DBFS
-		ic.emitIfDbfsFile(lib.Whl)
-		ic.emitIfDbfsFile(lib.Jar)
-		ic.emitIfDbfsFile(lib.Egg)
-		// Files on WSFS
-		ic.emitIfWsfsFile(lib.Whl)
-		ic.emitIfWsfsFile(lib.Jar)
-		ic.emitIfWsfsFile(lib.Egg)
-		ic.emitIfWsfsFile(lib.Requirements)
-		// Files on UC Volumes
-		ic.emitIfVolumeFile(lib.Whl)
-		// TODO: we should emit UC allow list as well
-		ic.emitIfVolumeFile(lib.Jar)
-		ic.emitIfVolumeFile(lib.Requirements)
+		ic.emitLibrary(&lib)
 	}
+}
+
+func (ic *importContext) emitLibrary(lib *compute.Library) {
+	// Files on DBFS
+	ic.emitIfDbfsFile(lib.Whl)
+	ic.emitIfDbfsFile(lib.Jar)
+	ic.emitIfDbfsFile(lib.Egg)
+	// Files on WSFS
+	ic.emitIfWsfsFile(lib.Whl)
+	ic.emitIfWsfsFile(lib.Jar)
+	ic.emitIfWsfsFile(lib.Egg)
+	ic.emitIfWsfsFile(lib.Requirements)
+	// Files on UC Volumes
+	ic.emitIfVolumeFile(lib.Whl)
+	// TODO: we should emit UC allow list as well
+	ic.emitIfVolumeFile(lib.Jar)
+	ic.emitIfVolumeFile(lib.Requirements)
 }
 
 func (ic *importContext) importLibraries(d *schema.ResourceData, s map[string]*schema.Schema) error {
@@ -71,22 +75,16 @@ func (ic *importContext) importLibraries(d *schema.ResourceData, s map[string]*s
 	return nil
 }
 
-func (ic *importContext) importClusterLibraries(d *schema.ResourceData, s map[string]*schema.Schema) error {
+func (ic *importContext) importClusterLibraries(d *schema.ResourceData) error {
 	libraries := ic.workspaceClient.Libraries
 	cll, err := libraries.ClusterStatusByClusterId(ic.Context, d.Id())
 	if err != nil {
 		return err
 	}
 	for _, lib := range cll.LibraryStatuses {
-		ic.emitIfDbfsFile(lib.Library.Egg)
-		ic.emitIfDbfsFile(lib.Library.Jar)
-		ic.emitIfDbfsFile(lib.Library.Whl)
-		// Files on UC Volumes
-		ic.emitIfVolumeFile(lib.Library.Whl)
-		ic.emitIfVolumeFile(lib.Library.Jar)
-		// Files on WSFS
-		ic.emitIfWsfsFile(lib.Library.Whl)
-		ic.emitIfWsfsFile(lib.Library.Jar)
+		if lib.Library != nil {
+			ic.emitLibrary(lib.Library)
+		}
 	}
 	return nil
 }

--- a/exporter/util_workspace.go
+++ b/exporter/util_workspace.go
@@ -133,6 +133,7 @@ func (ic *importContext) emitWorkspaceObject(objType, path string) {
 }
 
 func (ic *importContext) emitDirectoryOrRepo(path string) {
+	log.Printf("[DEBUG] Emitting directory or repo for %s", path)
 	ic.emitWorkspaceObject("databricks_directory", path)
 }
 
@@ -246,6 +247,9 @@ func (ic *importContext) maybeEmitWorkspaceObject(resourceType, path string, obj
 			}
 			if data != nil {
 				data = ic.generateNewData(data, resourceType, path, obj)
+				if data != nil {
+					workspace.SetWorkspaceObjectComputedProperties(data, ic.Client)
+				}
 			}
 		}
 		ic.Emit(&resource{

--- a/workspace/resource_directory.go
+++ b/workspace/resource_directory.go
@@ -60,7 +60,7 @@ func ResourceDirectory() common.Resource {
 		if err != nil {
 			return err
 		}
-		d.Set("workspace_path", "/Workspace"+d.Id())
+		SetWorkspaceObjectComputedProperties(d, c)
 		return nil
 	}
 

--- a/workspace/resource_notebook.go
+++ b/workspace/resource_notebook.go
@@ -221,7 +221,7 @@ func (a NotebooksAPI) Delete(path string, recursive bool) error {
 	}, nil)
 }
 
-func setComputedProperties(d *schema.ResourceData, c *common.DatabricksClient) {
+func SetWorkspaceObjectComputedProperties(d *schema.ResourceData, c *common.DatabricksClient) {
 	d.Set("url", c.FormatURL("#workspace", d.Id()))
 	d.Set("workspace_path", "/Workspace"+d.Id())
 }
@@ -326,7 +326,7 @@ func ResourceNotebook() common.Resource {
 			}
 			d.Set("object_id", resp.ObjectID)
 			d.SetId(path)
-			setComputedProperties(d, c)
+			SetWorkspaceObjectComputedProperties(d, c)
 			return nil
 		},
 		Read: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
@@ -351,7 +351,7 @@ func ResourceNotebook() common.Resource {
 			if err != nil {
 				return err
 			}
-			setComputedProperties(d, c)
+			SetWorkspaceObjectComputedProperties(d, c)
 			err = common.StructToData(objectStatus, s, d)
 			if err != nil {
 				return err
@@ -390,7 +390,7 @@ func ResourceNotebook() common.Resource {
 				return err
 			}
 			d.Set("object_id", resp.ObjectID)
-			setComputedProperties(d, c)
+			SetWorkspaceObjectComputedProperties(d, c)
 			return nil
 		},
 		Delete: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {

--- a/workspace/resource_workspace_file.go
+++ b/workspace/resource_workspace_file.go
@@ -78,8 +78,7 @@ func ResourceWorkspaceFile() common.Resource {
 			if err != nil {
 				return err
 			}
-			d.Set("url", c.FormatURL("#workspace", d.Id()))
-			d.Set("workspace_path", "/Workspace"+objectStatus.Path)
+			SetWorkspaceObjectComputedProperties(d, c)
 			return common.StructToData(objectStatus, s, d)
 		},
 		Update: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

During optimization of workspace objects handling we started to generate WS resources directly, but forgot to set properties like `workspace_path` that are used in the matching, so no references were generated (not critical, but still incorrect).  It did happen only when notebooks/directories were listed in the same execution.

Also refactored code a bit to avoid code duplicates, and improve matching.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] using Go SDK
- [ ] using TF Plugin Framework
