### PR TITLE
Aggressive caching for installations with large number of users and groups

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/ProtonMail/go-crypto v1.1.3 // indirect
 	github.com/agext/levenshtein v1.2.3 // indirect
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
+	github.com/bluele/gcache v0.0.2 // indirect
 	github.com/cloudflare/circl v1.3.7 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fatih/color v1.16.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -17,6 +17,8 @@ github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki
 github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=
 github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew1u1fNQOlOtuGxQY=
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=
+github.com/bluele/gcache v0.0.2 h1:WcbfdXICg7G/DGBh1PFfcirkWOQV+v077yF1pSy3DGw=
+github.com/bluele/gcache v0.0.2/go.mod h1:m15KV+ECjptwSPxKhOhQoAFQVtUFjTVkc3H8o0t/fp0=
 github.com/bufbuild/protocompile v0.4.0 h1:LbFKd2XowZvQ/kajzguUp2DC9UEIQhIq77fZZlaQsNA=
 github.com/bufbuild/protocompile v0.4.0/go.mod h1:3v93+mbWn/v3xzN+31nwkJfrEpAUwp+BagBSZWx+TP8=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=

--- a/scim/data_user.go
+++ b/scim/data_user.go
@@ -3,25 +3,80 @@ package scim
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/databricks/terraform-provider-databricks/common"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
+
+
+func NewUsersCache(expiration time.Duration) *UsersCache {
+	return &UsersCache {
+		cache: map[string]User{},
+		mutex: sync.Mutex{},
+		cacheExpiration: expiration,
+		// Make sure the cache is populated on the first read
+		populateTime: time.Time{},
+	}
+}
+
+type UsersCache struct {
+	mutex sync.Mutex
+	cache map[string]User
+	cacheExpiration time.Duration
+	populateTime time.Time
+}
+
+var usersCache *UsersCache = NewUsersCache(time.Second * 60)
+
+func (c *UsersCache) populate(api UsersAPI) error {
+	var users UserList
+	req := map[string]string{}
+	req["excludedAttributes"] = "roles"
+	err := api.client.Scim(api.context, http.MethodGet, "/preview/scim/v2/Users", req, &users)
+	if err != nil {
+		return err
+	}
+	u := users.Resources
+	for _, user := range u {
+		tflog.Info(api.context, fmt.Sprintf("Caching user %s", user.UserName))
+		c.cache[strings.ToLower(user.UserName)] = user
+	}
+	c.populateTime = time.Now()
+	return nil
+}
+
+func (c *UsersCache) Get(api UsersAPI, userName string) (User, error) {
+	// Databricks' search is case-insensitive
+	userName = strings.ToLower(userName)
+
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	if time.Since(c.populateTime) > c.cacheExpiration {
+		if err := c.populate(api); err != nil {
+			return User{}, err
+		}
+	}
+
+	tflog.Debug(api.context, fmt.Sprintf("Getting user %s from cache", userName))
+	user, ok := c.cache[userName]
+	tflog.Debug(api.context, fmt.Sprintf("User %s found in cache: %t", userName, ok))
+	if ok {
+		return user, nil
+	}
+
+	return User{}, fmt.Errorf("cannot find user %s", userName)
+}
 
 func getUser(usersAPI UsersAPI, id, name string) (user User, err error) {
 	if id != "" {
 		return usersAPI.Read(id, "userName,displayName,externalId,applicationId")
 	}
-	userList, err := usersAPI.Filter(fmt.Sprintf(`userName eq "%s"`, name), true)
-	if err != nil {
-		return
-	}
-	if len(userList) == 0 {
-		err = fmt.Errorf("cannot find user %s", name)
-		return
-	}
-	user = userList[0]
+	user, err = usersCache.Get(usersAPI, name)
 	return
 }
 

