### PR TITLE
[Internal] Mark `ModelServingProvisionedThroughputResource` as flacky

### DIFF
--- a/test-config.yaml
+++ b/test-config.yaml
@@ -113,4 +113,7 @@ ignored_tests:
       comment: Failure due to stale results being returned from cache on using empty etag.  
     - package: github.com/databricks/terraform-provider-databricks/permissions
       test_name: TestMwsAccAccountGroupRuleSetsFullLifeCycle
-      comment: Failure due to stale results being returned from cache on using empty etag.        
+      comment: Failure due to stale results being returned from cache on using empty etag.
+    - package: github.com/databricks/terraform-provider-databricks/serving
+      test_name: TestUcAccModelServingProvisionedThroughputResource
+      comment: Failure due to limited capacity in specific regions


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

We started to get errors due to the lack of capacity on the backend, so marking this test as flacky

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] using Go SDK
- [ ] using TF Plugin Framework

NO_CHANGELOG=true
