### PR TITLE
[Internal] Enable Apps integration tests on GCP

### DIFF
--- a/internal/providers/pluginfw/products/app/data_app_acc_test.go
+++ b/internal/providers/pluginfw/products/app/data_app_acc_test.go
@@ -34,9 +34,6 @@ const fastApp = `
 
 func TestAccAppDataSource(t *testing.T) {
 	acceptance.LoadWorkspaceEnv(t)
-	if acceptance.IsGcp(t) {
-		acceptance.Skipf(t)("not available on GCP")
-	}
 	acceptance.WorkspaceLevel(t, acceptance.Step{
 		Template: fastApp + `
 		data "databricks_app" "this" {

--- a/internal/providers/pluginfw/products/app/data_apps_acc_test.go
+++ b/internal/providers/pluginfw/products/app/data_apps_acc_test.go
@@ -8,9 +8,6 @@ import (
 
 func TestAccAppsDataSource(t *testing.T) {
 	acceptance.LoadWorkspaceEnv(t)
-	if acceptance.IsGcp(t) {
-		acceptance.Skipf(t)("not available on GCP")
-	}
 	acceptance.WorkspaceLevel(t, acceptance.Step{
 		Template: `
 		data "databricks_apps" "this" { }

--- a/internal/providers/pluginfw/products/app/resource_app_acc_test.go
+++ b/internal/providers/pluginfw/products/app/resource_app_acc_test.go
@@ -128,9 +128,6 @@ is required`),
 func TestAccAppResource(t *testing.T) {
 	var updateTime string
 	acceptance.LoadWorkspaceEnv(t)
-	if acceptance.IsGcp(t) {
-		acceptance.Skipf(t)("not available on GCP")
-	}
 	acceptance.WorkspaceLevel(t, acceptance.Step{
 		Template: makeTemplate("My app"),
 		Check: func(s *terraform.State) error {
@@ -156,9 +153,6 @@ func TestAccAppResource(t *testing.T) {
 
 func TestAccAppResource_NoCompute(t *testing.T) {
 	acceptance.LoadWorkspaceEnv(t)
-	if acceptance.IsGcp(t) {
-		acceptance.Skipf(t)("not available on GCP")
-	}
 	acceptance.WorkspaceLevel(t, acceptance.Step{
 		Template: `
 	resource "databricks_secret_scope" "this" {

--- a/internal/providers/pluginfw/products/app/resource_app_acc_test.go
+++ b/internal/providers/pluginfw/products/app/resource_app_acc_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const baseResources = `
+const baseResourcesCore = `
 	resource "databricks_secret_scope" "this" {
 		name = "tf-{var.STICKY_RANDOM}"
 	}
@@ -43,7 +43,9 @@ const baseResources = `
 	resource "databricks_job" "this" {
 		name = "tf-{var.STICKY_RANDOM}"
 	}
+`
 
+const modelServingResource = `
 	resource "databricks_model_serving" "this" {
 		name = "tf-{var.STICKY_RANDOM}"
 		config {
@@ -58,8 +60,25 @@ const baseResources = `
 	}
 `
 
-func makeTemplate(description string) string {
-	appTemplate := baseResources + `
+func makeTemplate(description string, includeModelServing bool) string {
+	base := baseResourcesCore
+	if includeModelServing {
+		base += modelServingResource
+	}
+
+	var servingResourceBlock string
+	if includeModelServing {
+		servingResourceBlock = `, {
+			name = "serving endpoint"
+			description = "serving endpoint for app"
+			serving_endpoint = {
+				name = databricks_model_serving.this.name
+				permission = "CAN_MANAGE"
+			}
+		}`
+	}
+
+	appTemplate := base + `
 	resource "databricks_app" "this" {
 		name = "tf-{var.STICKY_RANDOM}"
 		description = "%s"
@@ -78,14 +97,7 @@ func makeTemplate(description string) string {
 				id = databricks_job.this.id
 				permission = "CAN_MANAGE"
 			}
-		}, {
-			name = "serving endpoint"
-			description = "serving endpoint for app"
-			serving_endpoint = {
-				name = databricks_model_serving.this.name
-				permission = "CAN_MANAGE"
-			}
-		}, {
+		}` + servingResourceBlock + `, {
 			name = "sql warehouse"
 			description = "sql warehouse for app"
 			sql_warehouse = {
@@ -128,14 +140,15 @@ is required`),
 func TestAccAppResource(t *testing.T) {
 	var updateTime string
 	acceptance.LoadWorkspaceEnv(t)
+	includeModelServing := !acceptance.IsGcp(t)
 	acceptance.WorkspaceLevel(t, acceptance.Step{
-		Template: makeTemplate("My app"),
+		Template: makeTemplate("My app", includeModelServing),
 		Check: func(s *terraform.State) error {
 			updateTime = s.RootModule().Resources["databricks_app.this"].Primary.Attributes["update_time"]
 			return nil
 		},
 	}, acceptance.Step{
-		Template: makeTemplate("My new app"),
+		Template: makeTemplate("My new app", includeModelServing),
 		Check: func(s *terraform.State) error {
 			var newUpdateTime = s.RootModule().Resources["databricks_app.this"].Primary.Attributes["update_time"]
 			assert.NotEqual(t, updateTime, newUpdateTime)

--- a/permissions/permissions_test.go
+++ b/permissions/permissions_test.go
@@ -994,9 +994,6 @@ func TestAccPermissions_Query(t *testing.T) {
 
 func TestAccPermissions_App(t *testing.T) {
 	acceptance.LoadDebugEnvIfRunsFromIDE(t, "workspace")
-	if acceptance.IsGcp(t) {
-		acceptance.Skipf(t)("not available on GCP")
-	}
 	queryTemplate := `
 		resource "databricks_app" "this" {
 			name = "{var.RANDOM}"


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

Apps are now available on GCP, so it makes sense to enable tests there as well

NO_CHANGELOG=true

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [x] covered with integration tests in `internal/acceptance`
- [ ] using Go SDK
- [ ] using TF Plugin Framework
- [ ] has entry in `NEXT_CHANGELOG.md` file
