### PR TITLE
[Doc] Document additional custom properties for resource `workspace_conf`

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Documentation
 
-* Document additional custom configuration properties for resource `workspace_conf`
+* Document additional custom configuration properties for resource `workspace_conf` ([#4859](https://github.com/databricks/terraform-provider-databricks/pull/4859))
 
 ### Exporter
 

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Documentation
 
+* Document additional custom configuration properties for resource `workspace_conf`
+
 ### Exporter
 
 ### Internal Changes

--- a/docs/resources/workspace_conf.md
+++ b/docs/resources/workspace_conf.md
@@ -21,6 +21,12 @@ Allows specification of custom configuration properties for expert usage:
 - `enableTokensConfig` - (boolean) Enable or disable personal access tokens for this workspace.
 - `enableDeprecatedClusterNamedInitScripts` - (boolean) Enable or disable [legacy cluster-named init scripts](https://docs.databricks.com/clusters/init-scripts.html#disable-legacy-cluster-named-init-scripts-for-a-workspace) for this workspace.
 - `enableDeprecatedGlobalInitScripts` - (boolean) Enable or disable [legacy global init scripts](https://docs.databricks.com/clusters/init-scripts.html#migrate-legacy-scripts) for this workspace.
+- `enableExportNotebook` - (boolean) Enable or disable users from exporting notebooks and files for this workspace.
+- `enableFileStoreEndpoint` - (boolean) Enable or disable users from exporting notebooks and files for this workspace.
+- `enableNotebookTableClipboard` - (boolean) Controls the ability for users to copy tabular data to the clipboard via the UI.
+- `enableResultsDownloading` - (boolean) Enable or disable users from downloading notebook results.
+- `enableVerboseAuditLogs` - (boolean) Enable or disable verbose audit logs.
+- `storeInteractiveNotebookResultsInCustomerAccount` - (boolean) When enabled, all interactive notebook results are stored in the customer account.
 
 ```hcl
 resource "databricks_workspace_conf" "this" {


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

Document additional custom properties for resource `workspace_conf`. These custom properties are currently supported, but not available in the current docs. 

## Tests
<!--
How is this tested? Please see the checklist below and also describe any other relevant tests
-->

- [ ] `make test` run locally
- [ X] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] using Go SDK
- [ ] using TF Plugin Framework
- [ X] has entry in `NEXT_CHANGELOG.md` file
