### PR TITLE
Fix release.yml treatment of release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,16 +38,11 @@ jobs:
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           PASSPHRASE: ${{ secrets.PASSPHRASE }}
 
-      - name: Extract Release Notes
-        id: release_notes
-        run: |
-          git for-each-ref --format='%(body)' ${{ github.ref }} > release_notes.md
-
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:
           version: ~> v2
-          args: release --clean --release-notes=release_notes.md ${{ !startsWith(github.ref, 'refs/tags/v') && '--snapshot' || '' }}
+          args: release --clean ${{ !startsWith(github.ref, 'refs/tags/v') && '--snapshot' || '' }} --release-notes <(git for-each-ref --format='%(body)' ${{ github.ref }})
         env:
           # use GITHUB_TOKEN that is already available in secrets.GITHUB_TOKEN
           # https://docs.github.com/en/free-pro-team@latest/actions/reference/authentication-in-a-workflow#permissions-for-the-github_token


### PR DESCRIPTION
## Changes
There is a bug in the current release job: writing out the release notes to a file causes the following error message to be printed:
```
  ⨯ release failed after 0s                 
    error=
    │ git is in a dirty state
    │ Please check in your pipeline what can be changing the following files:
    │ ?? release_notes.md
```
Instead of writing the notes to a file, we can pipe them directly to the `goreleaser` command as described in https://goreleaser.com/customization/release/#custom-release-notes.

## Tests
Ran the command locally. It's hard to test this effectively. We can try it again once this is merged.

NO_CHANGELOG=true