### PR TITLE
[Fix] handle auto-enabled errors with`databricks_system_schema`

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Bug Fixes
 
+* Handle auto-enabled errors with `databricks_system_schema` [#4547](https://github.com/databricks/terraform-provider-databricks/pull/4547)
+
 ### Documentation
 
 ### Exporter

--- a/catalog/resource_system_schema.go
+++ b/catalog/resource_system_schema.go
@@ -50,7 +50,8 @@ func ResourceSystemSchema() common.Resource {
 			SchemaName:  new,
 		})
 		//ignore "schema <schema-name> already exists" error
-		if err != nil && !strings.Contains(err.Error(), "already exists") {
+		//ignore "<schema-name> system schema can only be enabled by Databricks" error
+		if err != nil && !strings.Contains(err.Error(), "already exists") && !strings.Contains(err.Error(), "can only be enabled by Databricks") {
 			return err
 		}
 		//disable old schemas if needed

--- a/catalog/resource_system_schema.go
+++ b/catalog/resource_system_schema.go
@@ -108,8 +108,7 @@ func ResourceSystemSchema() common.Resource {
 					// only track enabled/legacy schemas
 					if schema.State != catalog.SystemSchemaInfoStateEnableCompleted &&
 						schema.State != catalog.SystemSchemaInfoStateEnableInitialized &&
-						schema.State != catalog.SystemSchemaInfoStateUnavailable &&
-						schema.State != catalog.SystemSchemaInfoStateAvailable {
+						schema.State != catalog.SystemSchemaInfoStateUnavailable {
 						log.Printf("[WARN] %s is not enabled, ignoring it", schemaName)
 						d.SetId("")
 						return nil

--- a/catalog/system_schema_test.go
+++ b/catalog/system_schema_test.go
@@ -1,20 +1,19 @@
 package catalog_test
 
 import (
-	"os"
 	"testing"
 
 	"github.com/databricks/terraform-provider-databricks/internal/acceptance"
 )
 
 func TestUcAccResourceSystemSchema(t *testing.T) {
-	if os.Getenv("GOOGLE_CREDENTIALS") != "" {
-		t.Skipf("databricks_system_schema resource not available on GCP")
-	}
 	acceptance.UnityWorkspaceLevel(t, acceptance.Step{
 		Template: `
 		resource "databricks_system_schema" "this" {
 			schema = "access"
+		}
+		resource "databricks_system_schema" "this" {
+			schema = "billing"
 		}`,
 	})
 }

--- a/catalog/system_schema_test.go
+++ b/catalog/system_schema_test.go
@@ -9,10 +9,10 @@ import (
 func TestUcAccResourceSystemSchema(t *testing.T) {
 	acceptance.UnityWorkspaceLevel(t, acceptance.Step{
 		Template: `
-		resource "databricks_system_schema" "this" {
+		resource "databricks_system_schema" "access" {
 			schema = "access"
 		}
-		resource "databricks_system_schema" "this" {
+		resource "databricks_system_schema" "billing" {
 			schema = "billing"
 		}`,
 	})

--- a/docs/resources/system_schema.md
+++ b/docs/resources/system_schema.md
@@ -9,6 +9,8 @@ subcategory: "Unity Catalog"
 
 Manages system tables enablement. System tables are a Databricks-hosted analytical store of your account’s operational data. System tables can be used for historical observability across your account. System tables must be enabled by an account admin.
 
+Certain system schemas (such as `billing`) may be auto-enabled once GA and should not be manually declared in Terraform configurations.
+
 ## Example Usage
 
 Enable the system schema `access`

--- a/docs/resources/system_schema.md
+++ b/docs/resources/system_schema.md
@@ -7,9 +7,9 @@ subcategory: "Unity Catalog"
 
 -> This resource can only be used with a workspace-level provider!
 
-Manages system tables enablement. System tables are a Databricks-hosted analytical store of your account’s operational data. System tables can be used for historical observability across your account. System tables must be enabled by an account admin.
+-> Certain system schemas (such as `billing`) may be auto-enabled once GA and should not be manually declared in Terraform configurations.
 
-Certain system schemas (such as `billing`) may be auto-enabled once GA and should not be manually declared in Terraform configurations.
+Manages system tables enablement. System tables are a Databricks-hosted analytical store of your account’s operational data. System tables can be used for historical observability across your account. System tables must be enabled by an account admin.
 
 ## Example Usage
 


### PR DESCRIPTION
## Changes
- Handle new error message `billing system schema can only be enabled by Databricks`. Resolves #4539
- Update documentation with warnings about auto-enabled system schemas.
- Enable system schema integration test on GCP

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [x] covered with integration tests in `internal/acceptance`
- [x] using Go SDK
- [x] using TF Plugin Framework
