### PR TITLE
[Exporter] Generate correct code for Databricks and Azure-managed service principals

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -10,4 +10,6 @@
 
 ### Exporter
 
+ * Generate correct code for Databricks and Azure-managed service principals [#4715](https://github.com/databricks/terraform-provider-databricks/pull/4715)
+
 ### Internal Changes

--- a/exporter/codegen.go
+++ b/exporter/codegen.go
@@ -286,10 +286,10 @@ func (ic *importContext) dataToHcl(i importable, path []string,
 		raw, nonZero := d.GetOk(pathString)
 		// log.Printf("[DEBUG] path=%s, raw='%v'", pathString, raw)
 		if i.ShouldOmitField == nil { // we don't have custom function, so skip computed & default fields
-			if defaultShouldOmitFieldFunc(ic, pathString, as, d) {
+			if defaultShouldOmitFieldFunc(ic, pathString, as, d, res) {
 				continue
 			}
-		} else if i.ShouldOmitField(ic, pathString, as, d) {
+		} else if i.ShouldOmitField(ic, pathString, as, d, res) {
 			continue
 		}
 		mpath := dependsRe.ReplaceAllString(pathString, "")
@@ -312,7 +312,7 @@ func (ic *importContext) dataToHcl(i importable, path []string,
 			// In case when have zero value, but there is non-zero default, we also need to produce it
 			shouldSkip = false
 		}
-		if shouldSkip && (i.ShouldGenerateField == nil || !i.ShouldGenerateField(ic, pathString, as, d)) {
+		if shouldSkip && (i.ShouldGenerateField == nil || !i.ShouldGenerateField(ic, pathString, as, d, res)) {
 			continue
 		}
 		switch as.Type {

--- a/exporter/impl_jobs.go
+++ b/exporter/impl_jobs.go
@@ -312,7 +312,7 @@ func listJobs(ic *importContext) error {
 	return nil
 }
 
-func shouldOmitFieldInJob(ic *importContext, pathString string, as *schema.Schema, d *schema.ResourceData) bool {
+func shouldOmitFieldInJob(ic *importContext, pathString string, as *schema.Schema, d *schema.ResourceData, r *resource) bool {
 	switch pathString {
 	case "url", "format":
 		return true
@@ -376,9 +376,9 @@ func shouldOmitFieldInJob(ic *importContext, pathString string, as *schema.Schem
 		// TODO: double check it
 	}
 	if res := jobClustersRegex.FindStringSubmatch(pathString); res != nil { // analyze job clusters
-		return makeShouldOmitFieldForCluster(jobClustersRegex)(ic, pathString, as, d)
+		return makeShouldOmitFieldForCluster(jobClustersRegex)(ic, pathString, as, d, r)
 	}
-	return defaultShouldOmitFieldFunc(ic, pathString, as, d)
+	return defaultShouldOmitFieldFunc(ic, pathString, as, d, r)
 }
 
 func shouldIgnoreJob(ic *importContext, r *resource) bool {

--- a/exporter/impl_uc.go
+++ b/exporter/impl_uc.go
@@ -364,18 +364,18 @@ func emitUserSpOrGroup(ic *importContext, userOrSOrGroupPName string) {
 	}
 }
 
-func shouldOmitForUnityCatalog(ic *importContext, pathString string, as *schema.Schema, d *schema.ResourceData) bool {
+func shouldOmitForUnityCatalog(ic *importContext, pathString string, as *schema.Schema, d *schema.ResourceData, r *resource) bool {
 	if pathString == "owner" {
 		return d.Get(pathString).(string) == ""
 	}
-	return defaultShouldOmitFieldFunc(ic, pathString, as, d)
+	return defaultShouldOmitFieldFunc(ic, pathString, as, d, r)
 }
 
-func shouldOmitWithIsolationMode(ic *importContext, pathString string, as *schema.Schema, d *schema.ResourceData) bool {
+func shouldOmitWithIsolationMode(ic *importContext, pathString string, as *schema.Schema, d *schema.ResourceData, r *resource) bool {
 	if pathString == "isolation_mode" {
 		return d.Get(pathString).(string) != "ISOLATION_MODE_ISOLATED"
 	}
-	return shouldOmitForUnityCatalog(ic, pathString, as, d)
+	return shouldOmitForUnityCatalog(ic, pathString, as, d, r)
 }
 
 func createIsMatchingCatalogAndSchema(catalog_name_attr, schema_name_attr string) func(ic *importContext, res *resource,

--- a/exporter/importables_test.go
+++ b/exporter/importables_test.go
@@ -672,11 +672,21 @@ func TestSpnSearchSuccess(t *testing.T) {
 		assert.NoError(t, err)
 
 		assert.True(t, resourcesMap["databricks_service_principal"].ShouldOmitField(ic, "application_id",
-			scim.ResourceServicePrincipal().Schema["application_id"], d))
+			scim.ResourceServicePrincipal().Schema["application_id"], d, r))
 		ic.Client.Config.Host = "https://abc.azuredatabricks.net"
+		// We shouldn't omit display_name for Databricks-managed SPs
+		assert.False(t, resourcesMap["databricks_service_principal"].ShouldOmitField(ic, "display_name",
+			scim.ResourceServicePrincipal().Schema["display_name"], d, r))
+		assert.True(t, resourcesMap["databricks_service_principal"].ShouldOmitField(ic, "application_id",
+			scim.ResourceServicePrincipal().Schema["application_id"], d, r))
+		// We shouldn't omit application_id for Azure-managed SPs, but omit display_name
+		d.Set("external_id", "60622399-fd3f-4faf-8810-bf08b225cf3b")
+		assert.False(t, resourcesMap["databricks_service_principal"].ShouldOmitField(ic, "application_id",
+			scim.ResourceServicePrincipal().Schema["application_id"], d, r))
 		assert.True(t, resourcesMap["databricks_service_principal"].ShouldOmitField(ic, "display_name",
-			scim.ResourceServicePrincipal().Schema["display_name"], d))
+			scim.ResourceServicePrincipal().Schema["display_name"], d, r))
 
+		// test for different branches in Name function
 		// test for different branches in Name function
 		d2 := scim.ResourceServicePrincipal().ToResource().TestResourceData()
 		d2.SetId("123")
@@ -695,32 +705,42 @@ func TestShouldOmitForUsers(t *testing.T) {
 	d.SetId("user1")
 	d.Set("user_name", "user@domain.com")
 	d.Set("display_name", "")
+	r := &resource{
+		Attribute: "databricks_user",
+		Value:     "user@domain.com",
+		Data:      d,
+	}
 	assert.True(t, resourcesMap["databricks_user"].ShouldOmitField(nil, "display_name",
-		scim.ResourceUser().Schema["application_id"], d))
+		scim.ResourceUser().Schema["display_name"], d, r))
 	d.Set("display_name", "user@domain.com")
 	assert.True(t, resourcesMap["databricks_user"].ShouldOmitField(nil, "display_name",
-		scim.ResourceUser().Schema["application_id"], d))
+		scim.ResourceUser().Schema["display_name"], d, r))
 	d.Set("display_name", "Some user")
 	assert.False(t, resourcesMap["databricks_user"].ShouldOmitField(nil, "display_name",
-		scim.ResourceUser().Schema["application_id"], d))
+		scim.ResourceUser().Schema["display_name"], d, r))
 }
 
 func TestShouldOmitFoRepos(t *testing.T) {
 	d := repos.ResourceRepo().ToResource().TestResourceData()
 	d.SetId("1234")
 	d.Set("path", "/Repos/Test/repo")
+	r := &resource{
+		Attribute: "databricks_repo",
+		Value:     "repo",
+		Data:      d,
+	}
 	assert.False(t, resourcesMap["databricks_repo"].ShouldOmitField(nil, "path",
-		repos.ResourceRepo().Schema["path"], d))
+		repos.ResourceRepo().Schema["path"], d, r))
 	assert.True(t, resourcesMap["databricks_repo"].ShouldOmitField(nil, "branch",
-		repos.ResourceRepo().Schema["branch"], d))
+		repos.ResourceRepo().Schema["branch"], d, r))
 	assert.True(t, resourcesMap["databricks_repo"].ShouldOmitField(nil, "tag",
-		repos.ResourceRepo().Schema["tag"], d))
+		repos.ResourceRepo().Schema["tag"], d, r))
 	d.Set("branch", "test")
 	assert.False(t, resourcesMap["databricks_repo"].ShouldOmitField(nil, "branch",
-		repos.ResourceRepo().Schema["branch"], d))
+		repos.ResourceRepo().Schema["branch"], d, r))
 	d.Set("tag", "v123")
 	assert.False(t, resourcesMap["databricks_repo"].ShouldOmitField(nil, "tag",
-		repos.ResourceRepo().Schema["tag"], d))
+		repos.ResourceRepo().Schema["tag"], d, r))
 }
 
 func TestUserImportSkipNonDirectGroups(t *testing.T) {
@@ -2177,15 +2197,20 @@ func TestVolumes(t *testing.T) {
 	assert.True(t, ic.testEmits["databricks_schema[<unknown>] (id: ctest.stest)"])
 
 	//
+	r := &resource{
+		Attribute: "databricks_volume",
+		Value:     "dbc",
+		Data:      d,
+	}
 	shouldOmitFunc := resourcesMap["databricks_volume"].ShouldOmitField
 	require.NotNil(t, shouldOmitFunc)
 	scm := tf_uc.ResourceVolume().Schema
-	assert.False(t, shouldOmitFunc(nil, "volume_type", scm["volume_type"], d))
-	assert.False(t, shouldOmitFunc(nil, "name", scm["name"], d))
+	assert.False(t, shouldOmitFunc(nil, "volume_type", scm["volume_type"], d, r))
+	assert.False(t, shouldOmitFunc(nil, "name", scm["name"], d, r))
 	d.Set("volume_type", "MANAGED")
 	d.Set("storage_location", "s3://abc/")
-	assert.False(t, shouldOmitFunc(nil, "volume_type", scm["volume_type"], d))
-	assert.True(t, shouldOmitFunc(nil, "storage_location", scm["storage_location"], d))
+	assert.False(t, shouldOmitFunc(nil, "volume_type", scm["volume_type"], d, r))
+	assert.True(t, shouldOmitFunc(nil, "storage_location", scm["storage_location"], d, r))
 }
 
 func TestSqlTables(t *testing.T) {
@@ -2206,16 +2231,20 @@ func TestSqlTables(t *testing.T) {
 	assert.True(t, ic.testEmits["databricks_schema[<unknown>] (id: ctest.stest)"])
 
 	//
+	r := &resource{
+		Attribute: "databricks_sql_table",
+		Value:     "ttest",
+		Data:      d,
+	}
 	shouldOmitFunc := resourcesMap["databricks_sql_table"].ShouldOmitField
 	require.NotNil(t, shouldOmitFunc)
 	scm := tf_uc.ResourceSqlTable().Schema
-	assert.False(t, shouldOmitFunc(nil, "table_type", scm["table_type"], d))
-	assert.False(t, shouldOmitFunc(nil, "name", scm["name"], d))
+	assert.False(t, shouldOmitFunc(nil, "table_type", scm["table_type"], d, r))
+	assert.False(t, shouldOmitFunc(nil, "name", scm["name"], d, r))
 	d.Set("table_type", "MANAGED")
 	d.Set("storage_location", "s3://abc/")
-	assert.False(t, shouldOmitFunc(nil, "table_type", scm["table_type"], d))
-	assert.True(t, shouldOmitFunc(nil, "storage_location", scm["storage_location"], d))
-	assert.True(t, shouldOmitFunc(nil, "storage_location", scm["storage_location"], d))
+	assert.False(t, shouldOmitFunc(nil, "table_type", scm["table_type"], d, r))
+	assert.True(t, shouldOmitFunc(nil, "storage_location", scm["storage_location"], d, r))
 }
 
 func TestRegisteredModels(t *testing.T) {
@@ -2236,17 +2265,22 @@ func TestRegisteredModels(t *testing.T) {
 	assert.True(t, ic.testEmits["databricks_schema[<unknown>] (id: ctest.stest)"])
 
 	//
+	r := &resource{
+		Attribute: "databricks_registered_model",
+		Value:     "mtest",
+		Data:      d,
+	}
 	shouldOmitFunc := resourcesMap["databricks_registered_model"].ShouldOmitField
 	require.NotNil(t, shouldOmitFunc)
 	scm := tf_uc.ResourceRegisteredModel().Schema
-	assert.True(t, shouldOmitFunc(nil, "storage_location", scm["storage_location"], d))
+	assert.True(t, shouldOmitFunc(nil, "storage_location", scm["storage_location"], d, r))
 	d.Set("storage_location", "s3://abc/")
-	assert.False(t, shouldOmitFunc(nil, "storage_location", scm["storage_location"], d))
-	assert.False(t, shouldOmitFunc(nil, "name", scm["name"], d))
+	assert.False(t, shouldOmitFunc(nil, "storage_location", scm["storage_location"], d, r))
+	assert.False(t, shouldOmitFunc(nil, "name", scm["name"], d, r))
 
 	ic.currentMetastore = currentMetastoreResponse
 	d.Set("storage_location", "s3://abc/"+currentMetastoreResponse.MetastoreId+"/models/123456")
-	assert.True(t, shouldOmitFunc(ic, "storage_location", scm["storage_location"], d))
+	assert.True(t, shouldOmitFunc(ic, "storage_location", scm["storage_location"], d, r))
 }
 
 func TestListShares(t *testing.T) {
@@ -2279,18 +2313,28 @@ func TestAuxUcFunctions(t *testing.T) {
 	d := tf_uc.ResourceMetastoreAssignment().ToResource().TestResourceData()
 	d.Set("workspace_id", 123)
 	assert.Equal(t, "ws_123", resourcesMap["databricks_metastore_assignment"].Name(nil, d))
+	r := &resource{
+		Attribute: "databricks_metastore_assignment",
+		Value:     "ws_123",
+		Data:      d,
+	}
 
 	shouldOmitFunc := resourcesMap["databricks_metastore_assignment"].ShouldOmitField
 	require.NotNil(t, shouldOmitFunc)
 	d.Set("default_catalog_name", "")
 
 	scm := tf_uc.ResourceMetastoreAssignment().Schema
-	assert.True(t, shouldOmitFunc(nil, "default_catalog_name", scm["default_catalog_name"], d))
-	assert.False(t, shouldOmitFunc(nil, "metastore_id", scm["metastore_id"], d))
+	assert.True(t, shouldOmitFunc(nil, "default_catalog_name", scm["default_catalog_name"], d, r))
+	assert.False(t, shouldOmitFunc(nil, "metastore_id", scm["metastore_id"], d, r))
 
 	// Metastore
 	d = tf_uc.ResourceMetastore().ToResource().TestResourceData()
 	d.SetId("1234")
+	r = &resource{
+		Attribute: "databricks_metastore",
+		Value:     "1234",
+		Data:      d,
+	}
 	assert.Equal(t, "1234", resourcesMap["databricks_metastore"].Name(nil, d))
 	d.Set("name", "test")
 	assert.Equal(t, "test", resourcesMap["databricks_metastore"].Name(nil, d))
@@ -2298,11 +2342,11 @@ func TestAuxUcFunctions(t *testing.T) {
 	shouldOmitFunc = resourcesMap["databricks_metastore"].ShouldOmitField
 	require.NotNil(t, shouldOmitFunc)
 	scm = tf_uc.ResourceMetastore().Schema
-	assert.True(t, shouldOmitFunc(nil, "default_data_access_config_id", scm["default_data_access_config_id"], d))
-	assert.True(t, shouldOmitFunc(nil, "owner", scm["owner"], d))
+	assert.True(t, shouldOmitFunc(nil, "default_data_access_config_id", scm["default_data_access_config_id"], d, r))
+	assert.True(t, shouldOmitFunc(nil, "owner", scm["owner"], d, r))
 	d.Set("owner", "test")
-	assert.False(t, shouldOmitFunc(nil, "owner", scm["owner"], d))
-	assert.False(t, shouldOmitFunc(nil, "name", scm["name"], d))
+	assert.False(t, shouldOmitFunc(nil, "owner", scm["owner"], d, r))
+	assert.False(t, shouldOmitFunc(nil, "name", scm["name"], d, r))
 
 	// Connections
 	d = tf_uc.ResourceConnection().ToResource().TestResourceData()
@@ -2315,14 +2359,19 @@ func TestAuxUcFunctions(t *testing.T) {
 	// Catalogs
 	d = tf_uc.ResourceCatalog().ToResource().TestResourceData()
 	d.SetId("test")
+	r = &resource{
+		Attribute: "databricks_catalog",
+		Value:     "test",
+		Data:      d,
+	}
 	shouldOmitFunc = resourcesMap["databricks_catalog"].ShouldOmitField
 	require.NotNil(t, shouldOmitFunc)
 	scm = tf_uc.ResourceCatalog().Schema
 	d.Set("isolation_mode", "OPEN")
-	assert.True(t, shouldOmitFunc(nil, "isolation_mode", scm["isolation_mode"], d))
+	assert.True(t, shouldOmitFunc(nil, "isolation_mode", scm["isolation_mode"], d, r))
 	d.Set("isolation_mode", "ISOLATED")
-	assert.False(t, shouldOmitFunc(nil, "isolation_mode", scm["isolation_mode"], d))
-	assert.False(t, shouldOmitFunc(nil, "name", scm["name"], d))
+	assert.False(t, shouldOmitFunc(nil, "isolation_mode", scm["isolation_mode"], d, r))
+	assert.False(t, shouldOmitFunc(nil, "name", scm["name"], d, r))
 }
 
 func TestImportUcVolumeFile(t *testing.T) {
@@ -2353,11 +2402,16 @@ func TestImportUcVolumeFile(t *testing.T) {
 		assert.Equal(t, file_path, d.Get("path"))
 		assert.Equal(t, "uc_files/main/default/wheels/some.whl", d.Get("source"))
 		// Testing auxiliary functions
+		r := &resource{
+			Attribute: "databricks_file",
+			Value:     file_path,
+			Data:      d,
+		}
 		shouldOmitFunc := resourcesMap["databricks_file"].ShouldOmitField
 		require.NotNil(t, shouldOmitFunc)
 		scm := storage.ResourceFile().Schema
-		assert.True(t, shouldOmitFunc(ic, "md5", scm["md5"], d))
-		assert.False(t, shouldOmitFunc(ic, "path", scm["path"], d))
+		assert.True(t, shouldOmitFunc(ic, "md5", scm["md5"], d, r))
+		assert.False(t, shouldOmitFunc(ic, "path", scm["path"], d, r))
 
 		assert.Equal(t, "main/default/wheels/some.whl_f27badf8", resourcesMap["databricks_file"].Name(nil, d))
 	})
@@ -2694,12 +2748,17 @@ func TestNotificationDestinationShouldOmitField(t *testing.T) {
 
 	ic := importContextForTest()
 	schema := tf_settings.ResourceNotificationDestination().Schema
+	r := &resource{
+		Attribute: "databricks_notification_destination",
+		Value:     "test-notification",
+		Data:      d,
+	}
 
 	// URL should be omitted because url_set is false
 	assert.True(t, resourcesMap["databricks_notification_destination"].ShouldOmitField(
-		ic, "config.0.generic_webhook.0.url", schema["config"], d))
+		ic, "config.0.generic_webhook.0.url", schema["config"], d, r))
 
 	// Username should not be omitted because username_set is true
 	assert.False(t, resourcesMap["databricks_notification_destination"].ShouldOmitField(
-		ic, "config.0.generic_webhook.0.username", schema["config"], d))
+		ic, "config.0.generic_webhook.0.username", schema["config"], d, r))
 }

--- a/exporter/model.go
+++ b/exporter/model.go
@@ -152,9 +152,9 @@ type importable struct {
 	// Function to detect if the given resource should be ignored or not
 	Ignore func(ic *importContext, r *resource) bool
 	// Function to check if the field in the given resource should be omitted or not
-	ShouldOmitField func(ic *importContext, pathString string, as *schema.Schema, d *schema.ResourceData) bool
+	ShouldOmitField func(ic *importContext, pathString string, as *schema.Schema, d *schema.ResourceData, r *resource) bool
 	// Function to check if the field in the given resource should be generated or not independently of the value
-	ShouldGenerateField func(ic *importContext, pathString string, as *schema.Schema, d *schema.ResourceData) bool
+	ShouldGenerateField func(ic *importContext, pathString string, as *schema.Schema, d *schema.ResourceData, r *resource) bool
 	// Defines which API version should be used for this specific resource
 	ApiVersion common.ApiVersion
 	// Defines if specific service is account level resource

--- a/exporter/util.go
+++ b/exporter/util.go
@@ -311,7 +311,7 @@ func (ic *importContext) saveFileIn(dir, name string, content []byte) (string, e
 	return relativeName, nil
 }
 
-func defaultShouldOmitFieldFunc(_ *importContext, pathString string, as *schema.Schema, d *schema.ResourceData) bool {
+func defaultShouldOmitFieldFunc(_ *importContext, pathString string, as *schema.Schema, d *schema.ResourceData, _ *resource) bool {
 	if as.Computed {
 		return true
 	} else if as.Default != nil && d.Get(pathString) == as.Default {

--- a/exporter/util_compute.go
+++ b/exporter/util_compute.go
@@ -115,8 +115,9 @@ func (ic *importContext) getBuiltinPolicyFamilies() map[string]compute.PolicyFam
 	return ic.builtInPolicies
 }
 
-func makeShouldOmitFieldForCluster(regex *regexp.Regexp) func(ic *importContext, pathString string, as *schema.Schema, d *schema.ResourceData) bool {
-	return func(ic *importContext, pathString string, as *schema.Schema, d *schema.ResourceData) bool {
+func makeShouldOmitFieldForCluster(regex *regexp.Regexp) func(ic *importContext, pathString string, as *schema.Schema,
+	d *schema.ResourceData, r *resource) bool {
+	return func(ic *importContext, pathString string, as *schema.Schema, d *schema.ResourceData, r *resource) bool {
 		prefix := ""
 		if regex != nil {
 			if res := regex.FindStringSubmatch(pathString); res != nil {
@@ -146,6 +147,6 @@ func makeShouldOmitFieldForCluster(regex *regexp.Regexp) func(ic *importContext,
 			return fmt.Sprintf("%v", d.Get(prefix+"spark_env_vars")) == "map[PYSPARK_PYTHON:/databricks/python3/bin/python3]"
 		}
 
-		return defaultShouldOmitFieldFunc(ic, pathString, as, d)
+		return defaultShouldOmitFieldFunc(ic, pathString, as, d, r)
 	}
 }

--- a/exporter/util_workspace.go
+++ b/exporter/util_workspace.go
@@ -201,11 +201,11 @@ func (ic *importContext) getAllWorkspaceObjects(visitor func([]workspace.ObjectS
 	return ic.allWorkspaceObjects
 }
 
-func shouldOmitMd5Field(ic *importContext, pathString string, as *schema.Schema, d *schema.ResourceData) bool {
+func shouldOmitMd5Field(ic *importContext, pathString string, as *schema.Schema, d *schema.ResourceData, r *resource) bool {
 	if pathString == "md5" { // `md5` is kind of computed, but not declared as it...
 		return true
 	}
-	return defaultShouldOmitFieldFunc(ic, pathString, as, d)
+	return defaultShouldOmitFieldFunc(ic, pathString, as, d, r)
 }
 
 func workspaceObjectResouceName(ic *importContext, d *schema.ResourceData) string {


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

We should generate `application_id` only for Azure-managed service principals, while Databricks-managed SPs should have only name.

Should be merged after #4712

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] using Go SDK
- [ ] using TF Plugin Framework
