### PR TITLE
Use single-node cluster for `databricks_sql_permissions`

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -6,7 +6,8 @@
 
 ### New Features and Improvements
 
-* Add `bearer_token` to the list of sensitive options in `databricks_connection` ([#4811](https://github.com/databricks/terraform-provider-databricks/pull/4811)).
+* Add `bearer_token` to the list of sensitive options in `databricks_connection` ([#4812](https://github.com/databricks/terraform-provider-databricks/pull/4812)).
+* Use single-node cluster for `databricks_sql_permissions` ([#4813](https://github.com/databricks/terraform-provider-databricks/pull/4813)).
 
 ### Bug Fixes
 

--- a/access/resource_sql_permissions.go
+++ b/access/resource_sql_permissions.go
@@ -287,16 +287,14 @@ func (ta *SqlPermissions) getOrCreateCluster(clustersAPI clusters.ClustersAPI) (
 			SparkVersion:           sparkVersion,
 			NodeTypeID:             nodeType,
 			AutoterminationMinutes: 10,
-			DataSecurityMode:       "LEGACY_TABLE_ACL",
-			// TODO: return back after backend fix is rolled out
-			NumWorkers: 1,
-			// SparkConf: map[string]string{
-			// 	"spark.databricks.cluster.profile": "singleNode",
-			// 	"spark.master":                     "local[*]",
-			// },
-			// CustomTags: map[string]string{
-			// 	"ResourceClass": "SingleNode",
-			// },
+			DataSecurityMode:       "USER_ISOLATION",
+			SparkConf: map[string]string{
+				"spark.databricks.cluster.profile": "singleNode",
+				"spark.master":                     "local[*]",
+			},
+			CustomTags: map[string]string{
+				"ResourceClass": "SingleNode",
+			},
 		})
 	if err != nil {
 		return "", err


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

In 27ad78d, we modified the default cluster launched by the `databricks_sql_permissions` resource to use a cluster with a worker node. This was done to mitigate an issue where it was no longer possible to create single-node clusters with legacy Table ACLs. Since the start of May, single-node `USER_ISOLATION` clusters are supported and can be used to manage Table ACLs. This PR changes this resource to use such a cluster going forward.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [x] covered with integration tests in `internal/acceptance`
- [ ] using Go SDK
- [ ] using TF Plugin Framework
