### PR TITLE
[Fix] Mark `default_catalog_name` attribute in `databricks_metastore_assignment` as deprecated

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bug Fixes
 
+ * Mark `default_catalog_name` attribute in `databricks_metastore_assignment` as deprecated ([#4522](https://github.com/databricks/terraform-provider-databricks/pull/4522))
+
 ### Documentation
 
  * Update `databricks_cluster` and `databricks_clusters` data source documentation ([#4506](https://github.com/databricks/terraform-provider-databricks/pull/4506)).

--- a/catalog/resource_metastore_assignment.go
+++ b/catalog/resource_metastore_assignment.go
@@ -77,6 +77,7 @@ func ResourceMetastoreAssignment() common.Resource {
 					return err
 				}
 				d.Set("metastore_id", ma.MetastoreId)
+				d.Set("default_catalog_name", ma.DefaultCatalogName)
 				d.Set("workspace_id", workspaceId)
 				return nil
 			})

--- a/catalog/resource_metastore_assignment.go
+++ b/catalog/resource_metastore_assignment.go
@@ -77,7 +77,6 @@ func ResourceMetastoreAssignment() common.Resource {
 					return err
 				}
 				d.Set("metastore_id", ma.MetastoreId)
-				d.Set("default_catalog_name", ma.DefaultCatalogName)
 				d.Set("workspace_id", workspaceId)
 				return nil
 			})

