### PR TITLE
[Fix] Don't fail delete when `databricks_system_schema` can be disabled only by Databricks

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Bug Fixes
 
+ * Don't fail delete when `databricks_system_schema` can be disabled only by Databricks [#4727](https://github.com/databricks/terraform-provider-databricks/pull/4727)
+
 ### Documentation
 
 ### Exporter

--- a/catalog/resource_system_schema.go
+++ b/catalog/resource_system_schema.go
@@ -143,10 +143,18 @@ func ResourceSystemSchema() common.Resource {
 			if err != nil {
 				return err
 			}
-			return w.SystemSchemas.Disable(ctx, catalog.DisableRequest{
+			err = w.SystemSchemas.Disable(ctx, catalog.DisableRequest{
 				MetastoreId: metastoreSummary.MetastoreId,
 				SchemaName:  schemaName,
 			})
+			if err != nil {
+				//ignore "<schema-name> system schema can only be disabled by Databricks" error
+				if !strings.Contains(err.Error(), "can only be disabled by Databricks") {
+					return err
+				}
+				log.Printf("[WARN] %s can be disabled only by Databricks, ignoring it", schemaName)
+			}
+			return nil
 		},
 	}
 }

--- a/catalog/resource_system_schema.go
+++ b/catalog/resource_system_schema.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"strings"
 
+	"github.com/databricks/databricks-sdk-go"
 	"github.com/databricks/databricks-sdk-go/service/catalog"
 	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -70,10 +71,7 @@ func ResourceSystemSchema() common.Resource {
 				log.Printf("[WARN] %s is auto enabled, ignoring it", old)
 				return nil
 			}
-			err = w.SystemSchemas.Disable(ctx, catalog.DisableRequest{
-				MetastoreId: metastoreSummary.MetastoreId,
-				SchemaName:  old,
-			})
+			err = safeDisable(ctx, w, metastoreSummary.MetastoreId, old)
 			if err != nil {
 				return err
 			}
@@ -143,18 +141,22 @@ func ResourceSystemSchema() common.Resource {
 			if err != nil {
 				return err
 			}
-			err = w.SystemSchemas.Disable(ctx, catalog.DisableRequest{
-				MetastoreId: metastoreSummary.MetastoreId,
-				SchemaName:  schemaName,
-			})
-			if err != nil {
-				//ignore "<schema-name> system schema can only be disabled by Databricks" error
-				if !strings.Contains(err.Error(), "can only be disabled by Databricks") {
-					return err
-				}
-				log.Printf("[WARN] %s can be disabled only by Databricks, ignoring it", schemaName)
-			}
-			return nil
+			return safeDisable(ctx, w, metastoreSummary.MetastoreId, schemaName)
 		},
 	}
+}
+
+func safeDisable(ctx context.Context, w *databricks.WorkspaceClient, metastoreId, schemaName string) error {
+	err := w.SystemSchemas.Disable(ctx, catalog.DisableRequest{
+		MetastoreId: metastoreId,
+		SchemaName:  schemaName,
+	})
+	if err != nil {
+		//ignore "<schema-name> system schema can only be disabled by Databricks" error
+		if !strings.Contains(err.Error(), "can only be disabled by Databricks") {
+			return err
+		}
+		log.Printf("[WARN] %s can be disabled only by Databricks, ignoring it", schemaName)
+	}
+	return nil
 }

