### PR TITLE
[Documentation ]Added documentation for GITHUB OIDC authentication type

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Bug Fixes
 
 ### Documentation
+* Added documentation for GITHUB OIDC authentication type
 
 ### Exporter
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -225,6 +225,32 @@ resource "databricks_group" "cluster_admin" {
 * `client_id` - The `application_id` of the [Service Principal](resources/service_principal.md). Alternatively, you can provide this value as an environment variable `DATABRICKS_CLIENT_ID`.
 * `client_secret` - Secret of the service principal. Alternatively, you can provide this value as an environment variable `DATABRICKS_CLIENT_SECRET`.
 
+### Authenticating with GITHUB OIDC | Workload Identity Federation (WIF)
+The arguments `host` and `client_id` are used for the authentication which maps to the `github-oidc` authentication type. 
+
+These can be declared in the provider block or set in the environment variables `DATABRICKS_HOST` and `DATABRICKS_CLIENT_ID` respectively. Example:
+
+Workspace level provider:
+```hcl
+provider "databricks" {
+  alias     = "workspace"
+  auth_type = "github-oidc" 
+  host      = var.workspace_host
+  client_id = var.client_id
+}
+```
+
+Account level provider:
+```hcl
+provider "databricks" {
+  alias     = "account"
+  auth_type = "github-oidc" 
+  host      = var.account_host
+  client_id = var.client_id
+}
+```
+Depending on how the WIF policy is configured, you might also have to provide the audience. This can be set in the provider block using the `audience` argument or in environment variable `DATABRICKS_TOKEN_AUDIENCE`. 
+
 ## Argument Reference
 
 -> **Note** If you experience technical difficulties with rolling out resources in this example, please make sure that [environment variables](#environment-variables) don't [conflict with other](#empty-provider-block) provider block attributes. When in doubt, please run `TF_LOG=DEBUG terraform apply` to enable [debug mode](https://www.terraform.io/docs/internals/debugging.html) through the [`TF_LOG`](https://www.terraform.io/docs/cli/config/environment-variables.html#tf_log) environment variable. Look specifically for `Explicit and implicit attributes` lines, that should indicate authentication attributes used.
@@ -238,7 +264,8 @@ Alternatively, you can provide this value as an environment variable `DATABRICKS
 * `profile` - (optional) Connection profile specified within ~/.databrickscfg. Please check [connection profiles section](https://docs.databricks.com/dev-tools/cli/index.html#connection-profiles) for more details. This field defaults to
 `DEFAULT`.
 * `account_id` - (required for account-level operations) Account ID found in the top right corner of [Accounts Console](https://accounts.cloud.databricks.com/). Alternatively, you can provide this value as an environment variable `DATABRICKS_ACCOUNT_ID`. Only has effect when `host = "https://accounts.cloud.databricks.com/"`, and is currently used to provision account admins via [databricks_user](resources/user.md). **Note:  do NOT use in the workspace-level provider to avoid `...invalid Databricks Account configuration` errors**.
-* `auth_type` - (optional) enforce specific auth type to be used in very rare cases, where a single Terraform state manages Databricks workspaces on more than one cloud and `more than one authorization method configured` error is a false positive. Valid values are `pat`, `basic`, `oauth-m2m`, `azure-client-secret`, `azure-msi`, `azure-cli`, `github-oidc-azure`, `google-credentials`, and `google-id`.
+* `auth_type` - (optional) enforce specific auth type to be used in very rare cases, where a single Terraform state manages Databricks workspaces on more than one cloud and `more than one authorization method configured` error is a false positive. Valid values are `pat`, `basic`, `oauth-m2m`, `azure-client-secret`, `azure-msi`, `azure-cli`, `github-oidc-azure`, `github-oidc` `google-credentials`, and `google-id`.
+* `audience` - (optional) When using Workload Identity Federation, the audience to specify when fetching an ID token from the ID token supplier.
 
 ## Special configurations for Azure
 


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
Document how the GITHUB OIDC authentication can be used in TF.

Note: This does NOT contain the documentation for how WIF / Github OIDC works as that would be part of the general documentation which would be published soon. Once that is published, we will add a link to that documentation under the `### Authenticating with GITHUB OIDC | Workload Identity Federation (WIF)` heading. 

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->
N/A
- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] using Go SDK
- [ ] using TF Plugin Framework
