### PR TITLE
[Doc] Update existing docs to match Go SDK 0.81.0

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -16,6 +16,7 @@
 * Document `gcp_attributes.first_on_demand` attribute in `databricks_cluster` ([#4934](https://github.com/databricks/terraform-provider-databricks/pull/4934))
 * Improve `databricks_mws_permission_assignment` documentation ([#4943](https://github.com/databricks/terraform-provider-databricks/pull/4943))
 * Update `databricks_job` example to use `environment_version` ([#4942](https://github.com/databricks/terraform-provider-databricks/pull/4942))
+* Update existing docs to match Go SDK 0.81.0 ([#4960](https://github.com/databricks/terraform-provider-databricks/pull/4960))
 
 ### Exporter
 

--- a/docs/resources/model_serving.md
+++ b/docs/resources/model_serving.md
@@ -242,6 +242,7 @@ The following arguments are supported:
 * `key` - (Optional) Key field for a serving endpoint rate limit. Currently, `user`, `user_group`, `service_principal`, and `endpoint` are supported, with `endpoint` being the default if not specified.
 * `principal` - (Optional) Principal field for a user, user group, or service principal to apply rate limiting to. Accepts a user email, group name, or service principal application ID.
 * `renewal_period` - (Required) Renewal period field for a serving endpoint rate limit. Currently, only `minute` is supported.
+* `tokens` - (Optional, int) Specifies how many tokens are allowed for a key within the renewal_period.
 
 ### ai_gateway Configuration Block
 

--- a/docs/resources/vector_search_index.md
+++ b/docs/resources/vector_search_index.md
@@ -45,7 +45,8 @@ The following arguments are supported (change of any parameter leads to recreati
 * `columns_to_sync` - (optional) list of columns to sync. If not specified, all columns are syncronized.
 * `embedding_source_columns` - (required if `embedding_vector_columns` isn't provided) array of objects representing columns that contain the embedding source.  Each entry consists of:
   * `name` - The name of the column
-  * `embedding_model_endpoint_name` - The name of the embedding model endpoint
+  * `embedding_model_endpoint_name` - The name of the embedding model endpoint, used by default for both ingestion and querying.
+  * `model_endpoint_name_for_query` - (Optional) The name of the embedding model endpoint which, if specified, is used for querying (not ingestion).
 * `embedding_vector_columns`  - (required if `embedding_source_columns` isn't provided)  array of objects representing columns that contain the embedding vectors. Each entry consists of:
   * `name` - The name of the column.
   * `embedding_dimension` - Dimension of the embedding vector.
@@ -60,6 +61,7 @@ The following arguments are supported (change of any parameter leads to recreati
 * `embedding_source_columns` - (required if `embedding_vector_columns` isn't provided) array of objects representing columns that contain the embedding source.  Each entry consists of:
   * `name` - The name of the column
   * `embedding_model_endpoint_name` - The name of the embedding model endpoint
+  * `model_endpoint_name_for_query` - (Optional) The name of the embedding model endpoint which, if specified, is used for querying (not ingestion).
 * `embedding_vector_columns`  - (required if `embedding_source_columns` isn't provided)  array of objects representing columns that contain the embedding vectors. Each entry consists of:
   * `name` - The name of the column.
   * `embedding_dimension` - Dimension of the embedding vector.


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

There are new fields in Go SDK for `databricks_vector_search_index` and `databricks_model_serving` resources, so documenting them.

## Tests
<!--
How is this tested? Please see the checklist below and also describe any other relevant tests
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] using Go SDK
- [ ] using TF Plugin Framework
- [x] has entry in `NEXT_CHANGELOG.md` file
