### PR TITLE
Set suppressDiff on string_shared_as in the Legacy databricks_share Resource

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -19,6 +19,7 @@
 * Restricted create or replace statement to managed tables in `databricks_sql_table`([#4874](https://github.com/databricks/terraform-provider-databricks/pull/4874)).
 * Mitigate issue due to internal caching in `databricks_secret_acl` by retrying until ACL are applied with the right permission ([#4885](https://github.com/databricks/terraform-provider-databricks/pull/4885)).
 * Fix schema mismatch bug in `databricks_functions` data source ([#4902](https://github.com/databricks/terraform-provider-databricks/pull/4902)).
+* Set suppressDiff on string_shared_as in the Legacy databricks_share Resource ([#4904](https://github.com/databricks/terraform-provider-databricks/pull/4904)).
 
 ### Documentation
 

--- a/sharing/resource_share.go
+++ b/sharing/resource_share.go
@@ -28,6 +28,7 @@ func (ShareInfo) CustomizeSchema(s *common.CustomizableSchema) *common.Customiza
 	s.SchemaPath("object").SetMinItems(1)
 	s.SchemaPath("object", "data_object_type").SetRequired()
 	s.SchemaPath("object", "shared_as").SetSuppressDiff()
+	s.SchemaPath("object", "string_shared_as").SetSuppressDiff()
 	s.SchemaPath("object", "cdf_enabled").SetSuppressDiff()
 	s.SchemaPath("object", "start_version").SetSuppressDiff()
 	s.SchemaPath("object", "history_data_sharing_status").SetSuppressDiff()
@@ -98,6 +99,9 @@ func (si ShareInfo) resourceShareMap() map[string]sharing.SharedDataObject {
 func Equal(this sharing.SharedDataObject, other sharing.SharedDataObject) bool {
 	if other.SharedAs == "" {
 		other.SharedAs = this.SharedAs
+	}
+	if other.StringSharedAs == "" {
+		other.StringSharedAs = this.StringSharedAs
 	}
 	// don't compare computed fields
 	other.AddedAt = this.AddedAt


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
This PR adds diff suppression to the `string_shared_as` field of the legacy SDKv2 `databricks_share` resource to match the behavior of the new plugin framework implementation. The new version treats `string_shared_as` as a user-settable field with a server-settable effective companion field.

## Tests
<!--
How is this tested? Please see the checklist below and also describe any other relevant tests
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] using Go SDK
- [ ] using TF Plugin Framework
- [x] has entry in `NEXT_CHANGELOG.md` file
