### PR TITLE
Use databricks_sql_table Instead of databricks_table in Sharing Tests

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -27,3 +27,4 @@
 ### Internal Changes
 
 * Replaced `common.APIErrorBody` with corresponding structs in Go SDK ([#4936](https://github.com/databricks/terraform-provider-databricks/pull/4936))
+* Use databricks_sql_table Instead of databricks_table in Sharing Tests ([#4981](https://github.com/databricks/terraform-provider-databricks/pull/4981)

--- a/internal/providers/pluginfw/products/sharing/data_shares_acc_test.go
+++ b/internal/providers/pluginfw/products/sharing/data_shares_acc_test.go
@@ -45,9 +45,6 @@ func TestUcAccDataSourceShares(t *testing.T) {
 			name = "bar"
 			table_type = "MANAGED"
 			warehouse_id = "{env.TEST_DEFAULT_WAREHOUSE_ID}"
-			properties = {
-				"delta.enableDeletionVectors" = "false"
-			}
 
 			column {
 				name = "id"
@@ -61,9 +58,6 @@ func TestUcAccDataSourceShares(t *testing.T) {
 			name = "bar_2"
 			table_type = "MANAGED"
 			warehouse_id = "{env.TEST_DEFAULT_WAREHOUSE_ID}"
-			properties = {
-				"delta.enableDeletionVectors" = "false"
-			}
 
 			column {
 				name = "id"
@@ -77,12 +71,13 @@ func TestUcAccDataSourceShares(t *testing.T) {
 				name = databricks_sql_table.mytable.id
 				comment = "c"
 				data_object_type = "TABLE"
+				history_data_sharing_status = "ENABLED"
 			}
 			object {
 				name = databricks_sql_table.mytable_2.id
-				cdf_enabled = false
 				comment = "c"
 				data_object_type = "TABLE"
+				history_data_sharing_status = "ENABLED"
 			}
 		}
 

--- a/internal/providers/pluginfw/products/sharing/data_shares_acc_test.go
+++ b/internal/providers/pluginfw/products/sharing/data_shares_acc_test.go
@@ -39,47 +39,47 @@ func TestUcAccDataSourceShares(t *testing.T) {
 			}
 		}
 
-		resource "databricks_table" "mytable" {
+		resource "databricks_sql_table" "mytable" {
 			catalog_name = databricks_catalog.sandbox.id
 			schema_name = databricks_schema.things.name
 			name = "bar"
 			table_type = "MANAGED"
-			data_source_format = "DELTA"
+			warehouse_id = "{env.TEST_DEFAULT_WAREHOUSE_ID}"
+			properties = {
+				"delta.enableDeletionVectors" = "false"
+			}
 
 			column {
-				name      = "id"
-				position  = 0
-				type_name = "INT"
-				type_text = "int"
-				type_json = "{\"name\":\"id\",\"type\":\"integer\",\"nullable\":true,\"metadata\":{}}"
+				name = "id"
+				type = "int"
 			}
 		}
 
-		resource "databricks_table" "mytable_2" {
+		resource "databricks_sql_table" "mytable_2" {
 			catalog_name = databricks_catalog.sandbox.id
 			schema_name = databricks_schema.things.name
 			name = "bar_2"
 			table_type = "MANAGED"
-			data_source_format = "DELTA"
+			warehouse_id = "{env.TEST_DEFAULT_WAREHOUSE_ID}"
+			properties = {
+				"delta.enableDeletionVectors" = "false"
+			}
 
 			column {
-				name      = "id"
-				position  = 0
-				type_name = "INT"
-				type_text = "int"
-				type_json = "{\"name\":\"id\",\"type\":\"integer\",\"nullable\":true,\"metadata\":{}}"
+				name = "id"
+				type = "int"
 			}
 		}
 
 		resource "databricks_share_pluginframework" "myshare" {
 			name = "{var.RANDOM}-terraform-delta-share"
 			object {
-				name = databricks_table.mytable.id
+				name = databricks_sql_table.mytable.id
 				comment = "c"
 				data_object_type = "TABLE"
 			}
 			object {
-				name = databricks_table.mytable_2.id
+				name = databricks_sql_table.mytable_2.id
 				cdf_enabled = false
 				comment = "c"
 				data_object_type = "TABLE"

--- a/internal/providers/pluginfw/products/sharing/resource_acc_test.go
+++ b/internal/providers/pluginfw/products/sharing/resource_acc_test.go
@@ -25,51 +25,51 @@ const preTestTemplate = `
 		}
 	}
 
-	resource "databricks_table" "mytable" {
+	resource "databricks_sql_table" "mytable" {
 		catalog_name = databricks_catalog.sandbox.id
 		schema_name = databricks_schema.things.name
 		name = "bar"
 		table_type = "MANAGED"
-		data_source_format = "DELTA"
+		warehouse_id = "{env.TEST_DEFAULT_WAREHOUSE_ID}"
+		properties = {
+			"delta.enableDeletionVectors" = "false"
+		}
 
 		column {
-			name      = "id"
-			position  = 0
-			type_name = "INT"
-			type_text = "int"
-			type_json = "{\"name\":\"id\",\"type\":\"integer\",\"nullable\":true,\"metadata\":{}}"
+			name = "id"
+			type = "int"
 		}
 	}
 
-	resource "databricks_table" "mytable_2" {
+	resource "databricks_sql_table" "mytable_2" {
 		catalog_name = databricks_catalog.sandbox.id
 		schema_name = databricks_schema.things.name
 		name = "bar_2"
 		table_type = "MANAGED"
-		data_source_format = "DELTA"
+		warehouse_id = "{env.TEST_DEFAULT_WAREHOUSE_ID}"
+		properties = {
+			"delta.enableDeletionVectors" = "false"
+		}
 
 		column {
-			name      = "id"
-			position  = 0
-			type_name = "INT"
-			type_text = "int"
-			type_json = "{\"name\":\"id\",\"type\":\"integer\",\"nullable\":true,\"metadata\":{}}"
+			name = "id"
+			type = "int"
 		}
 	}
 
-	resource "databricks_table" "mytable_3" {
+	resource "databricks_sql_table" "mytable_3" {
 		catalog_name = databricks_catalog.sandbox.id
 		schema_name = databricks_schema.things.name
 		name = "bar_3"
 		table_type = "MANAGED"
-		data_source_format = "DELTA"
+		warehouse_id = "{env.TEST_DEFAULT_WAREHOUSE_ID}"
+		properties = {
+			"delta.enableDeletionVectors" = "false"
+		}
 
 		column {
-			name      = "id"
-			position  = 0
-			type_name = "INT"
-			type_text = "int"
-			type_json = "{\"name\":\"id\",\"type\":\"integer\",\"nullable\":true,\"metadata\":{}}"
+			name = "id"
+			type = "int"
 		}
 	}
 `
@@ -95,12 +95,12 @@ func TestUcAccCreateShare(t *testing.T) {
 			name  = "{var.STICKY_RANDOM}-terraform-delta-share"
 			owner = "account users"
 			object {
-				name = databricks_table.mytable.id
+				name = databricks_sql_table.mytable.id
 				comment = "c"
 				data_object_type = "TABLE"
          	}
 			object {
-				name = databricks_table.mytable_2.id
+				name = databricks_sql_table.mytable_2.id
 				cdf_enabled = false
 				comment = "c"
 				data_object_type = "TABLE"
@@ -135,7 +135,7 @@ func shareTemplateWithOwner(comment string, owner string) string {
 			name  = "{var.STICKY_RANDOM}-terraform-delta-share"
 			owner = "%s"
 			object {
-				name = databricks_table.mytable.id
+				name = databricks_sql_table.mytable.id
 				comment = "%s"
 				data_object_type = "TABLE"
 				history_data_sharing_status = "DISABLED"
@@ -163,13 +163,13 @@ func TestUcAccUpdateShareAddObject(t *testing.T) {
 			name  = "{var.STICKY_RANDOM}-terraform-delta-share"
 			owner = "account users"
 			object {
-				name = databricks_table.mytable.id
+				name = databricks_sql_table.mytable.id
 				comment = "A"
 				data_object_type = "TABLE"
 				history_data_sharing_status = "DISABLED"
 			}
 			object {
-				name = databricks_table.mytable_3.id
+				name = databricks_sql_table.mytable_3.id
 				comment = "C"
 				data_object_type = "TABLE"
 				history_data_sharing_status = "DISABLED"
@@ -182,19 +182,19 @@ func TestUcAccUpdateShareAddObject(t *testing.T) {
 			name  = "{var.STICKY_RANDOM}-terraform-delta-share"
 			owner = "account users"
 			object {
-				name = databricks_table.mytable.id
+				name = databricks_sql_table.mytable.id
 				comment = "AA"
 				data_object_type = "TABLE"
 				history_data_sharing_status = "DISABLED"
 			}
 			object {
-				name = databricks_table.mytable_2.id
+				name = databricks_sql_table.mytable_2.id
 				comment = "BB"
 				data_object_type = "TABLE"
 				history_data_sharing_status = "DISABLED"
 			}
 			object {
-				name = databricks_table.mytable_3.id
+				name = databricks_sql_table.mytable_3.id
 				comment = "CC"
 				data_object_type = "TABLE"
 				history_data_sharing_status = "DISABLED"
@@ -210,11 +210,11 @@ func TestUcAccUpdateShareReorderObject(t *testing.T) {
 			name  = "{var.STICKY_RANDOM}-terraform-delta-share"
 			owner = "account users"
 			object {
-				name = databricks_table.mytable.id
+				name = databricks_sql_table.mytable.id
 				data_object_type = "TABLE"
 			}
 			object {
-				name = databricks_table.mytable_3.id
+				name = databricks_sql_table.mytable_3.id
 				data_object_type = "TABLE"
 			}
 		}`,
@@ -224,11 +224,11 @@ func TestUcAccUpdateShareReorderObject(t *testing.T) {
 			name  = "{var.STICKY_RANDOM}-terraform-delta-share"
 			owner = "account users"
 			object {
-				name = databricks_table.mytable_3.id
+				name = databricks_sql_table.mytable_3.id
 				data_object_type = "TABLE"
 			}
 			object {
-				name = databricks_table.mytable.id
+				name = databricks_sql_table.mytable.id
 				data_object_type = "TABLE"
 			}
 		}`,

--- a/internal/providers/pluginfw/products/sharing/resource_acc_test.go
+++ b/internal/providers/pluginfw/products/sharing/resource_acc_test.go
@@ -31,9 +31,6 @@ const preTestTemplate = `
 		name = "bar"
 		table_type = "MANAGED"
 		warehouse_id = "{env.TEST_DEFAULT_WAREHOUSE_ID}"
-		properties = {
-			"delta.enableDeletionVectors" = "false"
-		}
 
 		column {
 			name = "id"
@@ -47,9 +44,6 @@ const preTestTemplate = `
 		name = "bar_2"
 		table_type = "MANAGED"
 		warehouse_id = "{env.TEST_DEFAULT_WAREHOUSE_ID}"
-		properties = {
-			"delta.enableDeletionVectors" = "false"
-		}
 
 		column {
 			name = "id"
@@ -63,9 +57,6 @@ const preTestTemplate = `
 		name = "bar_3"
 		table_type = "MANAGED"
 		warehouse_id = "{env.TEST_DEFAULT_WAREHOUSE_ID}"
-		properties = {
-			"delta.enableDeletionVectors" = "false"
-		}
 
 		column {
 			name = "id"
@@ -98,12 +89,13 @@ func TestUcAccCreateShare(t *testing.T) {
 				name = databricks_sql_table.mytable.id
 				comment = "c"
 				data_object_type = "TABLE"
+				history_data_sharing_status = "ENABLED"
          	}
 			object {
 				name = databricks_sql_table.mytable_2.id
-				cdf_enabled = false
 				comment = "c"
 				data_object_type = "TABLE"
+				history_data_sharing_status = "ENABLED"
 			}
 		}
 
@@ -138,7 +130,7 @@ func shareTemplateWithOwner(comment string, owner string) string {
 				name = databricks_sql_table.mytable.id
 				comment = "%s"
 				data_object_type = "TABLE"
-				history_data_sharing_status = "DISABLED"
+				history_data_sharing_status = "ENABLED"
 			}
 
 		}`, owner, comment)
@@ -166,13 +158,13 @@ func TestUcAccUpdateShareAddObject(t *testing.T) {
 				name = databricks_sql_table.mytable.id
 				comment = "A"
 				data_object_type = "TABLE"
-				history_data_sharing_status = "DISABLED"
+				history_data_sharing_status = "ENABLED"
 			}
 			object {
 				name = databricks_sql_table.mytable_3.id
 				comment = "C"
 				data_object_type = "TABLE"
-				history_data_sharing_status = "DISABLED"
+				history_data_sharing_status = "ENABLED"
 			}
 
 		}`,
@@ -185,19 +177,19 @@ func TestUcAccUpdateShareAddObject(t *testing.T) {
 				name = databricks_sql_table.mytable.id
 				comment = "AA"
 				data_object_type = "TABLE"
-				history_data_sharing_status = "DISABLED"
+				history_data_sharing_status = "ENABLED"
 			}
 			object {
 				name = databricks_sql_table.mytable_2.id
 				comment = "BB"
 				data_object_type = "TABLE"
-				history_data_sharing_status = "DISABLED"
+				history_data_sharing_status = "ENABLED"
 			}
 			object {
 				name = databricks_sql_table.mytable_3.id
 				comment = "CC"
 				data_object_type = "TABLE"
-				history_data_sharing_status = "DISABLED"
+				history_data_sharing_status = "ENABLED"
 			}
 		}`,
 	})
@@ -212,10 +204,12 @@ func TestUcAccUpdateShareReorderObject(t *testing.T) {
 			object {
 				name = databricks_sql_table.mytable.id
 				data_object_type = "TABLE"
+				history_data_sharing_status = "ENABLED"
 			}
 			object {
 				name = databricks_sql_table.mytable_3.id
 				data_object_type = "TABLE"
+				history_data_sharing_status = "ENABLED"
 			}
 		}`,
 	}, acceptance.Step{
@@ -226,10 +220,12 @@ func TestUcAccUpdateShareReorderObject(t *testing.T) {
 			object {
 				name = databricks_sql_table.mytable_3.id
 				data_object_type = "TABLE"
+				history_data_sharing_status = "ENABLED"
 			}
 			object {
 				name = databricks_sql_table.mytable.id
 				data_object_type = "TABLE"
+				history_data_sharing_status = "ENABLED"
 			}
 		}`,
 	})

--- a/sharing/data_shares_acc_test.go
+++ b/sharing/data_shares_acc_test.go
@@ -45,9 +45,6 @@ func TestUcAccDataSourceShares(t *testing.T) {
 			name = "bar"
 			table_type = "MANAGED"
 			warehouse_id = "{env.TEST_DEFAULT_WAREHOUSE_ID}"
-			properties = {
-				"delta.enableDeletionVectors" = "false"
-			}
 
 			column {
 				name = "id"
@@ -61,9 +58,6 @@ func TestUcAccDataSourceShares(t *testing.T) {
 			name = "bar_2"
 			table_type = "MANAGED"
 			warehouse_id = "{env.TEST_DEFAULT_WAREHOUSE_ID}"
-			properties = {
-				"delta.enableDeletionVectors" = "false"
-			}
 
 			column {
 				name = "id"
@@ -77,12 +71,13 @@ func TestUcAccDataSourceShares(t *testing.T) {
 				name = databricks_sql_table.mytable.id
 				comment = "c"
 				data_object_type = "TABLE"
+				history_data_sharing_status = "ENABLED"
 			}
 			object {
 				name = databricks_sql_table.mytable_2.id
-				cdf_enabled = false
 				comment = "c"
 				data_object_type = "TABLE"
+				history_data_sharing_status = "ENABLED"
 			}
 		}
 

--- a/sharing/data_shares_acc_test.go
+++ b/sharing/data_shares_acc_test.go
@@ -39,47 +39,47 @@ func TestUcAccDataSourceShares(t *testing.T) {
 			}
 		}
 
-		resource "databricks_table" "mytable" {
+		resource "databricks_sql_table" "mytable" {
 			catalog_name = databricks_catalog.sandbox.id
 			schema_name = databricks_schema.things.name
 			name = "bar"
 			table_type = "MANAGED"
-			data_source_format = "DELTA"
+			warehouse_id = "{env.TEST_DEFAULT_WAREHOUSE_ID}"
+			properties = {
+				"delta.enableDeletionVectors" = "false"
+			}
 
 			column {
-				name      = "id"
-				position  = 0
-				type_name = "INT"
-				type_text = "int"
-				type_json = "{\"name\":\"id\",\"type\":\"integer\",\"nullable\":true,\"metadata\":{}}"
+				name = "id"
+				type = "int"
 			}
 		}
 
-		resource "databricks_table" "mytable_2" {
+		resource "databricks_sql_table" "mytable_2" {
 			catalog_name = databricks_catalog.sandbox.id
 			schema_name = databricks_schema.things.name
 			name = "bar_2"
 			table_type = "MANAGED"
-			data_source_format = "DELTA"
+			warehouse_id = "{env.TEST_DEFAULT_WAREHOUSE_ID}"
+			properties = {
+				"delta.enableDeletionVectors" = "false"
+			}
 
 			column {
-				name      = "id"
-				position  = 0
-				type_name = "INT"
-				type_text = "int"
-				type_json = "{\"name\":\"id\",\"type\":\"integer\",\"nullable\":true,\"metadata\":{}}"
+				name = "id"
+				type = "int"
 			}
 		}
 
 		resource "databricks_share" "myshare" {
 			name = "{var.RANDOM}-terraform-delta-share"
 			object {
-				name = databricks_table.mytable.id
+				name = databricks_sql_table.mytable.id
 				comment = "c"
 				data_object_type = "TABLE"
 			}
 			object {
-				name = databricks_table.mytable_2.id
+				name = databricks_sql_table.mytable_2.id
 				cdf_enabled = false
 				comment = "c"
 				data_object_type = "TABLE"

--- a/sharing/share_test.go
+++ b/sharing/share_test.go
@@ -31,9 +31,6 @@ const preTestTemplate = `
 		name = "bar"
 		table_type = "MANAGED"
 		warehouse_id = "{env.TEST_DEFAULT_WAREHOUSE_ID}"
-		properties = {
-			"delta.enableDeletionVectors" = "false"
-		}
 
 		column {
 			name = "id"
@@ -47,9 +44,6 @@ const preTestTemplate = `
 		name = "bar_2"
 		table_type = "MANAGED"
 		warehouse_id = "{env.TEST_DEFAULT_WAREHOUSE_ID}"
-		properties = {
-			"delta.enableDeletionVectors" = "false"
-		}
 
 		column {
 			name = "id"
@@ -82,12 +76,13 @@ func TestUcAccCreateShare(t *testing.T) {
 				name = databricks_sql_table.mytable.id
 				comment = "c"
 				data_object_type = "TABLE"
+				history_data_sharing_status = "ENABLED"
 			}
 			object {
 				name = databricks_sql_table.mytable_2.id
-				cdf_enabled = false
 				comment = "c"
 				data_object_type = "TABLE"
+				history_data_sharing_status = "ENABLED"
 			}
 		}
 
@@ -122,6 +117,7 @@ func shareTemplateWithOwner(comment string, owner string) string {
 				name = databricks_sql_table.mytable.id
 				comment = "%s"
 				data_object_type = "TABLE"
+				history_data_sharing_status = "ENABLED"
 			}
 		}`, owner, comment)
 }

--- a/sharing/share_test.go
+++ b/sharing/share_test.go
@@ -25,35 +25,35 @@ const preTestTemplate = `
 		}
 	}
 
-	resource "databricks_table" "mytable" {
+	resource "databricks_sql_table" "mytable" {
 		catalog_name = databricks_catalog.sandbox.id
 		schema_name = databricks_schema.things.name
 		name = "bar"
 		table_type = "MANAGED"
-		data_source_format = "DELTA"
+		warehouse_id = "{env.TEST_DEFAULT_WAREHOUSE_ID}"
+		properties = {
+			"delta.enableDeletionVectors" = "false"
+		}
 
 		column {
-			name      = "id"
-			position  = 0
-			type_name = "INT"
-			type_text = "int"
-			type_json = "{\"name\":\"id\",\"type\":\"integer\",\"nullable\":true,\"metadata\":{}}"
+			name = "id"
+			type = "int"
 		}
 	}
 
-	resource "databricks_table" "mytable_2" {
+	resource "databricks_sql_table" "mytable_2" {
 		catalog_name = databricks_catalog.sandbox.id
 		schema_name = databricks_schema.things.name
 		name = "bar_2"
 		table_type = "MANAGED"
-		data_source_format = "DELTA"
+		warehouse_id = "{env.TEST_DEFAULT_WAREHOUSE_ID}"
+		properties = {
+			"delta.enableDeletionVectors" = "false"
+		}
 
 		column {
-			name      = "id"
-			position  = 0
-			type_name = "INT"
-			type_text = "int"
-			type_json = "{\"name\":\"id\",\"type\":\"integer\",\"nullable\":true,\"metadata\":{}}"
+			name = "id"
+			type = "int"
 		}
 	}
 `
@@ -79,12 +79,12 @@ func TestUcAccCreateShare(t *testing.T) {
 			name  = "{var.STICKY_RANDOM}-terraform-delta-share"
 			owner = "account users"
 			object {
-				name = databricks_table.mytable.id
+				name = databricks_sql_table.mytable.id
 				comment = "c"
 				data_object_type = "TABLE"
 			}
 			object {
-				name = databricks_table.mytable_2.id
+				name = databricks_sql_table.mytable_2.id
 				cdf_enabled = false
 				comment = "c"
 				data_object_type = "TABLE"
@@ -119,7 +119,7 @@ func shareTemplateWithOwner(comment string, owner string) string {
 			name  = "{var.STICKY_RANDOM}-terraform-delta-share"
 			owner = "%s"
 			object {
-				name = databricks_table.mytable.id
+				name = databricks_sql_table.mytable.id
 				comment = "%s"
 				data_object_type = "TABLE"
 			}


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
Replace deprecated `databricks_table` with `databricks_sql_table` in sharing tests.

This PR migrates all share-related acceptance tests from the deprecated `databricks_table` resource to `databricks_sql_table to` resolve test failures caused by:

  1. Partition spec validation errors when sharing tables created with the deprecated resource
  2. Delta deletion vectors conflicts that prevent table sharing without full history
 
## Tests
<!--
How is this tested? Please see the checklist below and also describe any other relevant tests
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [x] covered with integration tests in `internal/acceptance`
- [x] using Go SDK
- [x] using TF Plugin Framework
- [x] has entry in `NEXT_CHANGELOG.md` file
