### PR TITLE
[Internal] Split Constants Outside Version File

### DIFF
--- a/common/constants.go
+++ b/common/constants.go
@@ -1,0 +1,28 @@
+package common
+
+import "context"
+
+var (
+	// ResourceName is resource name without databricks_ prefix
+	ResourceName contextKey = 1
+	// Provider is the current instance of provider
+	Provider contextKey = 2
+	// Current is the current name of integration test
+	Current contextKey = 3
+	// If current resource is data
+	IsData contextKey = 4
+	// apiVersion
+	Api contextKey = 5
+	// SDK used
+	Sdk contextKey = 6
+)
+
+type contextKey int
+
+func (k contextKey) GetOrUnknown(ctx context.Context) string {
+	rn, ok := ctx.Value(k).(string)
+	if !ok {
+		return "unknown"
+	}
+	return rn
+}

--- a/common/version.go
+++ b/common/version.go
@@ -1,32 +1,6 @@
 package common
 
-import "context"
-
-var (
-	version = "1.72.0"
-	// ResourceName is resource name without databricks_ prefix
-	ResourceName contextKey = 1
-	// Provider is the current instance of provider
-	Provider contextKey = 2
-	// Current is the current name of integration test
-	Current contextKey = 3
-	// If current resource is data
-	IsData contextKey = 4
-	// apiVersion
-	Api contextKey = 5
-	// SDK used
-	Sdk contextKey = 6
-)
-
-type contextKey int
-
-func (k contextKey) GetOrUnknown(ctx context.Context) string {
-	rn, ok := ctx.Value(k).(string)
-	if !ok {
-		return "unknown"
-	}
-	return rn
-}
+var version = "1.72.0"
 
 // Version returns version of provider
 func Version() string {


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
The constants in `version.go` are being moved to the internal repository. However, we need to maintain control over the dynamic versioning aspect through the public tagging process. This pull request separates the constants from `version.go` and transfers them to `constants.go`, which will also move to the internal repository. The version-related components will remain in `version.go`, allowing the public tagging process to continue incrementing versions as needed.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally

NO_CHANGELOG=true
