### PR TITLE
[Doc] Update disable_legacy_dbfs setting documentation

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Documentation
 
 * Refreshed `databricks_job` documentation ([#4861](https://github.com/databricks/terraform-provider-databricks/pull/4861)).
+* Updated documentation for `databricks_disable_legacy_dbfs_setting` resource ([#4870](https://github.com/databricks/terraform-provider-databricks/pull/4870)).
 
 ### Exporter
 

--- a/docs/resources/disable_legacy_dbfs_setting.md
+++ b/docs/resources/disable_legacy_dbfs_setting.md
@@ -4,10 +4,20 @@ subcategory: "Settings"
 
 # databricks_disable_legacy_dbfs_setting Resource
 
-The `databricks_disable_legacy_dbfs_setting` resource allows you to disable legacy dbfs features.
-When this setting is on, access to DBFS root and DBFS mounts is disallowed (as well as creation of new mounts). When the setting is off, all DBFS functionality is enabled. This setting has no impact on workspace internal storage (WIS).
+The `databricks_disable_legacy_dbfs_setting` resource allows you to disable legacy DBFS.
 
-~> This setting is currently in private preview, and only available for enrolled customers.
+Disabling legacy DBFS has the following implications:
+
+1. Access to DBFS root and DBFS mounts is disallowed (as well as the creation of new mounts). 
+2. Disables Databricks Runtime versions prior to 13.3LTS.
+
+When the setting is off, all DBFS functionality is enabled and no restrictions are imposed on Databricks Runtime versions. This setting can take up to 20 minutes to take effect and requires a manual restart of all-purpose compute clusters and SQL warehouses.
+
+Official docs:
+
+[Azure](https://learn.microsoft.com/azure/databricks/dbfs/disable-dbfs-root-mounts)
+[AWS](https://docs.databricks.com/aws/dbfs/disable-dbfs-root-mounts)
+[GCP](https://docs.gcp.databricks.com/dbfs/disable-dbfs-root-mounts)
 
 -> This resource can only be used with a workspace-level provider!
 
@@ -31,15 +41,6 @@ The resource supports the following arguments:
 ## Import
 
 This resource can be imported by predefined name `global`:
-
-```hcl
-import {
-  to = databricks_disable_legacy_dbfs_setting.this
-  id = "global"
-}
-```
-
-Alternatively, when using `terraform` version 1.4 or earlier, import using the `terraform import` command:
 
 ```bash
 terraform import databricks_disable_legacy_dbfs_setting.this global

--- a/docs/resources/disable_legacy_dbfs_setting.md
+++ b/docs/resources/disable_legacy_dbfs_setting.md
@@ -42,6 +42,15 @@ The resource supports the following arguments:
 
 This resource can be imported by predefined name `global`:
 
+```hcl
+import {
+  to = databricks_disable_legacy_dbfs_setting.this
+  id = "global"
+}
+```
+
+Alternatively, when using `terraform` version 1.4 or earlier, import using the `terraform import` command:
+
 ```bash
 terraform import databricks_disable_legacy_dbfs_setting.this global
 ```

--- a/docs/resources/disable_legacy_dbfs_setting.md
+++ b/docs/resources/disable_legacy_dbfs_setting.md
@@ -6,6 +6,8 @@ subcategory: "Settings"
 
 The `databricks_disable_legacy_dbfs_setting` resource allows you to disable legacy DBFS.
 
+-> This resource can only be used with a workspace-level provider!
+
 Disabling legacy DBFS has the following implications:
 
 1. Access to DBFS root and DBFS mounts is disallowed (as well as the creation of new mounts). 
@@ -13,13 +15,11 @@ Disabling legacy DBFS has the following implications:
 
 When the setting is off, all DBFS functionality is enabled and no restrictions are imposed on Databricks Runtime versions. This setting can take up to 20 minutes to take effect and requires a manual restart of all-purpose compute clusters and SQL warehouses.
 
-Official docs:
+Refer to official docs for more details:
 
-[Azure](https://learn.microsoft.com/azure/databricks/dbfs/disable-dbfs-root-mounts)
-[AWS](https://docs.databricks.com/aws/dbfs/disable-dbfs-root-mounts)
-[GCP](https://docs.gcp.databricks.com/dbfs/disable-dbfs-root-mounts)
-
--> This resource can only be used with a workspace-level provider!
+- [Azure](https://learn.microsoft.com/azure/databricks/dbfs/disable-dbfs-root-mounts)
+- [AWS](https://docs.databricks.com/aws/dbfs/disable-dbfs-root-mounts)
+- [GCP](https://docs.gcp.databricks.com/dbfs/disable-dbfs-root-mounts)
 
 ## Example Usage
 


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
This PR updates the documentation for the `databricks_disable_legacy_dbfs_setting` resource by removing the mention to workspace internal storage which is not consumer facing, mentioning the restriction to DBR versions 13.3+, and removing the warning that the feature is in private preview (planning to go public preview next Monday)

## Tests
<!--
How is this tested? Please see the checklist below and also describe any other relevant tests
-->

- [ ] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] using Go SDK
- [ ] using TF Plugin Framework
- [ ] has entry in `NEXT_CHANGELOG.md` file
