### PR TITLE
Add documentation for single-node clusters in `databricks_cluster`

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -13,6 +13,8 @@
 
 ### Documentation
 
+* Update documentation for single-node clusters in `databricks_cluster` resource.
+
 ### Exporter
 
 ### Internal Changes

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -98,16 +98,7 @@ When you [create a Databricks cluster](https://docs.databricks.com/clusters/conf
 * `min_workers` - (Optional) The minimum number of workers to which the cluster can scale down when underutilized. It is also the initial number of workers the cluster will have after creation.
 * `max_workers` - (Optional) The maximum number of workers to which the cluster can scale up when overloaded. max_workers must be strictly greater than min_workers.
 
-When using a [Single Node cluster](https://docs.databricks.com/clusters/single-node.html), `num_workers` needs to be `0`. It can be set to `0` explicitly, or simply not specified, as it defaults to `0`.  When `num_workers` is `0`, provider checks for presence of the required Spark configurations:
-
-* `spark.master` must have prefix `local`, like `local[*]`
-* `spark.databricks.cluster.profile` must have value `singleNode`
-
-and also `custom_tag` entry:
-
-* `"ResourceClass" = "SingleNode"`
-
-The following example demonstrates how to create an single node cluster:
+To create a [single node cluster](https://docs.databricks.com/clusters/single-node.html), set `is_single_node = true` and `kind = "CLASSIC_PREVIEW"` for the cluster. Single-node clusters are suitable for small, non-distributed workloads like single-node machine learning use-cases.
 
 ```hcl
 data "databricks_node_type" "smallest" {
@@ -123,16 +114,8 @@ resource "databricks_cluster" "single_node" {
   spark_version           = data.databricks_spark_version.latest_lts.id
   node_type_id            = data.databricks_node_type.smallest.id
   autotermination_minutes = 20
-
-  spark_conf = {
-    # Single-node
-    "spark.databricks.cluster.profile" : "singleNode"
-    "spark.master" : "local[*]"
-  }
-
-  custom_tags = {
-    "ResourceClass" = "SingleNode"
-  }
+  is_single_node          = true
+  kind                    = "CLASSIC_PREVIEW"
 }
 ```
 


### PR DESCRIPTION
## Changes
The `is_single_node` field was recently introduced for clusters to simplify creation of single-node clusters. This PR updates the Terraform documentation for `databricks_cluster` to show how to configure the cluster resource using this new flag. This simplifies the process from before, which required a number of settings to be configured simultaneously.

## Tests
Manually tested by creating a cluster with the documented template.