### PR TITLE
[Internal] Use Jobs.Get instead of JobsGetByJobId

### DIFF
--- a/jobs/job_test.go
+++ b/jobs/job_test.go
@@ -426,7 +426,9 @@ func TestAccPeriodicTrigger(t *testing.T) {
 			jobID, err := strconv.ParseInt(id, 10, 64)
 			assert.NoError(t, err)
 
-			res, err := w.Jobs.GetByJobId(ctx, jobID)
+			res, err := w.Jobs.Get(ctx, jobs.GetJobRequest{
+				JobId: jobID,
+			})
 			assert.NoError(t, err)
 
 			assert.Equal(t, jobs.PauseStatus("UNPAUSED"), res.Settings.Trigger.PauseStatus)

--- a/jobs/jobs_api_go_sdk.go
+++ b/jobs/jobs_api_go_sdk.go
@@ -309,7 +309,9 @@ func Update(jobID int64, js JobSettingsResource, w *databricks.WorkspaceClient, 
 }
 
 func Read(jobID int64, w *databricks.WorkspaceClient, ctx context.Context) (job *jobs.Job, err error) {
-	job, err = w.Jobs.GetByJobId(ctx, jobID)
+	job, err = w.Jobs.Get(ctx, jobs.GetJobRequest{
+		JobId: jobID,
+	})
 	err = wrapMissingJobError(err, fmt.Sprintf("%d", jobID))
 	if job.Settings != nil {
 		js := JobSettingsResource{JobSettings: *job.Settings}

--- a/jobs/resource_job_test.go
+++ b/jobs/resource_job_test.go
@@ -668,7 +668,9 @@ func TestResourceJobCreate_PowerBiTask(t *testing.T) {
 				Return(&jobs.CreateResponse{
 					JobId: 789,
 				}, nil)
-			e.GetByJobId(mock.Anything, int64(789)).Return(&jobs.Job{
+			e.Get(mock.Anything, jobs.GetJobRequest{
+				JobId: int64(789),
+			}).Return(&jobs.Job{
 				JobId: 789,
 				Settings: &jobs.JobSettings{
 					Name: "power_bi_task_name",

--- a/permissions/permission_definitions.go
+++ b/permissions/permission_definitions.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/databricks/databricks-sdk-go"
 	"github.com/databricks/databricks-sdk-go/service/iam"
+	"github.com/databricks/databricks-sdk-go/service/jobs"
 	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/databricks/terraform-provider-databricks/permissions/entity"
 	"github.com/databricks/terraform-provider-databricks/permissions/read"
@@ -408,7 +409,9 @@ func allResourcePermissions() []resourcePermissions {
 				if err != nil {
 					return "", err
 				}
-				job, err := w.Jobs.GetByJobId(ctx, jobId)
+				job, err := w.Jobs.Get(ctx, jobs.GetJobRequest{
+					JobId: jobId,
+				})
 				if err != nil {
 					return "", common.IgnoreNotFoundError(err)
 				}

--- a/permissions/permissions_test.go
+++ b/permissions/permissions_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/databricks/databricks-sdk-go"
 	"github.com/databricks/databricks-sdk-go/service/iam"
+	"github.com/databricks/databricks-sdk-go/service/jobs"
 	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/databricks/terraform-provider-databricks/internal/acceptance"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -321,7 +322,9 @@ func TestAccPermissions_Job(t *testing.T) {
 			assert.NoError(t, err)
 			idInt, err := strconv.Atoi(jobId)
 			assert.NoError(t, err)
-			job, err := w.Jobs.GetByJobId(context.Background(), int64(idInt))
+			job, err := w.Jobs.Get(context.Background(), jobs.GetJobRequest{
+				JobId: int64(idInt),
+			})
 			assert.NoError(t, err)
 			assertContainsPermission(t, permissions, currentPrincipalType(t), job.CreatorUserName, iam.PermissionLevelIsOwner)
 			return nil

--- a/permissions/resource_permissions_test.go
+++ b/permissions/resource_permissions_test.go
@@ -1373,7 +1373,9 @@ func TestResourcePermissionsUpdateTokensAlwaysThereForAdmins(t *testing.T) {
 
 func TestShouldKeepAdminsOnAnythingExceptPasswordsAndAssignsOwnerForJob(t *testing.T) {
 	qa.MockWorkspaceApply(t, func(mwc *mocks.MockWorkspaceClient) {
-		mwc.GetMockJobsAPI().EXPECT().GetByJobId(mock.Anything, int64(123)).Return(&jobs.Job{
+		mwc.GetMockJobsAPI().EXPECT().Get(mock.Anything, jobs.GetJobRequest{
+			JobId: int64(123),
+		}).Return(&jobs.Job{
 			CreatorUserName: "creator@example.com",
 		}, nil)
 		e := mwc.GetMockPermissionsAPI().EXPECT()
@@ -1445,7 +1447,9 @@ func TestShouldDeleteNonExistentJob(t *testing.T) {
 				},
 			},
 		}, nil)
-		mwc.GetMockJobsAPI().EXPECT().GetByJobId(mock.Anything, int64(123)).Return(nil, &apierr.APIError{
+		mwc.GetMockJobsAPI().EXPECT().Get(mock.Anything, jobs.GetJobRequest{
+			JobId: int64(123),
+		}).Return(nil, &apierr.APIError{
 			StatusCode: 400,
 			Message:    "Job 123 does not exist.",
 			ErrorCode:  "INVALID_PARAMETER_VALUE",


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

## Tests
<!--
How is this tested? Please see the checklist below and also describe any other relevant tests
-->

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] using Go SDK
- [ ] using TF Plugin Framework
- [ ] has entry in `NEXT_CHANGELOG.md` file
