### PR TITLE
[Exporter] Emit files installed with `%pip install` in Python notebooks

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### Exporter
 
+ * Emit files installed with `%pip install` in Python notebooks ([#4664](https://github.com/databricks/terraform-provider-databricks/pull/4664))
  * Correctly handle account-level identities when generating the code ([#4650](https://github.com/databricks/terraform-provider-databricks/pull/4650))
 
 ### Internal Changes

--- a/exporter/impl_workspace.go
+++ b/exporter/impl_workspace.go
@@ -1,0 +1,88 @@
+package exporter
+
+import (
+	"encoding/base64"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/databricks/databricks-sdk-go/apierr"
+	sdk_workspace "github.com/databricks/databricks-sdk-go/service/workspace"
+)
+
+func ImportNotebook(ic *importContext, r *resource) error {
+	ic.emitUserOrServicePrincipalForPath(r.ID, "/Users")
+	resp, err := ic.workspaceClient.Workspace.Export(ic.Context, sdk_workspace.ExportRequest{
+		Path:   r.ID,
+		Format: sdk_workspace.ExportFormat(ic.notebooksFormat),
+	})
+	if err != nil {
+		if apierr.IsMissing(err) {
+			ic.addIgnoredResource(fmt.Sprintf("databricks_notebook. path=%s", r.ID))
+		}
+		return err
+	}
+	var fileExtension string
+	if ic.notebooksFormat == "SOURCE" {
+		language := r.Data.Get("language").(string)
+		fileExtension = fileExtensionLanguageMapping[language]
+		r.Data.Set("language", "")
+	} else {
+		fileExtension = fileExtensionFormatMapping[ic.notebooksFormat]
+	}
+	r.Data.Set("format", ic.notebooksFormat)
+	objectId := r.Data.Get("object_id").(int)
+	name := fileNameNormalizationRegex.ReplaceAllString(r.ID[1:], "_") + "_" + strconv.Itoa(objectId) + fileExtension
+	content, _ := base64.StdEncoding.DecodeString(resp.Content)
+	fileName, err := ic.saveFileIn("notebooks", name, []byte(content))
+	if err != nil {
+		return err
+	}
+	if ic.notebooksFormat == "SOURCE" && r.Data.Get("language").(string) == "PYTHON" {
+		analyzeNotebook(ic, string(content))
+	}
+	ic.emitPermissionsIfNotIgnored(r, fmt.Sprintf("/notebooks/%d", objectId),
+		"notebook_"+ic.Importables["databricks_notebook"].Name(ic, r.Data))
+	// TODO: it's not completely correct condition - we need to make emit smarter -
+	// emit only if permissions are different from their parent's permission.
+	ic.emitWorkspaceObjectParentDirectory(r)
+	return r.Data.Set("source", fileName)
+}
+
+func analyzeNotebook(ic *importContext, content string) {
+	lines := strings.Split(content, "\n")
+	for _, line := range lines {
+		if strings.HasPrefix(strings.TrimSpace(line), "#") {
+			continue
+		}
+
+		if strings.HasPrefix(strings.TrimSpace(line), "%pip") && strings.Contains(line, " install ") {
+			parts := strings.Fields(line)
+			if len(parts) < 3 {
+				continue
+			}
+			for _, part := range parts[2:] {
+				if strings.HasPrefix(part, "-") || strings.Contains(part, "==") {
+					continue
+				}
+				if strings.HasPrefix(part, "/dbfs/") {
+					ic.Emit(&resource{
+						Resource: "databricks_dbfs_file",
+						ID:       strings.TrimPrefix(part, "/dbfs"),
+					})
+				} else if strings.HasPrefix(part, "/Workspace/") {
+					ic.Emit(&resource{
+						Resource: "databricks_workspace_file",
+						ID:       strings.TrimPrefix(part, "/Workspace"),
+					})
+				} else if strings.HasPrefix(part, "/Volumes/") {
+					ic.Emit(&resource{
+						Resource: "databricks_file",
+						ID:       part,
+					})
+				}
+			}
+		}
+	}
+
+}


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

This is quite a naive implementation, but it should help a bit for extracting dependencies, especially for DLT pipelines

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] using Go SDK
- [ ] using TF Plugin Framework
