### PR TITLE
Fix schema mismatch bug in `databricks_functions` data source

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -18,6 +18,7 @@
 * Fix handling of `force` option in `databricks_git_credential` ([#4873](https://github.com/databricks/terraform-provider-databricks/pull/4873)).
 * Restricted create or replace statement to managed tables in `databricks_sql_table`([#4874](https://github.com/databricks/terraform-provider-databricks/pull/4874)).
 * Mitigate issue due to internal caching in `databricks_secret_acl` by retrying until ACL are applied with the right permission ([#4885](https://github.com/databricks/terraform-provider-databricks/pull/4885)).
+* Fix schema mismatch bug in `databricks_functions` data source ([#4902](https://github.com/databricks/terraform-provider-databricks/pull/4902)).
 
 ### Documentation
 

--- a/internal/providers/pluginfw/products/catalog/data_functions.go
+++ b/internal/providers/pluginfw/products/catalog/data_functions.go
@@ -49,7 +49,7 @@ func (FunctionsData) ApplySchemaCustomizations(attrs map[string]tfschema.Attribu
 
 func (FunctionsData) GetComplexFieldTypes(context.Context) map[string]reflect.Type {
 	return map[string]reflect.Type{
-		"functions": reflect.TypeOf(catalog_tf.FunctionInfo_SdkV2{}),
+		"functions": reflect.TypeOf(catalog_tf.FunctionInfo{}),
 	}
 }
 


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

The cause of the bug was that SDKv2-compatible struct was used with the plugin framework. Switching to use correct struct fixed the problem.

Bug wasn't found previously because we don't have integration test for it as we don't have `databricks_function` resource yet.

Resolves #4365


## Tests
<!--
How is this tested? Please see the checklist below and also describe any other relevant tests
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [x] using Go SDK
- [x] using TF Plugin Framework
- [x] has entry in `NEXT_CHANGELOG.md` file
