### PR TITLE
[Fix] Support updating `databricks_cluster` to Auto AZ

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bug Fixes
 
- * Stop suppressing diff for `zone_id = "auto"` after backend fix [#4697](https://github.com/databricks/terraform-provider-databricks/pull/4697).
+ * Support updating `databricks_clusters` to Auto AZ [#4697](https://github.com/databricks/terraform-provider-databricks/pull/4697).
 
 ### Documentation
 

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bug Fixes
 
- * Support updating `databricks_clusters` to Auto AZ [#4697](https://github.com/databricks/terraform-provider-databricks/pull/4697).
+ * Support updating `databricks_cluster` to Auto AZ [#4743](https://github.com/databricks/terraform-provider-databricks/pull/4743).
 
 ### Documentation
 

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bug Fixes
 
+ * Stop suppressing diff for `zone_id = "auto"` after backend fix [#4697](https://github.com/databricks/terraform-provider-databricks/pull/4697).
+
 ### Documentation
 
 ### Exporter

--- a/clusters/cluster_test.go
+++ b/clusters/cluster_test.go
@@ -93,6 +93,7 @@ func awsClusterTemplate(availability string) string {
 			autotermination_minutes = 10
 			aws_attributes {
 				availability = "%s"
+				zone_id      = "auto"
 			}
 			custom_tags = {
 				"Owner" = "eng-dev-ecosystem-team@databricks.com"

--- a/clusters/resource_cluster.go
+++ b/clusters/resource_cluster.go
@@ -102,14 +102,6 @@ func SparkConfDiffSuppressFunc(k, old, new string, d *schema.ResourceData) bool 
 	return false
 }
 
-func ZoneDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
-	if old != "" && (new == "auto" || new == "") {
-		log.Printf("[INFO] Suppressing diff on availability zone")
-		return true
-	}
-	return false
-}
-
 // This method is a duplicate of ModifyRequestOnInstancePool() in clusters/clusters_api.go that uses Go SDK.
 // Long term, ModifyRequestOnInstancePool() in clusters_api.go will be removed once all the resources using clusters are migrated to Go SDK.
 func ModifyRequestOnInstancePool(cluster any) error {
@@ -349,7 +341,6 @@ func (ClusterSpec) CustomizeSchema(s *common.CustomizableSchema) *common.Customi
 	s.SchemaPath("docker_image", "basic_auth", "username").SetRequired()
 	s.SchemaPath("spark_conf").SetCustomSuppressDiff(SparkConfDiffSuppressFunc)
 	s.SchemaPath("aws_attributes").SetSuppressDiff().SetConflictsWith([]string{"azure_attributes", "gcp_attributes"})
-	s.SchemaPath("aws_attributes", "zone_id").SetCustomSuppressDiff(ZoneDiffSuppress)
 	s.SchemaPath("azure_attributes").SetSuppressDiff().SetConflictsWith([]string{"aws_attributes", "gcp_attributes"})
 	s.SchemaPath("gcp_attributes").SetSuppressDiff().SetConflictsWith([]string{"aws_attributes", "azure_attributes"})
 	s.SchemaPath("autoscale", "max_workers").SetOptional()

--- a/clusters/resource_cluster_test.go
+++ b/clusters/resource_cluster_test.go
@@ -1438,7 +1438,7 @@ func TestResourceClusterUpdate_AutoAz(t *testing.T) {
 					AwsAttributes: &compute.AwsAttributes{
 						Availability:  "SPOT",
 						FirstOnDemand: 1,
-						ZoneId:        "us-west-2a",
+						ZoneId:        "auto",
 					},
 				},
 			},

--- a/pipelines/resource_pipeline.go
+++ b/pipelines/resource_pipeline.go
@@ -231,7 +231,6 @@ func (Pipeline) CustomizeSchema(s *common.CustomizableSchema) *common.Customizab
 	s.SchemaPath("edition").SetSuppressDiff()
 	s.SchemaPath("channel").SetSuppressDiff()
 	s.SchemaPath("cluster", "spark_conf").SetCustomSuppressDiff(clusters.SparkConfDiffSuppressFunc)
-	s.SchemaPath("cluster", "aws_attributes", "zone_id").SetCustomSuppressDiff(clusters.ZoneDiffSuppress)
 	s.SchemaPath("cluster", "autoscale", "mode").SetCustomSuppressDiff(common.EqualFoldDiffSuppress)
 	s.SchemaPath("edition").SetCustomSuppressDiff(common.EqualFoldDiffSuppress)
 	s.SchemaPath("storage").SetCustomSuppressDiff(suppressStorageDiff)

--- a/pools/resource_instance_pool.go
+++ b/pools/resource_instance_pool.go
@@ -185,6 +185,7 @@ func ResourceInstancePool() common.Resource {
 		if v, err := common.SchemaPath(s, "aws_attributes", "spot_bid_price_percent"); err == nil {
 			v.Default = 100
 		}
+		common.MustSchemaPath(s, "aws_attributes", "zone_id").DiffSuppressFunc = common.EqualFoldDiffSuppress
 
 		if v, err := common.SchemaPath(s, "azure_attributes", "availability"); err == nil {
 			v.Default = clusters.AzureAvailabilityOnDemand

--- a/pools/resource_instance_pool.go
+++ b/pools/resource_instance_pool.go
@@ -2,6 +2,7 @@ package pools
 
 import (
 	"context"
+	"strings"
 
 	"github.com/databricks/terraform-provider-databricks/clusters"
 	"github.com/databricks/terraform-provider-databricks/common"
@@ -185,7 +186,9 @@ func ResourceInstancePool() common.Resource {
 		if v, err := common.SchemaPath(s, "aws_attributes", "spot_bid_price_percent"); err == nil {
 			v.Default = 100
 		}
-		common.MustSchemaPath(s, "aws_attributes", "zone_id").DiffSuppressFunc = common.EqualFoldDiffSuppress
+		common.MustSchemaPath(s, "aws_attributes", "zone_id").DiffSuppressFunc = func(k, oldValue, newValue string, d *schema.ResourceData) bool {
+			return oldValue != "" && strings.ToLower(newValue) == "auto"
+		}
 
 		if v, err := common.SchemaPath(s, "azure_attributes", "availability"); err == nil {
 			v.Default = clusters.AzureAvailabilityOnDemand

--- a/pools/resource_instance_pool.go
+++ b/pools/resource_instance_pool.go
@@ -2,7 +2,6 @@ package pools
 
 import (
 	"context"
-	"strings"
 
 	"github.com/databricks/terraform-provider-databricks/clusters"
 	"github.com/databricks/terraform-provider-databricks/common"
@@ -185,9 +184,6 @@ func ResourceInstancePool() common.Resource {
 		}
 		if v, err := common.SchemaPath(s, "aws_attributes", "spot_bid_price_percent"); err == nil {
 			v.Default = 100
-		}
-		common.MustSchemaPath(s, "aws_attributes", "zone_id").DiffSuppressFunc = func(k, oldValue, newValue string, d *schema.ResourceData) bool {
-			return oldValue != "" && strings.ToLower(newValue) == "auto"
 		}
 
 		if v, err := common.SchemaPath(s, "azure_attributes", "availability"); err == nil {


### PR DESCRIPTION
## Changes
- Cluster API now correctly returns `zone_id`, so removing `ZoneDiffSuppress`
- Resolves #1700

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [x] covered with integration tests in `internal/acceptance`