### PR TITLE
[Fix] Update `databricks_mlflow_experiment` resource to include tags

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New Features and Improvements
 
 ### Bug Fixes
+* [Fix] Update databricks_mlflow_experiment resource to include tags ([#4569](https://github.com/databricks/terraform-provider-databricks/pull/4569))
 
 ### Documentation
 

--- a/docs/resources/mlflow_experiment.md
+++ b/docs/resources/mlflow_experiment.md
@@ -13,7 +13,14 @@ data "databricks_current_user" "me" {}
 resource "databricks_mlflow_experiment" "this" {
   name              = "${data.databricks_current_user.me.home}/Sample"
   artifact_location = "dbfs:/tmp/my-experiment"
-  description       = "My MLflow experiment description"
+  tags = [{
+      key = "key1"
+      value = "value1"
+    },
+    {
+      key = "key2"
+      value = "value2"
+  }]
 }
 ```
 
@@ -23,7 +30,7 @@ The following arguments are supported:
 
 * `name` - (Required) Name of MLflow experiment. It must be an absolute path within the Databricks workspace, e.g. `/Users/<some-username>/my-experiment`. For more information about changes to experiment naming conventions, see [mlflow docs](https://docs.databricks.com/applications/mlflow/experiments.html#experiment-migration).
 * `artifact_location` - Path to dbfs:/ or s3:// artifact location of the MLflow experiment.
-* `description` - The description of the MLflow experiment.
+* `tags` - List of tags consisting of key-value pairs for the experiment
 
 ## Attribute Reference
 

--- a/mlflow/mlflow_experiment_test.go
+++ b/mlflow/mlflow_experiment_test.go
@@ -12,7 +12,14 @@ func TestAccMLflowExperiment(t *testing.T) {
 		resource "databricks_mlflow_experiment" "e1" {
 			name = "/Shared/tf-{var.RANDOM}"
 			artifact_location = "dbfs:/tmp/tf-{var.RANDOM}"
-			description = "tf-{var.RANDOM} description"
+			tags {
+				key = "tag1-{var.STICKY_RANDOM}"
+				value = "value1-{var.STICKY_RANDOM}"
+			}
+			tags {
+				key = "tag2-{var.STICKY_RANDOM}"
+				value = "value2-{var.STICKY_RANDOM}"
+			}
 		}
 		`,
 	})

--- a/mlflow/resource_mlflow_experiment.go
+++ b/mlflow/resource_mlflow_experiment.go
@@ -9,13 +9,21 @@ import (
 
 // Experiment defines the response object from the API
 type Experiment struct {
-	Name             string `json:"name"`
-	Description      string `json:"description,omitempty"`
-	ExperimentId     string `json:"experiment_id,omitempty" tf:"computed"`
-	ArtifactLocation string `json:"artifact_location,omitempty" tf:"force_new,suppress_diff"`
-	LifecycleStage   string `json:"lifecycle_stage,omitempty" tf:"computed"`
-	LastUpdateTime   int64  `json:"last_update_time,omitempty" tf:"computed"`
-	CreationTime     int64  `json:"creation_time,omitempty" tf:"computed"`
+	Name             string          `json:"name"`
+	ArtifactLocation string          `json:"artifact_location,omitempty" tf:"force_new,suppress_diff"`
+	Tags             []ExperimentTag `json:"tags,omitempty"`
+	ExperimentId     string          `json:"experiment_id,omitempty" tf:"computed"`
+	LifecycleStage   string          `json:"lifecycle_stage,omitempty" tf:"computed"`
+	LastUpdateTime   int64           `json:"last_update_time,omitempty" tf:"computed"`
+	CreationTime     int64           `json:"creation_time,omitempty" tf:"computed"`
+}
+
+// A tag for an experiment.
+type ExperimentTag struct {
+	// The tag key.
+	Key string `json:"key"`
+	// The tag value.
+	Value string `json:"value"`
 }
 
 type experimentUpdate struct {


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
This resource is outdated as it is maintained manually. PR adds the tags field which is present in OpenAPI spec and removes the description field which isn't present. 

The right way to solve this is to migrate this to Go SDK however since the bandwidth is low for this quarter to include that work and this is required in CLI, adding a quick fix until this is migrated to autogeneration framework. 

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->
Added unit test
- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] using Go SDK
- [ ] using TF Plugin Framework
