### PR TITLE
Document and handle additional Slack options in `databricks_notification_destination`

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### New Features and Improvements
 
+* Document and handle additional Slack options in `databricks_notification_destination` ([#4933](https://github.com/databricks/terraform-provider-databricks/pull/4933))
+
 ### Bug Fixes
 
 ### Documentation

--- a/docs/resources/notification_destination.md
+++ b/docs/resources/notification_destination.md
@@ -83,6 +83,8 @@ The following arguments are supported:
     * `addresses` - (Required) The list of email addresses to send notifications to.
   * `slack` - The Slack configuration of the Notification Destination. It must contain the following:
     * `url` - (Required) The Slack webhook URL.
+    * `channel_id`  - (Optional) Slack channel ID for notifications.
+    * `oauth_token` - (Optional) OAuth token for Slack authentication.
   * `pagerduty` - The PagerDuty configuration of the Notification Destination. It must contain the following:
     * `integration_key` - (Required) The PagerDuty integration key.
   * `microsoft_teams` - The Microsoft Teams configuration of the Notification Destination. It must contain the following:

--- a/settings/resource_notification_destination.go
+++ b/settings/resource_notification_destination.go
@@ -14,15 +14,27 @@ func setStruct(s *settings.NotificationDestination, readND *settings.Notificatio
 		switch readND.DestinationType {
 		case settings.DestinationTypeSlack:
 			if readND.Config.Slack != nil && s.Config.Slack != nil {
-				readND.Config.Slack.Url = s.Config.Slack.Url
+				if readND.Config.Slack.UrlSet {
+					readND.Config.Slack.Url = s.Config.Slack.Url
+				}
+				if readND.Config.Slack.ChannelIdSet {
+					readND.Config.Slack.ChannelId = s.Config.Slack.ChannelId
+				}
+				if readND.Config.Slack.OauthTokenSet {
+					readND.Config.Slack.OauthToken = s.Config.Slack.OauthToken
+				}
 			}
 		case settings.DestinationTypePagerduty:
 			if readND.Config.Pagerduty != nil && s.Config.Pagerduty != nil {
-				readND.Config.Pagerduty.IntegrationKey = s.Config.Pagerduty.IntegrationKey
+				if readND.Config.Pagerduty.IntegrationKeySet {
+					readND.Config.Pagerduty.IntegrationKey = s.Config.Pagerduty.IntegrationKey
+				}
 			}
 		case settings.DestinationTypeMicrosoftTeams:
 			if readND.Config.MicrosoftTeams != nil && s.Config.MicrosoftTeams != nil {
-				readND.Config.MicrosoftTeams.Url = s.Config.MicrosoftTeams.Url
+				if readND.Config.MicrosoftTeams.UrlSet {
+					readND.Config.MicrosoftTeams.Url = s.Config.MicrosoftTeams.Url
+				}
 			}
 		case settings.DestinationTypeWebhook:
 			if readND.Config.GenericWebhook != nil && s.Config.GenericWebhook != nil {
@@ -94,6 +106,8 @@ func (NDStruct) CustomizeSchema(s *common.CustomizableSchema) *common.Customizab
 	s.SchemaPath("id").SetComputed()
 	s.SchemaPath("destination_type").SetComputed()
 	s.SchemaPath("config", "slack", "url_set").SetComputed()
+	s.SchemaPath("config", "slack", "channel_id_set").SetComputed()
+	s.SchemaPath("config", "slack", "oauth_token_set").SetComputed()
 	s.SchemaPath("config", "pagerduty", "integration_key_set").SetComputed()
 	s.SchemaPath("config", "microsoft_teams", "url_set").SetComputed()
 	s.SchemaPath("config", "generic_webhook", "url_set").SetComputed()
@@ -125,6 +139,8 @@ func (NDStruct) CustomizeSchema(s *common.CustomizableSchema) *common.Customizab
 	s.SchemaPath("config", "microsoft_teams", "url").SetSensitive()
 	s.SchemaPath("config", "pagerduty", "integration_key").SetSensitive()
 	s.SchemaPath("config", "slack", "url").SetSensitive()
+	s.SchemaPath("config", "slack", "oauth_token").SetSensitive()
+	s.SchemaPath("config", "slack", "channel_id").SetSensitive()
 
 	return s
 }


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

The new Go SDK added two Slack options: `channel_id` and `oauth_token`, so we need to handle them correctly as they are input-only in SDK.

## Tests
<!--
How is this tested? Please see the checklist below and also describe any other relevant tests
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] using Go SDK
- [ ] using TF Plugin Framework
- [x] has entry in `NEXT_CHANGELOG.md` file
