### PR TITLE
[Exporter] Fix panic caused by incorrect values in the cluster policies

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -19,5 +19,6 @@
 
  * Add support for special selectors in `-listing` and `-services` [#4573](https://github.com/databricks/terraform-provider-databricks/pull/4573)
  * Allow the selective export of `databricks_mws_permission_assignment`, and change its service name to `idfed` instead of `access` ([#4571](https://github.com/databricks/terraform-provider-databricks/pull/4571))
+  * Fix panic caused by incorrect values in the cluster policies ([#4585](https://github.com/databricks/terraform-provider-databricks/pull/4585))
 
 ### Internal Changes

--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -1712,12 +1712,6 @@ func TestImportingUser(t *testing.T) {
 		})
 }
 
-func TestEitherString(t *testing.T) {
-	assert.Equal(t, "a", eitherString("a", nil))
-	assert.Equal(t, "a", eitherString(nil, "a"))
-	assert.Equal(t, "", eitherString(nil, nil))
-}
-
 func TestImportingRepos(t *testing.T) {
 	resp := repos.ReposInformation{
 		ID:           121232342,

--- a/exporter/util.go
+++ b/exporter/util.go
@@ -271,10 +271,14 @@ func (ic *importContext) getMountsThroughCluster(
 
 func eitherString(a any, b any) string {
 	if a != nil {
-		return a.(string)
+		if t, ok := a.(string); ok {
+			return t
+		}
 	}
 	if b != nil {
-		return b.(string)
+		if t, ok := b.(string); ok {
+			return t
+		}
 	}
 	return ""
 }

--- a/exporter/util_test.go
+++ b/exporter/util_test.go
@@ -33,6 +33,18 @@ func TestImportClusterEmitsInitScripts(t *testing.T) {
 	assert.True(t, ic.testEmits["databricks_dbfs_file[<unknown>] (id: /mnt/abc/test.sh)"])
 }
 
+func TestEitherString(t *testing.T) {
+	assert.Equal(t, "foo", eitherString("foo", "bar"))
+	assert.Equal(t, "bar", eitherString(nil, "bar"))
+	assert.Equal(t, "foo", eitherString("foo", ""))
+	assert.Equal(t, "a", eitherString("a", nil))
+	assert.Equal(t, "a", eitherString(nil, "a"))
+	assert.Equal(t, "", eitherString(nil, nil))
+	assert.Equal(t, "a", eitherString(1, "a"))
+	assert.Equal(t, "", eitherString(1, nil))
+	assert.Equal(t, "", eitherString(1, 1))
+}
+
 func TestAddAwsMounts(t *testing.T) {
 	ic := importContextForTest()
 	ic.mountMap = map[string]mount{}


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

The cluster policy is supposed to use `string` type for `value` and `defaultValue` fields of the cluster policy, so explicit cast was done in the code. But it caused the crash when reading an incorrectly specific cluster policy (the user error).  This PR checks if interface type is correct before casting

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] using Go SDK
- [ ] using TF Plugin Framework
