### PR TITLE
Update storage_credential docs to reference name not id

### DIFF
--- a/docs/resources/storage_credential.md
+++ b/docs/resources/storage_credential.md
@@ -26,7 +26,7 @@ resource "databricks_storage_credential" "external" {
 }
 
 resource "databricks_grants" "external_creds" {
-  storage_credential = databricks_storage_credential.external.id
+  storage_credential = databricks_storage_credential.external.name
   grant {
     principal  = "Data Engineers"
     privileges = ["CREATE_EXTERNAL_TABLE"]
@@ -46,7 +46,7 @@ resource "databricks_storage_credential" "external_mi" {
 }
 
 resource "databricks_grants" "external_creds" {
-  storage_credential = databricks_storage_credential.external_mi.id
+  storage_credential = databricks_storage_credential.external_mi.name
   grant {
     principal  = "Data Engineers"
     privileges = ["CREATE_EXTERNAL_TABLE"]
@@ -63,7 +63,7 @@ resource "databricks_storage_credential" "external" {
 }
 
 resource "databricks_grants" "external_creds" {
-  storage_credential = databricks_storage_credential.external.id
+  storage_credential = databricks_storage_credential.external.name
   grant {
     principal  = "Data Engineers"
     privileges = ["CREATE_EXTERNAL_TABLE"]


### PR DESCRIPTION
## Changes
Updates docs/resources/storage_credential.md examples of creating databricks_grants resources that reference a storage_credential. Previously it had indicated referencing the credential by id. In my case, the name and id are not identical, and referencing credential by id caused errors, where referencing by name did not.

It appears that this package may be written with the assumption that name and id have the same value.
On line 117 of this same storage_credential.md it says
`- 'id' - ID of this storage credential - same as the 'name'.`
And there is a test `catalog/external_location_test.go` that indicates storage_credential name and id are interchangeable
```
func externalLocationTemplateWithOwner(comment string, owner string) string {
	return fmt.Sprintf(`
		resource "databricks_external_location" "some" {
			name            = "external-{var.STICKY_RANDOM}"
			url             = "s3://{env.TEST_BUCKET}/some{var.STICKY_RANDOM}"
			credential_name = databricks_storage_credential.external.id
			isolation_mode  = "ISOLATION_MODE_ISOLATED"
			comment         = "%s"
			owner = "%s"
		}
	`, comment, owner)
}
```

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] using Go SDK
- [ ] using TF Plugin Framework
