### PR TITLE
[Fix] Fail when creating `databricks_query` and `databricks_alert` with already existing names

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Bug Fixes
 
+ * Fail when creating `databricks_query` and `databricks_alert` with already existing names [#4697](https://github.com/databricks/terraform-provider-databricks/pull/4697).
+
 ### Documentation
 
 ### Exporter

--- a/sql/resource_alert.go
+++ b/sql/resource_alert.go
@@ -57,7 +57,9 @@ func ResourceAlert() common.Resource {
 			var a sql.CreateAlertRequestAlert
 			common.DataToStructPointer(d, s, &a)
 			apiAlert, err := w.Alerts.Create(ctx, sql.CreateAlertRequest{
-				Alert: &a,
+				AutoResolveDisplayName: false,
+				Alert:                  &a,
+				ForceSendFields:        []string{"AutoResolveDisplayName"},
 			})
 			if err != nil {
 				return err

--- a/sql/resource_alert_test.go
+++ b/sql/resource_alert_test.go
@@ -52,6 +52,7 @@ var (
     }
   }`
 	createAlertRequest = sql.CreateAlertRequest{
+		AutoResolveDisplayName: false,
 		Alert: &sql.CreateAlertRequestAlert{
 			QueryId:     "123456",
 			DisplayName: "TF new alert",
@@ -70,7 +71,9 @@ var (
 					},
 				},
 			},
-		}}
+		},
+		ForceSendFields: []string{"AutoResolveDisplayName"},
+	}
 )
 
 func TestAlertCreate(t *testing.T) {
@@ -104,13 +107,13 @@ func TestAlertCreate_BackendError(t *testing.T) {
 			e := w.GetMockAlertsAPI().EXPECT()
 			e.Create(mock.Anything, createAlertRequest).Return(nil, &apierr.APIError{
 				StatusCode: http.StatusBadRequest,
-				Message:    "bad payload",
+				Message:    "Node named 'TF new alert' already exists",
 			})
 		},
 		Resource: ResourceAlert(),
 		Create:   true,
 		HCL:      createHcl,
-	}.ExpectError(t, "bad payload")
+	}.ExpectError(t, "Node named 'TF new alert' already exists")
 }
 
 func TestAlertCreate_ErrorMultipleValues(t *testing.T) {

--- a/sql/resource_query.go
+++ b/sql/resource_query.go
@@ -100,7 +100,9 @@ func ResourceQuery() common.Resource {
 			var q queryCreateStruct
 			common.DataToStructPointer(d, s, &q)
 			apiQuery, err := w.Queries.Create(ctx, sql.CreateQueryRequest{
-				Query: &q.CreateQueryRequestQuery,
+				AutoResolveDisplayName: false,
+				Query:                  &q.CreateQueryRequestQuery,
+				ForceSendFields:        []string{"AutoResolveDisplayName"},
 			})
 			if err != nil {
 				return err

--- a/sql/resource_query_test.go
+++ b/sql/resource_query_test.go
@@ -27,12 +27,15 @@ var (
   owner_user_name = "user@domain.com"
 `
 	createQueryRequest = sql.CreateQueryRequest{
+		AutoResolveDisplayName: false,
 		Query: &sql.CreateQueryRequestQuery{
 			WarehouseId: "123456",
 			QueryText:   "select 42 as value",
 			DisplayName: "TF new query",
 			ParentPath:  "/Shared/Querys",
-		}}
+		},
+		ForceSendFields: []string{"AutoResolveDisplayName"},
+	}
 )
 
 func TestQueryCreate(t *testing.T) {
@@ -66,13 +69,13 @@ func TestQueryCreate_Error(t *testing.T) {
 			e := w.GetMockQueriesAPI().EXPECT()
 			e.Create(mock.Anything, createQueryRequest).Return(nil, &apierr.APIError{
 				StatusCode: http.StatusBadRequest,
-				Message:    "bad payload",
+				Message:    "Node named 'TF new query' already exists",
 			})
 		},
 		Resource: ResourceQuery(),
 		Create:   true,
 		HCL:      createQueryHcl,
-	}.ExpectError(t, "bad payload")
+	}.ExpectError(t, "Node named 'TF new query' already exists")
 }
 
 func TestQueryRead_Import(t *testing.T) {


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

Right now, when an object with the same name already exists in a workspace, the Query and Alert APIs just create an object with a different name (by appending `(1)` or something like that). This leads to permanent configuration drift as TF will try to rename the object to the name specified in the HCL.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] using Go SDK
- [ ] using TF Plugin Framework
