### PR TITLE
Update GoReleaser configurations

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -20,7 +20,7 @@ builds:
     - arm64
 
 archives:
-- format: zip
+- formats: [zip]
   name_template: '{{ .ProjectName }}_{{ replace .Version "v" "" }}_{{ .Os }}_{{ .Arch }}'
   files:
     - LICENSE*
@@ -32,7 +32,7 @@ checksum:
   algorithm: sha256
 
 snapshot:
-  name_template: "{{ .Tag }}"
+  version_template: "{{ .Tag }}"
 
 signs:
   - artifacts: checksum


### PR DESCRIPTION
## Changes
This small PR updates the GoReleaser configuration to resolve the following warning which you can find in the [CI logs](https://github.com/databricks/terraform-provider-databricks/actions/runs/15505676646/job/43660148228#step:7:26): 
```
DEPRECATED: snapshot.name_template should not be used anymore, check https://goreleaser.com/deprecations#snapshotname_template for more info
DEPRECATED: archives.format should not be used anymore, check https://goreleaser.com/deprecations#archivesformat for more info
```

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] using Go SDK
- [ ] using TF Plugin Framework

NO_CHANGELOG=true