### PR TITLE
[DOCS] added example of granting Account Admin role to a service principal

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -20,6 +20,7 @@
 * Document `tags` attribute in `databricks_pipeline` resource ([#4783](https://github.com/databricks/terraform-provider-databricks/pull/4783)).
 * Recommend OAuth instead of PAT in guides ([#4787](https://github.com/databricks/terraform-provider-databricks/pull/4787))
 * Document new options in `databricks_model_serving` resource ([#4789](https://github.com/databricks/terraform-provider-databricks/pull/4789))
+* Added example of granting Account Admin role with `databricks_service_principal_role` resource ([#4807](https://github.com/databricks/terraform-provider-databricks/pull/4807))
 
 ### Exporter
 

--- a/docs/resources/service_principal_role.md
+++ b/docs/resources/service_principal_role.md
@@ -46,7 +46,7 @@ resource "databricks_service_principal_role" "tf_admin_account" {
 The following arguments are supported:
 
 * `service_principal_id` - (Required) This is the id of the [service principal](service_principal.md) resource.
-* `role` -  (Required) This is the id of the role or [instance profile](instance_profile.md) resource.
+* `role` -  (Required) This is the role name, role id, or [instance profile](instance_profile.md) resource.
 
 ## Attribute Reference
 
@@ -67,3 +67,4 @@ The following resources are often used in the same context:
 * [databricks_group_instance_profile](group_instance_profile.md) to attach [databricks_instance_profile](instance_profile.md) (AWS) to [databricks_group](group.md).
 * [databricks_group_member](group_member.md) to attach [users](user.md) and [groups](group.md) as group members.
 * [databricks_instance_profile](instance_profile.md) to manage AWS EC2 instance profiles that users can launch [databricks_cluster](cluster.md) and access data, like [databricks_mount](mount.md).
+* [databricks_access_control_rule_set](access_control_rule_set.md#grant_rules) to attach other roles to account level resources.

--- a/docs/resources/service_principal_role.md
+++ b/docs/resources/service_principal_role.md
@@ -26,6 +26,21 @@ resource "databricks_service_principal_role" "my_service_principal_instance_prof
 }
 ```
 
+Granting a service principal the Account Admin role.
+
+-> This can only be used with an account-level provider.
+
+```hcl
+resource "databricks_service_principal" "tf_admin" {
+  display_name = "Terraform Admin"
+}
+
+resource "databricks_service_principal_role" "tf_admin_account" {
+  service_principal_id = databricks_service_principal.tf_admin.id
+  role                 = "account_admin"
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
This PR makes changes to docs only, no code changes. The `databricks_service_principal_role` is capable of giving account admin role to a service principal; however, this was not very clear in the docs whereas we do have an example given in `databricks_user_role` for users. 

I added an example demonstrating this capability of setting `role = "account_admin"` and a note that it can only be used with an account-level provider.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [X] relevant change in `docs/` folder
