### PR TITLE
Disable queueing by default in databricks_job

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -11,6 +11,8 @@
 
 ### Bug Fixes
 
+ * Preserve `queue` setting for `databricks_job` resource when upgrading from provider version <1.71.0.
+
 ### Documentation
 
 ### Exporter


### PR DESCRIPTION
## Changes
`databricks_job` disables queueing by default so as not to cause a behavior change for existing `databricks_job` instances when upgrading the provider to later versions that support queueing. Before version 1.71.0 of the provider, the `databricks_job` resource was backed by the 2.1 version of the Jobs API, which supports queueing but was disabled by default. If queue was not specified, it was also not returned by the API:

```
2025-06-12T11:55:12.994Z [DEBUG] provider.terraform-provider-databricks_v1.70.0: POST /api/2.1/jobs/create
> {
>   "max_concurrent_runs": 1,
>   "name": "test-job",
>   "tasks": [
>     {
>       "notebook_task": {
>         "notebook_path": "<PATH>"
>       },
>       "task_key": "task-1"
>     }
>   ]
> }
< HTTP/2.0 200 OK
< {
<   "job_id": <id>
< }
2025-06-12T11:55:13.250Z [DEBUG] provider.terraform-provider-databricks_v1.70.0: GET /api/2.1/jobs/get?job_id=<ID>
< HTTP/2.0 200 OK
< {
<   ...
<   "settings": {
<     "email_notifications": {},
<     "format": "MULTI_TASK",
<     "max_concurrent_runs": 1,
<     "name": "test-job",
<     "tasks": [
<       {
<         "email_notifications": {},
<         "notebook_task": {
<           "notebook_path": "<PATH>",
<           "source": "WORKSPACE"
<         },
<         "run_if": "ALL_SUCCESS",
<         "task_key": "task-1",
<         "timeout_seconds": 0
<       }
<     ],
<     "timeout_seconds": 0,
<     "webhook_notifications": {}
<   }
< }
```

Starting in 1.71.0, this resource is now backed by the 2.2 API, which enables queueing by default. Because of the old behavior, the disabled queue is not stored in the state and not sent back in the Reset API call. With the new endpoint, the Jobs service suddenly enables queueing for the job:

```
2025-06-12T11:56:43.247Z [DEBUG] provider.terraform-provider-databricks_v1.71.0: POST /api/2.2/jobs/reset
> {
>   "job_id": <ID>,
>   "new_settings": {
>     "email_notifications": {},
>     "format": "MULTI_TASK",
>     "max_concurrent_runs": 1,
>     "name": "test-job",
>     "run_as": {
>       "user_name": "<USERNAME>"
>     },
>     "tasks": [
>       {
>         "email_notifications": {},
>         "notebook_task": {
>           "notebook_path": "<NEW-PATH>",
>           "source": "WORKSPACE"
>         },
>         "run_if": "ALL_SUCCESS",
>         "task_key": "task-1"
>       }
>     ],
>     "webhook_notifications": {}
>   }
> }
< HTTP/2.0 200 OK
< {}
2025-06-12T11:56:43.430Z [DEBUG] provider.terraform-provider-databricks_v1.71.0: GET /api/2.2/jobs/get?job_id=<ID>
< HTTP/2.0 200 OK
< {
<   ...
<   "settings": {
<     "email_notifications": {},
<     "format": "MULTI_TASK",
<     "max_concurrent_runs": 1,
<     "name": "test-job",
<     "queue": {
<       "enabled": true
<     },
<     "tasks": [
<       {
<         "email_notifications": {},
<         "notebook_task": {
<           "notebook_path": "<NEW-PATH>",
<           "source": "WORKSPACE"
<         },
<         "run_if": "ALL_SUCCESS",
<         "task_key": "task-1",
<         "timeout_seconds": 0
<       }
<     ],
<     "timeout_seconds": 0,
<     "webhook_notifications": {}
<   }
< }
```

For jobs created on 1.71 or later, the queue status (either enabled or disabled) is persisted in Terraform state, so it will always be included in the Reset call thereafter.

## Tests
- [ ] TODO: add unit test to verify
- [ ] TODO: manual test by creating a job on v1.70.0 without queueing and then upgrading to v1.71.0 and applying a change.
