### PR TITLE
Add `catalog_id` to the output of `databricks_catalog` resource

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Breaking Changes
 
 ### New Features and Improvements
+* Add `catalog_id` to the output of `databricks_catalog` resource.
 
 ### Bug Fixes
 

--- a/catalog/resource_catalog.go
+++ b/catalog/resource_catalog.go
@@ -41,6 +41,7 @@ type CatalogInfo struct {
 	Owner                        string            `json:"owner,omitempty" tf:"computed"`
 	IsolationMode                string            `json:"isolation_mode,omitempty" tf:"computed"`
 	MetastoreID                  string            `json:"metastore_id,omitempty" tf:"computed"`
+	CatalogID                    string            `json:"catalog_id" tf:"computed"`
 }
 
 func ResourceCatalog() common.Resource {

--- a/docs/data-sources/catalog.md
+++ b/docs/data-sources/catalog.md
@@ -36,8 +36,9 @@ This data source exports the following attributes:
 * `catalog_info` - the [CatalogInfo](https://pkg.go.dev/github.com/databricks/databricks-sdk-go/service/catalog#CatalogInfo) object for a Unity Catalog catalog. This contains the following attributes (see ):
   * `name` - Name of the catalog
   * `full_name` The full name of the catalog. Corresponds with the name field.
-  * `catalog_type` - Type of the catalog, e.g. `MANAGED_CATALOG`, `DELTASHARING_CATALOG`, `SYSTEM_CATALOG`, 
+  * `catalog_type` - Type of the catalog, e.g. `MANAGED_CATALOG`, `DELTASHARING_CATALOG`, `SYSTEM_CATALOG`,
   * `owner` - Current owner of the catalog
+  * `catalog_id` - The unique identifier of the catalog.
   * `comment` - Free-form text description
   * `storage_location` -  Storage Location URL (full path) for managed tables within catalog.
   * `storage_root` - Storage root URL for managed tables within catalog.

--- a/docs/resources/catalog.md
+++ b/docs/resources/catalog.md
@@ -43,6 +43,7 @@ The following arguments are required:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - ID of this catalog - same as the `name`.
+* `catalog_id` - The unique identifier of the catalog.
 * `metastore_id` - ID of the parent metastore.
 
 ## Import


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
Catalog now exports a stable UUID identifier in the catalog_id field. This PR adds this to the model for schema as a computed attribute.

## Tests
<!--
How is this tested? Please see the checklist below and also describe any other relevant tests
-->

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] using Go SDK
- [ ] using TF Plugin Framework
- [ ] has entry in `NEXT_CHANGELOG.md` file
