### PR TITLE
Add support for continuous.task_retry_mode in databricks_job

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -7,6 +7,8 @@
 ### New Features and Improvements
 
 * Document and handle additional Microsoft Teams options in `databricks_notification_destination` ([#4990](https://github.com/databricks/terraform-provider-databricks/pull/4990))
+* Added support for `continuous.task_retry_mode` in `databricks_job`  ([#4999](https://github.com/databricks/terraform-provider-databricks/pull/4999))
+
 
 ### Bug Fixes
 

--- a/jobs/resource_job.go
+++ b/jobs/resource_job.go
@@ -251,7 +251,8 @@ type JobCluster struct {
 }
 
 type ContinuousConf struct {
-	PauseStatus string `json:"pause_status,omitempty" tf:"default:UNPAUSED"`
+	PauseStatus   string `json:"pause_status,omitempty" tf:"default:UNPAUSED"`
+	TaskRetryMode string `json:"task_retry_mode,omitempty" tf:"default:NEVER"`
 }
 
 type JobRunAs struct {
@@ -566,6 +567,7 @@ func (JobSettingsResource) CustomizeSchema(s *common.CustomizableSchema) *common
 	s.SchemaPath("schedule", "pause_status").SetValidateFunc(validation.StringInSlice([]string{"PAUSED", "UNPAUSED"}, false))
 	s.SchemaPath("trigger", "pause_status").SetValidateFunc(validation.StringInSlice([]string{"PAUSED", "UNPAUSED"}, false))
 	s.SchemaPath("continuous", "pause_status").SetValidateFunc(validation.StringInSlice([]string{"PAUSED", "UNPAUSED"}, false))
+	s.SchemaPath("continuous", "task_retry_mode").SetValidateFunc(validation.StringInSlice([]string{"NEVER", "ON_FAILURE"}, false))
 	s.SchemaPath("max_concurrent_runs").SetDefault(1).SetValidateDiagFunc(validation.ToDiagFunc(validation.IntAtLeast(0)))
 
 	s.AddNewField("url", &schema.Schema{

--- a/jobs/resource_job_test.go
+++ b/jobs/resource_job_test.go
@@ -1543,7 +1543,8 @@ func TestResourceJobCreate_ControlRunState_ContinuousCreate(t *testing.T) {
 					MaxConcurrentRuns: 1,
 					Name:              "Test",
 					Continuous: &ContinuousConf{
-						PauseStatus: "UNPAUSED",
+						PauseStatus:   "UNPAUSED",
+						TaskRetryMode: "NEVER",
 					},
 				},
 				Response: Job{
@@ -1559,7 +1560,8 @@ func TestResourceJobCreate_ControlRunState_ContinuousCreate(t *testing.T) {
 						MaxConcurrentRuns: 1,
 						Name:              "Test",
 						Continuous: &ContinuousConf{
-							PauseStatus: "UNPAUSED",
+							PauseStatus:   "UNPAUSED",
+							TaskRetryMode: "NEVER",
 						},
 					},
 				},
@@ -1568,6 +1570,7 @@ func TestResourceJobCreate_ControlRunState_ContinuousCreate(t *testing.T) {
 		HCL: `
 		continuous {
 			pause_status = "UNPAUSED"
+			task_retry_mode = "NEVER"
 		}
 		control_run_state = true
 		max_concurrent_runs = 1


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
Added missing property to the continuous configuration block of the databricks_job resource and should resolve issue [#4998](https://github.com/databricks/terraform-provider-databricks/issues/4998).

## Tests
<!--
How is this tested? Please see the checklist below and also describe any other relevant tests
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] using Go SDK
- [ ] using TF Plugin Framework
- [x] has entry in `NEXT_CHANGELOG.md` file
