### PR TITLE
[Doc] Explicitly mention SCIM ID in `databricks_group_member` docs

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Documentation
 
+ * Explicitly mention SCIM ID in `databricks_group_member` docs [#4709](https://github.com/databricks/terraform-provider-databricks/pull/4709)
+
 ### Exporter
 
 ### Internal Changes

--- a/docs/resources/group.md
+++ b/docs/resources/group.md
@@ -101,12 +101,12 @@ The following arguments are supported:
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` -  The id for the group object.
+* `id` - Canonical unique identifier for the group (SCIM ID).
 * `acl_principal_id` - identifier for use in [databricks_access_control_rule_set](access_control_rule_set.md), e.g. `groups/Some Group`.
 
 ## Import
 
-You can import a `databricks_group` resource with the name `my_group` like the following:
+You can import a `databricks_group` resource by its SCIM ID:
 
 ```hcl
 import {

--- a/docs/resources/group_member.md
+++ b/docs/resources/group_member.md
@@ -41,8 +41,8 @@ resource "databricks_group_member" "bb" {
 
 The following arguments are supported:
 
-* `group_id` - (Required) This is the id of the [group](group.md) resource.
-* `member_id` - (Required) This is the id of the [group](group.md), [service principal](service_principal.md), or [user](user.md).
+* `group_id` - (Required) This is the `id` attribute (SCIM ID) of the [group](group.md) resource.
+* `member_id` - (Required) This is the `id` attribute (SCIM ID) of the [group](group.md), [service principal](service_principal.md), or [user](user.md).
 
 ## Attribute Reference
 

--- a/docs/resources/service_principal.md
+++ b/docs/resources/service_principal.md
@@ -114,14 +114,14 @@ The following arguments are available:
 
 In addition to all arguments above, the following attributes are exported:
 
-- `id` - Canonical unique identifier for the service principal.
+- `id` - Canonical unique identifier for the service principal (SCIM ID).
 - `home` - Home folder of the service principal, e.g. `/Users/00000000-0000-0000-0000-000000000000`.
 - `repos` - Personal Repos location of the service principal, e.g. `/Repos/00000000-0000-0000-0000-000000000000`.
 - `acl_principal_id` - identifier for use in [databricks_access_control_rule_set](access_control_rule_set.md), e.g. `servicePrincipals/00000000-0000-0000-0000-000000000000`.
 
 ## Import
 
-The resource scim service principal can be imported using its id, for example `2345678901234567`. To get the service principal ID, call [Get service principals](https://docs.databricks.com/dev-tools/api/latest/scim/scim-sp.html#get-service-principals).
+The resource scim service principal can be imported using its SCIM id, for example `2345678901234567`. To get the service principal ID, call [Get service principals](https://docs.databricks.com/dev-tools/api/latest/scim/scim-sp.html#get-service-principals).
 
 ```hcl
 import {

--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -109,14 +109,14 @@ The following arguments are available:
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - Canonical unique identifier for the user.
+* `id` - Canonical unique identifier for the user (SCIM ID).
 * `home` - Home folder of the user, e.g. `/Users/mr.foo@example.com`.
 * `repos` - Personal Repos location of the user, e.g. `/Repos/mr.foo@example.com`.
 * `acl_principal_id` - identifier for use in [databricks_access_control_rule_set](access_control_rule_set.md), e.g. `users/mr.foo@example.com`.
 
 ## Import
 
-The resource scim user can be imported using id:
+The resource scim user can be imported using its SCIM id:
 
 ```hcl
 import {


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

It looks like customers are confused what ID should be used in `databricks_group_member` resource, so it makes sense to explicitly mention that it's SCIM ID.

Resolves #4194

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] using Go SDK
- [ ] using TF Plugin Framework
