### PR TITLE
Another attempt at fixing release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,27 +38,38 @@ jobs:
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           PASSPHRASE: ${{ secrets.PASSPHRASE }}
 
-      - name: Set GoReleaser args
+      - name: Write release notes to file
         run: |
           if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
-            RELEASE_NOTES_DIR=$(mktemp -d)
+            RELEASE_NOTES_DIR=/tmp/release-notes
+            mkdir -p "$RELEASE_NOTES_DIR"
             RELEASE_NOTES_FILE="$RELEASE_NOTES_DIR/release-notes.md"
             git for-each-ref --format='%(body)' ${{ github.ref }} > "$RELEASE_NOTES_FILE"
+            echo "Release notes file: $RELEASE_NOTES_FILE"
             echo "Release notes contents:"
             cat "$RELEASE_NOTES_FILE"
-            GORELEASER_ARGS="--release-notes $RELEASE_NOTES_FILE"
-            echo "GORELEASER_ARGS=$GORELEASER_ARGS" >> $GITHUB_ENV
           else
             echo "Not a release tag, skipping release notes"
-            GORELEASER_ARGS="--snapshot"
-            echo "GORELEASER_ARGS=$GORELEASER_ARGS" >> $GITHUB_ENV
           fi
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         with:
           version: ~> v2
-          args: release --clean $GORELEASER_ARGS
+          args: release --clean --release-notes=/tmp/release-notes/release-notes.md
+        env:
+          # use GITHUB_TOKEN that is already available in secrets.GITHUB_TOKEN
+          # https://docs.github.com/en/free-pro-team@latest/actions/reference/authentication-in-a-workflow#permissions-for-the-github_token
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
+
+      - name: Run GoReleaser (snapshot)
+        uses: goreleaser/goreleaser-action@v6
+        if: ${{ ! startsWith(github.ref , 'refs/tags/v') }}
+        with:
+          version: ~> v2
+          args: release --clean --snapshot
         env:
           # use GITHUB_TOKEN that is already available in secrets.GITHUB_TOKEN
           # https://docs.github.com/en/free-pro-team@latest/actions/reference/authentication-in-a-workflow#permissions-for-the-github_token

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,6 +57,8 @@ jobs:
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         with:
           version: ~> v2
+          # Arguments cannot reference environment variables, so we write the release notes
+          # to a well-known location and use that in the goreleaser command.
           args: release --clean --release-notes=/tmp/release-notes/release-notes.md
         env:
           # use GITHUB_TOKEN that is already available in secrets.GITHUB_TOKEN


### PR DESCRIPTION
## Changes
Apparently environment variables cannot be interpolated into the arguments of another Github action. This is the last attempt which should work by writing the release notes into a well-known file outside of the current directory (in `/tmp`). 

## Tests

NO_CHANGELOG=true
