### PR TITLE
Unify client construction pathways and logging between SDKv2 and Plugin Framework implementations

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bug Fixes
 
+ * Don't fail delete when `databricks_system_schema` can be disabled only by Databricks [#4727](https://github.com/databricks/terraform-provider-databricks/pull/4727)
  * Fix debug logging for attributes used to configure the provider ([#4728](https://github.com/databricks/terraform-provider-databricks/pull/4728)).
 
 ### Documentation

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Bug Fixes
 
+ * Fix debug logging for attributes used to configure the provider ([#4728](https://github.com/databricks/terraform-provider-databricks/pull/4728)).
+
 ### Documentation
 
 ### Exporter

--- a/catalog/system_schema_test.go
+++ b/catalog/system_schema_test.go
@@ -9,6 +9,9 @@ import (
 func TestUcAccResourceSystemSchema(t *testing.T) {
 	acceptance.UnityWorkspaceLevel(t, acceptance.Step{
 		Template: `
+		resource "databricks_system_schema" "access" {
+			schema = "access"
+		}
 		resource "databricks_system_schema" "billing" {
 			schema = "billing"
 		}`,

--- a/catalog/system_schema_test.go
+++ b/catalog/system_schema_test.go
@@ -9,9 +9,6 @@ import (
 func TestUcAccResourceSystemSchema(t *testing.T) {
 	acceptance.UnityWorkspaceLevel(t, acceptance.Step{
 		Template: `
-		resource "databricks_system_schema" "access" {
-			schema = "access"
-		}
 		resource "databricks_system_schema" "billing" {
 			schema = "billing"
 		}`,

--- a/internal/providers/client/databricks_client.go
+++ b/internal/providers/client/databricks_client.go
@@ -1,0 +1,57 @@
+package client
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/databricks/databricks-sdk-go/client"
+	"github.com/databricks/databricks-sdk-go/config"
+	"github.com/databricks/terraform-provider-databricks/commands"
+	"github.com/databricks/terraform-provider-databricks/common"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+func PrepareDatabricksClient(ctx context.Context, cfg *config.Config, configCustomizer func(*config.Config) error) (*common.DatabricksClient, error) {
+	if cfg.AuthType != "" {
+		// mapping from previous Google authentication types
+		// and current authentication types from Databricks Go SDK
+		oldToNewerAuthType := map[string]string{
+			"google-creds":     "google-credentials",
+			"google-accounts":  "google-id",
+			"google-workspace": "google-id",
+		}
+		newer, ok := oldToNewerAuthType[cfg.AuthType]
+		if ok {
+			tflog.Info(ctx, fmt.Sprintf("Changing required auth_type from %s to %s", cfg.AuthType, newer))
+			cfg.AuthType = newer
+		}
+	}
+	cfg.EnsureResolved()
+	// Unless set explicitly, the provider will retry indefinitely until context is cancelled
+	// by either a timeout or interrupt.
+	if cfg.RetryTimeoutSeconds == 0 {
+		cfg.RetryTimeoutSeconds = -1
+	}
+	// If not set, the default provider timeout is 65 seconds. Most APIs have a server-side timeout of 60 seconds.
+	// The additional 5 seconds is to account for network latency.
+	if cfg.HTTPTimeoutSeconds == 0 {
+		cfg.HTTPTimeoutSeconds = 65
+	}
+	if configCustomizer != nil {
+		err := configCustomizer(cfg)
+		if err != nil {
+			return nil, err
+		}
+	}
+	client, err := client.New(cfg)
+	if err != nil {
+		return nil, err
+	}
+	pc := &common.DatabricksClient{
+		DatabricksClient: client,
+	}
+	pc.WithCommandExecutor(func(ctx context.Context, client *common.DatabricksClient) common.CommandExecutor {
+		return commands.NewCommandsAPI(ctx, client)
+	})
+	return pc, nil
+}

--- a/internal/providers/client/databricks_client.go
+++ b/internal/providers/client/databricks_client.go
@@ -11,6 +11,16 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
+// PrepareDatabricksClient makes some common adjustments to the config that apply in all cases
+// and returns a ready-to-use Databricks client. This includes:
+// - mapping deprecated auth types to their newer counterparts
+// - ensuring the config is resolved
+// - setting a default retry timeout if not set
+// - setting a default HTTP timeout if not set
+//
+// TODO: this should be colocated with the definition of DatabricksClient in common/client.go, but
+// this isn't possible without introducing a circular dependency. Fixing this will require refactoring
+// DatabricksClient out of the common package.
 func PrepareDatabricksClient(ctx context.Context, cfg *config.Config, configCustomizer func(*config.Config) error) (*common.DatabricksClient, error) {
 	if cfg.AuthType != "" {
 		// mapping from previous Google authentication types

--- a/internal/providers/pluginfw/pluginfw.go
+++ b/internal/providers/pluginfw/pluginfw.go
@@ -6,15 +6,13 @@ package pluginfw
 import (
 	"context"
 	"fmt"
-	"log"
 	"reflect"
 	"sort"
 	"strings"
 
-	"github.com/databricks/databricks-sdk-go/client"
 	"github.com/databricks/databricks-sdk-go/config"
-	"github.com/databricks/terraform-provider-databricks/commands"
 	"github.com/databricks/terraform-provider-databricks/common"
+	"github.com/databricks/terraform-provider-databricks/internal/providers/client"
 	providercommon "github.com/databricks/terraform-provider-databricks/internal/providers/common"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -22,6 +20,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
@@ -98,90 +97,73 @@ func providerSchemaPluginFramework() schema.Schema {
 	}
 }
 
+// setAttribute sets the attribute value in the SDK config corresponding to the attribute name in the provider configuration.
+// It returns true if the attribute was set, false if it was not set (because it was unknown or null), and a diag.Diagnostics object in case of error.
+func (p *DatabricksProviderPluginFramework) setAttribute(ctx context.Context, providerConfig tfsdk.Config, attr config.ConfigAttribute, cfg *config.Config) (bool, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	switch attr.Kind {
+	case reflect.Bool:
+		var attrValue types.Bool
+		diags.Append(providerConfig.GetAttribute(ctx, path.Root(attr.Name), &attrValue)...)
+		if diags.HasError() {
+			return false, diags
+		}
+		if attrValue.IsNull() || attrValue.IsUnknown() {
+			return false, diags
+		}
+		err := attr.Set(cfg, attrValue.ValueBool())
+		if err != nil {
+			diags.Append(diag.NewErrorDiagnostic("Failed to set attribute", err.Error()))
+			return false, diags
+		}
+	case reflect.Int:
+		var attrValue types.Int64
+		diags.Append(providerConfig.GetAttribute(ctx, path.Root(attr.Name), &attrValue)...)
+		if diags.HasError() {
+			return false, diags
+		}
+		if attrValue.IsNull() || attrValue.IsUnknown() {
+			return false, diags
+		}
+		err := attr.Set(cfg, int(attrValue.ValueInt64()))
+		if err != nil {
+			diags.Append(diag.NewErrorDiagnostic("Failed to set attribute", err.Error()))
+			return false, diags
+		}
+	case reflect.String:
+		var attrValue types.String
+		diags.Append(providerConfig.GetAttribute(ctx, path.Root(attr.Name), &attrValue)...)
+		if diags.HasError() {
+			return false, diags
+		}
+		if attrValue.IsNull() || attrValue.IsUnknown() {
+			return false, diags
+		}
+		err := attr.Set(cfg, attrValue.ValueString())
+		if err != nil {
+			diags.Append(diag.NewErrorDiagnostic(fmt.Sprintf("Failed to set attribute: %s", attr.Name), err.Error()))
+			return false, diags
+		}
+	}
+	return true, diags
+}
+
 func (p *DatabricksProviderPluginFramework) configureDatabricksClient(ctx context.Context, req provider.ConfigureRequest, resp *provider.ConfigureResponse) any {
 	cfg := &config.Config{}
 	attrsUsed := []string{}
 	for _, attr := range config.ConfigAttributes {
-		switch attr.Kind {
-		case reflect.Bool:
-			var attrValue types.Bool
-			diags := req.Config.GetAttribute(ctx, path.Root(attr.Name), &attrValue)
-			resp.Diagnostics.Append(diags...)
-			if resp.Diagnostics.HasError() {
-				return nil
-			}
-			err := attr.Set(cfg, attrValue.ValueBool())
-			if err != nil {
-				resp.Diagnostics.Append(diag.NewErrorDiagnostic("Failed to set attribute", err.Error()))
-				return nil
-			}
-		case reflect.Int:
-			var attrValue types.Int64
-			diags := req.Config.GetAttribute(ctx, path.Root(attr.Name), &attrValue)
-			resp.Diagnostics.Append(diags...)
-			if resp.Diagnostics.HasError() {
-				return nil
-			}
-			err := attr.Set(cfg, int(attrValue.ValueInt64()))
-			if err != nil {
-				resp.Diagnostics.Append(diag.NewErrorDiagnostic("Failed to set attribute", err.Error()))
-				return nil
-			}
-		case reflect.String:
-			var attrValue types.String
-			diags := req.Config.GetAttribute(ctx, path.Root(attr.Name), &attrValue)
-			resp.Diagnostics.Append(diags...)
-			if resp.Diagnostics.HasError() {
-				return nil
-			}
-			err := attr.Set(cfg, attrValue.ValueString())
-			if err != nil {
-				resp.Diagnostics.AddError(fmt.Sprintf("Failed to set attribute: %s", attr.Name), err.Error())
-				return nil
-			}
-		}
-		if attr.Kind == reflect.String {
+		ok, diags := p.setAttribute(ctx, req.Config, attr, cfg)
+		resp.Diagnostics.Append(diags...)
+		if ok {
 			attrsUsed = append(attrsUsed, attr.Name)
 		}
 	}
 	sort.Strings(attrsUsed)
-	tflog.Info(ctx, fmt.Sprintf("Explicit and implicit attributes: %s", strings.Join(attrsUsed, ", ")))
-	if cfg.AuthType != "" {
-		// mapping from previous Google authentication types
-		// and current authentication types from Databricks Go SDK
-		oldToNewerAuthType := map[string]string{
-			"google-creds":     "google-credentials",
-			"google-accounts":  "google-id",
-			"google-workspace": "google-id",
-		}
-		newer, ok := oldToNewerAuthType[cfg.AuthType]
-		if ok {
-			log.Printf("[INFO] Changing required auth_type from %s to %s", cfg.AuthType, newer)
-			cfg.AuthType = newer
-		}
-	}
-	// If not set, the default provider timeout is 65 seconds. Most APIs have a server-side timeout of 60 seconds.
-	// The additional 5 seconds is to account for network latency.
-	if cfg.HTTPTimeoutSeconds == 0 {
-		cfg.HTTPTimeoutSeconds = 65
-	}
-	if p.configCustomizer != nil {
-		err := p.configCustomizer(cfg)
-		if err != nil {
-			resp.Diagnostics.AddError("Failed to customize config", err.Error())
-			return nil
-		}
-	}
-	client, err := client.New(cfg)
+	tflog.Info(ctx, fmt.Sprintf("(plugin framework) Attributes configured from provider configuration: %s", strings.Join(attrsUsed, ", ")))
+	databricksClient, err := client.PrepareDatabricksClient(ctx, cfg, p.configCustomizer)
 	if err != nil {
-		resp.Diagnostics.Append(diag.NewErrorDiagnostic(err.Error(), ""))
+		resp.Diagnostics.AddError("Failed to configure Databricks client", err.Error())
 		return nil
 	}
-	pc := &common.DatabricksClient{
-		DatabricksClient: client,
-	}
-	pc.WithCommandExecutor(func(ctx context.Context, client *common.DatabricksClient) common.CommandExecutor {
-		return commands.NewCommandsAPI(ctx, client)
-	})
-	return pc
+	return databricksClient
 }

--- a/internal/providers/pluginfw/pluginfw.go
+++ b/internal/providers/pluginfw/pluginfw.go
@@ -163,8 +163,12 @@ func (p *DatabricksProviderPluginFramework) configureDatabricksClient(ctx contex
 			attrsUsed = append(attrsUsed, attr.Name)
 		}
 	}
-	sort.Strings(attrsUsed)
-	tflog.Info(ctx, fmt.Sprintf("(plugin framework) Attributes configured from provider configuration: %s", strings.Join(attrsUsed, ", ")))
+	if len(attrsUsed) > 0 {
+		sort.Strings(attrsUsed)
+		tflog.Info(ctx, fmt.Sprintf("(plugin framework) Attributes specified in provider configuration: %s", strings.Join(attrsUsed, ", ")))
+	} else {
+		tflog.Info(ctx, "(plugin framework) No attributes specified in provider configuration")
+	}
 	databricksClient, err := client.PrepareDatabricksClient(ctx, cfg, p.configCustomizer)
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to configure Databricks client", err.Error())

--- a/internal/providers/pluginfw/pluginfw.go
+++ b/internal/providers/pluginfw/pluginfw.go
@@ -99,7 +99,12 @@ func providerSchemaPluginFramework() schema.Schema {
 
 // setAttribute sets the attribute value in the SDK config corresponding to the attribute name in the provider configuration.
 // It returns true if the attribute was set, false if it was not set (because it was unknown or null), and a diag.Diagnostics object in case of error.
-func (p *DatabricksProviderPluginFramework) setAttribute(ctx context.Context, providerConfig tfsdk.Config, attr config.ConfigAttribute, cfg *config.Config) (bool, diag.Diagnostics) {
+func (p *DatabricksProviderPluginFramework) setAttribute(
+	ctx context.Context,
+	providerConfig tfsdk.Config,
+	attr config.ConfigAttribute,
+	cfg *config.Config,
+) (bool, diag.Diagnostics) {
 	var diags diag.Diagnostics
 	switch attr.Kind {
 	case reflect.Bool:

--- a/internal/providers/providers_test_utils.go
+++ b/internal/providers/providers_test_utils.go
@@ -118,7 +118,7 @@ func (pf providerFixture) applyWithPluginFramework(t *testing.T) *common.Databri
 func (pf providerFixture) applyAssertions(c *common.DatabricksClient, t *testing.T, err error) *common.DatabricksClient {
 	if pf.assertError != "" {
 		require.NotNilf(t, err, "Expected to have %s error", pf.assertError)
-		require.True(t, strings.HasPrefix(err.Error(), pf.assertError),
+		require.True(t, strings.Contains(err.Error(), pf.assertError),
 			"Expected to have '%s' error, but got '%s'", pf.assertError, err)
 		return nil
 	}
@@ -184,7 +184,7 @@ func (pf providerFixture) configureProviderAndReturnClient_PluginFramework(t *te
 	if len(diags) > 0 {
 		issues := []string{}
 		for _, d := range diags {
-			issues = append(issues, d.Summary())
+			issues = append(issues, d.Summary(), d.Detail())
 		}
 		return nil, errors.New(strings.Join(issues, ", "))
 	}


### PR DESCRIPTION
## Changes
Currently, the SDKv2 and Plugin Framework provider implementations have slightly different behavior in how the provider is configured. The SDKv2's schema.Schema is constructed using `DefaultFunc`, which allows setting provider-level configuration attributes to have default values based on environment variables. The specific environment variables are taken from struct tags in the Go SDK's Config object. On the other hand, the Plugin Framework's provider.Schema has no support for default values. Eventually, when the config.Config from the Databricks Go SDK is resolved, those attributes will be populated from the environment anyways. Thus, it should be safe to remove these environment variable defaults from the SDKv2 implementation, ensuring a uniform treatment of provider configuration between both implementations.

Beyond this, the code to construct the `DatabricksClient` used by each provider was copied, resulting in a small, unexpected divergence between the two. This common code has now been refactored into `internal/providers/client/databricks_client.go` and is used by both implementations.

Lastly, the Plugin Framework implementation incorrectly logged which attributes were configured by the user. This makes it challenging to review debug logs and interpret what attributes were actually set by a user in their provider configuration. This PR addresses this, with a small refactor of the logic to set an individual attribute refactored into a function.

## Tests
This should pass existing integration tests.

Additionally, when running integration tests locally, I can see the following log output:
```
2025-05-20T10:41:14.603Z [INFO]  databricks: (sdkv2) No attributes specified in provider configuration: tf_provider_addr=registry.terraform.io/hashicorp/databricks tf_rpc=ConfigureProvider tf_mux_provider=tf5to6server.v5tov6Server tf_req_id=b6fd5713-ac58-ef1e-ec8e-10ca5ecb8aa4
2025-05-20T10:41:14.604Z [INFO]  databricks: (plugin framework) No attributes specified in provider configuration: tf_provider_addr=registry.terraform.io/hashicorp/databricks tf_rpc=ConfigureProvider tf_mux_provider="*proto6server.Server" tf_req_id=b6fd5713-ac58-ef1e-ec8e-10ca5ecb8aa4
```

which is now accurate as the provider configuration is empty for integration tests.