### PR TITLE
[Feature] Add AWS support for `databricks_mws_ncc_private_endpoint_rule`

### DIFF
--- a/docs/resources/mws_ncc_private_endpoint_rule.md
+++ b/docs/resources/mws_ncc_private_endpoint_rule.md
@@ -7,9 +7,11 @@ Allows you to create a private endpoint in a [Network Connectivity Config](mws_n
 
 -> This resource can only be used with an account-level provider!
 
--> This feature is only available in Azure.
+-> This feature is available on Azure, and in Public Preview on AWS.
 
 ## Example Usage
+
+Create a private endpoint to an Azure storage account
 
 ```hcl
 variable "region" {}
@@ -29,13 +31,42 @@ resource "databricks_mws_ncc_private_endpoint_rule" "storage" {
 }
 ```
 
+Create a private endpoint rule to an AWS VPC endpoint and to an S3 bucket
+
+```hcl
+variable "region" {}
+variable "prefix" {}
+
+resource "databricks_mws_network_connectivity_config" "ncc" {
+  provider = databricks.account
+  name     = "ncc-for-${var.prefix}"
+  region   = var.region
+}
+
+resource "databricks_mws_ncc_private_endpoint_rule" "storage" {
+  provider                       = databricks.account
+  network_connectivity_config_id = databricks_mws_network_connectivity_config.ncc.network_connectivity_config_id
+  resource_names                 = ["bucket"]
+}
+
+resource "databricks_mws_ncc_private_endpoint_rule" "vpce" {
+  provider                       = databricks.account  
+  network_connectivity_config_id = databricks_mws_network_connectivity_config.ncc.network_connectivity_config_id
+  endpoint_service               = "com.amazonaws.vpce.us-west-2.vpce-svc-xyz"
+  domain_names                   = ["subdomain.internal.net"]
+}
+```
+
 ## Argument Reference
 
 The following arguments are available:
 
 * `network_connectivity_config_id` - Canonical unique identifier of Network Connectivity Config in Databricks Account. Change forces creation of a new resource.
-* `resource_id` - The Azure resource ID of the target resource. Change forces creation of a new resource.
-* `group_id` - The sub-resource type (group ID) of the target resource. Must be one of supported resource types (i.e., `blob`, `dfs`, `sqlServer` , etc. Consult the [Azure documentation](https://learn.microsoft.com/en-us/azure/private-link/private-endpoint-overview#private-link-resource) for full list of supported resources). Note that to connect to workspace root storage (root DBFS), you need two endpoints, one for `blob` and one for `dfs`. Change forces creation of a new resource.
+* `resource_id` - (Azure only) The Azure resource ID of the target resource. Change forces creation of a new resource.
+* `group_id` - (Azure only) The sub-resource type (group ID) of the target resource. Must be one of supported resource types (i.e., `blob`, `dfs`, `sqlServer` , etc. Consult the [Azure documentation](https://learn.microsoft.com/en-us/azure/private-link/private-endpoint-overview#private-link-resource) for full list of supported resources). Note that to connect to workspace root storage (root DBFS), you need two endpoints, one for `blob` and one for `dfs`. Change forces creation of a new resource.
+* `domain_names` - (AWS only) Only used by private endpoints towards a VPC endpoint service behind a customer-managed VPC endpoint service. List of target AWS resource FQDNs accessible via the VPC endpoint service. Conflicts with `resource_names`.
+* `endpoint_service` - (AWS only) Example `com.amazonaws.vpce.us-east-1.vpce-svc-123abcc1298abc123`. The full target AWS endpoint service name that connects to the destination resources of the private endpoint.
+* `resource_names` - (AWS only) Only used by private endpoints towards AWS S3 service. List of globally unique S3 bucket names that will be accessed via the VPC endpoint. The bucket names must be in the same region as the NCC/endpoint service. Conflict with `domain_names`.
 
 ## Attribute Reference
 

--- a/mws/mws_network_connectivity_config_test.go
+++ b/mws/mws_network_connectivity_config_test.go
@@ -44,6 +44,11 @@ func TestMwsAccNetworkConnectivityConfig(t *testing.T) {
 				name = "tf-{var.RANDOM}"
 				region = "{env.AWS_REGION}"
 			}
+
+			resource "databricks_mws_ncc_private_endpoint_rule" "this" {
+				network_connectivity_config_id = databricks_mws_network_connectivity_config.this.network_connectivity_config_id
+				resource_names = ["{env.TEST_LOGDELIVERY_BUCKET}"]
+			}
 			`,
 		}, acceptance.Step{
 			Template: `
@@ -52,6 +57,11 @@ func TestMwsAccNetworkConnectivityConfig(t *testing.T) {
 				name = "tf-{var.RANDOM}"
 				region = "{env.AWS_REGION}"
 			}
+				
+			resource "databricks_mws_ncc_private_endpoint_rule" "this" {
+				network_connectivity_config_id = databricks_mws_network_connectivity_config.this.network_connectivity_config_id
+				resource_names = ["{env.TEST_LOGDELIVERY_BUCKET}"]
+			}				
 			`,
 		})
 	}

--- a/mws/resource_mws_ncc_private_endpoint_rule.go
+++ b/mws/resource_mws_ncc_private_endpoint_rule.go
@@ -17,6 +17,10 @@ func ResourceMwsNccPrivateEndpointRule() common.Resource {
 		for _, p := range []string{"rule_id", "endpoint_name", "connection_state", "creation_time", "updated_time"} {
 			common.CustomizeSchemaPath(m, p).SetComputed()
 		}
+		conflicts := []string{"group_id", "resource_names", "domain_names"}
+		for _, p := range conflicts {
+			common.CustomizeSchemaPath(m, p).SetOptional().SetConflictsWith(conflicts)
+		}
 		return m
 	})
 	p := common.NewPairSeparatedID("network_connectivity_config_id", "rule_id", "/")


### PR DESCRIPTION
## Changes

- Add documentation and tests for `databricks_mws_ncc_private_endpoint_rule` on AWS.

Resolve #4685

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [x] covered with integration tests in `internal/acceptance`
- [x] using Go SDK
