### PR TITLE
[Internal] Disable `TestAccTableACL` test since users would soon be able to disable public DBFS root

### DIFF
--- a/sql/sql_permissions_test.go
+++ b/sql/sql_permissions_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestAccTableACL(t *testing.T) {
+	t.Skip("Skipping this test since users will be able to disable public DBFS root which is required for this test")
 	acceptance.LoadWorkspaceEnv(t)
 	tableName := qa.RandomName("table_acl_")
 	clusterId := acceptance.GetEnvOrSkipTest(t, "TEST_TABLE_ACL_CLUSTER_ID")


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
Title

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->
N/A
- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] using Go SDK
- [ ] using TF Plugin Framework
