### PR TITLE
Add `schema_id` to the output of `databricks_schema` resource

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -7,6 +7,7 @@
 ### New Features and Improvements
 
  * Support for `uc_securable` resource in `databricks_app` ([#4767](https://github.com/databricks/terraform-provider-databricks/pull/4767))
+ * Add `schema_id` to the output of `databricks_schema` resource ([#4773](https://github.com/databricks/terraform-provider-databricks/pull/4773)).
 
 ### Bug Fixes
 

--- a/catalog/resource_schema.go
+++ b/catalog/resource_schema.go
@@ -19,6 +19,7 @@ type SchemaInfo struct {
 	Owner                        string            `json:"owner,omitempty" tf:"computed"`
 	MetastoreID                  string            `json:"metastore_id,omitempty" tf:"computed"`
 	FullName                     string            `json:"full_name,omitempty" tf:"computed"`
+	SchemaID                     string            `json:"schema_id" tf:"computed"`
 }
 
 func ResourceSchema() common.Resource {

--- a/catalog/schema_test.go
+++ b/catalog/schema_test.go
@@ -18,6 +18,7 @@ const catalogTemplate = `
 `
 
 func TestUcAccSchema(t *testing.T) {
+	acceptance.LoadUcwsEnv(t)
 	acceptance.UnityWorkspaceLevel(t, acceptance.Step{
 		Template: catalogTemplate + `
 		data "databricks_catalogs" "all" {

--- a/docs/data-sources/schema.md
+++ b/docs/data-sources/schema.md
@@ -55,7 +55,7 @@ In addition to all arguments above, the following attributes are exported:
   * `name` - Name of schema, relative to parent catalog.
   * `owner` - the identifier of the user who owns the schema
   * `properties` - map of properties set on the schema
-  * `schema_id` - the unique identifier of the volume
+  * `schema_id` - the unique identifier of the schema
   * `storage_location` - the storage location on the cloud.
   * `storage_root` - storage root URL for managed tables within schema.
   * `updated_at` - the timestamp of the last time changes were made to the schema

--- a/docs/resources/schema.md
+++ b/docs/resources/schema.md
@@ -48,6 +48,7 @@ The following arguments are required:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - ID of this schema in form of `<catalog_name>.<name>`.
+* `schema_id` - The unique identifier of the schema.
 
 ## Import
 


### PR DESCRIPTION
## Changes
Schema now exports a stable UUID identifier in the `schema_id` field. This PR adds this to the model for schema as a computed attribute.

## Tests
Manually verified that the schema_id was populated in state in GCP. I don't want to add a test for this per se since it's possible that it isn't populated in all environments (yet).