### PR TITLE
[Internal] Move some tests from HTTPFixture to Go SDK mocks, part 2

### DIFF
--- a/catalog/data_tables_test.go
+++ b/catalog/data_tables_test.go
@@ -3,32 +3,36 @@ package catalog
 import (
 	"testing"
 
+	"github.com/databricks/databricks-sdk-go/apierr"
+	"github.com/databricks/databricks-sdk-go/experimental/mocks"
 	"github.com/databricks/databricks-sdk-go/service/catalog"
 	"github.com/databricks/terraform-provider-databricks/qa"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
 func TestTablesData(t *testing.T) {
 	qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:   "GET",
-				Resource: "/api/2.1/unity-catalog/tables?catalog_name=a&schema_name=b",
-				Response: catalog.ListTablesResponse{
-					Tables: []catalog.TableInfo{
-						{
-							FullName: "a.b.c",
-							Name:     "c",
-						},
-						{
-							FullName: "a.b.d",
-							Name:     "d",
-						},
+		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
+			w.GetMockTablesAPI().EXPECT().
+				ListAll(mock.Anything, catalog.ListTablesRequest{
+					CatalogName: "a",
+					SchemaName:  "b",
+				}).
+				Return([]catalog.TableInfo{
+					{
+						FullName:  "a.b.c",
+						Name:      "c",
+						TableType: "TABLE",
 					},
-				},
-			},
+					{
+						FullName:  "a.b.d",
+						Name:      "d",
+						TableType: "TABLE",
+					},
+				}, nil)
 		},
 		Resource: DataSourceTables(),
 		HCL: `
@@ -37,30 +41,33 @@ func TestTablesData(t *testing.T) {
 		Read:        true,
 		NonWritable: true,
 		ID:          "_",
-	}.ApplyNoError(t)
+	}.ApplyAndExpectData(t, map[string]any{
+		"ids": []string{"a.b.c", "a.b.d"},
+	})
 }
 
 // https://github.com/databricks/terraform-provider-databricks/issues/1264
 func TestTablesDataIssue1264(t *testing.T) {
 	r := DataSourceTables()
 	d, err := qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:   "GET",
-				Resource: "/api/2.1/unity-catalog/tables?catalog_name=a&schema_name=b",
-				Response: catalog.ListTablesResponse{
-					Tables: []catalog.TableInfo{
-						{
-							Name:     "a",
-							FullName: "a.b.a",
-						},
-						{
-							Name:     "b",
-							FullName: "a.b.b",
-						},
+		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
+			w.GetMockTablesAPI().EXPECT().
+				ListAll(mock.Anything, catalog.ListTablesRequest{
+					CatalogName: "a",
+					SchemaName:  "b",
+				}).
+				Return([]catalog.TableInfo{
+					{
+						Name:      "a",
+						FullName:  "a.b.a",
+						TableType: "TABLE",
 					},
-				},
-			},
+					{
+						Name:      "b",
+						FullName:  "a.b.b",
+						TableType: "TABLE",
+					},
+				}, nil)
 		},
 		Resource: r,
 		HCL: `
@@ -76,23 +83,24 @@ func TestTablesDataIssue1264(t *testing.T) {
 	assert.True(t, s.Contains("a.b.a"))
 
 	d, err = qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:   "GET",
-				Resource: "/api/2.1/unity-catalog/tables?catalog_name=a&schema_name=b",
-				Response: catalog.ListTablesResponse{
-					Tables: []catalog.TableInfo{
-						{
-							Name:     "c",
-							FullName: "a.b.c",
-						},
-						{
-							Name:     "d",
-							FullName: "a.b.d",
-						},
+		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
+			w.GetMockTablesAPI().EXPECT().
+				ListAll(mock.Anything, catalog.ListTablesRequest{
+					CatalogName: "a",
+					SchemaName:  "b",
+				}).
+				Return([]catalog.TableInfo{
+					{
+						Name:      "c",
+						FullName:  "a.b.c",
+						TableType: "TABLE",
 					},
-				},
-			},
+					{
+						Name:      "d",
+						FullName:  "a.b.d",
+						TableType: "TABLE",
+					},
+				}, nil)
 		},
 		Resource: r,
 		HCL: `
@@ -110,10 +118,20 @@ func TestTablesDataIssue1264(t *testing.T) {
 
 func TestTablesData_Error(t *testing.T) {
 	qa.ResourceFixture{
-		Fixtures:    qa.HTTPFailures,
+		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
+			w.GetMockTablesAPI().EXPECT().
+				ListAll(mock.Anything, catalog.ListTablesRequest{
+					CatalogName: "",
+					SchemaName:  "",
+				}).
+				Return(nil, &apierr.APIError{
+					ErrorCode: "BAD_REQUEST",
+					Message:   "Bad request: unable to list tables",
+				})
+		},
 		Resource:    DataSourceTables(),
 		Read:        true,
 		NonWritable: true,
 		ID:          "_",
-	}.ExpectError(t, "i'm a teapot")
+	}.ExpectError(t, "Bad request: unable to list tables")
 }

--- a/catalog/data_views_test.go
+++ b/catalog/data_views_test.go
@@ -3,35 +3,37 @@ package catalog
 import (
 	"testing"
 
+	"github.com/databricks/databricks-sdk-go/apierr"
+	"github.com/databricks/databricks-sdk-go/experimental/mocks"
 	"github.com/databricks/databricks-sdk-go/service/catalog"
 	"github.com/databricks/terraform-provider-databricks/qa"
+	"github.com/stretchr/testify/mock"
 )
 
 func TestViewsData(t *testing.T) {
 	qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:   "GET",
-				Resource: "/api/2.1/unity-catalog/tables?catalog_name=a&schema_name=b",
-				Response: catalog.ListTablesResponse{
-					Tables: []catalog.TableInfo{
-						{
-							CatalogName: "a",
-							SchemaName:  "b",
-							Name:        "c",
-							FullName:    "a.b.c",
-							TableType:   "MANAGED",
-						},
-						{
-							CatalogName: "a",
-							SchemaName:  "b",
-							Name:        "d",
-							FullName:    "a.b.d",
-							TableType:   "VIEW",
-						},
+		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
+			w.GetMockTablesAPI().EXPECT().
+				ListAll(mock.Anything, catalog.ListTablesRequest{
+					CatalogName: "a",
+					SchemaName:  "b",
+				}).
+				Return([]catalog.TableInfo{
+					{
+						CatalogName: "a",
+						SchemaName:  "b",
+						Name:        "c",
+						FullName:    "a.b.c",
+						TableType:   "MANAGED",
 					},
-				},
-			},
+					{
+						CatalogName: "a",
+						SchemaName:  "b",
+						Name:        "d",
+						FullName:    "a.b.d",
+						TableType:   "VIEW",
+					},
+				}, nil)
 		},
 		Resource: DataSourceViews(),
 		HCL: `
@@ -47,10 +49,20 @@ func TestViewsData(t *testing.T) {
 
 func TestViewsData_Error(t *testing.T) {
 	qa.ResourceFixture{
-		Fixtures:    qa.HTTPFailures,
+		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
+			w.GetMockTablesAPI().EXPECT().
+				ListAll(mock.Anything, catalog.ListTablesRequest{
+					CatalogName: "",
+					SchemaName:  "",
+				}).
+				Return(nil, &apierr.APIError{
+					ErrorCode: "BAD_REQUEST",
+					Message:   "Bad request: unable to list views",
+				})
+		},
 		Resource:    DataSourceViews(),
 		Read:        true,
 		NonWritable: true,
 		ID:          "_",
-	}.ExpectError(t, "i'm a teapot")
+	}.ExpectError(t, "Bad request: unable to list views")
 }

