### PR TITLE
[Internal] Fix Quality Monitor test by removing parallelism

### DIFF
--- a/internal/providers/pluginfw/products/qualitymonitor/resource_quality_monitor_acc_test.go
+++ b/internal/providers/pluginfw/products/qualitymonitor/resource_quality_monitor_acc_test.go
@@ -75,6 +75,7 @@ func TestUcAccQualityMonitor(t *testing.T) {
 			}
 
 			resource "databricks_sql_table" "myTimeseries" {
+				depends_on = [databricks_quality_monitor.testMonitorInference]
 				catalog_name = databricks_catalog.sandbox.id
 				schema_name = databricks_schema.things.name
 				name = "bar{var.STICKY_RANDOM}_timeseries"
@@ -100,6 +101,7 @@ func TestUcAccQualityMonitor(t *testing.T) {
 			}
 
 			resource "databricks_sql_table" "mySnapshot" {
+				depends_on = [databricks_quality_monitor.testMonitorTimeseries]
 				catalog_name = databricks_catalog.sandbox.id
 				schema_name = databricks_schema.things.name
 				name = "bar{var.STICKY_RANDOM}_snapshot"


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
This PR removes parallelism in the quality monitor test. Currently, we create multiple databricks_sql_table concurrently, which causes the following error: `[OCC check failure] Entity proto at /metastores:<metastore_id> may have been updated during the transaction`. 
This is already fixed in its non-plugin framework counterpart. https://github.com/databricks/terraform-provider-databricks/pull/4566

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] using Go SDK
- [ ] using TF Plugin Framework
NO_CHANGELOG=true