### PR TITLE
Deprecate `egg` library type in `databricks_cluster`, `databricks_job`, and `databricks_library`

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -6,7 +6,8 @@
 
 ### New Features and Improvements
 
-* Added output attribute `endpoint_url` in `databricks_model_serving`([#4877](https://github.com/databricks/terraform-provider-databricks/pull/4877)).
+* Added output attribute `endpoint_url` in `databricks_model_serving` ([#4877](https://github.com/databricks/terraform-provider-databricks/pull/4877)).
+* Deprecate `egg` library type in `databricks_cluster`, `databricks_job`, and `databricks_library` ([#4881](https://github.com/databricks/terraform-provider-databricks/pull/4881)).
 
 ### Bug Fixes
 

--- a/clusters/resource_cluster.go
+++ b/clusters/resource_cluster.go
@@ -330,6 +330,7 @@ func (ClusterSpec) CustomizeSchema(s *common.CustomizableSchema) *common.Customi
 		lib := libraries.NewLibraryFromInstanceState(i)
 		return schema.HashString(lib.String())
 	}
+	s.SchemaPath("library", "egg").SetDeprecated(EggDeprecationWarning)
 	s.AddNewField("idempotency_token", &schema.Schema{
 		Type:     schema.TypeString,
 		Optional: true,

--- a/clusters/resource_library.go
+++ b/clusters/resource_library.go
@@ -25,7 +25,10 @@ func (LibraryResource) CustomizeSchemaResourceSpecific(s *common.CustomizableSch
 	return s
 }
 
+const EggDeprecationWarning = "The `egg` library type is deprecated. Please use `whl` or `pypi` instead."
+
 func (LibraryResource) CustomizeSchema(s *common.CustomizableSchema) *common.CustomizableSchema {
+	s.SchemaPath("egg").SetDeprecated(EggDeprecationWarning)
 	return s
 }
 

--- a/internal/providers/pluginfw/products/library/resource_library.go
+++ b/internal/providers/pluginfw/products/library/resource_library.go
@@ -106,6 +106,7 @@ func (r *LibraryResource) Schema(ctx context.Context, req resource.SchemaRequest
 		c.SetRequired("cluster_id")
 		c.SetOptional("id")
 		c.SetComputed("id")
+		c.SetDeprecated(clusters.EggDeprecationWarning, "egg")
 		return c
 	})
 	resp.Schema = schema.Schema{

--- a/jobs/resource_job.go
+++ b/jobs/resource_job.go
@@ -616,6 +616,8 @@ func (JobSettingsResource) CustomizeSchema(s *common.CustomizableSchema) *common
 		}
 	}
 
+	s.SchemaPath("library", "egg").SetDeprecated(clusters.EggDeprecationWarning)
+
 	// we need to have only one of user name vs service principal in the run_as block
 	run_as_eoo := []string{"run_as.0.user_name", "run_as.0.service_principal_name"}
 	s.SchemaPath("run_as", "user_name").SetExactlyOneOf(run_as_eoo)


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

EGG libraries aren't supported since DBR 14, so it makes sense to put a deprecation message in relevant resources

## Tests
<!--
How is this tested? Please see the checklist below and also describe any other relevant tests
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] using Go SDK
- [ ] using TF Plugin Framework
- [x] has entry in `NEXT_CHANGELOG.md` file
