### PR TITLE
Fix TestUcAccModelServingProvisionedThroughput

### DIFF
--- a/serving/model_serving_test.go
+++ b/serving/model_serving_test.go
@@ -125,8 +125,8 @@ func TestUcAccModelServingProvisionedThroughput(t *testing.T) {
 				config {
 					served_entities{
 						name = "pt_model"
-						entity_name = "system.ai.mistral_7b_instruct_v0_2"
-						entity_version = "1"
+						entity_name = "system.ai.meta_llama_v3_1_8b_instruct"
+						entity_version = "2"
 						min_provisioned_throughput = 0
 						max_provisioned_throughput = 970
 					}
@@ -146,8 +146,8 @@ func TestUcAccModelServingProvisionedThroughput(t *testing.T) {
 				config {
 					served_entities{
 						name = "pt_model"
-						entity_name = "system.ai.mistral_7b_instruct_v0_2"
-						entity_version = "1"
+						entity_name = "system.ai.meta_llama_v3_1_8b_instruct"
+						entity_version = "2"
 						min_provisioned_throughput = 970
 						max_provisioned_throughput = 1940
 					}
@@ -167,8 +167,8 @@ func TestUcAccModelServingProvisionedThroughput(t *testing.T) {
 				config {
 					served_entities{
 						name = "pt_model"
-						entity_name = "system.ai.mistral_7b_instruct_v0_2"
-						entity_version = "1"
+						entity_name = "system.ai.meta_llama_v3_1_8b_instruct"
+						entity_version = "2"
 						min_provisioned_throughput = 0
 						max_provisioned_throughput = 1940
 					}


### PR DESCRIPTION
## Changes
TestUcAccModelServingProvisionedThroughput times out today while waiting for the mistral model to load. This PR changes this test to use a different model type which seems to work. After this PR, the test takes around 10 minutes.

## Tests
Ran locally, the test passes.

NO_CHANGELOG=true