### PR TITLE
Fix regression with `databricks_group` data source introduced by a recent change

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -10,10 +10,14 @@
 
 ### Bug Fixes
 
+* Fix regression with `databricks_group` data source introduced by a recent change ([#4995](https://github.com/databricks/terraform-provider-databricks/pull/4995))
+
 ### Documentation
-* Document `continuous.task_retry_mode` in `databricks_job`  ([#4993](https://github.com/databricks/terraform-provider-databricks/pull/4993))
+
+* Document `continuous.task_retry_mode` in `databricks_job` ([#4993](https://github.com/databricks/terraform-provider-databricks/pull/4993))
 
 
 ### Exporter
 
 ### Internal Changes
+

--- a/scim/data_group.go
+++ b/scim/data_group.go
@@ -40,14 +40,20 @@ func DataSourceGroup() common.Resource {
 		Schema: s,
 		Read: func(ctx context.Context, d *schema.ResourceData, m *common.DatabricksClient) error {
 			var this entity
+			var group Group
+			var err error
 			common.DataToStructPointer(d, s, &this)
 			groupsAPI := NewGroupsAPI(ctx, m)
 			groupAttributes := "members,roles,entitlements,externalId"
-			group, err := groupsAPI.ReadByDisplayName(this.DisplayName, "id")
-			if err != nil {
-				return err
+			if m.DatabricksClient.Config.IsAccountClient() {
+				group, err = groupsAPI.ReadByDisplayName(this.DisplayName, "id")
+				if err != nil {
+					return err
+				}
+				group, err = groupsAPI.Read(group.ID, groupAttributes)
+			} else {
+				group, err = groupsAPI.ReadByDisplayName(this.DisplayName, groupAttributes)
 			}
-			group, err = groupsAPI.Read(group.ID, groupAttributes)
 			if err != nil {
 				return err
 			}

--- a/scim/data_group_test.go
+++ b/scim/data_group_test.go
@@ -18,50 +18,41 @@ func TestDataSourceGroup(t *testing.T) {
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   "GET",
-				Resource: `/api/2.0/preview/scim/v2/Groups?attributes=id&filter=displayName%20eq%20%22ds%22`,
+				Resource: `/api/2.0/preview/scim/v2/Groups?attributes=members%2Croles%2Centitlements%2CexternalId&filter=displayName%20eq%20%22ds%22`,
 				Response: GroupList{
 					Resources: []Group{
 						{
 							DisplayName: "ds",
 							ID:          "eerste",
-						},
-					},
-				},
-			},
-			{
-				Method:   "GET",
-				Resource: "/api/2.0/preview/scim/v2/Groups/eerste?attributes=members,roles,entitlements,externalId",
-
-				Response: Group{
-					DisplayName: "ds",
-					ID:          "eerste",
-					Entitlements: []ComplexValue{
-						{
-							Value: "allow-cluster-create",
-						},
-					},
-					Members: []ComplexValue{
-						{
-							Ref:   "Users/1112",
-							Value: "1112",
-						},
-						{
-							Ref:   "ServicePrincipals/1113",
-							Value: "1113",
-						},
-						{
-							Ref:   "Groups/1114",
-							Value: "1114",
-						},
-					},
-					Groups: []ComplexValue{
-						{
-							Value: "abc",
-						},
-					},
-					Roles: []ComplexValue{
-						{
-							Value: "a",
+							Entitlements: []ComplexValue{
+								{
+									Value: "allow-cluster-create",
+								},
+							},
+							Members: []ComplexValue{
+								{
+									Ref:   "Users/1112",
+									Value: "1112",
+								},
+								{
+									Ref:   "ServicePrincipals/1113",
+									Value: "1113",
+								},
+								{
+									Ref:   "Groups/1114",
+									Value: "1114",
+								},
+							},
+							Groups: []ComplexValue{
+								{
+									Value: "abc",
+								},
+							},
+							Roles: []ComplexValue{
+								{
+									Value: "a",
+								},
+							},
 						},
 					},
 				},
@@ -109,6 +100,82 @@ func TestDataSourceGroup(t *testing.T) {
 	assert.Equal(t, true, d.Get("allow_instance_pool_create"))
 	assert.Equal(t, true, d.Get("allow_cluster_create"))
 
+	assertContains(t, d.Get("users"), "1112")
+	assertContains(t, d.Get("service_principals"), "1113")
+	assertContains(t, d.Get("child_groups"), "1114")
+}
+
+func TestDataSourceGroupAccountClient(t *testing.T) {
+	d, err := qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "GET",
+				Resource: `/api/2.0/accounts/1234567890/scim/v2/Groups?attributes=id&filter=displayName%20eq%20%22ds%22`,
+				Response: GroupList{
+					Resources: []Group{
+						{
+							DisplayName: "ds",
+							ID:          "eerste",
+						},
+					},
+				},
+			},
+			{
+				Method:   "GET",
+				Resource: "/api/2.0/accounts/1234567890/scim/v2/Groups/eerste?attributes=members,roles,entitlements,externalId",
+				Response: Group{
+					DisplayName: "ds",
+					ID:          "eerste",
+					Members: []ComplexValue{
+						{
+							Ref:   "Users/1112",
+							Value: "1112",
+						},
+						{
+							Ref:   "ServicePrincipals/1113",
+							Value: "1113",
+						},
+						{
+							Ref:   "Groups/1114",
+							Value: "1114",
+						},
+					},
+					Groups: []ComplexValue{
+						{
+							Value: "abc",
+						},
+					},
+				},
+			},
+			{
+				Method:   "GET",
+				Resource: "/api/2.0/accounts/1234567890/scim/v2/Groups/abc?attributes=members,roles,entitlements,externalId",
+				Response: Group{
+					DisplayName: "product",
+					ID:          "abc",
+					Members: []ComplexValue{
+						{
+							Value: "1113",
+						},
+					},
+				},
+			},
+		},
+		Read:        true,
+		NonWritable: true,
+		Resource:    DataSourceGroup(),
+		AccountID:   "1234567890",
+		ID:          ".",
+		State: map[string]any{
+			"display_name": "ds",
+		},
+	}.Apply(t)
+	require.NoError(t, err)
+	assert.Equal(t, "eerste", d.Id())
+	assert.Equal(t, d.Get("acl_principal_id"), "groups/ds")
+	assertContains(t, d.Get("members"), "1112")
+	assertContains(t, d.Get("members"), "1113")
+	assertContains(t, d.Get("groups"), "abc")
 	assertContains(t, d.Get("users"), "1112")
 	assertContains(t, d.Get("service_principals"), "1113")
 	assertContains(t, d.Get("child_groups"), "1114")


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

It looks like some users are using the `databricks_group` data source as non-admin users (in some cases, incorrectly).  Recent change in SCIM API required to change from List to List for `id` + Get to retrieve group members, but it had an unexpected effect that Get for non-admin users throws an error as we request for `externalId` attribute.

I got clarification from the SCIM team that changes in the `members` retrieval are affecting only the account-level API, and not the workspace-level API.  So this PR reimplements the required changes as follows:

- on account level we do `List` for group ID by name, followed by `Get` to retrieve `members`, `externalId`, etc.
- on workspace level we use the old implementation of `List` + all attributes

Resolves #4994


## Tests
<!--
How is this tested? Please see the checklist below and also describe any other relevant tests
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] using Go SDK
- [ ] using TF Plugin Framework
- [x] has entry in `NEXT_CHANGELOG.md` file
