### PR TITLE
Increase HTTP timeout to 65 seconds

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Bug Fixes
 
+ * Increase the default HTTP timeout to 65 seconds.
+
 ### Documentation
 
  * Document `user_api_scopes` in `databricks_app` resource and data sources ([#4614](https://github.com/databricks/terraform-provider-databricks/pull/4614))

--- a/internal/providers/pluginfw/pluginfw.go
+++ b/internal/providers/pluginfw/pluginfw.go
@@ -160,6 +160,11 @@ func (p *DatabricksProviderPluginFramework) configureDatabricksClient(ctx contex
 			cfg.AuthType = newer
 		}
 	}
+	// If not set, the default provider timeout is 65 seconds. Most APIs have a server-side timeout of 60 seconds.
+	// The additional 5 seconds is to account for network latency.
+	if cfg.HTTPTimeoutSeconds == 0 {
+		cfg.HTTPTimeoutSeconds = 65
+	}
 	if p.configCustomizer != nil {
 		err := p.configCustomizer(cfg)
 		if err != nil {

--- a/internal/providers/sdkv2/sdkv2.go
+++ b/internal/providers/sdkv2/sdkv2.go
@@ -367,6 +367,11 @@ func ConfigureDatabricksClient(ctx context.Context, d *schema.ResourceData, conf
 	if cfg.RetryTimeoutSeconds == 0 {
 		cfg.RetryTimeoutSeconds = -1
 	}
+	// If not set, the default provider timeout is 65 seconds. Most APIs have a server-side timeout of 60 seconds.
+	// The additional 5 seconds is to account for network latency.
+	if cfg.HTTPTimeoutSeconds == 0 {
+		cfg.HTTPTimeoutSeconds = 65
+	}
 	if configCustomizer != nil {
 		err := configCustomizer(cfg)
 		if err != nil {


### PR DESCRIPTION
## Changes
The SDK's default HTTP timeout is 30 seconds for making a request (after the last byte has been sent) and 30 seconds for reading the response. This does not align with the REST API, where the HTTP timeout for many services is closer to 60 seconds. This causes some long-running requests to be canceled on the client side before the service finishes handling the request. Additionally, if the server-side timeout is exceeded, an error message is returned, but this message is currently ignored by the SDK because it is only returned after the client-side timeout is reached.

This PR addresses this by setting the default client-side timeout to 65 seconds for both the SDKv2 and Plugin Framework provider implementations. If this setting is already configured, we'll respect the configured value.

## Tests
- [x] Unit test verifying that the default timeout is set to 65 seconds when unspecified but can be overridden to a different value.
