### PR TITLE
[Exporter] Add `Ignore` implementation for `databricks_grants` to fix issue with wrongly generated dependencies

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -16,5 +16,6 @@
 ### Exporter
 
  * Correctly handle account-level identities when generating the code ([#4650](https://github.com/databricks/terraform-provider-databricks/pull/4650))
+ * Add `Ignore` implementation for `databricks_grants` to fix issue with wrongly generated dependencies ([#4661](https://github.com/databricks/terraform-provider-databricks/pull/4650))
 
 ### Internal Changes

--- a/exporter/importables.go
+++ b/exporter/importables.go
@@ -2110,6 +2110,10 @@ var resourcesMap map[string]importable = map[string]importable{
 		WorkspaceLevel: true,
 		Service:        "uc-grants",
 		Import:         importUcGrants,
+		Ignore: func(ic *importContext, r *resource) bool {
+			return (r.Data.Get("grant.#").(int) == 0)
+		},
+
 		Depends: []reference{
 			{Path: "catalog", Resource: "databricks_catalog"},
 			{Path: "schema", Resource: "databricks_schema"},


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

The lack of `Ignore` led to the situation when we added a `depends_on` on grant and grants list was empty, but the reference wasn't removed from `depends_on` list because we didn't have `Ignore` implementation.

Resolves #4025

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] using Go SDK
- [ ] using TF Plugin Framework
