### PR TITLE
[Fix] Fix creation of `databricks_storage_credential` and `databricks_credential` resources on GCP with isolation mode

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Bug Fixes
 
+ * Fix creation of `databricks_storage_credential` and `databricks_credential` resources on GCP with isolation mode ([#4563](https://github.com/databricks/terraform-provider-databricks/pull/4563))
+
 ### Documentation
 
 ### Exporter

--- a/catalog/resource_credential.go
+++ b/catalog/resource_credential.go
@@ -82,6 +82,9 @@ func ResourceCredential() common.Resource {
 			var update catalog.UpdateCredentialRequest
 			common.DataToStructPointer(d, credentialSchema, &update)
 			update.NameArg = d.Id()
+			if update.DatabricksGcpServiceAccount != nil { // we can't update it at all
+				update.DatabricksGcpServiceAccount = nil
+			}
 			_, err = w.Credentials.UpdateCredential(ctx, update)
 			if err != nil {
 				return err

--- a/catalog/resource_storage_credential.go
+++ b/catalog/resource_storage_credential.go
@@ -48,6 +48,9 @@ func ResourceStorageCredential() common.Resource {
 			common.DataToStructPointer(d, storageCredentialSchema, &create)
 			common.DataToStructPointer(d, storageCredentialSchema, &update)
 			update.Name = d.Get("name").(string)
+			if update.DatabricksGcpServiceAccount != nil { // we can't update it at all
+				update.DatabricksGcpServiceAccount = nil
+			}
 
 			return c.AccountOrWorkspaceRequest(func(acc *databricks.AccountClient) error {
 				storageCredential, err := acc.StorageCredentials.Create(ctx,


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

Resolves #4562 

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] using Go SDK
- [ ] using TF Plugin Framework
