### PR TITLE
[Fix] Add missing external Id in trust relationship for `databricks_aws_unity_catalog_assume_role_policy`

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -10,6 +10,7 @@
 
  * Don't fail delete when `databricks_system_schema` can be disabled only by Databricks [#4727](https://github.com/databricks/terraform-provider-databricks/pull/4727)
  * Fix debug logging for attributes used to configure the provider ([#4728](https://github.com/databricks/terraform-provider-databricks/pull/4728)).
+ * Add missing external Id in trust relationship for `databricks_aws_unity_catalog_assume_role_policy` ([#4738](https://github.com/databricks/terraform-provider-databricks/pull/4738)).
 
 ### Documentation
 

--- a/aws/data_aws_unity_catalog_assume_role_policy.go
+++ b/aws/data_aws_unity_catalog_assume_role_policy.go
@@ -53,6 +53,9 @@ func DataAwsUnityCatalogAssumeRolePolicy() common.Resource {
 						"ArnLike": {
 							"aws:PrincipalArn": fmt.Sprintf("arn:%s:iam::%s:role/%s", awsNamespace, data.AwsAccountId, data.RoleName),
 						},
+						"StringEquals": {
+							"sts:ExternalId": data.ExternalId,
+						},
 					},
 					Principal: map[string]string{
 						"AWS": fmt.Sprintf("arn:%s:iam::%s:root", awsNamespace, data.AwsAccountId),

--- a/aws/data_aws_unity_catalog_assume_role_policy_test.go
+++ b/aws/data_aws_unity_catalog_assume_role_policy_test.go
@@ -99,6 +99,9 @@ func TestDataAwsUnityCatalogAssumeRolePolicyWithoutUcArn(t *testing.T) {
               "Condition": {
                 "ArnLike": {
                   "aws:PrincipalArn": "arn:aws:iam::123456789098:role/databricks-role"
+                },
+                "StringEquals": {
+                  "sts:ExternalId": "12345"
                 }
               }
             }
@@ -148,6 +151,9 @@ func TestDataAwsUnityCatalogAssumeRolePolicyGovWithoutUcArn(t *testing.T) {
               "Condition": {
                 "ArnLike": {
                   "aws:PrincipalArn": "arn:aws-us-gov:iam::123456789098:role/databricks-role"
+                },
+                "StringEquals": {
+                  "sts:ExternalId": "12345"
                 }
               }
             }
@@ -197,7 +203,10 @@ func TestDataAwsUnityCatalogAssumeRolePolicyGovDoDWithoutUcArn(t *testing.T) {
               "Condition": {
                 "ArnLike": {
                   "aws:PrincipalArn": "arn:aws-us-gov:iam::123456789098:role/databricks-role"
-                }
+                },
+                "StringEquals": {
+                  "sts:ExternalId": "12345"
+                }                
               }
             }
           ]

--- a/aws/data_aws_unity_catalog_assume_role_policy_test.go
+++ b/aws/data_aws_unity_catalog_assume_role_policy_test.go
@@ -48,6 +48,9 @@ func TestDataAwsUnityCatalogAssumeRolePolicy(t *testing.T) {
               "Condition": {
                 "ArnLike": {
                   "aws:PrincipalArn": "arn:aws:iam::123456789098:role/databricks-role"
+                },
+                "StringEquals": {
+                  "sts:ExternalId": "12345"
                 }
               }
             }


### PR DESCRIPTION
## Changes
- `databricks_aws_unity_catalog_assume_role_policy` data source requires external id in the self-assumption trust relationship

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [x] covered with integration tests in `internal/acceptance`
- [x] using Go SDK