--- a/catalog/resource_system_schema_test.go
+++ b/catalog/resource_system_schema_test.go
@@ -2,55 +2,37 @@ package catalog
 
 import (
 	"errors"
-	"net/http"
 	"testing"
 
 	"github.com/databricks/databricks-sdk-go/experimental/mocks"
 	"github.com/databricks/databricks-sdk-go/service/catalog"
-	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/databricks/terraform-provider-databricks/qa"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
 
 func TestSystemSchemaCreate(t *testing.T) {
 	qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:   http.MethodGet,
-				Resource: "/api/2.1/unity-catalog/metastore_summary",
-				Response: catalog.GetMetastoreSummaryResponse{
-					MetastoreId: "abc",
-				},
-			},
-			{
-				Method:   http.MethodPut,
-				Resource: "/api/2.1/unity-catalog/metastores/abc/systemschemas/access",
-				Status:   200,
-			},
-			{
-				Method:   http.MethodGet,
-				Resource: "/api/2.1/unity-catalog/metastore_summary",
-				Response: catalog.GetMetastoreSummaryResponse{
-					MetastoreId: "abc",
-				},
-			},
-			{
-				Method:   http.MethodGet,
-				Resource: "/api/2.1/unity-catalog/metastores/abc/systemschemas?",
-				Response: catalog.ListSystemSchemasResponse{
-					Schemas: []catalog.SystemSchemaInfo{
-						{
-							Schema: "access",
-							State:  string(SystemSchemaInfoStateEnableCompleted),
-						},
-						{
-							Schema: "billing",
-							State:  string(SystemSchemaInfoStateEnableCompleted),
-						},
+		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
+			w.GetMockMetastoresAPI().EXPECT().Summary(mock.Anything).Return(&catalog.GetMetastoreSummaryResponse{
+				MetastoreId: "abc",
+			}, nil)
+			e := w.GetMockSystemSchemasAPI().EXPECT()
+			e.Enable(mock.Anything, catalog.EnableRequest{
+				MetastoreId: "abc",
+				SchemaName:  "access",
+			}).Return(nil)
+			e.ListByMetastoreId(mock.Anything, "abc").Return(&catalog.ListSystemSchemasResponse{
+				Schemas: []catalog.SystemSchemaInfo{
+					{
+						Schema: "access",
+						State:  string(SystemSchemaInfoStateEnableCompleted),
+					},
+					{
+						Schema: "billing",
+						State:  string(SystemSchemaInfoStateEnableCompleted),
 					},
 				},
-			},
+			}, nil)
 		},
 		Resource: ResourceSystemSchema(),
 		HCL:      `schema = "access"`,
@@ -63,31 +45,20 @@ func TestSystemSchemaCreate(t *testing.T) {
 }
 
 func TestSystemSchemaCreate_Error(t *testing.T) {
-	d, err := qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:   http.MethodGet,
-				Resource: "/api/2.1/unity-catalog/metastore_summary",
-				Response: catalog.GetMetastoreSummaryResponse{
-					MetastoreId: "abc",
-				},
-			},
-			{
-				Method:   http.MethodPut,
-				Resource: "/api/2.1/unity-catalog/metastores/abc/systemschemas/access",
-				Response: common.APIErrorBody{
-					ErrorCode: "INVALID_REQUEST",
-					Message:   "Internal error happened",
-				},
-				Status: 400,
-			},
+	qa.ResourceFixture{
+		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
+			w.GetMockMetastoresAPI().EXPECT().Summary(mock.Anything).Return(&catalog.GetMetastoreSummaryResponse{
+				MetastoreId: "abc",
+			}, nil)
+			w.GetMockSystemSchemasAPI().EXPECT().Enable(mock.Anything, catalog.EnableRequest{
+				MetastoreId: "abc",
+				SchemaName:  "access",
+			}).Return(errors.New("Internal error happened"))
 		},
 		Resource: ResourceSystemSchema(),
 		HCL:      `schema = "access"`,
 		Create:   true,
-	}.Apply(t)
-	qa.AssertErrorStartsWith(t, err, "Internal error happened")
-	assert.Equal(t, "", d.Id(), "Id should be empty for error creates")
+	}.ExpectError(t, "Internal error happened")
 }
 
 func TestSystemSchemaCreateAlreadyEnabled(t *testing.T) {
@@ -125,48 +96,32 @@ func TestSystemSchemaCreateAlreadyEnabled(t *testing.T) {
 }
 
 func TestSystemSchemaUpdate(t *testing.T) {
-	d, err := qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:   http.MethodGet,
-				Resource: "/api/2.1/unity-catalog/metastore_summary",
-				Response: catalog.GetMetastoreSummaryResponse{
-					MetastoreId: "abc",
-				},
-			},
-			{
-				Method:   http.MethodPut,
-				Resource: "/api/2.1/unity-catalog/metastores/abc/systemschemas/access",
-				Status:   200,
-			},
-			{
-				Method:   http.MethodDelete,
-				Resource: "/api/2.1/unity-catalog/metastores/abc/systemschemas/information_schema?",
-				Status:   200,
-			},
-			{
-				Method:   http.MethodGet,
-				Resource: "/api/2.1/unity-catalog/metastore_summary",
-				Response: catalog.GetMetastoreSummaryResponse{
-					MetastoreId: "abc",
-				},
-			},
-			{
-				Method:   http.MethodGet,
-				Resource: "/api/2.1/unity-catalog/metastores/abc/systemschemas?",
-				Response: catalog.ListSystemSchemasResponse{
-					Schemas: []catalog.SystemSchemaInfo{
-						{
-							Schema: "access",
-							State:  string(SystemSchemaInfoStateEnableCompleted),
-						},
-						{
-							Schema: "billing",
-							State:  string(SystemSchemaInfoStateEnableCompleted),
-						},
+	qa.ResourceFixture{
+		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
+			w.GetMockMetastoresAPI().EXPECT().Summary(mock.Anything).Return(&catalog.GetMetastoreSummaryResponse{
+				MetastoreId: "abc",
+			}, nil)
+			e := w.GetMockSystemSchemasAPI().EXPECT()
+			e.Enable(mock.Anything, catalog.EnableRequest{
+				MetastoreId: "abc",
+				SchemaName:  "access",
+			}).Return(nil)
+			e.Disable(mock.Anything, catalog.DisableRequest{
+				MetastoreId: "abc",
+				SchemaName:  "information_schema",
+			}).Return(nil)
+			e.ListByMetastoreId(mock.Anything, "abc").Return(&catalog.ListSystemSchemasResponse{
+				Schemas: []catalog.SystemSchemaInfo{
+					{
+						Schema: "access",
+						State:  string(SystemSchemaInfoStateEnableCompleted),
+					},
+					{
+						Schema: "billing",
+						State:  string(SystemSchemaInfoStateEnableCompleted),
 					},
 				},
-			},
+			}, nil)
 		},
 		Resource: ResourceSystemSchema(),
 		InstanceState: map[string]string{
@@ -175,31 +130,22 @@ func TestSystemSchemaUpdate(t *testing.T) {
 		HCL:    `schema = "access"`,
 		Update: true,
 		ID:     "abc|information_schema",
-	}.Apply(t)
-	assert.NoError(t, err)
-	assert.Equal(t, "abc|access", d.Id())
-	assert.Equal(t, "access", d.Get("schema"))
+	}.ApplyAndExpectData(t, map[string]any{
+		"schema": "access",
+		"id":     "abc|access",
+	})
 }
 
 func TestSystemSchemaUpdate_Error(t *testing.T) {
-	_, err := qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:   http.MethodGet,
-				Resource: "/api/2.1/unity-catalog/metastore_summary",
-				Response: catalog.GetMetastoreSummaryResponse{
-					MetastoreId: "abc",
-				},
-			},
-			{
-				Method:   http.MethodPut,
-				Resource: "/api/2.1/unity-catalog/metastores/abc/systemschemas/access",
-				Response: common.APIErrorBody{
-					ErrorCode: "INVALID_REQUEST",
-					Message:   "Internal error happened",
-				},
-				Status: 400,
-			},
+	qa.ResourceFixture{
+		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
+			w.GetMockMetastoresAPI().EXPECT().Summary(mock.Anything).Return(&catalog.GetMetastoreSummaryResponse{
+				MetastoreId: "abc",
+			}, nil)
+			w.GetMockSystemSchemasAPI().EXPECT().Enable(mock.Anything, catalog.EnableRequest{
+				MetastoreId: "abc",
+				SchemaName:  "access",
+			}).Return(errors.New("Internal error happened"))
 		},
 		Resource: ResourceSystemSchema(),
 		InstanceState: map[string]string{
@@ -208,36 +154,27 @@ func TestSystemSchemaUpdate_Error(t *testing.T) {
 		HCL:    `schema = "access"`,
 		Update: true,
 		ID:     "abc|information_schema",
-	}.Apply(t)
-	qa.AssertErrorStartsWith(t, err, "Internal error happened")
+	}.ExpectError(t, "Internal error happened")
 }
 
 func TestSystemSchemaRead(t *testing.T) {
 	qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:   http.MethodGet,
-				Resource: "/api/2.1/unity-catalog/metastore_summary",
-				Response: catalog.GetMetastoreSummaryResponse{
-					MetastoreId: "abc",
-				},
-			},
-			{
-				Method:   http.MethodGet,
-				Resource: "/api/2.1/unity-catalog/metastores/abc/systemschemas?",
-				Response: catalog.ListSystemSchemasResponse{
-					Schemas: []catalog.SystemSchemaInfo{
-						{
-							Schema: "access",
-							State:  string(SystemSchemaInfoStateEnableCompleted),
-						},
-						{
-							Schema: "billing",
-							State:  string(SystemSchemaInfoStateEnableCompleted),
-						},
+		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
+			w.GetMockMetastoresAPI().EXPECT().Summary(mock.Anything).Return(&catalog.GetMetastoreSummaryResponse{
+				MetastoreId: "abc",
+			}, nil)
+			w.GetMockSystemSchemasAPI().EXPECT().ListByMetastoreId(mock.Anything, "abc").Return(&catalog.ListSystemSchemasResponse{
+				Schemas: []catalog.SystemSchemaInfo{
+					{
+						Schema: "access",
+						State:  string(SystemSchemaInfoStateEnableCompleted),
+					},
+					{
+						Schema: "billing",
+						State:  string(SystemSchemaInfoStateEnableCompleted),
 					},
 				},
-			},
+			}, nil)
 		},
 		Resource: ResourceSystemSchema(),
 		Read:     true,
@@ -249,156 +186,120 @@ func TestSystemSchemaRead(t *testing.T) {
 }
 
 func TestSystemSchemaRead_Error(t *testing.T) {
-	d, err := qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:   http.MethodGet,
-				Resource: "/api/2.1/unity-catalog/metastore_summary",
-				Response: catalog.GetMetastoreSummaryResponse{
-					MetastoreId: "abc",
-				},
-			},
-			{
-				Method:   http.MethodGet,
-				Resource: "/api/2.1/unity-catalog/metastores/abc/systemschemas?",
-				Response: common.APIErrorBody{
-					ErrorCode: "INVALID_REQUEST",
-					Message:   "Internal error happened",
-				},
-				Status: 400,
-			},
+	qa.ResourceFixture{
+		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
+			w.GetMockMetastoresAPI().EXPECT().Summary(mock.Anything).Return(&catalog.GetMetastoreSummaryResponse{
+				MetastoreId: "abc",
+			}, nil)
+			w.GetMockSystemSchemasAPI().EXPECT().ListByMetastoreId(mock.Anything, "abc").Return(nil, errors.New("Internal error happened"))
 		},
 		Resource: ResourceSystemSchema(),
 		Read:     true,
 		ID:       "abc|access",
-	}.Apply(t)
-	qa.AssertErrorStartsWith(t, err, "Internal error happened")
-	assert.Equal(t, "abc|access", d.Id(), "Id should not be empty for error reads")
+	}.ExpectError(t, "Internal error happened")
 }
 
 func TestSystemSchemaRead_NotEnabled(t *testing.T) {
-	d, err := qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:   http.MethodGet,
-				Resource: "/api/2.1/unity-catalog/metastore_summary",
-				Response: catalog.GetMetastoreSummaryResponse{
-					MetastoreId: "abc",
-				},
-			},
-			{
-				Method:   http.MethodGet,
-				Resource: "/api/2.1/unity-catalog/metastores/abc/systemschemas?",
-				Response: catalog.ListSystemSchemasResponse{
-					Schemas: []catalog.SystemSchemaInfo{
-						{
-							Schema: "access",
-							State:  string(SystemSchemaInfoStateAvailable),
-						},
-						{
-							Schema: "billing",
-							State:  string(SystemSchemaInfoStateEnableCompleted),
-						},
+	qa.ResourceFixture{
+		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
+			w.GetMockMetastoresAPI().EXPECT().Summary(mock.Anything).Return(&catalog.GetMetastoreSummaryResponse{
+				MetastoreId: "abc",
+			}, nil)
+			w.GetMockSystemSchemasAPI().EXPECT().ListByMetastoreId(mock.Anything, "abc").Return(&catalog.ListSystemSchemasResponse{
+				Schemas: []catalog.SystemSchemaInfo{
+					{
+						Schema: "access",
+						State:  string(SystemSchemaInfoStateAvailable),
+					},
+					{
+						Schema: "billing",
+						State:  string(SystemSchemaInfoStateEnableCompleted),
 					},
 				},
-			},
+			}, nil)
 		},
 		Resource: ResourceSystemSchema(),
 		Read:     true,
 		Removed:  true,
 		ID:       "abc|access",
-	}.Apply(t)
-	assert.NoError(t, err)
-	assert.Equal(t, "", d.Id(), "Id should be empty if a schema is not enabled")
+	}.ApplyAndExpectData(t, map[string]any{})
 }
 
 func TestSystemSchemaRead_NotExists(t *testing.T) {
-	d, err := qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:   http.MethodGet,
-				Resource: "/api/2.1/unity-catalog/metastore_summary",
-				Response: catalog.GetMetastoreSummaryResponse{
-					MetastoreId: "abc",
-				},
-			},
-			{
-				Method:   http.MethodGet,
-				Resource: "/api/2.1/unity-catalog/metastores/abc/systemschemas?",
-				Response: catalog.ListSystemSchemasResponse{
-					Schemas: []catalog.SystemSchemaInfo{
-						{
-							Schema: "billing",
-							State:  string(SystemSchemaInfoStateEnableCompleted),
-						},
+	qa.ResourceFixture{
+		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
+			w.GetMockMetastoresAPI().EXPECT().Summary(mock.Anything).Return(&catalog.GetMetastoreSummaryResponse{
+				MetastoreId: "abc",
+			}, nil)
+			w.GetMockSystemSchemasAPI().EXPECT().ListByMetastoreId(mock.Anything, "abc").Return(&catalog.ListSystemSchemasResponse{
+				Schemas: []catalog.SystemSchemaInfo{
+					{
+						Schema: "billing",
+						State:  string(SystemSchemaInfoStateEnableCompleted),
 					},
 				},
-			},
+			}, nil)
 		},
 		Resource: ResourceSystemSchema(),
 		Read:     true,
 		Removed:  true,
 		ID:       "abc|access",
-	}.Apply(t)
-	assert.NoError(t, err)
-	assert.Equal(t, "", d.Id(), "Id should be empty if a schema does not exist")
+	}.ApplyAndExpectData(t, map[string]any{"id": ""})
 }
 
 func TestSystemSchemaDelete(t *testing.T) {
-	d, err := qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:   http.MethodGet,
-				Resource: "/api/2.1/unity-catalog/metastore_summary",
-				Response: catalog.GetMetastoreSummaryResponse{
-					MetastoreId: "abc",
-				},
-			},
-			{
-				Method:   http.MethodDelete,
-				Resource: "/api/2.1/unity-catalog/metastores/abc/systemschemas/access?",
-				Status:   200,
-			},
-			{
-				Method:   http.MethodDelete,
-				Resource: "/api/2.1/unity-catalog/metastores/abc/systemschemas/billing?",
-				Status:   200,
-			},
+	qa.ResourceFixture{
+		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
+			w.GetMockMetastoresAPI().EXPECT().Summary(mock.Anything).Return(&catalog.GetMetastoreSummaryResponse{
+				MetastoreId: "abc",
+			}, nil)
+			e := w.GetMockSystemSchemasAPI().EXPECT()
+			e.Disable(mock.Anything, catalog.DisableRequest{
+				MetastoreId: "abc",
+				SchemaName:  "access",
+			}).Return(nil)
 		},
 		HCL:      `schema = "access"`,
 		Resource: ResourceSystemSchema(),
 		Delete:   true,
 		ID:       "abc|access",
