### PR TITLE
Remove GKE test cases from databricks_mws_workspaces and databricks_mws_networks

### DIFF
--- a/mws/mws_networks_test.go
+++ b/mws/mws_networks_test.go
@@ -1,17 +1,9 @@
 package mws_test
 
 import (
-	"context"
-	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/databricks/terraform-provider-databricks/internal/acceptance"
-	tfjson "github.com/hashicorp/terraform-json"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/plancheck"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestMwsAccNetworks(t *testing.T) {
@@ -33,89 +25,11 @@ func TestMwsAccNetworks(t *testing.T) {
 	})
 }
 
-type checkResourceActions struct {
-	address         string
-	expectedActions []tfjson.Action
-}
-
-func (c checkResourceActions) CheckPlan(ctx context.Context, req plancheck.CheckPlanRequest, resp *plancheck.CheckPlanResponse) {
-	var resource *tfjson.ResourceChange
-	for _, r := range req.Plan.ResourceChanges {
-		if r.Address == c.address {
-			resource = r
-			break
-		}
-	}
-	if resource == nil {
-		foundAddresses := make([]string, 0, len(req.Plan.ResourceChanges))
-		for _, r := range req.Plan.ResourceChanges {
-			foundAddresses = append(foundAddresses, r.Address)
-		}
-		resp.Error = fmt.Errorf("address %s not found in plan, found changes for the following resources: %s", c.address, strings.Join(foundAddresses, ", "))
-		return
-	}
-	if err := c.checkActions(resource.Change.Actions); err != nil {
-		resp.Error = err
-	}
-}
-
-// checkActions compares the actual actions for a resource to the expected actions.
-func (c checkResourceActions) checkActions(actualActions tfjson.Actions) error {
-	if len(c.expectedActions) != len(actualActions) {
-		return fmt.Errorf("mismatch in number of actions. Expected %d actions, actual %d actions. Expected actions: %v, actual actions: %v", len(c.expectedActions), len(actualActions), c.expectedActions, actualActions)
-	}
-	for i := range actualActions {
-		expectedAction := c.expectedActions[i]
-		actualAction := actualActions[i]
-		if expectedAction != actualAction {
-			return fmt.Errorf("mismatch in action %d. Expected %q, actual %q. Expected actions: %v, actual actions: %v", i, expectedAction, actualAction, c.expectedActions, actualActions)
-		}
-	}
-	return nil
-}
-
 func TestMwsAccGcpPscNetworks(t *testing.T) {
 	acceptance.AccountLevel(t, acceptance.Step{
 		Template: `
 		resource "databricks_mws_networks" "my_network" {
 			account_id   = "{env.DATABRICKS_ACCOUNT_ID}"
-			network_name = "network-test-{var.STICKY_RANDOM}"
-			gcp_network_info {
-			  network_project_id = "{env.GOOGLE_PROJECT}"
-			  vpc_id = "{env.TEST_VPC_ID}"
-			  subnet_id = "{env.TEST_SUBNET_ID}"
-			  subnet_region = "{env.GOOGLE_REGION}"
-              pod_ip_range_name = "pods"
-              service_ip_range_name = "svc"
-            }
-		}`,
-	}, acceptance.Step{
-		// Changing the name should cause the network to be recreated.
-		Template: `
-		resource "databricks_mws_networks" "my_network" {
-			account_id   = "{env.DATABRICKS_ACCOUNT_ID}"
-			network_name = "network-test-new-{var.STICKY_RANDOM}"
-			gcp_network_info {
-			  network_project_id = "{env.GOOGLE_PROJECT}"
-			  vpc_id = "{env.TEST_VPC_ID}"
-			  subnet_id = "{env.TEST_SUBNET_ID}"
-			  subnet_region = "{env.GOOGLE_REGION}"
-              pod_ip_range_name = "pods"
-              service_ip_range_name = "svc"
-            }
-		}`,
-		ConfigPlanChecks: resource.ConfigPlanChecks{
-			PreApply: []plancheck.PlanCheck{
-				checkResourceActions{"databricks_mws_networks.my_network", []tfjson.Action{tfjson.ActionDelete, tfjson.ActionCreate}},
-			},
-		},
-	}, acceptance.Step{
-		// Removing the pod_ip_range_name and service_ip_range_name fields should
-		// 1. plan a resource update instead of a delete-create.
-		// 2. result in those fields being removed from the state.
-		Template: `
-		resource "databricks_mws_networks" "my_network" {
-			account_id   = "{env.DATABRICKS_ACCOUNT_ID}"
 			network_name = "network-test-new-{var.STICKY_RANDOM}"
 			gcp_network_info {
 			  network_project_id = "{env.GOOGLE_PROJECT}"
@@ -124,30 +38,5 @@ func TestMwsAccGcpPscNetworks(t *testing.T) {
 			  subnet_region = "{env.GOOGLE_REGION}"
             }
 		}`,
-		ConfigPlanChecks: resource.ConfigPlanChecks{
-			PreApply: []plancheck.PlanCheck{
-				checkResourceActions{"databricks_mws_networks.my_network", []tfjson.Action{tfjson.ActionUpdate}},
-			},
-		},
-		Check: func(s *terraform.State) error {
-			r := s.RootModule().Resources["databricks_mws_networks.my_network"].Primary
-			assert.Empty(t, r.Attributes["gcp_network_info.0.pod_ip_range_name"])
-			assert.Empty(t, r.Attributes["gcp_network_info.0.service_ip_range_name"])
-			return nil
-		},
-	}, acceptance.Step{
-		// Destroy and recreate this resource without deprecated GKE-related fields.
-		Template: `
-		resource "databricks_mws_networks" "my_network" {
-			account_id   = "{env.DATABRICKS_ACCOUNT_ID}"
-			network_name = "network-test-new-{var.STICKY_RANDOM}"
-			gcp_network_info {
-			  network_project_id = "{env.GOOGLE_PROJECT}"
-			  vpc_id = "{env.TEST_VPC_ID}"
-			  subnet_id = "{env.TEST_SUBNET_ID}"
-			  subnet_region = "{env.GOOGLE_REGION}"
-            }
-		}`,
-		Taint: []string{"databricks_mws_networks.my_network"},
 	})
 }

