### PR TITLE
[Doc] Add instructions for migration from deprecated `databricks_catalog_workspace_binding` to `databricks_workspace_binding`

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Documentation
 
 * Clarify the use of `workspace-consume` entitlement and access to Databricks One ([#5043](https://github.com/databricks/terraform-provider-databricks/pull/5043))
+* Add instructions for migration from deprecated `databricks_catalog_workspace_binding` to `databricks_workspace_binding` ([#5054](https://github.com/databricks/terraform-provider-databricks/pull/5054))
 
 ### Exporter
 


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

## Tests
<!--
How is this tested? Please see the checklist below and also describe any other relevant tests
-->

- [x] relevant change in `docs/` folder
- [x] has entry in `NEXT_CHANGELOG.md` file