-	}.Apply(t)
-	assert.NoError(t, err)
-	assert.Equal(t, "abc|access", d.Id())
+	}.ApplyAndExpectData(t, map[string]any{
+		"id": "abc|access",
+	})
 }
 
 func TestSystemSchemaDelete_Error(t *testing.T) {
-	d, err := qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:   http.MethodGet,
-				Resource: "/api/2.1/unity-catalog/metastore_summary",
-				Response: catalog.GetMetastoreSummaryResponse{
-					MetastoreId: "abc",
-				},
-			},
-			{
-				Method:   http.MethodDelete,
-				Resource: "/api/2.1/unity-catalog/metastores/abc/systemschemas/access?",
-				Response: common.APIErrorBody{
-					ErrorCode: "INVALID_REQUEST",
-					Message:   "Internal error happened",
-				},
-				Status: 400,
-			},
+	qa.ResourceFixture{
+		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
+			w.GetMockMetastoresAPI().EXPECT().Summary(mock.Anything).Return(&catalog.GetMetastoreSummaryResponse{
+				MetastoreId: "abc",
+			}, nil)
+			w.GetMockSystemSchemasAPI().EXPECT().Disable(mock.Anything, catalog.DisableRequest{
+				MetastoreId: "abc",
+				SchemaName:  "access",
+			}).Return(errors.New("Internal error happened"))
 		},
 		Resource: ResourceSystemSchema(),
 		HCL:      `schema = "access"`,
 		Delete:   true,
 		ID:       "abc|access",
