### PR TITLE
[Doc] Replaced `managed_policy_arns` with `aws_iam_role_policy_attachment` in guides

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -13,7 +13,7 @@
 
 ### Documentation
 
- * Replaced `managed_policy_arns` with `aws_iam_role_policy_attachment` in AWS guides
+ * Replaced `managed_policy_arns` with `aws_iam_role_policy_attachment` in AWS guides ([#4737](https://github.com/databricks/terraform-provider-databricks/pull/4737)).
 
 ### Exporter
 

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -13,6 +13,8 @@
 
 ### Documentation
 
+ * Replaced `managed_policy_arns` with `aws_iam_role_policy_attachment` in AWS guides
+
 ### Exporter
 
 ### Internal Changes

--- a/docs/data-sources/aws_unity_catalog_assume_role_policy.md
+++ b/docs/data-sources/aws_unity_catalog_assume_role_policy.md
@@ -33,7 +33,11 @@ resource "aws_iam_policy" "unity_metastore" {
 resource "aws_iam_role" "metastore_data_access" {
   name                = "${var.prefix}-uc-access"
   assume_role_policy  = data.databricks_aws_unity_catalog_assume_role_policy.this.json
-  managed_policy_arns = [aws_iam_policy.unity_metastore.arn]
+}
+
+resource "aws_iam_role_policy_attachment" "metastore_data_access" {
+  role       = aws_iam_role.metastore_data_access.name
+  policy_arn = aws_iam_policy.unity_metastore.arn
 }
 ```
 

--- a/docs/data-sources/aws_unity_catalog_policy.md
+++ b/docs/data-sources/aws_unity_catalog_policy.md
@@ -33,7 +33,11 @@ resource "aws_iam_policy" "unity_metastore" {
 resource "aws_iam_role" "metastore_data_access" {
   name                = "${var.prefix}-uc-access"
   assume_role_policy  = data.databricks_aws_unity_catalog_assume_role_policy.this.json
-  managed_policy_arns = [aws_iam_policy.unity_metastore.arn]
+}
+
+resource "aws_iam_role_policy_attachment" "metastore_data_access" {
+  role       = aws_iam_role.metastore_data_access.name
+  policy_arn = aws_iam_policy.unity_metastore.arn
 }
 ```
 

--- a/docs/guides/unity-catalog.md
+++ b/docs/guides/unity-catalog.md
@@ -264,10 +264,14 @@ resource "aws_iam_policy" "external_data_access" {
 resource "aws_iam_role" "external_data_access" {
   name                = local.uc_iam_role
   assume_role_policy  = data.databricks_aws_unity_catalog_assume_role_policy.this.json
-  managed_policy_arns = [aws_iam_policy.external_data_access.arn]
   tags = merge(var.tags, {
     Name = "${local.prefix}-unity-catalog external access IAM role"
   })
+}
+
+resource "aws_iam_role_policy_attachment" "external_data_access" {
+  role       = aws_iam_role.external_data_access.name
+  policy_arn = aws_iam_policy.external_data_access.arn
 }
 ```
 


### PR DESCRIPTION
## Changes
`managed_policy_arns` are deprecated - https://github.com/hashicorp/terraform-provider-aws/issues/39771

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] relevant change in `docs/` folder