### PR TITLE
[Docs] minor example updates

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -14,6 +14,8 @@
 ### Documentation
 
 * Update documentation for single-node clusters in `databricks_cluster` resource ([#4817](https://github.com/databricks/terraform-provider-databricks/pull/4817)).
+* Update GCP example for `databricks_external_location` resource ([#4826](https://github.com/databricks/terraform-provider-databricks/pull/4826))
+* Fix formatting for HTTP connection example in `databricks_connection` resource ([#4826](https://github.com/databricks/terraform-provider-databricks/pull/4826))
 
 ### Exporter
 

--- a/docs/resources/connection.md
+++ b/docs/resources/connection.md
@@ -87,6 +87,7 @@ resource "databricks_connection" "http_bearer" {
     bearer_token = "bearer_token"
   }
 }
+```
 
 Create a HTTP connection with OAuth M2M
 

--- a/docs/resources/external_location.md
+++ b/docs/resources/external_location.md
@@ -91,6 +91,14 @@ resource "databricks_external_location" "some" {
   credential_name = databricks_storage_credential.ext.id
   comment         = "Managed by TF"
 }
+
+resource "databricks_grants" "some" {
+  external_location = databricks_external_location.some.id
+  grant {
+    principal  = "Data Engineers"
+    privileges = ["CREATE_EXTERNAL_TABLE", "READ_FILES"]
+  }
+}
 ```
 
 Example `encryption_details` specifying SSE_S3 encryption:


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
1. In `databricks_external_location` the AWS and Azure examples included a grant to show how to grant permission on the External Location. I updated the GCP example to match, for clarity.
2. In `databricks_connection` resource, I fixed the HTTP connection example missing closing backticks for the HCL code block.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [X] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] using Go SDK
- [ ] using TF Plugin Framework
- [X] has entry in `NEXT_CHANGELOG.md` file
