### PR TITLE
Fix Model Serving Endpoint Tests

### DIFF
--- a/internal/providers/pluginfw/products/app/resource_app_acc_test.go
+++ b/internal/providers/pluginfw/products/app/resource_app_acc_test.go
@@ -43,8 +43,8 @@ const baseResources = `
 		config {
 			served_entities {
 				name = "prod_model"
-				model_name = "experiment-fixture-model"
-				model_version = "1"
+				entity_name = "experiment-fixture-model"
+				entity_version = "1"
 				workload_size = "Small"
 				scale_to_zero_enabled = true
 				max_provisioned_concurrency = 4

--- a/internal/providers/pluginfw/products/app/resource_app_acc_test.go
+++ b/internal/providers/pluginfw/products/app/resource_app_acc_test.go
@@ -41,12 +41,14 @@ const baseResources = `
 	resource "databricks_model_serving" "this" {
 		name = "tf-{var.STICKY_RANDOM}"
 		config {
-			served_models {
+			served_entities {
 				name = "prod_model"
 				model_name = "experiment-fixture-model"
 				model_version = "1"
 				workload_size = "Small"
 				scale_to_zero_enabled = true
+				max_provisioned_concurrency = 4
+				min_provisioned_concurrency = 4
 			}
 		}
 	}

--- a/internal/providers/pluginfw/products/app/resource_app_acc_test.go
+++ b/internal/providers/pluginfw/products/app/resource_app_acc_test.go
@@ -47,7 +47,7 @@ const baseResources = `
 				entity_version = "1"
 				scale_to_zero_enabled = true
 				max_provisioned_concurrency = 4
-				min_provisioned_concurrency = 4
+				min_provisioned_concurrency = 0
 			}
 		}
 	}

--- a/internal/providers/pluginfw/products/app/resource_app_acc_test.go
+++ b/internal/providers/pluginfw/products/app/resource_app_acc_test.go
@@ -45,7 +45,6 @@ const baseResources = `
 				name = "prod_model"
 				entity_name = "experiment-fixture-model"
 				entity_version = "1"
-				workload_size = "Small"
 				scale_to_zero_enabled = true
 				max_provisioned_concurrency = 4
 				min_provisioned_concurrency = 4

--- a/serving/model_serving_test.go
+++ b/serving/model_serving_test.go
@@ -21,19 +21,23 @@ func TestAccModelServing(t *testing.T) {
 			resource "databricks_model_serving" "endpoint" {
 				name = "%s"
 				config {
-					served_models {
+					served_entities {
 						name = "prod_model"
 						model_name = "experiment-fixture-model"
 						model_version = "1"
 						workload_size = "Small"
 						scale_to_zero_enabled = true
+						max_provisioned_concurrency = 4
+						min_provisioned_concurrency = 4
 					}
-					served_models {
+					served_entities {
 						name = "candidate_model"
 						model_name = "experiment-fixture-model"
 						model_version = "2"
 						workload_size = "Small"
 						scale_to_zero_enabled = false
+						max_provisioned_concurrency = 4
+						min_provisioned_concurrency = 4
 					}
 					traffic_config {
 						routes {
@@ -77,12 +81,14 @@ func TestAccModelServing(t *testing.T) {
 			resource "databricks_model_serving" "endpoint" {
 				name = "%s"
 				config {
-					served_models {
+					served_entities {
 						name = "prod_model"
 						model_name = "experiment-fixture-model"
 						model_version = "1"
 						workload_size = "Small"
 						scale_to_zero_enabled = true
+						max_provisioned_concurrency = 4
+						min_provisioned_concurrency = 4
 					}
 					traffic_config {
 						routes {
@@ -123,10 +129,12 @@ func TestUcAccModelServingProvisionedThroughput(t *testing.T) {
 			resource "databricks_model_serving" "endpoint" {
 				name = "%s"
 				config {
-					served_entities{
+					served_entities {
 						name = "pt_model"
 						entity_name = "system.ai.meta_llama_v3_1_8b_instruct"
 						entity_version = "2"
+						max_provisioned_concurrency = 4
+						min_provisioned_concurrency = 4
 						min_provisioned_throughput = 0
 						max_provisioned_throughput = 970
 					}
@@ -144,10 +152,12 @@ func TestUcAccModelServingProvisionedThroughput(t *testing.T) {
 			resource "databricks_model_serving" "endpoint" {
 				name = "%s"
 				config {
-					served_entities{
+					served_entities {
 						name = "pt_model"
 						entity_name = "system.ai.meta_llama_v3_1_8b_instruct"
 						entity_version = "2"
+						max_provisioned_concurrency = 4
+						min_provisioned_concurrency = 4
 						min_provisioned_throughput = 970
 						max_provisioned_throughput = 1940
 					}
@@ -165,10 +175,12 @@ func TestUcAccModelServingProvisionedThroughput(t *testing.T) {
 			resource "databricks_model_serving" "endpoint" {
 				name = "%s"
 				config {
-					served_entities{
+					served_entities {
 						name = "pt_model"
 						entity_name = "system.ai.meta_llama_v3_1_8b_instruct"
 						entity_version = "2"
+						max_provisioned_concurrency = 4
+						min_provisioned_concurrency = 4
 						min_provisioned_throughput = 0
 						max_provisioned_throughput = 1940
 					}

--- a/serving/model_serving_test.go
+++ b/serving/model_serving_test.go
@@ -25,7 +25,6 @@ func TestAccModelServing(t *testing.T) {
 						name = "prod_model"
 						entity_name = "experiment-fixture-model"
 						entity_version = "1"
-						workload_size = "Small"
 						scale_to_zero_enabled = true
 						max_provisioned_concurrency = 4
 						min_provisioned_concurrency = 4
@@ -34,7 +33,6 @@ func TestAccModelServing(t *testing.T) {
 						name = "candidate_model"
 						entity_name = "experiment-fixture-model"
 						entity_version = "2"
-						workload_size = "Small"
 						scale_to_zero_enabled = false
 						max_provisioned_concurrency = 4
 						min_provisioned_concurrency = 4
@@ -85,7 +83,6 @@ func TestAccModelServing(t *testing.T) {
 						name = "prod_model"
 						entity_name = "experiment-fixture-model"
 						entity_version = "1"
-						workload_size = "Small"
 						scale_to_zero_enabled = true
 						max_provisioned_concurrency = 4
 						min_provisioned_concurrency = 4

--- a/serving/model_serving_test.go
+++ b/serving/model_serving_test.go
@@ -27,7 +27,7 @@ func TestAccModelServing(t *testing.T) {
 						entity_version = "1"
 						scale_to_zero_enabled = true
 						max_provisioned_concurrency = 4
-						min_provisioned_concurrency = 4
+						min_provisioned_concurrency = 0
 					}
 					served_entities {
 						name = "candidate_model"
@@ -85,7 +85,7 @@ func TestAccModelServing(t *testing.T) {
 						entity_version = "1"
 						scale_to_zero_enabled = true
 						max_provisioned_concurrency = 4
-						min_provisioned_concurrency = 4
+						min_provisioned_concurrency = 0
 					}
 					traffic_config {
 						routes {

--- a/serving/model_serving_test.go
+++ b/serving/model_serving_test.go
@@ -23,8 +23,8 @@ func TestAccModelServing(t *testing.T) {
 				config {
 					served_entities {
 						name = "prod_model"
-						model_name = "experiment-fixture-model"
-						model_version = "1"
+						entity_name = "experiment-fixture-model"
+						entity_version = "1"
 						workload_size = "Small"
 						scale_to_zero_enabled = true
 						max_provisioned_concurrency = 4
@@ -32,8 +32,8 @@ func TestAccModelServing(t *testing.T) {
 					}
 					served_entities {
 						name = "candidate_model"
-						model_name = "experiment-fixture-model"
-						model_version = "2"
+						entity_name = "experiment-fixture-model"
+						entity_version = "2"
 						workload_size = "Small"
 						scale_to_zero_enabled = false
 						max_provisioned_concurrency = 4
@@ -83,8 +83,8 @@ func TestAccModelServing(t *testing.T) {
 				config {
 					served_entities {
 						name = "prod_model"
-						model_name = "experiment-fixture-model"
-						model_version = "1"
+						entity_name = "experiment-fixture-model"
+						entity_version = "1"
 						workload_size = "Small"
 						scale_to_zero_enabled = true
 						max_provisioned_concurrency = 4


### PR DESCRIPTION
## Changes
A behavior change since Friday in the Serving Endpoints API causes Terraform tests to fail. The API now returns min and max provisioned concurrency attributes which are considered optional parameters, even if a user doesn't specify their value. As a result, there is a diff between state with those attributes present and config with those attributes absent.

To fix this, I've just added these attributes with their default values in our test cases, which eliminates the diff.

## Tests
This is tests.

NO_CHANGELOG=true
