### PR TITLE
Fix description of link to TF modules to use correct cloud instead of Azure

### DIFF
--- a/docs/guides/aws-e2-firewall-hub-and-spoke.md
+++ b/docs/guides/aws-e2-firewall-hub-and-spoke.md
@@ -4,7 +4,7 @@ page_title: "Provisioning AWS Databricks workspace with a Hub & Spoke firewall f
 
 # Provisioning AWS Databricks workspace with a Hub & Spoke firewall for data exfiltration protection
 
--> **Note** Refer to the [Databricks Terraform Registry modules](https://registry.terraform.io/modules/databricks/examples/databricks/latest) for Terraform modules and examples to deploy Azure Databricks resources.
+-> **Note** Refer to the [Databricks Terraform Registry modules](https://registry.terraform.io/modules/databricks/examples/databricks/latest) for Terraform modules and examples to deploy AWS Databricks resources.
 
 You can provision multiple Databricks workspaces with Terraform, and where many Databricks workspaces are deployed, we recommend a hub and spoke topology reference architecture powered by AWS Transit Gateway. The hub will consist of a central inspection and egress virtual private cloud (VPC), while the Spoke VPC houses federated Databricks workspaces for different business units or segregated teams. In this way, you create your version of a centralized deployment model for your egress architecture, as is recommended for large enterprises. For more information, please visit [Data Exfiltration Protection With Databricks on AWS](https://databricks.com/blog/2021/02/02/data-exfiltration-protection-with-databricks-on-aws.html).
 

--- a/docs/guides/aws-e2-firewall-workspace.md
+++ b/docs/guides/aws-e2-firewall-workspace.md
@@ -4,7 +4,7 @@ page_title: "Provisioning AWS Databricks workspace with a AWS Firewall"
 
 # Provisioning AWS Databricks workspace with a AWS Firewall
 
--> **Note** Refer to the [Databricks Terraform Registry modules](https://registry.terraform.io/modules/databricks/examples/databricks/latest) for Terraform modules and examples to deploy Azure Databricks resources.
+-> **Note** Refer to the [Databricks Terraform Registry modules](https://registry.terraform.io/modules/databricks/examples/databricks/latest) for Terraform modules and examples to deploy AWS Databricks resources.
 
 You can provision multiple Databricks workspaces with Terraform. This example shows how to deploy a Databricks workspace into a VPC, which uses an AWS Network firewall to manage egress out to the public network. For smaller Databricks deployments, this is our recommended configuration; for larger deployments, see [Provisioning AWS Databricks workspace with a Hub & Spoke firewall for data exfiltration protection](aws-e2-firewall-hub-and-spoke.md).
 

--- a/docs/guides/aws-private-link-workspace.md
+++ b/docs/guides/aws-private-link-workspace.md
@@ -4,7 +4,7 @@ page_title: "Provisioning Databricks on AWS with Private Link"
 
 # Provisioning Databricks on AWS with Private Link
 
--> **Note** Refer to the [Databricks Terraform Registry modules](https://registry.terraform.io/modules/databricks/examples/databricks/latest) for Terraform modules and examples to deploy Azure Databricks resources.
+-> **Note** Refer to the [Databricks Terraform Registry modules](https://registry.terraform.io/modules/databricks/examples/databricks/latest) for Terraform modules and examples to deploy AWS Databricks resources.
 
 Databricks PrivateLink support enables private connectivity between users and their Databricks workspaces and between clusters on the data plane and core services on the control plane within the Databricks workspace infrastructure. You can use Terraform to deploy the underlying cloud resources and the private access settings resources automatically using a programmatic approach. This guide assumes you are deploying into an existing VPC and have set up credentials and storage configurations as per prior examples, notably here.
 

--- a/docs/guides/aws-workspace.md
+++ b/docs/guides/aws-workspace.md
@@ -4,7 +4,7 @@ page_title: "Provisioning AWS Databricks workspace"
 
 # Provisioning AWS Databricks workspace
 
--> **Note** Refer to the [Databricks Terraform Registry modules](https://registry.terraform.io/modules/databricks/examples/databricks/latest) for Terraform modules and examples to deploy Azure Databricks resources.
+-> **Note** Refer to the [Databricks Terraform Registry modules](https://registry.terraform.io/modules/databricks/examples/databricks/latest) for Terraform modules and examples to deploy AWS Databricks resources.
 
 You can provision multiple Databricks workspaces with Terraform.
 

--- a/docs/guides/gcp-private-service-connect-workspace.md
+++ b/docs/guides/gcp-private-service-connect-workspace.md
@@ -4,7 +4,7 @@ page_title: "Provisioning Databricks on Google Cloud with Private Service Connec
 
 # Provisioning Databricks workspaces on GCP with Private Service Connect
 
--> **Note** Refer to the [Databricks Terraform Registry modules](https://registry.terraform.io/modules/databricks/examples/databricks/latest) for Terraform modules and examples to deploy Azure Databricks resources.
+-> **Note** Refer to the [Databricks Terraform Registry modules](https://registry.terraform.io/modules/databricks/examples/databricks/latest) for Terraform modules and examples to deploy GCP Databricks resources.
 
 Secure a workspace with private connectivity and mitigate data exfiltration risks by [enabling Google Private Service Connect (PSC) on the workspace](https://docs.gcp.databricks.com/administration-guide/cloud-configurations/gcp/private-service-connect.html). This guide assumes that you are already familiar with Hashicorp Terraform and provisioned some of the Google Compute Cloud infrastructure with it.
 

--- a/docs/guides/gcp-workspace.md
+++ b/docs/guides/gcp-workspace.md
@@ -4,7 +4,7 @@ page_title: "Provisioning Databricks workspaces on GCP."
 
 # Provisioning Databricks workspaces on GCP
 
--> **Note** Refer to the [Databricks Terraform Registry modules](https://registry.terraform.io/modules/databricks/examples/databricks/latest) for Terraform modules and examples to deploy Azure Databricks resources.
+-> **Note** Refer to the [Databricks Terraform Registry modules](https://registry.terraform.io/modules/databricks/examples/databricks/latest) for Terraform modules and examples to deploy GCP Databricks resources.
 
 You can provision multiple Databricks workspaces with Terraform.
 


### PR DESCRIPTION
NO_CHANGELOG=true

## Changes
<!-- Summary of your changes that are easy to understand -->

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] using Go SDK
- [ ] using TF Plugin Framework
