### PR TITLE
[Doc] Improve documentation for service principal data sources

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -25,6 +25,7 @@
 * Updated documentation for `databricks_disable_legacy_features_setting` resource ([#4884](https://github.com/databricks/terraform-provider-databricks/pull/4884)).
 * Improve docs for `databricks_compliance_security_profile_setting` ([#4880](https://github.com/databricks/terraform-provider-databricks/pull/4880)).
 * Improve instructions for the Terraform Exporter ([#4892](https://github.com/databricks/terraform-provider-databricks/pull/4892)).
+* Improve documentation for service principal data sources ([#4900](https://github.com/databricks/terraform-provider-databricks/pull/4900)).
 
 ### Exporter
 

--- a/docs/data-sources/service_principal.md
+++ b/docs/data-sources/service_principal.md
@@ -31,7 +31,7 @@ resource "databricks_group_member" "my_member_a" {
 
 Data source allows you to pick service principals by one of the following attributes (only one of them):
 
-- `application_id` - (Required if neither `display_name` nor `scim_id` is used) ID of the service principal. The service principal must exist before this resource can be retrieved.
+- `application_id` - (Required if neither `display_name` nor `scim_id` is used) Application ID of the service principal. The service principal must exist before this resource can be retrieved.
 - `display_name` - (Required if neither `application_id` nor `scim_id` is  used) Exact display name of the service principal. The service principal must exist before this resource can be retrieved.  In case if there are several service principals with the same name, an error is thrown.
 - `scim_id` - (Required if neither `application_id` nor `display_name` is used) Unique SCIM ID for a service principal in the Databricks workspace. The service principal must exist before this resource can be retrieved.
 
@@ -40,9 +40,10 @@ Data source allows you to pick service principals by one of the following attrib
 Data source exposes the following attributes:
 
 - `id` - The id of the service principal (SCIM ID).
-- `external_id` - ID of the service principal in an external identity provider.
+- `application_id` - Application ID of the service principal.
 - `display_name` - Display name of the [service principal](../resources/service_principal.md), e.g. `Foo SPN`.
 - `scim_id` - same as `id`.
+- `external_id` - ID of the service principal in an external identity provider.
 - `home` - Home folder of the [service principal](../resources/service_principal.md), e.g. `/Users/11111111-2222-3333-4444-555666777888`.
 - `repos` - Repos location of the [service principal](../resources/service_principal.md), e.g. `/Repos/11111111-2222-3333-4444-555666777888`.
 - `active` - Whether service principal is active or not.

--- a/docs/data-sources/service_principals.md
+++ b/docs/data-sources/service_principals.md
@@ -43,7 +43,7 @@ Data source allows you to pick service principals by the following attributes
 
 Data source exposes the following attributes:
 
-- `application_ids` - List of `application_ids` of service principals Individual service principal can be retrieved using [databricks_service_principal](service_principal.md) data source
+- `application_ids` - List of `application_ids` of service principals.  Individual service principal can be retrieved using [databricks_service_principal](service_principal.md) data source
 
 ## Related Resources
 

--- a/docs/resources/permissions.md
+++ b/docs/resources/permissions.md
@@ -1031,7 +1031,7 @@ Arguments for the `access_control` block are:
 Exactly one of the below arguments is required:
 
 - `user_name` - (Optional) name of the [user](user.md).
-- `service_principal_name` - (Optional) Application ID of the [service_principal](service_principal.md#application_id).
+- `service_principal_name` - (Optional) Application ID (**not service principal name!**) of the [service_principal](service_principal.md#application_id).
 - `group_name` - (Optional) name of the [group](group.md). We recommend setting permissions on groups.
 
 ## Attribute Reference


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

Explicitly documented `application_id` in `databricks_service_principal` data source. Also, put emphasis that `service_principal_name` in `databricks_permissions` is Application ID, not SP name.

Resolves #4604

## Tests
<!--
How is this tested? Please see the checklist below and also describe any other relevant tests
-->

- [x] relevant change in `docs/` folder
- [x] has entry in `NEXT_CHANGELOG.md` file
