### PR TITLE
[Feature] Added output attribute `endpoint_url` in `databricks_model_serving`

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### New Features and Improvements
 
+* Added output attribute `endpoint_url` in `databricks_model_serving`([#4877](https://github.com/databricks/terraform-provider-databricks/pull/4877)).
+
 ### Bug Fixes
 
 * Corrected accidentally removed `SpID` field from `databricks_service_principal` ([#4868](https://github.com/databricks/terraform-provider-databricks/pull/4868)).

--- a/docs/resources/model_serving.md
+++ b/docs/resources/model_serving.md
@@ -265,6 +265,7 @@ In addition to all the arguments above, the following attributes are exported:
 
 * `id` - Equal to the `name` argument and used to identify the serving endpoint.
 * `serving_endpoint_id` - Unique identifier of the serving endpoint primarily used to set permissions and refer to this instance for other operations.
+* `endpoint_url` - Invocation url of the endpoint.
 
 ## Access Control
 

--- a/docs/resources/model_serving.md
+++ b/docs/resources/model_serving.md
@@ -298,7 +298,6 @@ Alternatively, when using `terraform` version 1.4 or earlier, import using the `
 terraform import databricks_model_serving.this <model-serving-endpoint-name>
 ```
 
-
 ## Related Resources
 
 The following resources are often used in the same context:

--- a/serving/resource_model_serving.go
+++ b/serving/resource_model_serving.go
@@ -178,6 +178,10 @@ func ResourceModelServing() common.Resource {
 				Computed: true,
 				Type:     schema.TypeString,
 			}
+			m["endpoint_url"] = &schema.Schema{
+				Computed: true,
+				Type:     schema.TypeString,
+			}
 			return m
 		})
 
@@ -234,6 +238,7 @@ func ResourceModelServing() common.Resource {
 				return err
 			}
 			d.Set("serving_endpoint_id", endpoint.Id)
+			d.Set("endpoint_url", endpoint.EndpointUrl)
 			return nil
 		},
 		Update: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {

--- a/serving/resource_model_serving_test.go
+++ b/serving/resource_model_serving_test.go
@@ -393,6 +393,7 @@ func TestModelServingRead(t *testing.T) {
 					State: &serving.EndpointState{
 						ConfigUpdate: serving.EndpointStateConfigUpdateNotUpdating,
 					},
+					EndpointUrl: "https://example.com/endpoint",
 					Config: &serving.EndpointCoreConfigOutput{
 						ServedModels: []serving.ServedModelOutput{
 							{
@@ -443,7 +444,21 @@ func TestModelServingRead(t *testing.T) {
 		Resource: ResourceModelServing(),
 		Read:     true,
 		ID:       "test-endpoint",
-	}.ApplyNoError(t)
+	}.ApplyAndExpectData(t, map[string]any{
+		"serving_endpoint_id":                                   "test-endpoint",
+		"endpoint_url":                                          "https://example.com/endpoint",
+		"config.0.served_entities.#":                            2,
+		"config.0.served_entities.0.name":                       "prod_model",
+		"config.0.served_entities.1.name":                       "candidate_model",
+		"config.0.traffic_config.#":                             1,
+		"config.0.traffic_config.0.routes.#":                    2,
+		"config.0.traffic_config.0.routes.0.served_model_name":  "prod_model",
+		"config.0.traffic_config.0.routes.1.served_model_name":  "candidate_model",
+		"config.0.traffic_config.0.routes.0.served_entity_name": "prod_model",
+		"config.0.traffic_config.0.routes.1.served_entity_name": "candidate_model",
+		"config.0.traffic_config.0.routes.0.traffic_percentage": 90,
+		"config.0.traffic_config.0.routes.1.traffic_percentage": 10,
+	})
 }
 
 func TestModelServingReadEmptyConfig(t *testing.T) {

--- a/serving/resource_model_serving_test.go
+++ b/serving/resource_model_serving_test.go
@@ -618,6 +618,7 @@ func TestModelServingUpdate_RemoveConfigIsNoOp(t *testing.T) {
 			"config.0.served_models.#":      "1",
 			"config.0.served_models.0.name": "prod_model",
 			"serving_endpoint_id":           "id",
+			"endpoint_url":                  "https://example.com/endpoint",
 		},
 		HCL: `
 			name = "test-endpoint"


### PR DESCRIPTION
## Changes
- Added output attribute `endpoint_url` in `databricks_model_serving`
- Resolve #4858
## Tests
<!--
How is this tested? Please see the checklist below and also describe any other relevant tests
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [x] covered with integration tests in `internal/acceptance`
- [x] using Go SDK
- [x] has entry in `NEXT_CHANGELOG.md` file
