### PR TITLE
Set release notes in a separate step during the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,11 +38,27 @@ jobs:
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           PASSPHRASE: ${{ secrets.PASSPHRASE }}
 
+      - name: Set GoReleaser args
+        run: |
+          if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
+            RELEASE_NOTES_DIR=$(mktemp -d)
+            RELEASE_NOTES_FILE="$RELEASE_NOTES_DIR/release-notes.md"
+            git for-each-ref --format='%(body)' ${{ github.ref }} > "$RELEASE_NOTES_FILE"
+            echo "Release notes contents:"
+            cat "$RELEASE_NOTES_FILE"
+            GORELEASER_ARGS="--release-notes $RELEASE_NOTES_FILE"
+            echo "GORELEASER_ARGS=$GORELEASER_ARGS" >> $GITHUB_ENV
+          else
+            echo "Not a release tag, skipping release notes"
+            GORELEASER_ARGS="--snapshot"
+            echo "GORELEASER_ARGS=$GORELEASER_ARGS" >> $GITHUB_ENV
+          fi
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:
           version: ~> v2
-          args: release --clean ${{ !startsWith(github.ref, 'refs/tags/v') && '--snapshot' || '' }} --release-notes <(git for-each-ref --format='%(body)' ${{ github.ref }})
+          args: release --clean $GORELEASER_ARGS
         env:
           # use GITHUB_TOKEN that is already available in secrets.GITHUB_TOKEN
           # https://docs.github.com/en/free-pro-team@latest/actions/reference/authentication-in-a-workflow#permissions-for-the-github_token


### PR DESCRIPTION
## Changes
https://github.com/databricks/terraform-provider-databricks/actions/runs/14443278474 shows that the release workflow is currently failing after my changes to publish the correct release notes. This seems to be due to an issue with the process substitution recommended at https://goreleaser.com/customization/release/#gitea, maybe to do with github actions behavior. Here, I've modified the process to configure the goreleaser arguments in a separate step.

## Tests
Ran the if/else parts on my own machine with the `github.ref` interpolated.

NO_CHANGELOG=true