### PR TITLE
[Release] Release v1.66.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,53 @@
 # Version changelog
 
+## [Release] Release v1.66.1
+
+### New Features and Improvements
+
+ * Add support for cluster logs delivery to UC Volumes ([#4492](https://github.com/databricks/terraform-provider-databricks/pull/4492)).
+ * Expose more attributes for `databricks_connection` resource ([#4502](https://github.com/databricks/terraform-provider-databricks/pull/4502)).
+ * add `databricks_dashboards` data source ([#4521](https://github.com/databricks/terraform-provider-databricks/pull/4521)).
+
+
+### Bug Fixes
+
+ * Delete `databricks_sql_endpoint` that failed to start ([#4520](https://github.com/databricks/terraform-provider-databricks/pull/4520)).
+ * Fix filling of missing attributes in `databricks_quality_monitor` ([#4519](https://github.com/databricks/terraform-provider-databricks/pull/4519)).
+ * Mark `default_catalog_name` attribute in `databricks_metastore_assignment` as deprecated ([#4522](https://github.com/databricks/terraform-provider-databricks/pull/4522)).
+ * Only allow `authorized_paths` to be updated in the `options` field of `databricks_catalog` ([#4517](https://github.com/databricks/terraform-provider-databricks/pull/4517)).
+ * Populate `partitions` when reading `databricks_sql_table` ([#4486](https://github.com/databricks/terraform-provider-databricks/pull/4486)).
+ * Remove configuration drift when configuring `databricks_connection` to built-in Hive Metastore ([#4505](https://github.com/databricks/terraform-provider-databricks/pull/4505)).
+
+
+### Documentation
+
+ * Improve documentation for databricks_cluster and databricks_clusters ([#4506](https://github.com/databricks/terraform-provider-databricks/pull/4506)).
+ * Small fix to docs for data source `databricks_cluster` ([#4510](https://github.com/databricks/terraform-provider-databricks/pull/4510)).
+ * mark `databricks_volume` and `databricks_credential` as GA ([#4524](https://github.com/databricks/terraform-provider-databricks/pull/4524)).
+
+
+### Internal Changes
+
+ * Upgrade `staticcheck` to compatible with Go 1.24 ([#4507](https://github.com/databricks/terraform-provider-databricks/pull/4507)).
+ * Use InputGitAuthor when tagging a commit ([#4501](https://github.com/databricks/terraform-provider-databricks/pull/4501)).
+ * fix `TestUcAccDataSourceShares` flakiness ([#4526](https://github.com/databricks/terraform-provider-databricks/pull/4526)).
+ * switch `TestMwsAccWorkspacesTokenUpdate` to BYOVPC ([#4525](https://github.com/databricks/terraform-provider-databricks/pull/4525)).
+
+
+### Dependency Updates
+
+ * Bump github.com/hashicorp/terraform-plugin-framework from 1.14.0 to 1.14.1 ([#4515](https://github.com/databricks/terraform-provider-databricks/pull/4515)).
+ * Bump github.com/hashicorp/terraform-plugin-framework-validators from 0.16.0 to 0.17.0 ([#4511](https://github.com/databricks/terraform-provider-databricks/pull/4511)).
+ * Bump github.com/hashicorp/terraform-plugin-sdk/v2 from 2.36.0 to 2.36.1 ([#4512](https://github.com/databricks/terraform-provider-databricks/pull/4512)).
+ * Bump to 1.24.0 ([#4508](https://github.com/databricks/terraform-provider-databricks/pull/4508)).
+
+
+### Exporter
+
+ * Explicitly abort execution via `panic` if list of users can't be fetched ([#4500](https://github.com/databricks/terraform-provider-databricks/pull/4500)).
+ * Fix matching on `workspace_path` and refactoring ([#4504](https://github.com/databricks/terraform-provider-databricks/pull/4504)).
+
+
 ## Release v1.66.0
 
 ### New Features and Improvements

--- a/common/version.go
+++ b/common/version.go
@@ -3,7 +3,7 @@ package common
 import "context"
 
 var (
-	version = "1.66.0"
+	version = "1.66.1"
 	// ResourceName is resource name without databricks_ prefix
 	ResourceName contextKey = 1
 	// Provider is the current instance of provider


### PR DESCRIPTION

### New Features and Improvements

 * Add support for cluster logs delivery to UC Volumes ([#4492](https://github.com/databricks/terraform-provider-databricks/pull/4492)).
 * Expose more attributes for `databricks_connection` resource ([#4502](https://github.com/databricks/terraform-provider-databricks/pull/4502)).
 * add `databricks_dashboards` data source ([#4521](https://github.com/databricks/terraform-provider-databricks/pull/4521)).


### Bug Fixes

 * Delete `databricks_sql_endpoint` that failed to start ([#4520](https://github.com/databricks/terraform-provider-databricks/pull/4520)).
 * Fix filling of missing attributes in `databricks_quality_monitor` ([#4519](https://github.com/databricks/terraform-provider-databricks/pull/4519)).
 * Mark `default_catalog_name` attribute in `databricks_metastore_assignment` as deprecated ([#4522](https://github.com/databricks/terraform-provider-databricks/pull/4522)).
 * Only allow `authorized_paths` to be updated in the `options` field of `databricks_catalog` ([#4517](https://github.com/databricks/terraform-provider-databricks/pull/4517)).
 * Populate `partitions` when reading `databricks_sql_table` ([#4486](https://github.com/databricks/terraform-provider-databricks/pull/4486)).
 * Remove configuration drift when configuring `databricks_connection` to built-in Hive Metastore ([#4505](https://github.com/databricks/terraform-provider-databricks/pull/4505)).


### Documentation

 * Improve documentation for databricks_cluster and databricks_clusters ([#4506](https://github.com/databricks/terraform-provider-databricks/pull/4506)).
 * Small fix to docs for data source `databricks_cluster` ([#4510](https://github.com/databricks/terraform-provider-databricks/pull/4510)).
 * mark `databricks_volume` and `databricks_credential` as GA ([#4524](https://github.com/databricks/terraform-provider-databricks/pull/4524)).


### Internal Changes

 * Upgrade `staticcheck` to compatible with Go 1.24 ([#4507](https://github.com/databricks/terraform-provider-databricks/pull/4507)).
 * Use InputGitAuthor when tagging a commit ([#4501](https://github.com/databricks/terraform-provider-databricks/pull/4501)).
 * fix `TestUcAccDataSourceShares` flakiness ([#4526](https://github.com/databricks/terraform-provider-databricks/pull/4526)).
 * switch `TestMwsAccWorkspacesTokenUpdate` to BYOVPC ([#4525](https://github.com/databricks/terraform-provider-databricks/pull/4525)).


### Dependency Updates

 * Bump github.com/hashicorp/terraform-plugin-framework from 1.14.0 to 1.14.1 ([#4515](https://github.com/databricks/terraform-provider-databricks/pull/4515)).
 * Bump github.com/hashicorp/terraform-plugin-framework-validators from 0.16.0 to 0.17.0 ([#4511](https://github.com/databricks/terraform-provider-databricks/pull/4511)).
 * Bump github.com/hashicorp/terraform-plugin-sdk/v2 from 2.36.0 to 2.36.1 ([#4512](https://github.com/databricks/terraform-provider-databricks/pull/4512)).
 * Bump to 1.24.0 ([#4508](https://github.com/databricks/terraform-provider-databricks/pull/4508)).


### Exporter

 * Explicitly abort execution via `panic` if list of users can't be fetched ([#4500](https://github.com/databricks/terraform-provider-databricks/pull/4500)).
 * Fix matching on `workspace_path` and refactoring ([#4504](https://github.com/databricks/terraform-provider-databricks/pull/4504)).


