### PR TITLE
[Internal] Upgrade `staticcheck` to compatible with Go 1.24

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ fmt-docs:
 
 lint: vendor
 	@echo "✓ Linting source code with https://staticcheck.io/ ..."
-	@go run honnef.co/go/tools/cmd/staticcheck@v0.5.1 ./...
+	@go run honnef.co/go/tools/cmd/staticcheck@v0.6.0 ./...
 
 test: lint
 	@echo "✓ Running tests ..."


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

0.5.1 doesn't work with Go 1.24

NO_CHANGELOG=true

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] using Go SDK
- [ ] using TF Plugin Framework
