### PR TITLE
[Internal] Temporarily Mark Share Tests as Flaky

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -27,3 +27,4 @@
 ### Internal Changes
 
 * Replaced `common.APIErrorBody` with corresponding structs in Go SDK ([#4936](https://github.com/databricks/terraform-provider-databricks/pull/4936))
+* Mark `TestUcAccCreateShare`, `TestUcAccUpdateShare`, `TestUcAccDataSourceShares` and `TestUcAccUpdateShareReorderObject` as flaky tests ([#4979](https://github.com/databricks/terraform-provider-databricks/pull/4979)).

--- a/test-config.yaml
+++ b/test-config.yaml
@@ -117,3 +117,15 @@ ignored_tests:
     - package: github.com/databricks/terraform-provider-databricks/serving
       test_name: TestUcAccModelServingProvisionedThroughputResource
       comment: Failure due to limited capacity in specific regions
+    - package: github.com/databricks/terraform-provider-databricks/sharing
+      test_name: TestUcAccCreateShare
+      comment: Failure due to partition spec validation error when adding Delta tables to shares. Backend issue affecting Unity Catalog sharing validation.
+    - package: github.com/databricks/terraform-provider-databricks/sharing
+      test_name: TestUcAccUpdateShare
+      comment: Failure due to partition spec validation error when adding Delta tables to shares. Backend issue affecting Unity Catalog sharing validation.
+    - package: github.com/databricks/terraform-provider-databricks/sharing
+      test_name: TestUcAccDataSourceShares
+      comment: Failure due to partition spec validation error when adding Delta tables to shares. Backend issue affecting Unity Catalog sharing validation.
+    - package: github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/products/sharing
+      test_name: TestUcAccUpdateShareReorderObject
+      comment: Failure due to partition spec validation error when adding Delta tables to shares. Backend issue affecting Unity Catalog sharing validation.


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
This PR marks a few tests as flaky to allow other PRs to be merged. These changes will be reverted before the next release.

## Tests
<!--
How is this tested? Please see the checklist below and also describe any other relevant tests
-->

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] using Go SDK
- [ ] using TF Plugin Framework
- [ ] has entry in `NEXT_CHANGELOG.md` file
