### PR TITLE
Fix validation of S3 bucket name in `databricks_aws_unity_catalog_policy` and `databricks_aws_bucket_policy`

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Bug Fixes
 
+ * Fix validation of S3 bucket name in `databricks_aws_unity_catalog_policy` and `databricks_aws_bucket_policy` [#4691](https://github.com/databricks/terraform-provider-databricks/pull/4691)
+
 ### Documentation
 
 ### Exporter

--- a/aws/constants.go
+++ b/aws/constants.go
@@ -1,5 +1,7 @@
 package aws
 
+import "regexp"
+
 var AwsConfig = map[string]map[string]string{
 	"aws": {
 		"accountId":            "414351767826",
@@ -23,3 +25,6 @@ var AwsConfig = map[string]map[string]string{
 
 var AwsPartitions = []string{"aws", "aws-us-gov", "aws-us-gov-dod"}
 var AwsPartitionsValidationError = "aws_partition must be either 'aws' or 'aws-us-gov' or 'aws-us-gov-dod'"
+
+var AwsBucketNameRegex = regexp.MustCompile(`^[0-9a-z][-0-9a-z\.]{1,61}[0-9a-z]$`)
+var AwsBucketNameRegexError = "must contain only alphanumeric, dot, and hyphen characters"

--- a/aws/data_aws_bucket_policy.go
+++ b/aws/data_aws_bucket_policy.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"regexp"
+	"strings"
 
 	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -62,7 +62,7 @@ func DataAwsBucketPolicy() common.Resource {
 			if err != nil {
 				return err
 			}
-			d.SetId(bucket)
+			d.SetId(strings.Replace(bucket, ".", "-", -1))
 			// nolint
 			d.Set("json", string(policyJSON))
 			return nil
@@ -88,11 +88,9 @@ func DataAwsBucketPolicy() common.Resource {
 				Optional: true,
 			},
 			"bucket": {
-				Type:     schema.TypeString,
-				Required: true,
-				ValidateFunc: validation.StringMatch(
-					regexp.MustCompile(`^[0-9a-zA-Z_-]+$`),
-					"must contain only alphanumeric, underscore, and hyphen characters"),
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringMatch(AwsBucketNameRegex, AwsBucketNameRegexError),
 			},
 			"json": {
 				Type:     schema.TypeString,

--- a/aws/data_aws_bucket_policy.go
+++ b/aws/data_aws_bucket_policy.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strings"
 
 	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -62,7 +61,7 @@ func DataAwsBucketPolicy() common.Resource {
 			if err != nil {
 				return err
 			}
-			d.SetId(strings.Replace(bucket, ".", "-", -1))
+			d.SetId(bucket)
 			// nolint
 			d.Set("json", string(policyJSON))
 			return nil

--- a/aws/data_aws_unity_catalog_policy.go
+++ b/aws/data_aws_unity_catalog_policy.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"regexp"
 	"strings"
 
 	"github.com/databricks/terraform-provider-databricks/common"
@@ -125,7 +124,7 @@ func generateReadContext(ctx context.Context, d *schema.ResourceData, m *common.
 	if err != nil {
 		return err
 	}
-	d.SetId(fmt.Sprintf("%s-%s-%s", bucket, awsAccountId, roleName))
+	d.SetId(fmt.Sprintf("%s-%s-%s", strings.Replace(bucket, ".", "-", -1), awsAccountId, roleName))
 	err = d.Set("json", string(policyJSON))
 	if err != nil {
 		return err
@@ -140,11 +139,9 @@ func validateSchema() map[string]*schema.Schema {
 			Optional: true,
 		},
 		"bucket_name": {
-			Type:     schema.TypeString,
-			Required: true,
-			ValidateFunc: validation.StringMatch(
-				regexp.MustCompile(`^[0-9a-zA-Z_-]+$`),
-				"must contain only alphanumeric, underscore, and hyphen characters"),
+			Type:         schema.TypeString,
+			Required:     true,
+			ValidateFunc: validation.StringMatch(AwsBucketNameRegex, AwsBucketNameRegexError),
 		},
 		"role_name": {
 			Type:     schema.TypeString,

--- a/aws/data_aws_unity_catalog_policy.go
+++ b/aws/data_aws_unity_catalog_policy.go
@@ -124,7 +124,7 @@ func generateReadContext(ctx context.Context, d *schema.ResourceData, m *common.
 	if err != nil {
 		return err
 	}
-	d.SetId(fmt.Sprintf("%s-%s-%s", strings.Replace(bucket, ".", "-", -1), awsAccountId, roleName))
+	d.SetId(fmt.Sprintf("%s-%s-%s", bucket, awsAccountId, roleName))
 	err = d.Set("json", string(policyJSON))
 	if err != nil {
 		return err

--- a/aws/data_aws_unity_catalog_policy_test.go
+++ b/aws/data_aws_unity_catalog_policy_test.go
@@ -23,7 +23,7 @@ func TestDataAwsUnityCatalogPolicy(t *testing.T) {
         `,
 	}.Apply(t)
 	assert.NoError(t, err)
-	assert.Equal(t, "databricks-bucket-2-123456789098-databricks-role", d.Id())
+	assert.Equal(t, "databricks-bucket.2-123456789098-databricks-role", d.Id())
 	j := d.Get("json").(string)
 	p := `{
           "Version": "2012-10-17",

--- a/aws/data_aws_unity_catalog_policy_test.go
+++ b/aws/data_aws_unity_catalog_policy_test.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/databricks/terraform-provider-databricks/qa"
@@ -16,12 +17,13 @@ func TestDataAwsUnityCatalogPolicy(t *testing.T) {
 		ID:          ".",
 		HCL: `
         aws_account_id = "123456789098"
-        bucket_name = "databricks-bucket"
+        bucket_name = "databricks-bucket.2"
         role_name = "databricks-role"
         kms_name = "databricks-kms"
         `,
 	}.Apply(t)
 	assert.NoError(t, err)
+	assert.Equal(t, "databricks-bucket-2-123456789098-databricks-role", d.Id())
 	j := d.Get("json").(string)
 	p := `{
           "Version": "2012-10-17",
@@ -39,8 +41,8 @@ func TestDataAwsUnityCatalogPolicy(t *testing.T) {
 		"s3:AbortMultipartUpload"
               ],
               "Resource": [
-                "arn:aws:s3:::databricks-bucket/*",
-                "arn:aws:s3:::databricks-bucket"
+                "arn:aws:s3:::databricks-bucket.2/*",
+                "arn:aws:s3:::databricks-bucket.2"
               ]
             },
             {
@@ -88,7 +90,7 @@ func TestDataAwsUnityCatalogPolicy(t *testing.T) {
                 "sqs:PurgeQueue"
               ],
               "Resource": [
-                "arn:aws:s3:::databricks-bucket",
+                "arn:aws:s3:::databricks-bucket.2",
                 "arn:aws:sqs:*:123456789098:csms-*",
                 "arn:aws:sns:*:123456789098:csms-*"
               ]
@@ -576,6 +578,21 @@ func TestDataAwsUnityCatalogPolicyPartionGovDoD(t *testing.T) {
           ]
         }`
 	compareJSON(t, j, p)
+}
+
+func TestDataAwsUnityCatalogPolicy_BucketNameInvalid(t *testing.T) {
+	qa.ResourceFixture{
+		Read:        true,
+		Resource:    DataAwsUnityCatalogPolicy(),
+		NonWritable: true,
+		ID:          ".",
+		HCL: `
+        aws_account_id = "123456789098"
+        bucket_name = "-databricks-bucket"
+        role_name = "databricks-role"
+        kms_name = "databricks-kms"
+        `,
+	}.ExpectError(t, fmt.Sprintf("invalid config supplied. [bucket_name] invalid value for bucket_name (%s)", AwsBucketNameRegexError))
 }
 
 func compareJSON(t *testing.T, json1 string, json2 string) {

--- a/docs/data-sources/aws_bucket_policy.md
+++ b/docs/data-sources/aws_bucket_policy.md
@@ -76,7 +76,7 @@ resource "aws_s3_bucket_policy" "ds" {
 
 ## Argument Reference
 
-* `bucket` - (Required) AWS S3 Bucket name for which to generate the policy document.
+* `bucket` - (Required) AWS S3 Bucket name for which to generate the policy document. The name must follow the [S3 bucket naming rules](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html).
 * `aws_partition` - (Optional) AWS partition. The options are `aws`, `aws-us-gov`, or `aws-us-gov-dod`. Defaults to `aws`
 * `full_access_role` - (Optional) Data access role that can have full access for this bucket
 * `databricks_e2_account_id` - (Optional) Your Databricks account ID. Used to generate  restrictive IAM policies that will increase the security of your root bucket

--- a/docs/data-sources/aws_unity_catalog_policy.md
+++ b/docs/data-sources/aws_unity_catalog_policy.md
@@ -41,7 +41,7 @@ resource "aws_iam_role" "metastore_data_access" {
 
 * `aws_account_id` (Required) The Account ID of the current AWS account (not your Databricks account).
 * `aws_partition` - (Optional) AWS partition. The options are `aws`, `aws-us-gov`, or `aws-us-gov-dod`. Defaults to `aws`
-* `bucket_name` (Required) The name of the S3 bucket used as root storage location for [managed tables](https://docs.databricks.com/data-governance/unity-catalog/index.html#managed-table) in Unity Catalog.
+* `bucket_name` (Required) The name of the S3 bucket used as root storage location for [managed tables](https://docs.databricks.com/data-governance/unity-catalog/index.html#managed-table) in Unity Catalog.  The name must follow the [S3 bucket naming rules](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html).
 * `role_name` (Required) The name of the AWS IAM role that you created in the previous step in the [official documentation](https://docs.databricks.com/data-governance/unity-catalog/get-started.html#configure-a-storage-bucket-and-iam-role-in-aws).
 * `kms_name` (Optional) If encryption is enabled, provide the ARN of the KMS key that encrypts the S3 bucket contents. If encryption is disabled, do not provide this argument.
 


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

AWS S3 allows only alphanumeric, hyphens and dots in the S3 bucket names. Full list of naming rules is in the [docs](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html#general-purpose-bucket-names).

Resolves #4689

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] using Go SDK
- [ ] using TF Plugin Framework