--- a/catalog/data_volumes_test.go
+++ b/catalog/data_volumes_test.go
@@ -3,25 +3,27 @@ package catalog
 import (
 	"testing"
 
+	"github.com/databricks/databricks-sdk-go/apierr"
+	"github.com/databricks/databricks-sdk-go/experimental/mocks"
 	"github.com/databricks/databricks-sdk-go/service/catalog"
 	"github.com/databricks/terraform-provider-databricks/qa"
+	"github.com/stretchr/testify/mock"
 )
 
 func TestDataSourceVolumes(t *testing.T) {
 	qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:   "GET",
-				Resource: "/api/2.1/unity-catalog/volumes?catalog_name=a&schema_name=b",
-				Response: catalog.ListVolumesResponseContent{
-					Volumes: []catalog.VolumeInfo{
-						{
-							FullName: "a.b.c",
-							Name:     "a",
-						},
+		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
+			w.GetMockVolumesAPI().EXPECT().
+				ListAll(mock.Anything, catalog.ListVolumesRequest{
+					CatalogName: "a",
+					SchemaName:  "b",
+				}).
+				Return([]catalog.VolumeInfo{
+					{
+						FullName: "a.b.c",
+						Name:     "a",
 					},
-				},
-			},
+				}, nil)
 		},
 		Resource: DataSourceVolumes(),
 		HCL: `
@@ -30,15 +32,27 @@ func TestDataSourceVolumes(t *testing.T) {
 		Read:        true,
 		NonWritable: true,
 		ID:          "_",
-	}.ApplyNoError(t)
+	}.ApplyAndExpectData(t, map[string]any{
+		"ids": []string{"a.b.c"},
+	})
 }
 
 func TestDataSourceVolumes_Error(t *testing.T) {
 	qa.ResourceFixture{
-		Fixtures:    qa.HTTPFailures,
+		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
+			w.GetMockVolumesAPI().EXPECT().
+				ListAll(mock.Anything, catalog.ListVolumesRequest{
+					CatalogName: "",
+					SchemaName:  "",
+				}).
+				Return(nil, &apierr.APIError{
+					ErrorCode: "BAD_REQUEST",
+					Message:   "Bad request: unable to list volumes",
+				})
+		},
 		Resource:    DataSourceVolumes(),
 		Read:        true,
 		NonWritable: true,
 		ID:          "_",
-	}.ExpectError(t, "i'm a teapot")
+	}.ExpectError(t, "Bad request: unable to list volumes")
 }

--- a/jobs/data_jobs_test.go
+++ b/jobs/data_jobs_test.go
@@ -3,32 +3,33 @@ package jobs
 import (
 	"testing"
 
+	"github.com/databricks/databricks-sdk-go/experimental/mocks"
+	"github.com/databricks/databricks-sdk-go/listing"
+	"github.com/databricks/databricks-sdk-go/service/jobs"
 	"github.com/databricks/terraform-provider-databricks/qa"
+	"github.com/stretchr/testify/mock"
 )
 
 func TestJobsData(t *testing.T) {
 	qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:   "GET",
-				Resource: "/api/2.2/jobs/list?limit=100",
-				Response: JobListResponse{
-					Jobs: []Job{
-						{
-							JobID: 123,
-							Settings: &JobSettings{
-								Name: "First",
-							},
-						},
-						{
-							JobID: 234,
-							Settings: &JobSettings{
-								Name: "Second",
-							},
-						},
+		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
+			iterator := listing.SliceIterator[jobs.BaseJob]{
+				{
+					JobId: 123,
+					Settings: &jobs.JobSettings{
+						Name: "First",
 					},
 				},
-			},
+				{
+					JobId: 234,
+					Settings: &jobs.JobSettings{
+						Name: "Second",
+					},
+				},
+			}
+			w.GetMockJobsAPI().EXPECT().
+				List(mock.Anything, jobs.ListJobsRequest{ExpandTasks: false, Limit: 100}).
+				Return(&iterator)
 		},
 		Resource:    DataSourceJobs(),
 		Read:        true,
@@ -44,27 +45,24 @@ func TestJobsData(t *testing.T) {
 
 func TestJobsDataWithFilter(t *testing.T) {
 	qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:   "GET",
-				Resource: "/api/2.2/jobs/list?limit=100",
-				Response: JobListResponse{
-					Jobs: []Job{
-						{
-							JobID: 123,
-							Settings: &JobSettings{
-								Name: "First",
-							},
-						},
-						{
-							JobID: 234,
-							Settings: &JobSettings{
-								Name: "Second",
-							},
-						},
+		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
+			iterator := listing.SliceIterator[jobs.BaseJob]{
+				{
+					JobId: 123,
+					Settings: &jobs.JobSettings{
+						Name: "First",
 					},
 				},
-			},
+				{
+					JobId: 234,
+					Settings: &jobs.JobSettings{
+						Name: "Second",
+					},
+				},
+			}
+			w.GetMockJobsAPI().EXPECT().
+				List(mock.Anything, jobs.ListJobsRequest{ExpandTasks: false, Limit: 100}).
+				Return(&iterator)
 		},
 		Resource:    DataSourceJobs(),
 		Read:        true,


### PR DESCRIPTION
NO_CHANGELOG=true

## Changes
<!-- Summary of your changes that are easy to understand -->

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [x] using Go SDK
- [ ] using TF Plugin Framework