--- a/scim/data_user.go
+++ b/scim/data_user.go
@@ -13,11 +13,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-
 func NewUsersCache(expiration time.Duration) *UsersCache {
-	return &UsersCache {
-		cache: map[string]User{},
-		mutex: sync.Mutex{},
+	return &UsersCache{
+		cache:           map[string]User{},
+		mutex:           sync.Mutex{},
 		cacheExpiration: expiration,
 		// Make sure the cache is populated on the first read
 		populateTime: time.Time{},
@@ -25,10 +24,10 @@ func NewUsersCache(expiration time.Duration) *UsersCache {
 }
 
 type UsersCache struct {
-	mutex sync.Mutex
-	cache map[string]User
+	mutex           sync.Mutex
+	cache           map[string]User
 	cacheExpiration time.Duration
-	populateTime time.Time
+	populateTime    time.Time
 }
 
 var usersCache *UsersCache = NewUsersCache(time.Second * 60)

--- a/scim/data_user_test.go
+++ b/scim/data_user_test.go
@@ -16,7 +16,7 @@ func TestDataSourceUser(t *testing.T) {
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   "GET",
-				Resource: "/api/2.0/preview/scim/v2/Users?excludedAttributes=roles&filter=userName%20eq%20%22ds%22",
+				Resource: "/api/2.0/preview/scim/v2/Users?excludedAttributes=roles",
 				Response: UserList{
 					Resources: []User{
 						{
@@ -33,7 +33,7 @@ func TestDataSourceUser(t *testing.T) {
 		Resource:    DataSourceUser(),
 		ID:          ".",
 		State: map[string]any{
-			"user_name": "ds",
+			"user_name": "mr.test@example.com",
 		},
 	}.Apply(t)
 	require.NoError(t, err)
@@ -56,16 +56,11 @@ func TestDataSourceUserGerUser(t *testing.T) {
 		},
 		{
 			Method:   "GET",
-			Resource: "/api/2.0/preview/scim/v2/Users?excludedAttributes=roles&filter=userName%20eq%20%22searching_error%22",
+			Resource: "/api/2.0/preview/scim/v2/Users?excludedAttributes=roles",
 			Status:   404,
 			Response: apierr.APIError{
 				Message: "searching_error",
 			},
-		},
-		{
-			Method:   "GET",
-			Resource: "/api/2.0/preview/scim/v2/Users?excludedAttributes=roles&filter=userName%20eq%20%22empty_search%22",
-			Response: UserList{},
 		},
 	}, func(ctx context.Context, client *common.DatabricksClient) {
 		usersAPI := NewUsersAPI(ctx, client)
@@ -74,9 +69,21 @@ func TestDataSourceUserGerUser(t *testing.T) {
 		assert.Equal(t, "a", user.ID)
 
 		_, err = getUser(usersAPI, "", "searching_error")
-		assert.EqualError(t, err, "searching_error")
+		assert.EqualError(t, err, "cannot find user searching_error")
+	})
+}
 
-		_, err = getUser(usersAPI, "", "empty_search")
+
+func TestDataSourceUserGerUserEmpty(t *testing.T) {
+	qa.HTTPFixturesApply(t, []qa.HTTPFixture{
+		{
+			Method:   "GET",
+			Resource: "/api/2.0/preview/scim/v2/Users?excludedAttributes=roles",
+			Response: UserList{},
+		},
+	}, func(ctx context.Context, client *common.DatabricksClient) {
+		usersAPI := NewUsersAPI(ctx, client)
+		_, err := getUser(usersAPI, "", "empty_search")
 		assert.EqualError(t, err, "cannot find user empty_search")
 	})
 }

--- a/scim/data_user_test.go
+++ b/scim/data_user_test.go
@@ -73,7 +73,6 @@ func TestDataSourceUserGerUser(t *testing.T) {
 	})
 }
 
-
 func TestDataSourceUserGerUserEmpty(t *testing.T) {
 	qa.HTTPFixturesApply(t, []qa.HTTPFixture{
 		{

--- a/scim/groups.go
+++ b/scim/groups.go
@@ -31,11 +31,9 @@ func (a GroupsAPI) Create(scimGroupRequest Group) (group Group, err error) {
 
 // Read reads and returns a Group object via SCIM api
 func (a GroupsAPI) Read(groupID, attributes string) (group Group, err error) {
-	err = a.client.Scim(a.context, http.MethodGet, fmt.Sprintf(
-		"/preview/scim/v2/Groups/%v?attributes=%s", groupID, attributes), nil, &group)
-	if err != nil {
-		return
-	}
+	key := fmt.Sprintf(
+		"/preview/scim/v2/Groups/%v?attributes=%s", groupID, attributes)
+	err = a.client.Scim(a.context, http.MethodGet, key, nil, &group)
 	return
 }
 

--- a/scim/resource_group_member.go
+++ b/scim/resource_group_member.go
@@ -13,11 +13,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
-
 type GroupMembersInfo struct {
 	initialized bool
 	members     map[string]struct{}
-	lock 	    *sync.Mutex
+	lock        *sync.Mutex
 }
 
 type GroupCache struct {
@@ -25,18 +24,16 @@ type GroupCache struct {
 }
 
 func NewGroupsCache(expiration time.Duration) *GroupCache {
-	return &GroupCache {
+	return &GroupCache{
 		cache: gcache.New(1000).LRU().LoaderFunc(func(key interface{}) (interface{}, error) {
 			return &GroupMembersInfo{
 				initialized: false,
 				members:     make(map[string]struct{}),
 				lock:        &sync.Mutex{},
 			}, nil
-		}).
-		Expiration(expiration).Build(),
+		}).Expiration(expiration).Build(),
 	}
 }
-
 
 func (c *GroupCache) GetMembers(api GroupsAPI, groupID string) (map[string]struct{}, error) {
 	entry, err := c.cache.Get(groupID)
@@ -112,7 +109,6 @@ func hasMember(members map[string]struct{}, memberID string) bool {
 	_, ok := members[memberID]
 	return ok
 }
-
 
 var globalGroupsCache = NewGroupsCache(time.Second * 300)
 

--- a/scim/resource_group_member.go
+++ b/scim/resource_group_member.go
@@ -3,28 +3,134 @@ package scim
 import (
 	"context"
 	"fmt"
+	"strings"
+	"sync"
+	"time"
 
+	"github.com/bluele/gcache"
 	"github.com/databricks/databricks-sdk-go/apierr"
 	"github.com/databricks/terraform-provider-databricks/common"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
+
+
+type GroupMembersInfo struct {
+	initialized bool
+	members     map[string]struct{}
+	lock 	    *sync.Mutex
+}
+
+type GroupCache struct {
+	cache gcache.Cache
+}
+
+func NewGroupsCache(expiration time.Duration) *GroupCache {
+	return &GroupCache {
+		cache: gcache.New(1000).LRU().LoaderFunc(func(key interface{}) (interface{}, error) {
+			return &GroupMembersInfo{
+				initialized: false,
+				members:     make(map[string]struct{}),
+				lock:        &sync.Mutex{},
+			}, nil
+		}).
+		Expiration(expiration).Build(),
+	}
+}
+
+
+func (c *GroupCache) GetMembers(api GroupsAPI, groupID string) (map[string]struct{}, error) {
+	entry, err := c.cache.Get(groupID)
+	if err != nil {
+		return nil, err
+	}
+	groupInfo := entry.(*GroupMembersInfo)
+	groupInfo.lock.Lock()
+	defer groupInfo.lock.Unlock()
+
+	if !groupInfo.initialized {
+		tflog.Debug(api.context, fmt.Sprintf("Getting members for group %s", groupID))
+		group, err := api.Read(groupID, "members")
+		if err != nil {
+			return nil, err
+		}
+		tflog.Debug(api.context, fmt.Sprintf("Group %s has %d members", groupID, len(group.Members)))
+		for _, member := range group.Members {
+			memberKey := strings.ToLower(member.Value)
+			groupInfo.members[memberKey] = struct{}{}
+		}
+		groupInfo.initialized = true
+		return groupInfo.members, nil
+	}
+	tflog.Debug(api.context, fmt.Sprintf("Group %s has %d members (cached)", groupID, len(groupInfo.members)))
+	return groupInfo.members, nil
+}
+
+func (c *GroupCache) removeMember(api GroupsAPI, groupID string, memberID string) error {
+	entry, err := c.cache.Get(groupID)
+	if err != nil {
+		return err
+	}
+	groupInfo := entry.(*GroupMembersInfo)
+	groupInfo.lock.Lock()
+	defer groupInfo.lock.Unlock()
+
+	err = api.Patch(groupID, PatchRequest(
+		"remove", fmt.Sprintf(`members[value eq "%s"]`, memberID)))
+	if err != nil {
+		return err
+	}
+
+	if groupInfo.initialized {
+		memberKey := strings.ToLower(memberID)
+		delete(groupInfo.members, memberKey)
+	}
+	return err
+
+}
+
+func (c *GroupCache) addMember(api GroupsAPI, groupID string, memberID string) error {
+	entry, err := c.cache.Get(groupID)
+	if err != nil {
+		return err
+	}
+	groupInfo := entry.(*GroupMembersInfo)
+	groupInfo.lock.Lock()
+	defer groupInfo.lock.Unlock()
+
+	err = api.Patch(groupID, PatchRequestWithValue("add", "members", memberID))
+	if err != nil {
+		return err
+	}
+	if groupInfo.initialized {
+		memberKey := strings.ToLower(memberID)
+		groupInfo.members[memberKey] = struct{}{}
+	}
+	return err
+}
+
+func hasMember(members map[string]struct{}, memberID string) bool {
+	_, ok := members[memberID]
+	return ok
+}
+
+
+var globalGroupsCache = NewGroupsCache(time.Second * 300)
 
 // ResourceGroupMember bind group with member
 func ResourceGroupMember() common.Resource {
 	return common.NewPairID("group_id", "member_id").BindResource(common.BindResource{
 		CreateContext: func(ctx context.Context, groupID, memberID string, c *common.DatabricksClient) error {
-			return NewGroupsAPI(ctx, c).Patch(groupID, PatchRequestWithValue("add", "members", memberID))
+			return globalGroupsCache.addMember(NewGroupsAPI(ctx, c), groupID, memberID)
 		},
 		ReadContext: func(ctx context.Context, groupID, memberID string, c *common.DatabricksClient) error {
-			group, err := NewGroupsAPI(ctx, c).Read(groupID, "members")
-			hasMember := ComplexValues(group.Members).HasValue(memberID)
-			if err == nil && !hasMember {
-				return apierr.NotFound("Group has no member")
+			members, err := globalGroupsCache.GetMembers(NewGroupsAPI(ctx, c), groupID)
+			if err == nil && !hasMember(members, memberID) {
+				return apierr.NotFound(fmt.Sprintf("Group has no member %s %d", memberID, len(members)))
 			}
 			return err
 		},
 		DeleteContext: func(ctx context.Context, groupID, memberID string, c *common.DatabricksClient) error {
-			return NewGroupsAPI(ctx, c).Patch(groupID, PatchRequest(
-				"remove", fmt.Sprintf(`members[value eq "%s"]`, memberID)))
+			return globalGroupsCache.removeMember(NewGroupsAPI(ctx, c), groupID, memberID)
 		},
 	})
 }

--- a/scim/users.go
+++ b/scim/users.go
@@ -8,13 +8,14 @@ import (
 	"github.com/databricks/terraform-provider-databricks/common"
 )
 
-// NewUsersAPI creates UsersAPI instance from provider meta
+
 func NewUsersAPI(ctx context.Context, m any) UsersAPI {
 	return UsersAPI{
 		client:  m.(*common.DatabricksClient),
 		context: ctx,
 	}
 }
+
 
 // UsersAPI exposes the scim user API
 type UsersAPI struct {
@@ -36,15 +37,15 @@ func (a UsersAPI) Filter(filter string, excludeRoles bool) (u []User, err error)
 	var users UserList
 	req := map[string]string{}
 	if filter != "" {
-		req["filter"] = filter
+			req["filter"] = filter
 	}
 	// We exclude roles to reduce load on the scim service
 	if excludeRoles {
-		req["excludedAttributes"] = "roles"
+			req["excludedAttributes"] = "roles"
 	}
 	err = a.client.Scim(a.context, http.MethodGet, "/preview/scim/v2/Users", req, &users)
 	if err != nil {
-		return
+			return
 	}
 	u = users.Resources
 	return

--- a/scim/users.go
+++ b/scim/users.go
@@ -8,14 +8,13 @@ import (
 	"github.com/databricks/terraform-provider-databricks/common"
 )
 
-
+// NewUsersAPI creates UsersAPI instance from provider meta
 func NewUsersAPI(ctx context.Context, m any) UsersAPI {
 	return UsersAPI{
 		client:  m.(*common.DatabricksClient),
 		context: ctx,
 	}
 }
-
 
 // UsersAPI exposes the scim user API
 type UsersAPI struct {
@@ -37,15 +36,15 @@ func (a UsersAPI) Filter(filter string, excludeRoles bool) (u []User, err error)
 	var users UserList
 	req := map[string]string{}
 	if filter != "" {
-			req["filter"] = filter
+		req["filter"] = filter
 	}
 	// We exclude roles to reduce load on the scim service
 	if excludeRoles {
-			req["excludedAttributes"] = "roles"
+		req["excludedAttributes"] = "roles"
 	}
 	err = a.client.Scim(a.context, http.MethodGet, "/preview/scim/v2/Users", req, &users)
 	if err != nil {
-			return
+		return
 	}
 	u = users.Resources
 	return


### PR DESCRIPTION
## Changes

On the installations with large number of users the provider creates a large number of API calls to the Databricks API leading to slow deployments. Specifically, it runs a search on for each user as a separate API call. The provider also requests all members for each group membership check.

In this change users data provider and group member resource use expiring caches - in our case we halved the default deployment times on existing installation and eliminated Databricks API throttling.

I am also looking for some guidance on how to make this change more generic.

## Tests

We run this provider in production with about 800 users and ~100 groups.

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [x] using Go SDK
- [x] using TF Plugin Framework
