### PR TITLE
[Fix] Delete `databricks_sql_endpoint` that failed to start

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bug Fixes
 
+ * Delete `databricks_sql_endpoint` that failed to start ([#4520](https://github.com/databricks/terraform-provider-databricks/pull/4520))
+
 ### Documentation
 
  * Update `databricks_cluster` and `databricks_clusters` data source documentation ([#4506](https://github.com/databricks/terraform-provider-databricks/pull/4506)).

--- a/sql/resource_sql_endpoint.go
+++ b/sql/resource_sql_endpoint.go
@@ -103,6 +103,11 @@ func ResourceSqlEndpoint() common.Resource {
 			}
 			resp, err := wait.Get()
 			if err != nil {
+				// Rollback by deleting the warehouse
+				rollbackErr := w.Warehouses.DeleteById(ctx, wait.Id)
+				if rollbackErr != nil {
+					return fmt.Errorf("failed deleting warehouse: %w", rollbackErr)
+				}
 				return fmt.Errorf("failed waiting for warehouse to start: %w", err)
 			}
 			d.SetId(resp.Id)

--- a/sql/resource_sql_endpoint.go
+++ b/sql/resource_sql_endpoint.go
@@ -106,7 +106,7 @@ func ResourceSqlEndpoint() common.Resource {
 				// Rollback by deleting the warehouse
 				rollbackErr := w.Warehouses.DeleteById(ctx, wait.Id)
 				if rollbackErr != nil {
-					return fmt.Errorf("failed deleting warehouse: %w", rollbackErr)
+					return fmt.Errorf("failed waiting for warehouse to start: %w. when rolling back, also failed: %w", err, rollbackErr)
 				}
 				return fmt.Errorf("failed waiting for warehouse to start: %w", err)
 			}

--- a/sql/resource_sql_endpoint_test.go
+++ b/sql/resource_sql_endpoint_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/databricks/databricks-sdk-go/apierr"
 	"github.com/databricks/databricks-sdk-go/experimental/mocks"
@@ -190,6 +191,41 @@ func TestResourceSQLEndpointCreate_ErrorDisabled(t *testing.T) {
   		cluster_size = "Small"
 		`,
 	}.ExpectError(t, "failed creating warehouse: Databricks SQL is not supported")
+}
+
+// this is pending https://github.com/databricks/databricks-sdk-go/pull/1155
+func simpleError[R any](err error) poll.PollFunc[R] {
+	return func(_ time.Duration, _ func(*R)) (*R, error) {
+		return nil, err
+	}
+}
+
+func TestResourceSQLEndpointCreateRollback(t *testing.T) {
+	qa.ResourceFixture{
+		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
+			e := w.GetMockWarehousesAPI().EXPECT()
+			e.Create(mock.Anything, sql.CreateWarehouseRequest{
+				Name:               "foo",
+				ClusterSize:        "Small",
+				MaxNumClusters:     1,
+				AutoStopMins:       0,
+				EnablePhoton:       true,
+				SpotInstancePolicy: "COST_OPTIMIZED",
+				ForceSendFields:    []string{"AutoStopMins"},
+			}).Return(&sql.WaitGetWarehouseRunning[sql.CreateWarehouseResponse]{
+				Id:   "warehouse_id",
+				Poll: simpleError[sql.GetWarehouseResponse](errors.New("Clusters are failing to launch")),
+			}, nil)
+			e.DeleteById(mock.Anything, "warehouse_id").Return(nil)
+		},
+		Resource: ResourceSqlEndpoint(),
+		Create:   true,
+		HCL: `
+		name = "foo"
+  		cluster_size = "Small"
+		auto_stop_mins = 0
+		`,
+	}.ExpectError(t, "failed waiting for warehouse to start: Clusters are failing to launch")
 }
 
 func TestResourceSQLEndpointRead(t *testing.T) {


### PR DESCRIPTION
## Changes
- If SQL warehouse is created but failed to start, we need to delete it to avoid failure in the next apply. Resolves #4496

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] using Go SDK
