### PR TITLE
[Exporter] Fix crash when importing model serving endpoint

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -18,4 +18,6 @@
 
 ### Exporter
 
+* Fix crash when importing model serving endpoint ([#4806](https://github.com/databricks/terraform-provider-databricks/pull/4806))
+
 ### Internal Changes

--- a/exporter/importables.go
+++ b/exporter/importables.go
@@ -1501,7 +1501,7 @@ var resourcesMap map[string]importable = map[string]importable{
 			s := ic.Resources["databricks_model_serving"].Schema
 			var mse serving.CreateServingEndpoint
 			common.DataToStructPointer(r.Data, s, &mse)
-			if mse.Config.ServedEntities != nil {
+			if mse.Config != nil {
 				for _, se := range mse.Config.ServedEntities {
 					if se.EntityName != "" {
 						if se.EntityVersion != "" { // we have an UC model or model from model registry
@@ -1549,7 +1549,7 @@ var resourcesMap map[string]importable = map[string]importable{
 					}
 				}
 			}
-			if mse.Config.AutoCaptureConfig != nil && mse.Config.AutoCaptureConfig.CatalogName != "" &&
+			if mse.Config != nil && mse.Config.AutoCaptureConfig != nil && mse.Config.AutoCaptureConfig.CatalogName != "" &&
 				mse.Config.AutoCaptureConfig.SchemaName != "" {
 				ic.Emit(&resource{
 					Resource: "databricks_schema",


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

It looks like that there are situation when model serving endpoint provisioning failed, then it stays, but have no `config` block, leading to a crash (never seen before).

Resolves #4803

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] using Go SDK
- [ ] using TF Plugin Framework
