### PR TITLE
Fix use of `force` option for service principals in `databricks_git_credential`

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Bug Fixes
 
  * Fix validation of S3 bucket name in `databricks_aws_unity_catalog_policy` and `databricks_aws_bucket_policy` [#4691](https://github.com/databricks/terraform-provider-databricks/pull/4691)
+ * Fix use of `force` option for service principals in `databricks_git_credential` [#4704](https://github.com/databricks/terraform-provider-databricks/pull/4704)
 
 ### Documentation
 

--- a/docs/resources/git_credential.md
+++ b/docs/resources/git_credential.md
@@ -23,9 +23,9 @@ resource "databricks_git_credential" "ado" {
 
 The following arguments are supported:
 
-* `personal_access_token` - (Required) The personal access token used to authenticate to the corresponding Git provider. If value is not provided, it's sourced from the first environment variable of [`GITHUB_TOKEN`](https://registry.terraform.io/providers/integrations/github/latest/docs#oauth--personal-access-token), [`GITLAB_TOKEN`](https://registry.terraform.io/providers/gitlabhq/gitlab/latest/docs#required), or [`AZDO_PERSONAL_ACCESS_TOKEN`](https://registry.terraform.io/providers/microsoft/azuredevops/latest/docs#argument-reference), that has a non-empty value.
-* `git_username` - (Required) user name at Git provider.
-* `git_provider` -  (Required) case insensitive name of the Git provider.  Following values are supported right now (could be a subject for a change, consult [Git Credentials API documentation](https://docs.databricks.com/dev-tools/api/latest/gitcredentials.html)): `gitHub`, `gitHubEnterprise`, `bitbucketCloud`, `bitbucketServer`, `azureDevOpsServices`, `gitLab`, `gitLabEnterpriseEdition`, `awsCodeCommit`.
+* `personal_access_token` - (Optional, required for some Git providers) The personal access token used to authenticate to the corresponding Git provider. If value is not provided, it's sourced from the first environment variable of [`GITHUB_TOKEN`](https://registry.terraform.io/providers/integrations/github/latest/docs#oauth--personal-access-token), [`GITLAB_TOKEN`](https://registry.terraform.io/providers/gitlabhq/gitlab/latest/docs#required), or [`AZDO_PERSONAL_ACCESS_TOKEN`](https://registry.terraform.io/providers/microsoft/azuredevops/latest/docs#argument-reference), that has a non-empty value.
+* `git_username` - (Optional, required for some Git providers) user name at Git provider.
+* `git_provider` -  (Required) case insensitive name of the Git provider.  Following values are supported right now (could be a subject for a change, consult [Git Credentials API documentation](https://docs.databricks.com/dev-tools/api/latest/gitcredentials.html)): `gitHub`, `gitHubEnterprise`, `bitbucketCloud`, `bitbucketServer`, `azureDevOpsServices`, `gitLab`, `gitLabEnterpriseEdition`, `awsCodeCommit`, `azureDevOpsServicesAad`.
 * `force` - (Optional) specify if settings need to be enforced - right now, Databricks allows only single Git credential, so if it's already configured, the apply operation will fail.
 
 ## Attribute Reference

--- a/repos/resource_git_credential.go
+++ b/repos/resource_git_credential.go
@@ -39,7 +39,7 @@ func ResourceGitCredential() common.Resource {
 			resp, err := w.GitCredentials.Create(ctx, req)
 
 			if err != nil {
-				if !d.Get("force").(bool) || !strings.HasPrefix(err.Error(), "Only one Git credential is supported at this time") {
+				if !d.Get("force").(bool) || !(strings.Contains(err.Error(), "Only one Git credential is supported ") && strings.Contains(err.Error(), " at this time")) {
 					return err
 				}
 				creds, err := w.GitCredentials.ListAll(ctx)


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

When we're trying to set git authentication for service principal, the error message is slightly different from that for users, so I tweaked it to work with both.  Also adjusted the docs `git_username` and `personal_access_token` aren't required for all Git providers (i.e., for Entra ID Auth).

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] using Go SDK
- [ ] using TF Plugin Framework
