### PR TITLE
[Doc] Improve documentation for databricks_cluster and databricks_clusters

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Documentation
 
+ * Update `databricks_cluster` and `databricks_clusters` data source documentation.
+
 ### Exporter
 
  * Explicitly abort execution via `panic` if list of users can't be fetched ([#4500](https://github.com/databricks/terraform-provider-databricks/pull/4500)).

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Documentation
 
- * Update `databricks_cluster` and `databricks_clusters` data source documentation.
+ * Update `databricks_cluster` and `databricks_clusters` data source documentation ([#4506](https://github.com/databricks/terraform-provider-databricks/pull/4506)).
 
 ### Exporter
 

--- a/docs/data-sources/cluster.md
+++ b/docs/data-sources/cluster.md
@@ -22,10 +22,30 @@ data "databricks_cluster" "all" {
 
 ```
 
+### Multiple clusters with the same name
+
+When fetching a cluster whose name is not unique (including terminated but not permanently deleted clusters), you must use the `cluster_id` argument to uniquely identify the cluster. Combine this data source with `databricks_clusters` to get the `cluster_id` of the cluster you want to fetch.
+
+```hcl
+data "databricks_clusters" "my_cluster" {
+  cluster_name_contains = "my-cluster"
+  filter_by {
+    cluster_states = ["RUNNING"]
+    # Filter additionally on cluster sources if needed:
+    # cluster_sources = ["API"] # if created by Terraform or another API-based tool
+    # cluster_sources = ["UI"] # if created in the Databricks web interface
+  }
+}
+
+data "databricks_cluster" "my_cluster" {
+  cluster_id = data.databricks_clusters.my_cluster.ids[0]
+}
+```
+
 ## Argument Reference
 
-* `cluster_id` - (Required if `cluster_name` isn't specified) The id of the cluster
-* `cluster_name` - (Required if `cluster_id` isn't specified) The exact name of the cluster to search
+* `cluster_id` - (Required if `cluster_name` isn't specified) The id of the cluster.
+* `cluster_name` - (Required if `cluster_id` isn't specified) The exact name of the cluster to search. Can only be specified if there is exactly one cluster with the provided name.
 
 ## Attribute Reference
 

--- a/docs/data-sources/clusters.md
+++ b/docs/data-sources/clusters.md
@@ -26,7 +26,7 @@ data "databricks_clusters" "all_shared" {
 
 ### Filtering clusters
 
-Filter clusters by state, source, or policy:
+Listing clusters can be slow for workspaces containing many clusters. Use filters to limit the number of clusters returned for better performance. You can filter clusters by state, source, policy, or pinned status:
 
 ```hcl
 data "databricks_clusters" "all_running_clusters" {
@@ -44,6 +44,12 @@ data "databricks_clusters" "all_clusters_with_policy" {
 data "databricks_clusters" "all_api_clusters" {
   filter_by {
     cluster_sources = ["API"]
+  }
+}
+
+data "databricks_clusters" "all_pinned_clusters" {
+  filter_by {
+    is_pinned = true
   }
 }
 ```

--- a/docs/data-sources/clusters.md
+++ b/docs/data-sources/clusters.md
@@ -24,6 +24,30 @@ data "databricks_clusters" "all_shared" {
 }
 ```
 
+### Filtering clusters
+
+Filter clusters by state, source, or policy:
+
+```hcl
+data "databricks_clusters" "all_running_clusters" {
+  filter_by {
+    cluster_states = ["RUNNING"]
+  }
+}
+
+data "databricks_clusters" "all_clusters_with_policy" {
+  filter_by {
+    policy_id = "1234-5678-9012"
+  }
+}
+
+data "databricks_clusters" "all_api_clusters" {
+  filter_by {
+    cluster_sources = ["API"]
+  }
+}
+```
+
 ## Argument Reference
 
 * `cluster_name_contains` - (Optional) Only return [databricks_cluster](../resources/cluster.md#cluster_id) ids that match the given name string.


### PR DESCRIPTION
## Changes
We get periodic questions about how to use `databricks_cluster` and `databricks_clusters`, both around performance and errors with multiple clusters with the same name. This PR adds some examples and extra documentation about how to use these resources.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] using Go SDK
- [ ] using TF Plugin Framework
