### PR TITLE
Use force flag for schema deletion

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### New Features and Improvements
 
- * Faster and more reliable schema deletion. It now uses schemas/delete call with force=true flag instead of manually listing and deleting all resources.
+ * Faster and more reliable schema deletion. It now uses schemas/delete call with force=true flag instead of manually listing and deleting all resources.  [#4705](https://github.com/databricks/terraform-provider-databricks/pull/4705)
 
 ### Bug Fixes
 

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### New Features and Improvements
 
+ * Faster and more reliable schema deletion. It now uses schemas/delete call with force=true flag instead of manually listing and deleting all resources.
+
 ### Bug Fixes
 
  * Fix validation of S3 bucket name in `databricks_aws_unity_catalog_policy` and `databricks_aws_bucket_policy` [#4691](https://github.com/databricks/terraform-provider-databricks/pull/4691)

--- a/catalog/resource_schema.go
+++ b/catalog/resource_schema.go
@@ -2,7 +2,6 @@ package catalog
 
 import (
 	"context"
-	"strings"
 
 	"github.com/databricks/databricks-sdk-go/service/catalog"
 	"github.com/databricks/terraform-provider-databricks/common"
@@ -157,53 +156,7 @@ func ResourceSchema() common.Resource {
 			if err != nil {
 				return err
 			}
-			if force {
-				// delete all tables & views
-				tables, err := w.Tables.ListAll(ctx, catalog.ListTablesRequest{
-					CatalogName: strings.Split(name, ".")[0],
-					SchemaName:  strings.Split(name, ".")[1],
-				})
-				if err != nil {
-					return err
-				}
-				for _, t := range tables {
-					w.Tables.DeleteByFullName(ctx, t.FullName)
-				}
-				// delete all volumes
-				volumes, err := w.Volumes.ListAll(ctx, catalog.ListVolumesRequest{
-					CatalogName: strings.Split(name, ".")[0],
-					SchemaName:  strings.Split(name, ".")[1],
-				})
-				if err != nil {
-					return err
-				}
-				for _, v := range volumes {
-					w.Volumes.DeleteByName(ctx, v.FullName)
-				}
-				// delete all functions
-				functions, err := w.Functions.ListAll(ctx, catalog.ListFunctionsRequest{
-					CatalogName: strings.Split(name, ".")[0],
-					SchemaName:  strings.Split(name, ".")[1],
-				})
-				if err != nil {
-					return err
-				}
-				for _, f := range functions {
-					w.Functions.DeleteByName(ctx, f.FullName)
-				}
-				// delete all models
-				models, err := w.RegisteredModels.ListAll(ctx, catalog.ListRegisteredModelsRequest{
-					CatalogName: strings.Split(name, ".")[0],
-					SchemaName:  strings.Split(name, ".")[1],
-				})
-				if err != nil {
-					return err
-				}
-				for _, m := range models {
-					w.RegisteredModels.DeleteByFullName(ctx, m.FullName)
-				}
-			}
-			return w.Schemas.DeleteByFullName(ctx, name)
+			return w.Schemas.Delete(ctx, catalog.DeleteSchemaRequest{FullName: name, Force: force})
 		},
 	}
 }

--- a/catalog/resource_schema_test.go
+++ b/catalog/resource_schema_test.go
@@ -388,7 +388,7 @@ func TestUpdateSchemaForceNew(t *testing.T) {
 func TestDeleteSchema(t *testing.T) {
 	qa.ResourceFixture{
 		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
-			w.GetMockSchemasAPI().EXPECT().DeleteByFullName(mock.Anything, "b.a").Return(nil)
+			w.GetMockSchemasAPI().EXPECT().Delete(mock.Anything, catalog.DeleteSchemaRequest{FullName: "b.a"}).Return(nil)
 		},
 		Resource: ResourceSchema(),
 		Delete:   true,
@@ -405,77 +405,7 @@ func TestDeleteSchema(t *testing.T) {
 func TestForceDeleteSchema(t *testing.T) {
 	qa.ResourceFixture{
 		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
-			t := w.GetMockTablesAPI().EXPECT()
-			t.ListAll(mock.Anything, catalog.ListTablesRequest{
-				CatalogName: "b",
-				SchemaName:  "a",
-			}).Return([]catalog.TableInfo{
-				{
-					CatalogName: "b",
-					SchemaName:  "a",
-					Name:        "c",
-					FullName:    "b.a.c",
-					TableType:   "MANAGED",
-				},
-				{
-					CatalogName: "b",
-					SchemaName:  "a",
-					Name:        "d",
-					FullName:    "b.a.d",
-					TableType:   "VIEW",
-				},
-			}, nil)
-			t.DeleteByFullName(mock.Anything, "b.a.c").Return(nil)
-			t.DeleteByFullName(mock.Anything, "b.a.d").Return(nil)
-			v := w.GetMockVolumesAPI().EXPECT()
-			v.ListAll(mock.Anything, catalog.ListVolumesRequest{
-				CatalogName: "b",
-				SchemaName:  "a",
-			}).Return([]catalog.VolumeInfo{
-				{
-					CatalogName: "b",
-					SchemaName:  "a",
-					Name:        "c",
-					FullName:    "b.a.c",
-					VolumeType:  catalog.VolumeTypeManaged,
-				},
-				{
-					CatalogName: "b",
-					SchemaName:  "a",
-					Name:        "d",
-					FullName:    "b.a.d",
-					VolumeType:  catalog.VolumeTypeExternal,
-				},
-			}, nil)
-			v.DeleteByName(mock.Anything, "b.a.c").Return(nil)
-			v.DeleteByName(mock.Anything, "b.a.d").Return(nil)
-			f := w.GetMockFunctionsAPI().EXPECT()
-			f.ListAll(mock.Anything, catalog.ListFunctionsRequest{
-				CatalogName: "b",
-				SchemaName:  "a",
-			}).Return([]catalog.FunctionInfo{
-				{
-					CatalogName: "b",
-					SchemaName:  "a",
-					Name:        "c",
-					FullName:    "b.a.c",
-				},
-			}, nil)
-			f.DeleteByName(mock.Anything, "b.a.c").Return(nil)
-			m := w.GetMockRegisteredModelsAPI().EXPECT()
-			m.ListAll(mock.Anything, catalog.ListRegisteredModelsRequest{
-				CatalogName: "b",
-				SchemaName:  "a",
-			}).Return([]catalog.RegisteredModelInfo{
-				{
-					CatalogName: "b",
-					SchemaName:  "a",
-					Name:        "c",
-					FullName:    "b.a.c",
-				},
-			}, nil)
-			m.DeleteByFullName(mock.Anything, "b.a.c").Return(nil)
-			w.GetMockSchemasAPI().EXPECT().DeleteByFullName(mock.Anything, "b.a").Return(nil)
+			w.GetMockSchemasAPI().EXPECT().Delete(mock.Anything, catalog.DeleteSchemaRequest{FullName: "b.a", Force: true}).Return(nil)
 		},
 		Resource: ResourceSchema(),
 		Delete:   true,


### PR DESCRIPTION
## Changes
- Use https://docs.databricks.com/api/workspace/schemas/delete#force when deleting schemas
- No longer delete all the contained resources manually.

## Tests
Existing tests.

I haven't check if there is integration test for this.

Resolves #3388, resolves #3375
