### PR TITLE
[Doc] Small fix to docs for data source `databricks_cluster`

### DIFF
--- a/docs/data-sources/cluster.md
+++ b/docs/data-sources/cluster.md
@@ -38,7 +38,7 @@ data "databricks_clusters" "my_cluster" {
 }
 
 data "databricks_cluster" "my_cluster" {
-  cluster_id = data.databricks_clusters.my_cluster.ids[0]
+  cluster_id = tolist(data.databricks_clusters.my_cluster.ids)[0]
 }
 ```
 


### PR DESCRIPTION
## Changes
The `ids` field is a set type, so you can't index into it. You can, however, convert it to a list first, then index into it.

## Tests
Ran the following template locally, and this did not fail:

```hcl
data "databricks_clusters" "my_cluster" {
  filter_by {
    cluster_states = ["RUNNING"]
  }
}

data "databricks_cluster" "my_cluster" {
  cluster_id = tolist(data.databricks_clusters.my_cluster.ids)[0]
}
```

NO_CHANGELOG=true