### PR TITLE
[Documentation] `databricks_instance_pool`: auto zone_id can only be used for fleet node types

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Bug Fixes
 
 ### Documentation
+ * [Documentation] `databricks_instance_pool`: auto zone_id can only be used for fleet node types
 
 ### Exporter
 

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -12,7 +12,7 @@
 ### Bug Fixes
 
 ### Documentation
- * [Documentation] `databricks_instance_pool`: auto zone_id can only be used for fleet node types
+ * auto `zone_id` can only be used for fleet node types in `databricks_instance_pool` resource ([#4782](https://github.com/databricks/terraform-provider-databricks/pull/4782)).
 
 ### Exporter
 

--- a/docs/resources/instance_pool.md
+++ b/docs/resources/instance_pool.md
@@ -9,6 +9,8 @@ This resource allows you to manage [instance pools](https://docs.databricks.com/
 
 -> It is important to know that different cloud service providers have different `node_type_id`, `disk_specs` and potentially other configurations.
 
+-> "auto" `zone_id` is only supported for fleet node types.
+
 ## Example Usage
 
 ```hcl


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
As of now, auto is only supported for fleet node types, highlighting this as a note for instance pool resource.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->
N/A
- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] using Go SDK
- [ ] using TF Plugin Framework
