### PR TITLE
[Fix] Only allow `authorized_paths` to be updated in the `options` field of `databricks_catalog`

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Bug Fixes
 
+ * Only allow `authorized_paths` to be updated in the `options` field of `databricks_catalog`.
+
 ### Documentation
 
  * Update `databricks_cluster` and `databricks_clusters` data source documentation ([#4506](https://github.com/databricks/terraform-provider-databricks/pull/4506)).

--- a/catalog/catalog_test.go
+++ b/catalog/catalog_test.go
@@ -2,9 +2,11 @@ package catalog_test
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/databricks/terraform-provider-databricks/internal/acceptance"
+	"github.com/databricks/terraform-provider-databricks/qa"
 )
 
 func TestUcAccCatalog(t *testing.T) {
@@ -100,5 +102,105 @@ func TestUcAccCatalogUpdate(t *testing.T) {
 			%s
 			owner = "{env.TEST_METASTORE_ADMIN_GROUP_NAME}"
 		}`, getPredictiveOptimizationSetting(t, false)),
+	})
+}
+
+// Create a connection to an HMS catalog and update authorized_paths.
+func TestUcAccCatalogHmsConnectionUpdate(t *testing.T) {
+	authorizedPath := fmt.Sprintf("s3://%s/path/to/authorized", qa.RandomName("hms-bucket-"))
+	otherAuthorizedPath := fmt.Sprintf("s3://%s/path/to/authorized", qa.RandomName("hms-other-bucket-"))
+	otherInfra := fmt.Sprintf(`
+		resource "databricks_connection" "sandbox" {
+			name = "hms_connection{var.STICKY_RANDOM}"
+			connection_type = "HIVE_METASTORE"
+			comment         = "created in TestUcAccCatalogHmsConnectionUpdate"
+			options = {
+				host     = "test.mysql.database.azure.com"
+				port     = "3306"
+				user     = "user"
+				password = "password"
+				database = "metastore"
+				db_type  = "MYSQL"
+				version  = "2.3"
+			}
+			properties = {
+				purpose = "testing"
+			}
+		}
+		resource "databricks_storage_credential" "external" {
+			name = "cred-{var.STICKY_RANDOM}"
+			aws_iam_role {
+				role_arn = "{env.TEST_METASTORE_DATA_ACCESS_ARN}"
+			}
+			comment = "created in TestUcAccCatalogHmsConnectionUpdate"
+		}
+		resource "databricks_external_location" "sandbox" {
+		    name = "sandbox{var.STICKY_RANDOM}"
+			comment = "created in TestUcAccCatalogHmsConnectionUpdate"
+			url = "%s"
+			credential_name = "${databricks_storage_credential.external.name}"
+			skip_validation = true
+		}
+		resource "databricks_external_location" "sandbox-other" {
+		    name = "sandbox-other{var.STICKY_RANDOM}"
+			comment = "created in TestUcAccCatalogHmsConnectionUpdate"
+			url = "%s"
+			credential_name = "${databricks_storage_credential.external.name}"
+			skip_validation = true
+		}
+	`, authorizedPath, otherAuthorizedPath)
+	acceptance.LoadUcwsEnv(t)
+	acceptance.UnityWorkspaceLevel(t, acceptance.Step{
+		Template: otherInfra + fmt.Sprintf(`
+		resource "databricks_catalog" "sandbox" {
+			name           = "sandbox{var.STICKY_RANDOM}"
+			comment        = "created in TestUcAccCatalogHmsConnectionUpdate"
+			connection_name = "${databricks_connection.sandbox.name}"
+			options = {
+				authorized_paths = "%s"
+			}
+			lifecycle {
+			    prevent_destroy = true
+			}
+			depends_on = [databricks_external_location.sandbox, databricks_external_location.sandbox-other]
+		}`, authorizedPath),
+	}, acceptance.Step{
+		Template: otherInfra + fmt.Sprintf(`
+		resource "databricks_catalog" "sandbox" {
+			name           = "sandbox{var.STICKY_RANDOM}"
+			comment        = "created in TestUcAccCatalogHmsConnectionUpdate"
+			connection_name = "${databricks_connection.sandbox.name}"
+			options = {
+				authorized_paths = "%s,%s"
+			}
+			lifecycle {
+			    prevent_destroy = true
+			}
+		}`, authorizedPath, otherAuthorizedPath),
+	}, acceptance.Step{
+		Template: otherInfra + fmt.Sprintf(`
+		resource "databricks_catalog" "sandbox" {
+			name           = "sandbox{var.STICKY_RANDOM}"
+			comment        = "created in TestUcAccCatalogHmsConnectionUpdate"
+			connection_name = "${databricks_connection.sandbox.name}"
+			options = {
+				authorized_paths = "%s,%s"
+				other_option = "value"
+			}
+			lifecycle {
+			    prevent_destroy = true
+			}
+		}`, authorizedPath, otherAuthorizedPath),
+		ExpectError: regexp.MustCompile("Instance cannot be destroyed"),
+	}, acceptance.Step{
+		Template: otherInfra + fmt.Sprintf(`
+		resource "databricks_catalog" "sandbox" {
+			name           = "sandbox{var.STICKY_RANDOM}"
+			comment        = "created in TestUcAccCatalogHmsConnectionUpdate"
+			connection_name = "${databricks_connection.sandbox.name}"
+			options = {
+				authorized_paths = "%s,%s"
+			}
+		}`, authorizedPath, otherAuthorizedPath),
 	})
 }

--- a/catalog/catalog_test.go
+++ b/catalog/catalog_test.go
@@ -149,7 +149,6 @@ func TestUcAccCatalogHmsConnectionUpdate(t *testing.T) {
 			skip_validation = true
 		}
 	`, authorizedPath, otherAuthorizedPath)
-	acceptance.LoadUcwsEnv(t)
 	acceptance.UnityWorkspaceLevel(t, acceptance.Step{
 		Template: otherInfra + fmt.Sprintf(`
 		resource "databricks_catalog" "sandbox" {

--- a/catalog/resource_catalog.go
+++ b/catalog/resource_catalog.go
@@ -94,6 +94,8 @@ func ResourceCatalog() common.Resource {
 			var updateCatalogRequest catalog.UpdateCatalog
 			common.DataToStructPointer(d, catalogSchema, &updateCatalogRequest)
 			updateCatalogRequest.Name = d.Id()
+			// Options must be set in the create request only (aside from HMS-backed catalogs).
+			updateCatalogRequest.Options = nil
 			_, err = w.Catalogs.Update(ctx, updateCatalogRequest)
 			if err != nil {
 				return err

--- a/catalog/resource_catalog.go
+++ b/catalog/resource_catalog.go
@@ -204,5 +204,29 @@ func ResourceCatalog() common.Resource {
 			}
 			return w.Catalogs.Delete(ctx, catalog.DeleteCatalogRequest{Force: force, Name: d.Id()})
 		},
+		CustomizeDiff: func(ctx context.Context, d *schema.ResourceDiff) error {
+			// The only scenario in which we can update options is for the `authorized_paths` key. Any
+			// other changes to the options field will result in an error.
+			if d.HasChange("options") {
+				old, new := d.GetChange("options")
+				oldMap := old.(map[string]interface{})
+				newMap := new.(map[string]interface{})
+				delete(oldMap, "authorized_paths")
+				delete(newMap, "authorized_paths")
+				// If any attribute other than `authorized_paths` is removed, the resource should be recreated.
+				for k := range oldMap {
+					if _, ok := newMap[k]; !ok {
+						d.ForceNew("options." + k)
+					}
+				}
+				// If any attribute other than `authorized_paths` is added or changed, the resource should be recreated.
+				for k, v := range newMap {
+					if oldV, ok := oldMap[k]; !ok || oldV != v {
+						d.ForceNew("options." + k)
+					}
+				}
+			}
+			return nil
+		},
 	}
 }

--- a/internal/acceptance/init.go
+++ b/internal/acceptance/init.go
@@ -92,6 +92,7 @@ type Step struct {
 	Destroy                   bool
 	ExpectNonEmptyPlan        bool
 	ExpectError               *regexp.Regexp
+	ConfigPlanChecks          resource.ConfigPlanChecks
 	PlanOnly                  bool
 	PreventDiskCleanup        bool
 	PreventPostDestroyRefresh bool
@@ -219,6 +220,7 @@ func run(t *testing.T, steps []Step) {
 			Config:                               stepConfig,
 			Destroy:                              s.Destroy,
 			ExpectNonEmptyPlan:                   s.ExpectNonEmptyPlan,
+			ConfigPlanChecks:                     s.ConfigPlanChecks,
 			PlanOnly:                             s.PlanOnly,
 			PreventDiskCleanup:                   s.PreventDiskCleanup,
 			PreventPostDestroyRefresh:            s.PreventPostDestroyRefresh,


### PR DESCRIPTION
## Changes
There was a misunderstanding with the Unity Catalog API in connection with https://github.com/databricks/terraform-provider-databricks/pull/4476. Apparently, only `authorized_paths` is eligible for update in the UC Catalog API. Otherwise, any other changes to `options` must trigger resource recreation.

This PR customizes the logic of `databricks_catalog` to do this. To be specific:
* `CustomizeDiff` marks the `options` field as `ForceNew` if there is a key other than `authorized_paths` which was updated.
* The `Update` command removes any options that aren't `authorized_paths`. This might be the case in the future if other options are added for HMS catalogs that can be set at create time but not updated.
* The `Create` command removes any options from the `UpdateCatalog` RPC.

## Tests
Added two integration tests to verify the behavior of `databricks_catalog` update.
* Updated `TestUcAccCatalogUpdate` to verify that adding options with a key other than `authorized_paths` to a catalog defined without any options causes the catalog to be recreated.
* Added `TestUcAccCatalogHmsConnectionUpdate` which tests the lifecycle of HMS catalogs, including updating the `authorized_paths` option, enforcing that the catalog resource is never deleted during the lifecycle of the test.