### PR TITLE
[Fix] Populate partitions when reading `databricks_sql_table`

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Bug Fixes
 
  * Fix automatic cluster creation for `databricks_sql_permissions` ([#4141](https://github.com/databricks/terraform-provider-databricks/pull/4141))
+ * Populate `partitions` when reading `databricks_sql_table` ([#4486](https://github.com/databricks/terraform-provider-databricks/pull/4486)).
 
 ### Documentation
 

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -7,7 +7,7 @@
 ### Bug Fixes
 
  * Fix automatic cluster creation for `databricks_sql_permissions` ([#4141](https://github.com/databricks/terraform-provider-databricks/pull/4141))
- * Populate `partitions` when reading `databricks_sql_table` ([#4486](https://github.com/databricks/terraform-provider-databricks/pull/4486)).
+ * Populate `partitions` when reading `databricks_sql_table` ([#4674](https://github.com/databricks/terraform-provider-databricks/pull/4674)).
 
 ### Documentation
 

--- a/catalog/resource_sql_table.go
+++ b/catalog/resource_sql_table.go
@@ -68,16 +68,6 @@ type SqlTableInfo struct {
 	sqlExec sql.StatementExecutionInterface
 }
 
-// need a separate struct as partition_index is 0-based
-type ColumnPartitionInfo struct {
-	Name           string `json:"name"`
-	PartitionIndex *int   `json:"partition_index,omitempty"`
-}
-
-type PartitionInfo struct {
-	ColumnInfos []ColumnPartitionInfo `json:"columns,omitempty"`
-}
-
 func (ti SqlTableInfo) CustomizeSchema(s *common.CustomizableSchema) *common.CustomizableSchema {
 	caseInsensitiveFields := []string{"name", "catalog_name", "schema_name"}
 	for _, field := range caseInsensitiveFields {
@@ -117,11 +107,6 @@ func (a SqlTablesAPI) getTable(name string) (ti SqlTableInfo, err error) {
 	// Copy returned properties & options to read-only attributes
 	ti.EffectiveProperties = ti.Properties
 	ti.Properties = nil
-	return
-}
-
-func (a SqlTablesAPI) getPartitions(name string) (ti PartitionInfo, err error) {
-	err = a.client.Get(a.context, "/unity-catalog/tables/"+name, nil, &ti)
 	return
 }
 
@@ -691,7 +676,11 @@ func ResourceSqlTable() common.Resource {
 			if err != nil {
 				return err
 			}
-			partitionInfo, err := NewSqlTablesAPI(ctx, c).getPartitions(d.Id())
+			w, err := c.WorkspaceClient()
+			if err != nil {
+				return err
+			}
+			partitionInfo, err := w.Tables.GetByFullName(ctx, d.Id())
 			if err != nil {
 				return err
 			}
@@ -704,10 +693,10 @@ func ResourceSqlTable() common.Resource {
 				}
 			}
 
-			for i := range partitionInfo.ColumnInfos {
-				c := &partitionInfo.ColumnInfos[i]
-				if c.PartitionIndex != nil {
-					partitionIndexes[*c.PartitionIndex] = c.Name
+			for i := range partitionInfo.Columns {
+				c := &partitionInfo.Columns[i]
+				if slices.Contains(c.ForceSendFields, "PartitionIndex") {
+					partitionIndexes[c.PartitionIndex] = c.Name
 				}
 			}
 			indexes := []int{}

--- a/catalog/resource_sql_table.go
+++ b/catalog/resource_sql_table.go
@@ -50,7 +50,7 @@ type SqlTableInfo struct {
 	TableType             string            `json:"table_type" tf:"force_new"`
 	DataSourceFormat      string            `json:"data_source_format,omitempty" tf:"force_new"`
 	ColumnInfos           []SqlColumnInfo   `json:"columns,omitempty" tf:"alias:column,computed"`
-	Partitions            []string          `json:"partitions,omitempty" tf:"force_new"`
+	Partitions            []string          `json:"partitions,omitempty" tf:"force_new,computed"`
 	ClusterKeys           []string          `json:"cluster_keys,omitempty"`
 	StorageLocation       string            `json:"storage_location,omitempty" tf:"suppress_diff"`
 	StorageCredentialName string            `json:"storage_credential_name,omitempty" tf:"force_new"`

--- a/catalog/resource_sql_table_test.go
+++ b/catalog/resource_sql_table_test.go
@@ -251,8 +251,8 @@ func TestResourceSqlTableCreateTable(t *testing.T) {
 			},
 			{
 				Method:   "GET",
-				Resource: "/api/2.1/unity-catalog/tables/main.foo.bar",
-				Response: PartitionInfo{},
+				Resource: "/api/2.1/unity-catalog/tables/main.foo.bar?",
+				Response: catalog.TableInfo{},
 			},
 		}, useExistingClusterForSql...),
 		Create:   true,
@@ -331,8 +331,8 @@ func TestResourceSqlTableCreateTableWithOwner(t *testing.T) {
 			},
 			{
 				Method:   "GET",
-				Resource: "/api/2.1/unity-catalog/tables/main.foo.bar",
-				Response: PartitionInfo{},
+				Resource: "/api/2.1/unity-catalog/tables/main.foo.bar?",
+				Response: catalog.TableInfo{},
 			},
 		}, useExistingClusterForSql...),
 		Create:   true,
@@ -457,6 +457,11 @@ func TestResourceSqlTableUpdateTable(t *testing.T) {
 				},
 			},
 			{
+				Method:   "GET",
+				Resource: "/api/2.1/unity-catalog/tables/main.foo.bar?",
+				Response: catalog.TableInfo{},
+			},
+			{
 				Method:   "POST",
 				Resource: "/api/2.0/clusters/start",
 				ExpectedRequest: clusters.ClusterID{
@@ -558,6 +563,11 @@ func TestResourceSqlTableUpdateTableAndOwner(t *testing.T) {
 				},
 			},
 			{
+				Method:   "GET",
+				Resource: "/api/2.1/unity-catalog/tables/main.foo.bar?",
+				Response: catalog.TableInfo{},
+			},
+			{
 				Method:   "POST",
 				Resource: "/api/2.0/clusters/start",
 				ExpectedRequest: clusters.ClusterID{
@@ -654,6 +664,11 @@ func TestResourceSqlTableUpdateTableClusterKeys(t *testing.T) {
 				},
 			},
 			{
+				Method:   "GET",
+				Resource: "/api/2.1/unity-catalog/tables/main.foo.bar?",
+				Response: catalog.TableInfo{},
+			},
+			{
 				Method:   "POST",
 				Resource: "/api/2.0/clusters/start",
 				ExpectedRequest: clusters.ClusterID{
@@ -742,6 +757,11 @@ func TestResourceSqlTableUpdateView(t *testing.T) {
 						},
 					},
 				},
+			},
+			{
+				Method:   "GET",
+				Resource: "/api/2.1/unity-catalog/tables/main.foo.bar?",
+				Response: catalog.TableInfo{},
 			},
 			{
 				Method:   "POST",
@@ -854,8 +874,8 @@ func TestResourceSqlTableUpdateView_Definition(t *testing.T) {
 			},
 			{
 				Method:   "GET",
-				Resource: "/api/2.1/unity-catalog/tables/main.foo.barview",
-				Response: PartitionInfo{},
+				Resource: "/api/2.1/unity-catalog/tables/main.foo.barview?",
+				Response: catalog.TableInfo{},
 			},
 			{
 				Method:   "POST",
@@ -914,8 +934,8 @@ func TestResourceSqlTableUpdateView_Comments(t *testing.T) {
 			},
 			{
 				Method:   "GET",
-				Resource: "/api/2.1/unity-catalog/tables/main.foo.barview",
-				Response: PartitionInfo{},
+				Resource: "/api/2.1/unity-catalog/tables/main.foo.barview?",
+				Response: catalog.TableInfo{},
 			},
 			{
 				Method:   "POST",
@@ -1008,6 +1028,11 @@ func resourceSqlTableUpdateColumnHelper(t *testing.T, testMetaData resourceSqlTa
 					Comment:               "terraform managed",
 					ColumnInfos:           testMetaData.oldColumns,
 				},
+			},
+			{
+				Method:   "GET",
+				Resource: "/api/2.1/unity-catalog/tables/main.foo.bar?",
+				Response: catalog.TableInfo{},
 			},
 			{
 				Method:   "POST",
@@ -1399,8 +1424,8 @@ func TestResourceSqlTableCreateTable_ExistingSQLWarehouse(t *testing.T) {
 			},
 			{
 				Method:   "GET",
-				Resource: "/api/2.1/unity-catalog/tables/main.foo.bar",
-				Response: PartitionInfo{},
+				Resource: "/api/2.1/unity-catalog/tables/main.foo.bar?",
+				Response: catalog.TableInfo{},
 			},
 		},
 		Create:   true,
@@ -1497,8 +1522,8 @@ func TestResourceSqlTableCreateTableWithIdentityColumn_ExistingSQLWarehouse(t *t
 			},
 			{
 				Method:   "GET",
-				Resource: "/api/2.1/unity-catalog/tables/main.foo.bar",
-				Response: PartitionInfo{},
+				Resource: "/api/2.1/unity-catalog/tables/main.foo.bar?",
+				Response: catalog.TableInfo{},
 			},
 		},
 		Create:   true,
@@ -1568,8 +1593,8 @@ func TestResourceSqlTableReadTableWithIdentityColumn_ExistingSQLWarehouse(t *tes
 			},
 			{
 				Method:   "GET",
-				Resource: "/api/2.1/unity-catalog/tables/main.foo.bar",
-				Response: PartitionInfo{},
+				Resource: "/api/2.1/unity-catalog/tables/main.foo.bar?",
+				Response: catalog.TableInfo{},
 			},
 		},
 		ID:       "main.foo.bar",
@@ -1582,9 +1607,6 @@ func TestResourceSqlTableReadTableWithIdentityColumn_ExistingSQLWarehouse(t *tes
 	})
 }
 
-func getPtr(num int) *int {
-	return &num
-}
 func TestResourceSqlTableReadTableWithPartitionColumn_ExistingSQLWarehouse(t *testing.T) {
 	qa.ResourceFixture{
 		CommandMock: func(commandStr string) common.CommandResults {
@@ -1643,16 +1665,18 @@ func TestResourceSqlTableReadTableWithPartitionColumn_ExistingSQLWarehouse(t *te
 			},
 			{
 				Method:   "GET",
-				Resource: "/api/2.1/unity-catalog/tables/main.foo.bar",
-				Response: PartitionInfo{
-					ColumnInfos: []ColumnPartitionInfo{
+				Resource: "/api/2.1/unity-catalog/tables/main.foo.bar?",
+				Response: catalog.TableInfo{
+					Columns: []catalog.ColumnInfo{
 						{
-							Name:           "id",
-							PartitionIndex: getPtr(1),
+							Name:            "id",
+							PartitionIndex:  1,
+							ForceSendFields: []string{"PartitionIndex"},
 						},
 						{
-							Name:           "name",
-							PartitionIndex: getPtr(0),
+							Name:            "name",
+							PartitionIndex:  0,
+							ForceSendFields: []string{"PartitionIndex"},
 						},
 						{
 							Name: "number",
@@ -1734,8 +1758,8 @@ func TestResourceSqlTableCreateTable_OnlyManagedProperties(t *testing.T) {
 			},
 			{
 				Method:   "GET",
-				Resource: "/api/2.1/unity-catalog/tables/main.foo.bar",
-				Response: PartitionInfo{},
+				Resource: "/api/2.1/unity-catalog/tables/main.foo.bar?",
+				Response: catalog.TableInfo{},
 			},
 		},
 		Create:   true,

--- a/docs/resources/sql_table.md
+++ b/docs/resources/sql_table.md
@@ -188,7 +188,7 @@ The following arguments are supported:
 
 ### `column` configuration block
 
-For table columns
+For table columns. These can be optional for external tables.
 Currently, changing the column definitions for a table will require dropping and re-creating the table
 
 * `name` - User-visible name of column


### PR DESCRIPTION
## Changes
- Redo #4486, marking `partitions` column as optional computed to avoid unexpected diff.
- UC returns `partition_index` in the column struct, so we can calculate partitions value based on that
- Resolves https://github.com/databricks/terraform-provider-databricks/issues/3980

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [x] covered with integration tests in `internal/acceptance`
- [x] using Go SDK
- [x] using TF Plugin Framework
