### PR TITLE
[Internal] Relax the check for "parent folder doesn't exist" error

### DIFF
--- a/workspace/resource_notebook.go
+++ b/workspace/resource_notebook.go
@@ -401,6 +401,6 @@ func ResourceNotebook() common.Resource {
 }
 
 func isParentDoesntExistError(err error) bool {
-	errStr := err.Error()
-	return strings.HasPrefix(errStr, "The parent folder ") && strings.HasSuffix(errStr, " does not exist.")
+	errStr := strings.ToLower(err.Error())
+	return strings.Contains(errStr, "parent folder ") && strings.Contains(errStr, " does not exist")
 }


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

Check that parent folder doesn't exist in `databricks_notebook` and `databricks_workspace_file` is too specific and leads to an error in staging.  This PR relax this check a bit to avoid problems.

NO_CHANGELOG=true

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] using Go SDK
- [ ] using TF Plugin Framework