--- a/catalog/resource_metastore_assignment.go
+++ b/catalog/resource_metastore_assignment.go
@@ -13,7 +13,8 @@ import (
 func ResourceMetastoreAssignment() common.Resource {
 	s := common.StructToSchema(catalog.MetastoreAssignment{},
 		func(m map[string]*schema.Schema) map[string]*schema.Schema {
-			m["default_catalog_name"].Default = "hive_metastore"
+			m["default_catalog_name"].Computed = true
+			m["default_catalog_name"].Deprecated = "Use databricks_default_namespace_setting resource instead"
 			m["workspace_id"].ForceNew = true
 			m["metastore_id"].ForceNew = true
 			return m

--- a/catalog/resource_metastore_assignment_test.go
+++ b/catalog/resource_metastore_assignment_test.go
@@ -20,17 +20,15 @@ func TestMetastoreAssignment_Create(t *testing.T) {
 				Method:   "PUT",
 				Resource: "/api/2.1/unity-catalog/workspaces/123/metastore",
 				ExpectedRequest: catalog.CreateMetastoreAssignment{
-					DefaultCatalogName: "hive_metastore",
-					MetastoreId:        "a",
+					MetastoreId: "a",
 				},
 			},
 			{
 				Method:   "GET",
 				Resource: "/api/2.1/unity-catalog/current-metastore-assignment",
 				Response: catalog.MetastoreAssignment{
-					MetastoreId:        "a",
-					WorkspaceId:        123,
-					DefaultCatalogName: "hive_metastore",
+					MetastoreId: "a",
+					WorkspaceId: 123,
 				},
 			},
 		},
@@ -60,9 +58,8 @@ func TestMetastoreAssignment_Import(t *testing.T) {
 		Read:     true,
 		ID:       "123|a",
 	}.ApplyAndExpectData(t, map[string]any{
-		"workspace_id":         123,
-		"metastore_id":         "a",
-		"default_catalog_name": "test_metastore",
+		"workspace_id": 123,
+		"metastore_id": "a",
 	})
 }
 
@@ -74,8 +71,7 @@ func TestMetastoreAssignmentAccount_Create(t *testing.T) {
 				Resource: "/api/2.0/accounts/100/workspaces/123/metastores/a",
 				ExpectedRequest: catalog.AccountsCreateMetastoreAssignment{
 					MetastoreAssignment: &catalog.CreateMetastoreAssignment{
-						DefaultCatalogName: "hive_metastore",
-						MetastoreId:        "a",
+						MetastoreId: "a",
 					},
 				},
 			},
@@ -84,9 +80,8 @@ func TestMetastoreAssignmentAccount_Create(t *testing.T) {
 				Resource: "/api/2.0/accounts/100/workspaces/123/metastore?",
 				Response: catalog.AccountsMetastoreAssignment{
 					MetastoreAssignment: &catalog.MetastoreAssignment{
-						MetastoreId:        "a",
-						WorkspaceId:        123,
-						DefaultCatalogName: "hive_metastore",
+						MetastoreId: "a",
+						WorkspaceId: 123,
 					},
 				},
 			},
@@ -107,10 +102,10 @@ func TestMetastoreAssignmentAccount_Update(t *testing.T) {
 			{
 				Method:   "PUT",
 				Resource: "/api/2.0/accounts/100/workspaces/123/metastores/b",
-				ExpectedRequest: catalog.AccountsCreateMetastoreAssignment{
-					MetastoreAssignment: &catalog.CreateMetastoreAssignment{
-						DefaultCatalogName: "hive_metastore",
-						MetastoreId:        "b",
+				//CreateMetastoreAssignment needs to have default_catalog_name marked as omitempty
+				ExpectedRequest: map[string]any{
+					"metastore_assignment": map[string]any{
+						"metastore_id": "b",
 					},
 				},
 			},
@@ -119,9 +114,8 @@ func TestMetastoreAssignmentAccount_Update(t *testing.T) {
 				Resource: "/api/2.0/accounts/100/workspaces/123/metastore?",
 				Response: catalog.AccountsMetastoreAssignment{
 					MetastoreAssignment: &catalog.MetastoreAssignment{
-						MetastoreId:        "b",
-						WorkspaceId:        123,
-						DefaultCatalogName: "hive_metastore",
+						MetastoreId: "b",
+						WorkspaceId: 123,
 					},
 				},
 			},
@@ -148,10 +142,10 @@ func TestMetastoreAssignmentWorskpace_Update(t *testing.T) {
 			{
 				Method:   "PUT",
 				Resource: "/api/2.0/accounts/100/workspaces/124/metastores/a",
-				ExpectedRequest: catalog.AccountsCreateMetastoreAssignment{
-					MetastoreAssignment: &catalog.CreateMetastoreAssignment{
-						DefaultCatalogName: "hive_metastore",
-						MetastoreId:        "a",
+				//CreateMetastoreAssignment needs to have default_catalog_name marked as omitempty
+				ExpectedRequest: map[string]any{
+					"metastore_assignment": map[string]any{
+						"metastore_id": "a",
 					},
 				},
 			},
@@ -160,9 +154,8 @@ func TestMetastoreAssignmentWorskpace_Update(t *testing.T) {
 				Resource: "/api/2.0/accounts/100/workspaces/123/metastore?",
 				Response: catalog.AccountsMetastoreAssignment{
 					MetastoreAssignment: &catalog.MetastoreAssignment{
-						MetastoreId:        "a",
-						WorkspaceId:        123,
-						DefaultCatalogName: "hive_metastore",
+						MetastoreId: "a",
+						WorkspaceId: 123,
 					},
 				},
 			},

--- a/docs/guides/unity-catalog-azure.md
+++ b/docs/guides/unity-catalog-azure.md
@@ -108,7 +108,6 @@ resource "databricks_metastore_assignment" "this" {
   provider             = databricks.accounts
   workspace_id         = local.databricks_workspace_id
   metastore_id         = databricks_metastore.this.id
-  default_catalog_name = "hive_metastore"
 }
 ```
 

--- a/docs/guides/unity-catalog-gcp.md
+++ b/docs/guides/unity-catalog-gcp.md
@@ -117,7 +117,6 @@ resource "databricks_metastore_assignment" "this" {
   provider             = databricks.accounts
   workspace_id         = var.databricks_workspace_id
   metastore_id         = databricks_metastore.this.id
-  default_catalog_name = "hive_metastore"
 }
 ```
 

--- a/docs/guides/unity-catalog.md
+++ b/docs/guides/unity-catalog.md
@@ -184,8 +184,9 @@ resource "databricks_metastore_assignment" "default_metastore" {
   for_each             = toset(var.databricks_workspace_ids)
   workspace_id         = each.key
   metastore_id         = databricks_metastore.this.id
-  default_catalog_name = "hive_metastore"
 }
+
+
 ```
 
 ## Configure external locations and credentials


### PR DESCRIPTION
## Changes
- Mark `default_catalog_name` attribute in `databricks_metastore_assignment` as deprecated, as `databricks_default_namespace_setting` should be used instead. 
- Resolves #4147 

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [x] covered with integration tests in `internal/acceptance`
