### PR TITLE
[Fix] Reading model serving endpoint with no config

### DIFF
--- a/serving/resource_model_serving.go
+++ b/serving/resource_model_serving.go
@@ -87,7 +87,9 @@ func ResourceModelServing() common.Resource {
 			}
 			if sOrig.Config == nil {
 				// If it is a new resource, then we only return ServedEntities
-				endpoint.Config.ServedModels = nil
+				if endpoint.Config != nil {
+					endpoint.Config.ServedModels = nil
+				}
 			} else {
 				// If it is an existing resource, then have to set one of the responses to nil
 				if sOrig.Config.ServedModels == nil {

--- a/serving/resource_model_serving_test.go
+++ b/serving/resource_model_serving_test.go
@@ -444,6 +444,37 @@ func TestModelServingRead(t *testing.T) {
 	}.ApplyNoError(t)
 }
 
+func TestModelServingReadEmptyConfig(t *testing.T) {
+	qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   http.MethodGet,
+				Resource: "/api/2.0/serving-endpoints/test-endpoint?",
+				Response: map[string]any{
+					"creation_timestamp":           1743085336000,
+					"creator":                      "b76b6808-9e10-43b3-be20-6b6d19ed1af0",
+					"creator_display_name":         "DECO-TF-AWS-PROD-IS-SPN",
+					"creator_kind":                 "ServicePrincipal",
+					"id":                           "84f4b90597b94fb1846a96cb505772f1",
+					"last_updated_timestamp":       1743085336000,
+					"name":                         "test-endpoint-462f54a7-fefd-4d48-bdc2-2659a5439d94",
+					"permission_level":             "CAN_MANAGE",
+					"resource_credential_strategy": "EMBEDDED_CREDENTIALS",
+					"route_optimized":              false,
+					"state": map[string]any{
+						"config_update": "NOT_UPDATING",
+						"ready":         "NOT_READY",
+						"suspend":       "NOT_SUSPENDED",
+					},
+				},
+			},
+		},
+		Resource: ResourceModelServing(),
+		Read:     true,
+		ID:       "test-endpoint",
+	}.ApplyNoError(t)
+}
+
 func TestModelServingRead_Error(t *testing.T) {
 	qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
Importing model serving with empty config should not throw `Error: cannot read model serving: panic: runtime error: invalid memory address or nil pointer dereference`

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] covered with integration tests in `internal/acceptance`
- [x] using Go SDK

NO_CHANGELOG=true