### PR TITLE
Tolerate test failures for permissions APIs

### DIFF
--- a/test-config.yaml
+++ b/test-config.yaml
@@ -21,3 +21,9 @@ ignored_tests:
     - package: github.com/databricks/terraform-provider-databricks/scim
       test_name: TestAccServicePrincipalResourceOnAzure
       comment: Failure due to read-after-write inconsistency. Tracked in https://databricks.atlassian.net/browse/ES-1100061
+    - package: github.com/databricks/terraform-provider-databricks/permissions
+      test_name: TestAccPermissions_Cluster
+      comment: Failure due to API timeouts in the permissions APIs in AWS.
+    - package: github.com/databricks/terraform-provider-databricks/permissions
+      test_name: TestAccPermissions_InstancePool
+      comment: Failure due to API timeouts in the permissions APIs in AWS.


### PR DESCRIPTION
## Changes
With https://github.com/databricks/terraform-provider-databricks/pull/4597, we found that the clusters and instance pools permissions APIs were simply taking longer than a minute to respond to APIs, exceeding the server-side timeout. Because of this, these tests fail irrecoverably. For now, we can ignore these test failures. In parallel, we will investigate the reason for these APIs exceeding their server-side timeout.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] using Go SDK
- [ ] using TF Plugin Framework

NO_CHANGELOG=true