### PR TITLE
[Feature] Perform workspace-level permission assignment by `user_name`, `group_name`, or `service_principal_name`

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### New Features and Improvements
 
+* Perform workspace-level permission assignment by `user_name`, `group_name`, or `service_principal_name` ([#5068](https://github.com/databricks/terraform-provider-databricks/pull/5068)).
+
 ### Bug Fixes
 
 ### Documentation

--- a/access/resource_permission_assignment.go
+++ b/access/resource_permission_assignment.go
@@ -2,7 +2,9 @@ package access
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"strconv"
 
 	"github.com/databricks/databricks-sdk-go/apierr"
 	"github.com/databricks/terraform-provider-databricks/common"
@@ -22,9 +24,42 @@ type Permissions struct {
 	Permissions []string `json:"permissions"`
 }
 
-func (a PermissionAssignmentAPI) CreateOrUpdate(principalId int64, r Permissions) error {
-	path := fmt.Sprintf("/preview/permissionassignments/principals/%d", principalId)
-	return a.client.Put(a.context, path, r)
+func (a PermissionAssignmentAPI) CreateOrUpdate(assignment permissionAssignmentEntity) (principalInfo, error) {
+	if assignment.PrincipalId != 0 {
+		var resp permissionAssignmentResponseItem
+		path := fmt.Sprintf("/preview/permissionassignments/principals/%d", assignment.PrincipalId)
+		err := a.client.PutWithResponse(a.context, path, Permissions{Permissions: assignment.Permissions}, &resp)
+		if err != nil {
+			return principalInfo{}, err
+		}
+		return resp.Principal, nil
+	} else {
+		var principal permissionAssignmentResponse
+		path := "/preview/permissionassignments"
+		request := permissionAssignmentRequest{
+			PermissionAssignments: []permissionAssignmentRequestItem{
+				{
+					principalInfo: principalInfo{
+						ServicePrincipalName: assignment.ServicePrincipalName,
+						UserName:             assignment.UserName,
+						GroupName:            assignment.GroupName,
+					},
+					Permissions: assignment.Permissions,
+				},
+			},
+		}
+		err := a.client.Post(a.context, path, request, &principal)
+		if err != nil {
+			return principalInfo{}, err
+		}
+		if len(principal.PermissionAssignments) == 0 {
+			return principalInfo{}, fmt.Errorf("no permission assignment found")
+		}
+		if principal.PermissionAssignments[0].Error != "" {
+			return principalInfo{}, errors.New(principal.PermissionAssignments[0].Error)
+		}
+		return principal.PermissionAssignments[0].Principal, nil
+	}
 }
 
 func (a PermissionAssignmentAPI) Remove(principalId string) error {
@@ -32,29 +67,46 @@ func (a PermissionAssignmentAPI) Remove(principalId string) error {
 	return a.client.Delete(a.context, path, nil)
 }
 
-type Principal struct {
-	DisplayName          string `json:"display_name"`
-	PrincipalID          int64  `json:"principal_id"`
+type principalInfo struct {
+	DisplayName          string `json:"display_name,omitempty"`
+	PrincipalID          int64  `json:"principal_id,omitempty"`
 	ServicePrincipalName string `json:"service_principal_name,omitempty"`
 	UserName             string `json:"user_name,omitempty"`
 	GroupName            string `json:"group_name,omitempty"`
 }
 
-type PermissionAssignment struct {
+type permissionAssignmentRequestItem struct {
+	principalInfo
 	Permissions []string `json:"permissions"`
-	Principal   Principal
 }
 
-type PermissionAssignmentList struct {
-	PermissionAssignments []PermissionAssignment `json:"permission_assignments"`
+type permissionAssignmentRequest struct {
+	PermissionAssignments []permissionAssignmentRequestItem `json:"permission_assignments"`
 }
 
-func (l PermissionAssignmentList) ForPrincipal(principalId int64) (res Permissions, err error) {
+type permissionAssignmentResponseItem struct {
+	Permissions []string `json:"permissions"`
+	Principal   principalInfo
+	Error       string `json:"error,omitempty"`
+}
+
+type permissionAssignmentResponse struct {
+	PermissionAssignments []permissionAssignmentResponseItem `json:"permission_assignments"`
+}
+
+func (l permissionAssignmentResponse) ForPrincipal(principalId int64) (res permissionAssignmentEntity, err error) {
 	for _, v := range l.PermissionAssignments {
 		if v.Principal.PrincipalID != principalId {
 			continue
 		}
-		return Permissions{v.Permissions}, nil
+		return permissionAssignmentEntity{
+			PrincipalId:          v.Principal.PrincipalID,
+			ServicePrincipalName: v.Principal.ServicePrincipalName,
+			UserName:             v.Principal.UserName,
+			GroupName:            v.Principal.GroupName,
+			Permissions:          v.Permissions,
+			DisplayName:          v.Principal.DisplayName,
+		}, nil
 	}
 	return res, &apierr.APIError{
 		ErrorCode:  "NOT_FOUND",
@@ -63,31 +115,43 @@ func (l PermissionAssignmentList) ForPrincipal(principalId int64) (res Permissio
 	}
 }
 
-func (a PermissionAssignmentAPI) List() (list PermissionAssignmentList, err error) {
+func (a PermissionAssignmentAPI) List() (list permissionAssignmentResponse, err error) {
 	err = a.client.Get(a.context, "/preview/permissionassignments", nil, &list)
 	return
+}
+
+type permissionAssignmentEntity struct {
+	PrincipalId          int64    `json:"principal_id,omitempty" tf:"computed"`
+	ServicePrincipalName string   `json:"service_principal_name,omitempty" tf:"computed"`
+	UserName             string   `json:"user_name,omitempty" tf:"computed"`
+	GroupName            string   `json:"group_name,omitempty" tf:"computed"`
+	Permissions          []string `json:"permissions" tf:"slice_as_set"`
+	DisplayName          string   `json:"display_name,omitempty" tf:"computed"`
 }
 
 // ResourcePermissionAssignment performs of users to a workspace
 // from a workspace context, though it requires additional set
 // data resource for "workspace account scim", whicl will be added later.
 func ResourcePermissionAssignment() common.Resource {
-	type entity struct {
-		PrincipalId int64    `json:"principal_id"`
-		Permissions []string `json:"permissions" tf:"slice_as_set"`
-	}
-	s := common.StructToSchema(entity{}, common.NoCustomize)
+	s := common.StructToSchema(permissionAssignmentEntity{}, func(s map[string]*schema.Schema) map[string]*schema.Schema {
+		fields := []string{"principal_id", "service_principal_name", "user_name", "group_name"}
+		for _, field := range fields {
+			s[field].ExactlyOneOf = fields
+		}
+		common.CustomizeSchemaPath(s, "display_name").SetReadOnly().SetOptional()
+		return s
+	})
 	return common.Resource{
 		Schema: s,
 		Create: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
-			var assignment entity
+			var assignment permissionAssignmentEntity
 			common.DataToStructPointer(d, s, &assignment)
 			api := NewPermissionAssignmentAPI(ctx, c)
-			err := api.CreateOrUpdate(assignment.PrincipalId, Permissions{assignment.Permissions})
+			principal, err := api.CreateOrUpdate(assignment)
 			if err != nil {
 				return err
 			}
-			d.SetId(fmt.Sprintf("%d", assignment.PrincipalId))
+			d.SetId(strconv.FormatInt(principal.PrincipalID, 10))
 			return nil
 		},
 		Read: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
@@ -95,14 +159,10 @@ func ResourcePermissionAssignment() common.Resource {
 			if err != nil {
 				return err
 			}
-			data := entity{
-				PrincipalId: common.MustInt64(d.Id()),
-			}
-			permissions, err := list.ForPrincipal(data.PrincipalId)
+			data, err := list.ForPrincipal(common.MustInt64(d.Id()))
 			if err != nil {
 				return err
 			}
-			data.Permissions = permissions.Permissions
 			return common.StructToData(data, s, d)
 		},
 		Delete: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {

--- a/access/resource_permission_assignment_test.go
+++ b/access/resource_permission_assignment_test.go
@@ -15,15 +15,21 @@ func TestPermissionAssignmentCreate(t *testing.T) {
 				ExpectedRequest: Permissions{
 					Permissions: []string{"USER"},
 				},
+				Response: permissionAssignmentResponseItem{
+					Permissions: []string{"USER"},
+					Principal: principalInfo{
+						PrincipalID: 345,
+					},
+				},
 			},
 			{
 				Method:   "GET",
 				Resource: "/api/2.0/preview/permissionassignments",
-				Response: PermissionAssignmentList{
-					PermissionAssignments: []PermissionAssignment{
+				Response: permissionAssignmentResponse{
+					PermissionAssignments: []permissionAssignmentResponseItem{
 						{
 							Permissions: []string{"USER"},
-							Principal: Principal{
+							Principal: principalInfo{
 								PrincipalID: 345,
 							},
 						},
@@ -33,11 +39,212 @@ func TestPermissionAssignmentCreate(t *testing.T) {
 		},
 		Resource: ResourcePermissionAssignment(),
 		Create:   true,
+		New:      true,
 		HCL: `
 		principal_id = 345
 		permissions  = ["USER"]
 		`,
 	}.ApplyNoError(t)
+}
+
+func TestPermissionAssignmentCreateWithUserName(t *testing.T) {
+	qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "POST",
+				Resource: "/api/2.0/preview/permissionassignments",
+				ExpectedRequest: permissionAssignmentRequest{
+					PermissionAssignments: []permissionAssignmentRequestItem{
+						{
+							principalInfo: principalInfo{
+								UserName: "test.user@databricks.com",
+							},
+							Permissions: []string{"USER"},
+						},
+					},
+				},
+				Response: permissionAssignmentResponse{
+					PermissionAssignments: []permissionAssignmentResponseItem{
+						{
+							Permissions: []string{"USER"},
+							Principal: principalInfo{
+								PrincipalID: 123,
+								UserName:    "test.user@databricks.com",
+							},
+						},
+					},
+				},
+			},
+			{
+				Method:   "GET",
+				Resource: "/api/2.0/preview/permissionassignments",
+				Response: permissionAssignmentResponse{
+					PermissionAssignments: []permissionAssignmentResponseItem{
+						{
+							Permissions: []string{"USER"},
+							Principal: principalInfo{
+								PrincipalID: 123,
+								UserName:    "test.user@databricks.com",
+							},
+						},
+					},
+				},
+			},
+		},
+		Resource: ResourcePermissionAssignment(),
+		Create:   true,
+		New:      true,
+		HCL: `
+		user_name   = "test.user@databricks.com"
+		permissions = ["USER"]
+		`,
+	}.ApplyNoError(t)
+}
+
+func TestPermissionAssignmentCreateWithServicePrincipalName(t *testing.T) {
+	qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "POST",
+				Resource: "/api/2.0/preview/permissionassignments",
+				ExpectedRequest: permissionAssignmentRequest{
+					PermissionAssignments: []permissionAssignmentRequestItem{
+						{
+							principalInfo: principalInfo{
+								ServicePrincipalName: "spn-123",
+							},
+							Permissions: []string{"USER"},
+						},
+					},
+				},
+				Response: permissionAssignmentResponse{
+					PermissionAssignments: []permissionAssignmentResponseItem{
+						{
+							Permissions: []string{"USER"},
+							Principal: principalInfo{
+								PrincipalID:          456,
+								ServicePrincipalName: "spn-123",
+							},
+						},
+					},
+				},
+			},
+			{
+				Method:   "GET",
+				Resource: "/api/2.0/preview/permissionassignments",
+				Response: permissionAssignmentResponse{
+					PermissionAssignments: []permissionAssignmentResponseItem{
+						{
+							Permissions: []string{"USER"},
+							Principal: principalInfo{
+								PrincipalID:          456,
+								ServicePrincipalName: "spn-123",
+							},
+						},
+					},
+				},
+			},
+		},
+		Resource: ResourcePermissionAssignment(),
+		Create:   true,
+		New:      true,
+		HCL: `
+		service_principal_name = "spn-123"
+		permissions            = ["USER"]
+		`,
+	}.ApplyNoError(t)
+}
+
+func TestPermissionAssignmentCreateWithGroupName(t *testing.T) {
+	qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "POST",
+				Resource: "/api/2.0/preview/permissionassignments",
+				ExpectedRequest: permissionAssignmentRequest{
+					PermissionAssignments: []permissionAssignmentRequestItem{
+						{
+							principalInfo: principalInfo{
+								GroupName: "admins",
+							},
+							Permissions: []string{"USER"},
+						},
+					},
+				},
+				Response: permissionAssignmentResponse{
+					PermissionAssignments: []permissionAssignmentResponseItem{
+						{
+							Permissions: []string{"USER"},
+							Principal: principalInfo{
+								PrincipalID: 789,
+								GroupName:   "admins",
+							},
+						},
+					},
+				},
+			},
+			{
+				Method:   "GET",
+				Resource: "/api/2.0/preview/permissionassignments",
+				Response: permissionAssignmentResponse{
+					PermissionAssignments: []permissionAssignmentResponseItem{
+						{
+							Permissions: []string{"USER"},
+							Principal: principalInfo{
+								PrincipalID: 789,
+								GroupName:   "admins",
+							},
+						},
+					},
+				},
+			},
+		},
+		Resource: ResourcePermissionAssignment(),
+		Create:   true,
+		New:      true,
+		HCL: `
+		group_name  = "admins"
+		permissions = ["USER"]
+		`,
+	}.ApplyNoError(t)
+}
+
+func TestPermissionAssignmentCreateWithNonExistingGroup(t *testing.T) {
+	qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "POST",
+				Resource: "/api/2.0/preview/permissionassignments",
+				ExpectedRequest: permissionAssignmentRequest{
+					PermissionAssignments: []permissionAssignmentRequestItem{
+						{
+							principalInfo: principalInfo{
+								GroupName: "nonexistent-group",
+							},
+							Permissions: []string{"USER"},
+						},
+					},
+				},
+				Response: permissionAssignmentResponse{
+					PermissionAssignments: []permissionAssignmentResponseItem{
+						{
+							Principal: principalInfo{
+								GroupName: "nonexistent-group",
+							},
+							Error: "RESOURCE_DOES_NOT_EXIST: Principal not found in account.",
+						},
+					},
+				},
+			},
+		},
+		Resource: ResourcePermissionAssignment(),
+		Create:   true,
+		New:      true,
+		HCL: `
+		group_name  = "nonexistent-group"
+		permissions = ["USER"]
+		`,
+	}.ExpectError(t, "RESOURCE_DOES_NOT_EXIST: Principal not found in account.")
 }
 
 func TestPermissionAssignmentRead(t *testing.T) {
@@ -46,11 +253,11 @@ func TestPermissionAssignmentRead(t *testing.T) {
 			{
 				Method:   "GET",
 				Resource: "/api/2.0/preview/permissionassignments",
-				Response: PermissionAssignmentList{
-					PermissionAssignments: []PermissionAssignment{
+				Response: permissionAssignmentResponse{
+					PermissionAssignments: []permissionAssignmentResponseItem{
 						{
 							Permissions: []string{"USER"},
-							Principal: Principal{
+							Principal: principalInfo{
 								PrincipalID: 345,
 							},
 						},
@@ -74,11 +281,11 @@ func TestPermissionAssignmentReadNotFound(t *testing.T) {
 			{
 				Method:   "GET",
 				Resource: "/api/2.0/preview/permissionassignments",
-				Response: PermissionAssignmentList{
-					PermissionAssignments: []PermissionAssignment{
+				Response: permissionAssignmentResponse{
+					PermissionAssignments: []permissionAssignmentResponseItem{
 						{
 							Permissions: []string{"USER"},
-							Principal: Principal{
+							Principal: principalInfo{
 								PrincipalID: 345,
 							},
 						},

--- a/common/client.go
+++ b/common/client.go
@@ -269,6 +269,10 @@ func (c *DatabricksClient) Put(ctx context.Context, path string, request any) er
 	return c.Do(ctx, http.MethodPut, path, nil, nil, request, nil, c.addApiPrefix)
 }
 
+// Put on path
+func (c *DatabricksClient) PutWithResponse(ctx context.Context, path string, request any, response any) error {
+	return c.Do(ctx, http.MethodPut, path, nil, nil, request, response, c.addApiPrefix)
+}
 type ApiVersion string
 
 const (

--- a/docs/resources/permission_assignment.md
+++ b/docs/resources/permission_assignment.md
@@ -9,6 +9,8 @@ This resource is used to assign account-level users, service principals and grou
 
 ## Example Usage
 
+### Assign using `principal_id`
+
 In workspace context, adding account-level user to a workspace:
 
 ```hcl
@@ -68,12 +70,47 @@ output "databricks_group_id" {
 }
 ```
 
+### Assign using `user_name`, `group_name`, or `service_principal_name`
+
+In workspace context, adding account-level user to a workspace:
+
+```hcl
+resource "databricks_permission_assignment" "add_user" {
+  user_name   = "me@example.com"
+  permissions = ["USER"]
+  provider    = databricks.workspace
+}
+```
+
+In workspace context, adding account-level service principal to a workspace:
+
+```hcl
+resource "databricks_permission_assignment" "add_admin_spn" {
+  service_principal_name = "00000000-0000-0000-0000-000000000000"
+  permissions  = ["ADMIN"]
+  provider     = databricks.workspace
+}
+```
+
+In workspace context, adding account-level group to a workspace:
+
+```hcl
+resource "databricks_permission_assignment" "this" {
+  group_name  = "example-group"
+  permissions = ["USER"]
+  provider    = databricks.workspace
+}
+```
+
 ## Argument Reference
 
-The following arguments are required:
+The following arguments are supported (exactly one of `principal_id`, `user_name`, `group_name`, or `service_principal_name` is required):
 
 * `principal_id` - Databricks ID of the user, service principal, or group. The principal ID can be retrieved using the account-level SCIM API, or using [databricks_user](../data-sources/user.md), [databricks_service_principal](../data-sources/service_principal.md) or [databricks_group](../data-sources/group.md) data sources with account API (and has to be an account admin). A more sensible approach is to retrieve the list of `principal_id` as outputs from another Terraform stack.
-* `permissions` - The list of workspace permissions to assign to the principal:
+* `user_name` - the user name (email) to assign to a workspace.
+* `service_principal_name` - the application ID of service principal to assign to a workspace.
+* `group_name` - the group name to assign to a workspace.
+* `permissions` (Required) - The list of workspace permissions to assign to the principal:
   * `"USER"` - Adds principal to the workspace `users` group. This gives basic workspace access.
   * `"ADMIN"` - Adds principal to the workspace `admins` group. This gives workspace admin privileges to manage users and groups, workspace configurations, and more.
 
@@ -82,6 +119,7 @@ The following arguments are required:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - ID of the permission assignment - same as `principal_id`.
+* `display_name` - the display name of the assigned principal.
 
 ## Import
 


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

Use a previously not available API to perform permission assignment by user name, group name or SP application ID.  This solves a long-standing problem with the assignment of principals by workspace administrators who don't have access to account-level APIs.


## Tests
<!--
How is this tested? Please see the checklist below and also describe any other relevant tests
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] using Go SDK
- [ ] using TF Plugin Framework
- [x] has entry in `NEXT_CHANGELOG.md` file
