### PR TITLE
[Dependency] Bump to 1.24.0

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -16,4 +16,4 @@
 
 ### Internal Changes
 
- * Bump golange version to 1.24.0 ([#4508](https://github.com/databricks/terraform-provider-databricks/pull/4508)).
+ * Bump golang version to 1.24.0 ([#4508](https://github.com/databricks/terraform-provider-databricks/pull/4508)).

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -15,3 +15,5 @@
  * Explicitly abort execution via `panic` if list of users can't be fetched ([#4500](https://github.com/databricks/terraform-provider-databricks/pull/4500)).
 
 ### Internal Changes
+
+ * Bump golange version to 1.24.0 ([#4508](https://github.com/databricks/terraform-provider-databricks/pull/4508)).

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -174,7 +174,7 @@ func (a CommandsAPI) waitForCommandFinished(commandID, contextID, clusterID stri
 			return nil
 		}
 		log.Printf("[DEBUG] Command is in %s state", commandInfo.Status)
-		return resource.RetryableError(fmt.Errorf(commandInfo.Status))
+		return resource.RetryableError(fmt.Errorf("%s", commandInfo.Status))
 	})
 }
 

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -174,7 +174,7 @@ func (a CommandsAPI) waitForCommandFinished(commandID, contextID, clusterID stri
 			return nil
 		}
 		log.Printf("[DEBUG] Command is in %s state", commandInfo.Status)
-		return resource.RetryableError(fmt.Errorf("%s", commandInfo.Status))
+		return resource.RetryableError(errors.New(commandInfo.Status))
 	})
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/databricks/terraform-provider-databricks
 
-go 1.22.0
-
-toolchain go1.22.5
+go 1.24.0
 
 require (
 	github.com/databricks/databricks-sdk-go v0.58.1

--- a/mws/resource_mws_workspaces.go
+++ b/mws/resource_mws_workspaces.go
@@ -217,7 +217,7 @@ func (a WorkspacesAPI) verifyWorkspaceReachable(ws Workspace) *resource.RetryErr
 
 func (a WorkspacesAPI) explainWorkspaceFailure(ws Workspace) error {
 	if ws.NetworkID == "" {
-		return fmt.Errorf(ws.WorkspaceStatusMessage)
+		return fmt.Errorf("%s", ws.WorkspaceStatusMessage)
 	}
 	network, nerr := NewNetworksAPI(a.context, a.client).Read(ws.AccountID, ws.NetworkID)
 	if nerr != nil {
@@ -255,7 +255,7 @@ func (a WorkspacesAPI) WaitForRunning(ws Workspace, timeout time.Duration) error
 		default:
 			log.Printf("[INFO] Workspace %s is %s: %s", workspace.DeploymentName,
 				workspace.WorkspaceStatus, workspace.WorkspaceStatusMessage)
-			return resource.RetryableError(fmt.Errorf(workspace.WorkspaceStatusMessage))
+			return resource.RetryableError(fmt.Errorf("%s", workspace.WorkspaceStatusMessage))
 		}
 	})
 }

--- a/mws/resource_mws_workspaces.go
+++ b/mws/resource_mws_workspaces.go
@@ -217,7 +217,7 @@ func (a WorkspacesAPI) verifyWorkspaceReachable(ws Workspace) *resource.RetryErr
 
 func (a WorkspacesAPI) explainWorkspaceFailure(ws Workspace) error {
 	if ws.NetworkID == "" {
-		return fmt.Errorf("%s", ws.WorkspaceStatusMessage)
+		return errors.New(ws.WorkspaceStatusMessage)
 	}
 	network, nerr := NewNetworksAPI(a.context, a.client).Read(ws.AccountID, ws.NetworkID)
 	if nerr != nil {


### PR DESCRIPTION
## Changes
Let's upgrade the version of go we use to latest, so we can take advantages of new language features like range expressions and the iter library.

## Tests

Existing tests should cover this.