### PR TITLE
Fix `databricks_sql_permissions` to create a working cluster by default

### DIFF
--- a/access/resource_sql_permissions.go
+++ b/access/resource_sql_permissions.go
@@ -267,7 +267,7 @@ func (ta *SqlPermissions) initCluster(ctx context.Context, d *schema.ResourceDat
 		return
 	}
 	if v, ok := clusterInfo.SparkConf["spark.databricks.acl.dfAclsEnabled"]; (!ok || v != "true") && clusterInfo.DataSecurityMode != "USER_ISOLATION" && clusterInfo.DataSecurityMode != "LEGACY_TABLE_ACL" {
-		err = fmt.Errorf("cluster_id: pecified cluster does not support setting Table ACL: %s (%s)",
+		err = fmt.Errorf("cluster_id: specified cluster does not support setting Table ACL: %s (%s)",
 			clusterInfo.ClusterName, clusterInfo.ClusterID)
 		return
 	}

--- a/access/resource_sql_permissions.go
+++ b/access/resource_sql_permissions.go
@@ -287,13 +287,7 @@ func (ta *SqlPermissions) getOrCreateCluster(clustersAPI clusters.ClustersAPI) (
 			NodeTypeID:             nodeType,
 			AutoterminationMinutes: 10,
 			DataSecurityMode:       "LEGACY_TABLE_ACL",
-			SparkConf: map[string]string{
-				"spark.databricks.cluster.profile": "singleNode",
-				"spark.master":                     "local[*]",
-			},
-			CustomTags: map[string]string{
-				"ResourceClass": "SingleNode",
-			},
+			NumWorkers:             1,
 		})
 	if err != nil {
 		return "", err

--- a/access/sql_permissions_test.go
+++ b/access/sql_permissions_test.go
@@ -1,4 +1,4 @@
-package sql_test
+package access_test
 
 import (
 	"context"
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestAccTableACL(t *testing.T) {
+func TestAccSqlPermissions(t *testing.T) {
 	acceptance.LoadWorkspaceEnv(t)
 	tableName := qa.RandomName("table_acl_")
 	clusterId := acceptance.GetEnvOrSkipTest(t, "TEST_TABLE_ACL_CLUSTER_ID")

--- a/sql/sql_permissions_test.go
+++ b/sql/sql_permissions_test.go
@@ -46,7 +46,6 @@ func TestAccTableACL(t *testing.T) {
 				principal = "users"
 				privileges = ["SELECT"]
 			}
-			cluster_id = "` + clusterId + `"
 		}`,
 	})
 }


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] using Go SDK
- [ ] using TF Plugin Framework