-	}.Apply(t)
-	qa.AssertErrorStartsWith(t, err, "Internal error happened")
-	assert.Equal(t, "abc|access", d.Id())
+	}.ExpectError(t, "Internal error happened")
+}
+
+func TestSystemSchemaDelete_DisabledByDatabricks(t *testing.T) {
+	qa.ResourceFixture{
+		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
+			w.GetMockMetastoresAPI().EXPECT().Summary(mock.Anything).Return(&catalog.GetMetastoreSummaryResponse{
+				MetastoreId: "abc",
+			}, nil)
+			w.GetMockSystemSchemasAPI().EXPECT().Disable(mock.Anything, catalog.DisableRequest{
+				MetastoreId: "abc",
+				SchemaName:  "access",
+			}).Return(errors.New("access system schema can only be disabled by Databricks"))
+		},
+		Resource: ResourceSystemSchema(),
+		HCL:      `schema = "access"`,
+		Delete:   true,
+		ID:       "abc|access",
+	}.ApplyAndExpectData(t, map[string]any{})
 }

--- a/docs/resources/system_schema.md
+++ b/docs/resources/system_schema.md
@@ -7,7 +7,7 @@ Manages system tables enablement. System tables are a Databricks-hosted analytic
 
 -> This resource can only be used with a workspace-level provider!
 
--> Certain system schemas (such as `billing`) may be auto-enabled once GA and should not be manually declared in Terraform configurations.
+-> Certain system schemas (such as `billing`) may be auto-enabled once GA and should not be manually declared in Terraform configurations.  Certain schemas can't also be disabled completely.
 
 ## Example Usage
 


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

Also rewrote corresponding tests to use the mock framework from Go SDK

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [x] covered with integration tests in `internal/acceptance`
- [x] using Go SDK
- [ ] using TF Plugin Framework