--- a/mws/mws_workspaces_test.go
+++ b/mws/mws_workspaces_test.go
@@ -15,12 +15,9 @@ import (
 	"github.com/databricks/terraform-provider-databricks/internal/providers"
 	"github.com/databricks/terraform-provider-databricks/internal/providers/sdkv2"
 	"github.com/databricks/terraform-provider-databricks/tokens"
-	tfjson "github.com/hashicorp/terraform-json"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/stretchr/testify/assert"
 )
@@ -246,13 +243,8 @@ func TestMwsAccGcpWorkspaces(t *testing.T) {
 }
 
 func TestMwsAccGcpByovpcWorkspaces(t *testing.T) {
-	commonResources := func(includeGkeFields bool) string {
-		gkeFields := ""
-		if includeGkeFields {
-			gkeFields = `pod_ip_range_name = "pods"
-				service_ip_range_name = "service"`
-		}
-		return fmt.Sprintf(`
+	acceptance.AccountLevel(t, acceptance.Step{
+		Template: `
 		resource "databricks_mws_networks" "this" {
 			account_id   = "{env.DATABRICKS_ACCOUNT_ID}"
 			network_name = "psc-network-{var.STICKY_RANDOM}"
@@ -261,60 +253,8 @@ func TestMwsAccGcpByovpcWorkspaces(t *testing.T) {
 				vpc_id = "{env.TEST_VPC_ID}"
 				subnet_id = "{env.TEST_SUBNET_ID}"
 				subnet_region = "{env.GOOGLE_REGION}"
-				%s
 			}
 		}
-		`, gkeFields)
-	}
-	acceptance.AccountLevel(t, acceptance.Step{
-		Template: commonResources(true) + `
-		resource "databricks_mws_workspaces" "this" {
-			account_id      = "{env.DATABRICKS_ACCOUNT_ID}"
-			workspace_name  = "psc-test-{var.STICKY_RANDOM}"
-			location        = "{env.GOOGLE_REGION}"
-	
-			cloud_resource_container {
-				gcp {
-					project_id = "{env.GOOGLE_PROJECT}"
-				}
-			}
-						
-			gke_config {
-				connectivity_type = "PRIVATE_NODE_PUBLIC_MASTER"
-				master_ip_range = "10.3.0.0/28"
-			}
-            
-			network_id = databricks_mws_networks.this.network_id
-		}`,
-	}, acceptance.Step{
-		// Changing the workspace name recreates the workspace.
-		Template: commonResources(true) + `
-		resource "databricks_mws_workspaces" "this" {
-			account_id      = "{env.DATABRICKS_ACCOUNT_ID}"
-			workspace_name  = "psc-test-new-{var.STICKY_RANDOM}"
-			location        = "{env.GOOGLE_REGION}"
-	
-			cloud_resource_container {
-				gcp {
-					project_id = "{env.GOOGLE_PROJECT}"
-				}
-			}
-						
-			gke_config {
-				connectivity_type = "PRIVATE_NODE_PUBLIC_MASTER"
-				master_ip_range = "10.3.0.0/28"
-			}
-            
-			network_id = databricks_mws_networks.this.network_id
-		}`,
-		ConfigPlanChecks: resource.ConfigPlanChecks{
-			PreApply: []plancheck.PlanCheck{
-				checkResourceActions{"databricks_mws_workspaces.this", []tfjson.Action{tfjson.ActionDelete, tfjson.ActionCreate}},
-			},
-		},
-	}, acceptance.Step{
-		// Removing gke_config is a no-op because of suppress_diff.
-		Template: commonResources(true) + `
 		resource "databricks_mws_workspaces" "this" {
 			account_id      = "{env.DATABRICKS_ACCOUNT_ID}"
 			workspace_name  = "psc-test-new-{var.STICKY_RANDOM}"
@@ -328,36 +268,6 @@ func TestMwsAccGcpByovpcWorkspaces(t *testing.T) {
             
 			network_id = databricks_mws_networks.this.network_id
 		}`,
-		ConfigPlanChecks: resource.ConfigPlanChecks{
-			PreApply: []plancheck.PlanCheck{
-				checkResourceActions{"databricks_mws_workspaces.this", []tfjson.Action{tfjson.ActionNoop}},
-			},
-		},
-		Check: func(s *terraform.State) error {
-			r := s.RootModule().Resources["databricks_mws_workspaces.this"].Primary
-			assert.Empty(t, r.Attributes["gke_config"])
-			return nil
-		},
-	}, acceptance.Step{
-		// Destroy and recreate the workspace without gke_config.
-		Template: commonResources(false) + `
-		resource "databricks_mws_workspaces" "this" {
-			account_id      = "{env.DATABRICKS_ACCOUNT_ID}"
-			workspace_name  = "psc-test-new-{var.STICKY_RANDOM}"
-			location        = "{env.GOOGLE_REGION}"
-	
-			cloud_resource_container {
-				gcp {
-					project_id = "{env.GOOGLE_PROJECT}"
-				}
-			}
-            
-			network_id = databricks_mws_networks.this.network_id
-		}`,
-		Taint: []string{
-			"databricks_mws_workspaces.this",
-			"databricks_mws_networks.this",
-		},
 	})
 }
 


### PR DESCRIPTION
## Changes
GKE-based GCP workspaces are no longer supported, and all newly created workspaces are backed by GCE. The current GKE-based network and workspace tests can race because it is forbidden to use the same IP ranges in two different networks. As that feature is deprecated, we should be safe to simply remove these tests entirely.

Resolves #4618

## Tests
N/A.

NO_CHANGELOG=true