### PR TITLE
[Internal] Rewrite `databricks_job` data source to use Go SDK

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -17,3 +17,5 @@
 ### Exporter
 
 ### Internal Changes
+
+* Rewrite `databricks_job` data source to use Go SDK ([#5078](https://github.com/databricks/terraform-provider-databricks/pull/5078))

--- a/jobs/data_job.go
+++ b/jobs/data_job.go
@@ -3,22 +3,23 @@ package jobs
 import (
 	"context"
 	"fmt"
+	"strconv"
 
+	"github.com/databricks/databricks-sdk-go"
+	sdk_jobs "github.com/databricks/databricks-sdk-go/service/jobs"
 	"github.com/databricks/terraform-provider-databricks/common"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func DataSourceJob() common.Resource {
 	type queryableJobData struct {
-		Id      string `json:"id,omitempty" tf:"computed"`
-		JobId   string `json:"job_id,omitempty" tf:"computed"`
-		Name    string `json:"name,omitempty" tf:"computed"`
-		JobName string `json:"job_name,omitempty" tf:"computed"`
-		Job     *Job   `json:"job_settings,omitempty" tf:"computed"`
+		Id      string        `json:"id,omitempty" tf:"computed"`
+		JobId   string        `json:"job_id,omitempty" tf:"computed"`
+		Name    string        `json:"name,omitempty" tf:"computed"`
+		JobName string        `json:"job_name,omitempty" tf:"computed"`
+		Job     *sdk_jobs.Job `json:"job_settings,omitempty" tf:"computed"`
 	}
-	return common.DataResource(queryableJobData{}, func(ctx context.Context, e any, c *common.DatabricksClient) error {
-		data := e.(*queryableJobData)
-		jobsAPI := NewJobsAPI(ctx, c)
-		var list []Job
+	return common.WorkspaceDataWithCustomizeFunc(func(ctx context.Context, data *queryableJobData, w *databricks.WorkspaceClient) error {
 		var err error
 		if data.Id == "" {
 			data.Id = data.JobId
@@ -28,35 +29,52 @@ func DataSourceJob() common.Resource {
 		}
 		if data.Name != "" {
 			// if name is provided, need to list all jobs ny name
-			list, err = jobsAPI.ListByName(data.Name, true)
-		} else {
-			// otherwise, just read the job
-			var job Job
-			job, err = jobsAPI.Read(data.Id)
+			// find only job ID, then use `GetByJobId` to get the job with all fields
+			list, err := w.Jobs.ListAll(ctx, sdk_jobs.ListJobsRequest{ExpandTasks: false, Name: data.Name, Limit: 100})
 			if err != nil {
 				return err
 			}
-			data.Job = &job
-			data.Name = job.Settings.Name
+			found := false
+			for _, job := range list {
+				currentJob := job // De-referencing the temp variable used by the loop
+				currentJobName := currentJob.Settings.Name
+				jobIdString := strconv.FormatInt(currentJob.JobId, 10)
+				if currentJobName == data.Name || jobIdString == data.Id {
+					data.Name = currentJobName
+					data.Id = jobIdString
+					found = true
+					break // break the loop after we found the job
+				}
+			}
+			if !found {
+				return fmt.Errorf("no job found with specified name")
+			}
 		}
+		// read the job by ID
+		jobId, err := strconv.ParseInt(data.Id, 10, 64)
 		if err != nil {
 			return err
 		}
-		for _, job := range list {
-			currentJob := job // De-referencing the temp variable used by the loop
-			currentJobId := currentJob.ID()
-			currentJobName := currentJob.Settings.Name
-			if currentJobName == data.Name || currentJobId == data.Id {
-				data.Job = &currentJob
-				data.Name = currentJobName
-				data.Id = currentJobId
-				data.JobId = currentJobId
-				return nil // break the loop after we found the job
-			}
+		job, err := w.Jobs.Get(ctx, sdk_jobs.GetJobRequest{JobId: jobId})
+		if err != nil {
+			return err
 		}
+		data.Job = job
+		data.Name = job.Settings.Name
+		data.JobName = job.Settings.Name
+		data.JobId = data.Id
 		if data.Job == nil {
 			return fmt.Errorf("no job found with specified name")
 		}
+
 		return nil
+	}, func(s map[string]*schema.Schema) map[string]*schema.Schema {
+		// Customize the git_source schema to fix ConflictsWith paths
+		if gitSource, err := common.SchemaPath(s, "job_settings", "settings", "git_source"); err == nil {
+			if gitSourceResource, ok := gitSource.Elem.(*schema.Resource); ok {
+				gitSourceSchema(gitSourceResource.Schema, "job_settings.0.settings.0.")
+			}
+		}
+		return s
 	})
 }

--- a/jobs/data_job.go
+++ b/jobs/data_job.go
@@ -63,9 +63,6 @@ func DataSourceJob() common.Resource {
 		data.Name = job.Settings.Name
 		data.JobName = job.Settings.Name
 		data.JobId = data.Id
-		if data.Job == nil {
-			return fmt.Errorf("no job found with specified name")
-		}
 
 		return nil
 	}, func(s map[string]*schema.Schema) map[string]*schema.Schema {

--- a/jobs/data_job.go
+++ b/jobs/data_job.go
@@ -59,6 +59,19 @@ func DataSourceJob() common.Resource {
 		if err != nil {
 			return err
 		}
+		// Populate Job.Settings.RunAs from Job.RunAsUserName if not already set
+		if job != nil && job.Settings != nil && job.Settings.RunAs == nil && job.RunAsUserName != "" {
+			if common.StringIsUUID(job.RunAsUserName) {
+				job.Settings.RunAs = &sdk_jobs.JobRunAs{
+					ServicePrincipalName: job.RunAsUserName,
+				}
+			} else {
+				job.Settings.RunAs = &sdk_jobs.JobRunAs{
+					UserName: job.RunAsUserName,
+				}
+			}
+		}
+
 		data.Job = job
 		data.Name = job.Settings.Name
 		data.JobName = job.Settings.Name

--- a/jobs/data_job.go
+++ b/jobs/data_job.go
@@ -13,6 +13,8 @@ import (
 
 func DataSourceJob() common.Resource {
 	type queryableJobData struct {
+		common.Namespace
+
 		Id      string        `json:"id,omitempty" tf:"computed"`
 		JobId   string        `json:"job_id,omitempty" tf:"computed"`
 		Name    string        `json:"name,omitempty" tf:"computed"`

--- a/jobs/data_job_test.go
+++ b/jobs/data_job_test.go
@@ -22,8 +22,8 @@ func TestDataSourceQueryableJobMatchesId(t *testing.T) {
 		},
 		Resource:    DataSourceJob(),
 		Read:        true,
-		New:         true,
 		NonWritable: true,
+		New:         true,
 		HCL:         `job_id = "234"`,
 		ID:          "234",
 	}.ApplyAndExpectData(t, map[string]any{

--- a/jobs/resource_job.go
+++ b/jobs/resource_job.go
@@ -673,42 +673,6 @@ func (JobSettingsResource) MaxDepthForTypes() map[string]int {
 	return map[string]int{"jobs.ForEachTask": 1}
 }
 
-// List all jobs matching the name. If name is empty, returns all jobs
-func (a JobsAPI) ListByName(name string, expandTasks bool) ([]Job, error) {
-	jobs := []Job{}
-	params := map[string]interface{}{
-		"limit":        25,
-		"expand_tasks": expandTasks,
-	}
-	if name != "" {
-		params["name"] = name
-	}
-
-	nextPageToken := ""
-	ctx := context.WithValue(a.context, common.Api, common.API_2_1)
-	for {
-		var resp JobListResponse
-		if nextPageToken != "" {
-			params["page_token"] = nextPageToken
-		}
-		err := a.client.Get(ctx, "/jobs/list", params, &resp, a.client.AddWorkspaceIdHeader)
-		if err != nil {
-			return nil, err
-		}
-		jobs = append(jobs, resp.Jobs...)
-		if !resp.HasMore {
-			break
-		}
-		nextPageToken = resp.NextPageToken
-	}
-	return jobs, nil
-}
-
-// List all jobs
-func (a JobsAPI) List() (l []Job, err error) {
-	return a.ListByName("", false)
-}
-
 // RunsList returns a job runs list
 func (a JobsAPI) RunsList(r JobRunsListRequest) (jrl JobRunsList, err error) {
 	err = a.client.Get(a.context, "/jobs/runs/list", r, &jrl, a.client.AddWorkspaceIdHeader)
@@ -925,9 +889,9 @@ func jobSettingsSchema(s map[string]*schema.Schema, prefix string) {
 
 func gitSourceSchema(s map[string]*schema.Schema, prefix string) {
 	s["url"].ValidateFunc = validation.IsURLWithHTTPS
-	s["tag"].ConflictsWith = []string{"git_source.0.branch", "git_source.0.commit"}
-	s["branch"].ConflictsWith = []string{"git_source.0.commit", "git_source.0.tag"}
-	s["commit"].ConflictsWith = []string{"git_source.0.branch", "git_source.0.tag"}
+	s["tag"].ConflictsWith = []string{prefix + "git_source.0.branch", prefix + "git_source.0.commit"}
+	s["branch"].ConflictsWith = []string{prefix + "git_source.0.commit", prefix + "git_source.0.tag"}
+	s["commit"].ConflictsWith = []string{prefix + "git_source.0.branch", prefix + "git_source.0.tag"}
 }
 
 func fixWebhookNotifications(s map[string]*schema.Schema) {

--- a/jobs/resource_job_test.go
+++ b/jobs/resource_job_test.go
@@ -148,91 +148,26 @@ func TestResourceJobCreate(t *testing.T) {
 }
 
 func TestResourceJobCreate_MultiTask(t *testing.T) {
-	d, err := qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:   "POST",
-				Resource: "/api/2.2/jobs/create",
-				ExpectedRequest: JobSettings{
+	qa.ResourceFixture{
+		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
+			e := w.GetMockJobsAPI().EXPECT()
+			e.Create(mock.Anything, mock.MatchedBy(func(req jobs.CreateJob) bool {
+				return req.Name == "Featurizer" && len(req.Tasks) == 2
+			})).Return(&jobs.CreateResponse{
+				JobId: 789,
+			}, nil)
+			e.Get(mock.Anything, jobs.GetJobRequest{
+				JobId: 789,
+			}).Return(&jobs.Job{
+				JobId: 789,
+				Settings: &jobs.JobSettings{
 					Name: "Featurizer",
-					Tasks: []JobTaskSettings{
-						{
-							TaskKey:           "a",
-							ExistingClusterID: "abc",
-							Libraries: []compute.Library{
-								{
-									Jar: "dbfs://aa/bb/cc.jar",
-								},
-							},
-							SparkJarTask: &SparkJarTask{
-								MainClassName: "com.labs.BarMain",
-							},
-							Health: &JobHealth{
-								Rules: []JobHealthRule{
-									{
-										Metric:    "RUN_DURATION_SECONDS",
-										Operation: "GREATER_THAN",
-										Value:     50000000000, // 5 * 10^10
-									},
-								},
-							},
-						},
-						{
-							TaskKey: "b",
-							DependsOn: []jobs.TaskDependency{
-								{
-									TaskKey: "a",
-								},
-							},
-							RunIf: "ALL_DONE",
-							NewCluster: &clusters.Cluster{
-								SparkVersion: "a",
-								NodeTypeID:   "b",
-								NumWorkers:   1,
-								AzureAttributes: &clusters.AzureAttributes{
-									SpotBidMaxPrice: 0.99,
-								},
-							},
-							NotebookTask: &NotebookTask{
-								NotebookPath: "/Stuff",
-							},
-						},
-					},
-					Queue: &jobs.QueueSettings{
-						Enabled: false,
-					},
-					MaxConcurrentRuns: 1,
-					Health: &JobHealth{
-						Rules: []JobHealthRule{
-							{
-								Metric:    "RUN_DURATION_SECONDS",
-								Operation: "GREATER_THAN",
-								Value:     3600,
-							},
-						},
+					Tasks: []jobs.Task{
+						{TaskKey: "b"},
+						{TaskKey: "a"},
 					},
 				},
-				Response: Job{
-					JobID: 789,
-				},
-			},
-			{
-				Method:   "GET",
-				Resource: "/api/2.2/jobs/get?job_id=789",
-				Response: Job{
-					// good enough for mock
-					Settings: &JobSettings{
-						Tasks: []JobTaskSettings{
-							{
-								TaskKey: "b",
-							},
-							{
-								TaskKey: "a",
-							},
-						},
-					},
-				},
-			},
+			}, nil)
 		},
 		Create:   true,
 		Resource: ResourceJob(),
@@ -292,9 +227,10 @@ func TestResourceJobCreate_MultiTask(t *testing.T) {
 				notebook_path = "/Stuff"
 			}
 		}`,
-	}.Apply(t)
-	assert.NoError(t, err)
-	assert.Equal(t, "789", d.Id())
+	}.ApplyAndExpectData(t, map[string]any{
+		"id":   "789",
+		"name": "Featurizer",
+	})
 }
 
 func TestResourceJobCreate_DisabledTask(t *testing.T) {
@@ -400,108 +336,28 @@ func TestResourceJobCreate_DisabledTask(t *testing.T) {
 }
 
 func TestResourceJobCreate_TaskOrder(t *testing.T) {
-	d, err := qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:   "POST",
-				Resource: "/api/2.2/jobs/create",
-				ExpectedRequest: JobSettings{
+	qa.ResourceFixture{
+		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
+			e := w.GetMockJobsAPI().EXPECT()
+			e.Create(mock.Anything, mock.MatchedBy(func(req jobs.CreateJob) bool {
+				return req.Name == "Featurizer" && len(req.Tasks) == 4
+			})).Return(&jobs.CreateResponse{
+				JobId: 789,
+			}, nil)
+			e.Get(mock.Anything, jobs.GetJobRequest{
+				JobId: 789,
+			}).Return(&jobs.Job{
+				JobId: 789,
+				Settings: &jobs.JobSettings{
 					Name: "Featurizer",
-					Tasks: []JobTaskSettings{
-						{
-							TaskKey:           "a",
-							ExistingClusterID: "abc",
-							NotebookTask: &NotebookTask{
-								NotebookPath: "/a",
-							},
-						},
-						{
-							TaskKey: "b",
-							DependsOn: []jobs.TaskDependency{
-								{
-									TaskKey: "a",
-								},
-							},
-							ExistingClusterID: "abc",
-							NotebookTask: &NotebookTask{
-								NotebookPath: "/b",
-							},
-						},
-						{
-							TaskKey: "c",
-							DependsOn: []jobs.TaskDependency{
-								{
-									TaskKey: "a",
-								},
-								{
-									TaskKey: "b",
-								},
-							},
-							ExistingClusterID: "abc",
-							NotebookTask: &NotebookTask{
-								NotebookPath: "/c",
-							},
-						},
-						{
-							TaskKey: "d",
-							DependsOn: []jobs.TaskDependency{
-								{
-									TaskKey: "a",
-								},
-								{
-									TaskKey: "b",
-								},
-								{
-									TaskKey: "c",
-								},
-							},
-							ExistingClusterID: "abc",
-							NotebookTask: &NotebookTask{
-								NotebookPath: "/d",
-							},
-						},
-					},
-					Queue: &jobs.QueueSettings{
-						Enabled: false,
-					},
-					MaxConcurrentRuns: 1,
-					Health: &JobHealth{
-						Rules: []JobHealthRule{
-							{
-								Metric:    "RUN_DURATION_SECONDS",
-								Operation: "GREATER_THAN",
-								Value:     3600,
-							},
-						},
+					Tasks: []jobs.Task{
+						{TaskKey: "b"},
+						{TaskKey: "a"},
+						{TaskKey: "d"},
+						{TaskKey: "c"},
 					},
 				},
-				Response: Job{
-					JobID: 789,
-				},
-			},
-			{
-				Method:   "GET",
-				Resource: "/api/2.2/jobs/get?job_id=789",
-				Response: Job{
-					// good enough for mock
-					Settings: &JobSettings{
-						Tasks: []JobTaskSettings{
-							{
-								TaskKey: "b",
-							},
-							{
-								TaskKey: "a",
-							},
-							{
-								TaskKey: "d",
-							},
-							{
-								TaskKey: "c",
-							},
-						},
-					},
-				},
-			},
+			}, nil)
 		},
 		Create:   true,
 		Resource: ResourceJob(),
@@ -579,57 +435,39 @@ func TestResourceJobCreate_TaskOrder(t *testing.T) {
 				notebook_path = "/d"
 			}
 		}`,
-	}.Apply(t)
-	assert.NoError(t, err)
-	assert.Equal(t, "789", d.Id())
+	}.ApplyAndExpectData(t, map[string]any{
+		"id":   "789",
+		"name": "Featurizer",
+	})
 }
 
 func TestResourceJobCreate_ConditionTask(t *testing.T) {
-	d, err := qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:   "POST",
-				Resource: "/api/2.2/jobs/create",
-				ExpectedRequest: JobSettings{
+	qa.ResourceFixture{
+		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
+			e := w.GetMockJobsAPI().EXPECT()
+			e.Create(mock.Anything, mock.MatchedBy(func(req jobs.CreateJob) bool {
+				return req.Name == "ConditionTaskTesting" && len(req.Tasks) == 1
+			})).Return(&jobs.CreateResponse{
+				JobId: 231,
+			}, nil)
+			e.Get(mock.Anything, jobs.GetJobRequest{
+				JobId: 231,
+			}).Return(&jobs.Job{
+				JobId: 231,
+				Settings: &jobs.JobSettings{
 					Name: "ConditionTaskTesting",
-					Tasks: []JobTaskSettings{
+					Tasks: []jobs.Task{
 						{
 							TaskKey: "a",
 							ConditionTask: &jobs.ConditionTask{
 								Left:  "123",
-								Op:    "EQUAL_TO",
+								Op:    jobs.ConditionTaskOpEqualTo,
 								Right: "123",
 							},
 						},
 					},
-					Queue: &jobs.QueueSettings{
-						Enabled: false,
-					},
-					MaxConcurrentRuns: 1,
 				},
-				Response: Job{
-					JobID: 231,
-				},
-			},
-			{
-				Method:   "GET",
-				Resource: "/api/2.2/jobs/get?job_id=231",
-				Response: Job{
-					// good enough for mock
-					Settings: &JobSettings{
-						Tasks: []JobTaskSettings{
-							{
-								TaskKey: "a",
-								ConditionTask: &jobs.ConditionTask{
-									Left:  "123",
-									Op:    "EQUAL_TO",
-									Right: "123",
-								},
-							},
-						},
-					},
-				},
-			},
+			}, nil)
 		},
 		Create:   true,
 		Resource: ResourceJob(),
@@ -644,58 +482,32 @@ func TestResourceJobCreate_ConditionTask(t *testing.T) {
 				right = "123"
 			}
 		}`,
-	}.Apply(t)
-	assert.NoError(t, err)
-	assert.Equal(t, "231", d.Id())
+	}.ApplyAndExpectData(t, map[string]any{
+		"id":   "231",
+		"name": "ConditionTaskTesting",
+	})
 }
 
 func TestResourceJobCreate_ForEachTask(t *testing.T) {
-	d, err := qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:   "POST",
-				Resource: "/api/2.2/jobs/create",
-				ExpectedRequest: JobSettings{
+	qa.ResourceFixture{
+		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
+			e := w.GetMockJobsAPI().EXPECT()
+			e.Create(mock.Anything, mock.MatchedBy(func(req jobs.CreateJob) bool {
+				return req.Name == "Foreach-task-testing" && len(req.Tasks) == 1
+			})).Return(&jobs.CreateResponse{
+				JobId: 789,
+			}, nil)
+			e.Get(mock.Anything, jobs.GetJobRequest{
+				JobId: 789,
+			}).Return(&jobs.Job{
+				JobId: 789,
+				Settings: &jobs.JobSettings{
 					Name: "Foreach-task-testing",
-					Tasks: []JobTaskSettings{
-						{
-							TaskKey: "for_each_task_key",
-							ForEachTask: &ForEachTask{
-								Concurrency: 1,
-								Inputs:      "[1, 2, 3, 4, 5, 6]",
-								Task: ForEachNestedTask{
-									TaskKey:           "nested_task_key",
-									ExistingClusterID: "abc",
-									NotebookTask: &NotebookTask{
-										NotebookPath: "/Stuff",
-									},
-								},
-							},
-						},
-					},
-					Queue: &jobs.QueueSettings{
-						Enabled: false,
-					},
-					MaxConcurrentRuns: 1,
-				},
-				Response: Job{
-					JobID: 789,
-				},
-			},
-			{
-				Method:   "GET",
-				Resource: "/api/2.2/jobs/get?job_id=789",
-				Response: Job{
-					// good enough for mock
-					Settings: &JobSettings{
-						Tasks: []JobTaskSettings{
-							{
-								TaskKey: "for_each_task_key",
-							},
-						},
+					Tasks: []jobs.Task{
+						{TaskKey: "for_each_task_key"},
 					},
 				},
-			},
+			}, nil)
 		},
 		Create:   true,
 		Resource: ResourceJob(),
@@ -721,9 +533,10 @@ func TestResourceJobCreate_ForEachTask(t *testing.T) {
 				}
 			}
 		}`,
-	}.Apply(t)
-	assert.NoError(t, err)
-	assert.Equal(t, "789", d.Id())
+	}.ApplyAndExpectData(t, map[string]any{
+		"id":   "789",
+		"name": "Foreach-task-testing",
+	})
 }
 func TestResourceJobCreate_PowerBiTask(t *testing.T) {
 	d, err := qa.ResourceFixture{
@@ -845,67 +658,30 @@ func TestResourceJobCreate_PowerBiTask(t *testing.T) {
 	assert.Equal(t, "789", d.Id())
 }
 func TestResourceJobCreate_JobParameters(t *testing.T) {
-	d, err := qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:   "POST",
-				Resource: "/api/2.2/jobs/create",
-				ExpectedRequest: JobSettings{
+	qa.ResourceFixture{
+		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
+			e := w.GetMockJobsAPI().EXPECT()
+			e.Create(mock.Anything, mock.MatchedBy(func(req jobs.CreateJob) bool {
+				return req.Name == "JobParameterTesting" && len(req.Tasks) == 2 && len(req.Parameters) == 2
+			})).Return(&jobs.CreateResponse{
+				JobId: 231,
+			}, nil)
+			e.Get(mock.Anything, jobs.GetJobRequest{
+				JobId: 231,
+			}).Return(&jobs.Job{
+				JobId: 231,
+				Settings: &jobs.JobSettings{
 					Name: "JobParameterTesting",
-					Tasks: []JobTaskSettings{
-						{
-							TaskKey: "a",
-						},
-						{
-							TaskKey: "b",
-						},
+					Tasks: []jobs.Task{
+						{TaskKey: "a"},
+						{TaskKey: "b"},
 					},
-					Queue: &jobs.QueueSettings{
-						Enabled: false,
-					},
-					MaxConcurrentRuns: 1,
 					Parameters: []jobs.JobParameterDefinition{
-						{
-							Name:    "hello",
-							Default: "world",
-						},
-						{
-							Name:    "key",
-							Default: "value_default",
-						},
+						{Name: "hello", Default: "world"},
+						{Name: "key", Default: "value_default"},
 					},
 				},
-				Response: Job{
-					JobID: 231,
-				},
-			},
-			{
-				Method:   "GET",
-				Resource: "/api/2.2/jobs/get?job_id=231",
-				Response: Job{
-					// good enough for mock
-					Settings: &JobSettings{
-						Tasks: []JobTaskSettings{
-							{
-								TaskKey: "a",
-							},
-							{
-								TaskKey: "b",
-							},
-						},
-						Parameters: []jobs.JobParameterDefinition{
-							{
-								Name:    "hello",
-								Default: "world",
-							},
-							{
-								Name:    "key",
-								Default: "value_default",
-							},
-						},
-					},
-				},
-			},
+			}, nil)
 		},
 		Create:   true,
 		Resource: ResourceJob(),
@@ -928,59 +704,35 @@ func TestResourceJobCreate_JobParameters(t *testing.T) {
 		task {
 			task_key = "b"
 		}`,
-	}.Apply(t)
-	assert.NoError(t, err)
-	assert.Equal(t, "231", d.Id())
+	}.ApplyAndExpectData(t, map[string]any{
+		"id":   "231",
+		"name": "JobParameterTesting",
+	})
 }
 
 func TestResourceJobCreate_JobParameters_EmptyDefault(t *testing.T) {
-	d, err := qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:   "POST",
-				Resource: "/api/2.2/jobs/create",
-				ExpectedRequest: JobSettings{
-					Name:              "JobParameterTesting",
-					MaxConcurrentRuns: 1,
-					Tasks: []JobTaskSettings{
-						{
-							TaskKey: "a",
-						},
-					},
-					Queue: &jobs.QueueSettings{
-						Enabled: false,
+	qa.ResourceFixture{
+		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
+			e := w.GetMockJobsAPI().EXPECT()
+			e.Create(mock.Anything, mock.MatchedBy(func(req jobs.CreateJob) bool {
+				return req.Name == "JobParameterTesting" && len(req.Tasks) == 1 && len(req.Parameters) == 1
+			})).Return(&jobs.CreateResponse{
+				JobId: 231,
+			}, nil)
+			e.Get(mock.Anything, jobs.GetJobRequest{
+				JobId: 231,
+			}).Return(&jobs.Job{
+				JobId: 231,
+				Settings: &jobs.JobSettings{
+					Name: "JobParameterTesting",
+					Tasks: []jobs.Task{
+						{TaskKey: "a"},
 					},
 					Parameters: []jobs.JobParameterDefinition{
-						{
-							Name:    "key",
-							Default: "",
-						},
+						{Name: "key", Default: ""},
 					},
 				},
-				Response: Job{
-					JobID: 231,
-				},
-			},
-			{
-				Method:   "GET",
-				Resource: "/api/2.2/jobs/get?job_id=231",
-				Response: Job{
-					// good enough for mock
-					Settings: &JobSettings{
-						Tasks: []JobTaskSettings{
-							{
-								TaskKey: "a",
-							},
-						},
-						Parameters: []jobs.JobParameterDefinition{
-							{
-								Name:    "key",
-								Default: "",
-							},
-						},
-					},
-				},
-			},
+			}, nil)
 		},
 		Create:   true,
 		Resource: ResourceJob(),
@@ -995,9 +747,10 @@ func TestResourceJobCreate_JobParameters_EmptyDefault(t *testing.T) {
 		task {
 			task_key = "a"
 		}`,
-	}.Apply(t)
-	assert.NoError(t, err)
-	assert.Equal(t, "231", d.Id())
+	}.ApplyAndExpectData(t, map[string]any{
+		"id":   "231",
+		"name": "JobParameterTesting",
+	})
 }
 
 func TestResourceJobCreate_JobParameters_DefaultIsRequired(t *testing.T) {
@@ -1036,87 +789,26 @@ func TestResourceJobCreate_JobParameters_SingleTasksConflict(t *testing.T) {
 }
 
 func TestResourceJobCreate_JobClusters(t *testing.T) {
-	d, err := qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:   "POST",
-				Resource: "/api/2.2/jobs/create",
-				ExpectedRequest: JobSettings{
+	qa.ResourceFixture{
+		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
+			e := w.GetMockJobsAPI().EXPECT()
+			e.Create(mock.Anything, mock.MatchedBy(func(req jobs.CreateJob) bool {
+				return req.Name == "JobClustered" && len(req.Tasks) == 3 && len(req.JobClusters) == 2
+			})).Return(&jobs.CreateResponse{
+				JobId: 17,
+			}, nil)
+			e.Get(mock.Anything, jobs.GetJobRequest{
+				JobId: 17,
+			}).Return(&jobs.Job{
+				JobId: 17,
+				Settings: &jobs.JobSettings{
 					Name: "JobClustered",
-					Tasks: []JobTaskSettings{
-						{
-							TaskKey:       "a",
-							JobClusterKey: "j",
-						},
-						{
-							TaskKey: "b",
-							NewCluster: &clusters.Cluster{
-								SparkVersion: "a",
-								NodeTypeID:   "b",
-								NumWorkers:   3,
-							},
-							DependsOn: []jobs.TaskDependency{
-								{
-									TaskKey: "a",
-								},
-							},
-							NotebookTask: &NotebookTask{
-								NotebookPath: "/Stuff",
-							},
-						},
-						{
-							TaskKey: "c",
-							NewCluster: &clusters.Cluster{
-								SparkVersion: "d",
-								NodeTypeID:   "e",
-								NumWorkers:   0,
-							},
-						},
-					},
-					Queue: &jobs.QueueSettings{
-						Enabled: false,
-					},
-					MaxConcurrentRuns: 1,
-					JobClusters: []JobCluster{
-						{
-							JobClusterKey: "j",
-							NewCluster: &clusters.Cluster{
-								SparkVersion: "b",
-								NodeTypeID:   "c",
-								NumWorkers:   7,
-							},
-						},
-						{
-							JobClusterKey: "k",
-							NewCluster: &clusters.Cluster{
-								SparkVersion: "x",
-								NodeTypeID:   "y",
-								NumWorkers:   0,
-							},
-						},
+					Tasks: []jobs.Task{
+						{TaskKey: "b"},
+						{TaskKey: "a"},
 					},
 				},
-				Response: Job{
-					JobID: 17,
-				},
-			},
-			{
-				Method:   "GET",
-				Resource: "/api/2.2/jobs/get?job_id=17",
-				Response: Job{
-					// good enough for mock
-					Settings: &JobSettings{
-						Tasks: []JobTaskSettings{
-							{
-								TaskKey: "b",
-							},
-							{
-								TaskKey: "a",
-							},
-						},
-					},
-				},
-			},
+			}, nil)
 		},
 		Create:   true,
 		Resource: ResourceJob(),
@@ -1173,63 +865,32 @@ func TestResourceJobCreate_JobClusters(t *testing.T) {
 			}
 		}
 		`,
-	}.Apply(t)
-	assert.NoError(t, err)
-	assert.Equal(t, "17", d.Id())
+	}.ApplyAndExpectData(t, map[string]any{
+		"id":   "17",
+		"name": "JobClustered",
+	})
 }
 
 func TestResourceJobCreate_JobCompute(t *testing.T) {
-	d, err := qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:   "POST",
-				Resource: "/api/2.2/jobs/create",
-				ExpectedRequest: JobSettings{
+	qa.ResourceFixture{
+		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
+			e := w.GetMockJobsAPI().EXPECT()
+			e.Create(mock.Anything, mock.MatchedBy(func(req jobs.CreateJob) bool {
+				return req.Name == "JobEnvironments" && len(req.Tasks) == 1 && len(req.Environments) == 1
+			})).Return(&jobs.CreateResponse{
+				JobId: 18,
+			}, nil)
+			e.Get(mock.Anything, jobs.GetJobRequest{
+				JobId: 18,
+			}).Return(&jobs.Job{
+				JobId: 18,
+				Settings: &jobs.JobSettings{
 					Name: "JobEnvironments",
-					Tasks: []JobTaskSettings{
-						{
-							TaskKey:        "b",
-							EnvironmentKey: "j",
-							NotebookTask: &NotebookTask{
-								NotebookPath: "/Stuff",
-							},
-						},
-					},
-					Queue: &jobs.QueueSettings{
-						Enabled: false,
-					},
-					MaxConcurrentRuns: 1,
-					Environments: []jobs.JobEnvironment{
-						{
-							EnvironmentKey: "j",
-							Spec: &compute.Environment{
-								Client: "1",
-								Dependencies: []string{
-									"cowsay",
-									"-r /Workspace/Users/lisa@company.com/my.whl",
-								},
-							},
-						},
+					Tasks: []jobs.Task{
+						{TaskKey: "b"},
 					},
 				},
-				Response: Job{
-					JobID: 18,
-				},
-			},
-			{
-				Method:   "GET",
-				Resource: "/api/2.2/jobs/get?job_id=18",
-				Response: Job{
-					// good enough for mock
-					Settings: &JobSettings{
-						Tasks: []JobTaskSettings{
-							{
-								TaskKey: "b",
-							},
-						},
-					},
-				},
-			},
+			}, nil)
 		},
 		Create:   true,
 		Resource: ResourceJob(),
@@ -1249,23 +910,48 @@ func TestResourceJobCreate_JobCompute(t *testing.T) {
 				notebook_path = "/Stuff"
 			}
 		}`,
-	}.Apply(t)
-	assert.NoError(t, err)
-	assert.Equal(t, "18", d.Id())
+	}.ApplyAndExpectData(t, map[string]any{
+		"id":   "18",
+		"name": "JobEnvironments",
+	})
 }
 
 func TestResourceJobCreate_DashboardTask(t *testing.T) {
-	d, err := qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:   "POST",
-				Resource: "/api/2.2/jobs/create",
-				ExpectedRequest: jobs.CreateJob{
-					Name:              "DashboardTask",
-					MaxConcurrentRuns: 1,
-					Queue: &jobs.QueueSettings{
-						Enabled: false,
+	qa.ResourceFixture{
+		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
+			e := w.GetMockJobsAPI().EXPECT()
+			e.Create(mock.Anything, jobs.CreateJob{
+				Name:              "DashboardTask",
+				MaxConcurrentRuns: 1,
+				Queue: &jobs.QueueSettings{
+					Enabled: false,
+				},
+				Tasks: []jobs.Task{
+					{
+						TaskKey: "a",
+						DashboardTask: &jobs.DashboardTask{
+							Subscription: &jobs.Subscription{
+								Subscribers: []jobs.SubscriptionSubscriber{
+									{UserName: "user@domain.com"},
+									{DestinationId: "Test"},
+								},
+								Paused:        true,
+								CustomSubject: "\"custom subject\"",
+							},
+							WarehouseId: "\"dca3a0ba199040eb\"",
+							DashboardId: "3cf91a42-6217-4f3c-a6f0-345d489051b9",
+						},
 					},
+				},
+			}).Return(&jobs.CreateResponse{
+				JobId: 789,
+			}, nil)
+			e.Get(mock.Anything, jobs.GetJobRequest{
+				JobId: 789,
+			}).Return(&jobs.Job{
+				JobId: 789,
+				Settings: &jobs.JobSettings{
+					Name: "DashboardTask",
 					Tasks: []jobs.Task{
 						{
 							TaskKey: "a",
@@ -1284,37 +970,7 @@ func TestResourceJobCreate_DashboardTask(t *testing.T) {
 						},
 					},
 				},
-				Response: Job{
-					JobID: 789,
-				},
-			},
-			{
-				Method:   "GET",
-				Resource: "/api/2.2/jobs/get?job_id=789",
-				Response: jobs.Job{
-					JobId: 789,
-					Settings: &jobs.JobSettings{
-						Name: "DashboardTask",
-						Tasks: []jobs.Task{
-							{
-								TaskKey: "a",
-								DashboardTask: &jobs.DashboardTask{
-									Subscription: &jobs.Subscription{
-										Subscribers: []jobs.SubscriptionSubscriber{
-											{UserName: "user@domain.com"},
-											{DestinationId: "Test"},
-										},
-										Paused:        true,
-										CustomSubject: "\"custom subject\"",
-									},
-									WarehouseId: "\"dca3a0ba199040eb\"",
-									DashboardId: "3cf91a42-6217-4f3c-a6f0-345d489051b9",
-								},
-							},
-						},
-					},
-				},
-			},
+			}, nil)
 		},
 		Create:   true,
 		Resource: ResourceJob(),
@@ -1336,20 +992,62 @@ func TestResourceJobCreate_DashboardTask(t *testing.T) {
 			dashboard_id = "3cf91a42-6217-4f3c-a6f0-345d489051b9"
 		  }
 		}`,
-	}.Apply(t)
-	assert.NoError(t, err)
-	assert.Equal(t, "789", d.Id())
+	}.ApplyAndExpectData(t, map[string]any{
+		"id":   "789",
+		"name": "DashboardTask",
+	})
 }
 
 func TestResourceJobCreate_SqlSubscriptions(t *testing.T) {
-	d, err := qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:   "POST",
-				Resource: "/api/2.2/jobs/create",
-				ExpectedRequest: jobs.CreateJob{
-					Name:              "TF SQL task subscriptions",
-					MaxConcurrentRuns: 1,
+	qa.ResourceFixture{
+		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
+			e := w.GetMockJobsAPI().EXPECT()
+			e.Create(mock.Anything, jobs.CreateJob{
+				Name:              "TF SQL task subscriptions",
+				MaxConcurrentRuns: 1,
+				Tasks: []jobs.Task{
+					{
+						TaskKey: "a",
+						SqlTask: &jobs.SqlTask{
+							WarehouseId: "dca3a0ba199040eb",
+							Alert: &jobs.SqlTaskAlert{
+								AlertId: "3cf91a42-6217-4f3c-a6f0-345d489051b9",
+								Subscriptions: []jobs.SqlTaskSubscription{
+									{UserName: "user@domain.com"},
+									{DestinationId: "Test"},
+								},
+								PauseSubscriptions: true,
+							},
+						},
+					},
+					{
+						TaskKey: "d",
+						SqlTask: &jobs.SqlTask{
+							WarehouseId: "dca3a0ba199040eb",
+							Dashboard: &jobs.SqlTaskDashboard{
+								DashboardId:        "d81a7760-7fd2-443e-bf41-95a60c2f4c7c",
+								PauseSubscriptions: false,
+								Subscriptions: []jobs.SqlTaskSubscription{
+									{UserName: "user@domain.com"},
+									{DestinationId: "Test"},
+								},
+								CustomSubject: "test",
+							},
+						},
+					},
+				},
+				Queue: &jobs.QueueSettings{
+					Enabled: false,
+				},
+			}).Return(&jobs.CreateResponse{
+				JobId: 789,
+			}, nil)
+			e.Get(mock.Anything, jobs.GetJobRequest{
+				JobId: 789,
+			}).Return(&jobs.Job{
+				JobId: 789,
+				Settings: &jobs.JobSettings{
+					Name: "TF SQL task subscriptions",
 					Tasks: []jobs.Task{
 						{
 							TaskKey: "a",
@@ -1370,8 +1068,7 @@ func TestResourceJobCreate_SqlSubscriptions(t *testing.T) {
 							SqlTask: &jobs.SqlTask{
 								WarehouseId: "dca3a0ba199040eb",
 								Dashboard: &jobs.SqlTaskDashboard{
-									DashboardId:        "d81a7760-7fd2-443e-bf41-95a60c2f4c7c",
-									PauseSubscriptions: false,
+									DashboardId: "d81a7760-7fd2-443e-bf41-95a60c2f4c7c",
 									Subscriptions: []jobs.SqlTaskSubscription{
 										{UserName: "user@domain.com"},
 										{DestinationId: "Test"},
@@ -1381,54 +1078,8 @@ func TestResourceJobCreate_SqlSubscriptions(t *testing.T) {
 							},
 						},
 					},
-					Queue: &jobs.QueueSettings{
-						Enabled: false,
-					},
 				},
-				Response: Job{
-					JobID: 789,
-				},
-			},
-			{
-				Method:   "GET",
-				Resource: "/api/2.2/jobs/get?job_id=789",
-				Response: jobs.Job{
-					JobId: 789,
-					Settings: &jobs.JobSettings{
-						Name: "TF SQL task subscriptions",
-						Tasks: []jobs.Task{
-							{
-								TaskKey: "a",
-								SqlTask: &jobs.SqlTask{
-									WarehouseId: "dca3a0ba199040eb",
-									Alert: &jobs.SqlTaskAlert{
-										AlertId: "3cf91a42-6217-4f3c-a6f0-345d489051b9",
-										Subscriptions: []jobs.SqlTaskSubscription{
-											{UserName: "user@domain.com"},
-											{DestinationId: "Test"},
-										},
-										PauseSubscriptions: true,
-									},
-								},
-							},
-							{
-								TaskKey: "d",
-								SqlTask: &jobs.SqlTask{
-									WarehouseId: "dca3a0ba199040eb",
-									Dashboard: &jobs.SqlTaskDashboard{
-										DashboardId: "d81a7760-7fd2-443e-bf41-95a60c2f4c7c",
-										Subscriptions: []jobs.SqlTaskSubscription{
-											{UserName: "user@domain.com"},
-											{DestinationId: "Test"},
-										},
-										CustomSubject: "test",
-									},
-								},
-							},
-						},
-					},
-				},
-			},
+			}, nil)
 		},
 		Create:   true,
 		Resource: ResourceJob(),
@@ -1470,54 +1121,35 @@ func TestResourceJobCreate_SqlSubscriptions(t *testing.T) {
 			}
 		  }
 		}`,
-	}.Apply(t)
-	assert.NoError(t, err)
-	assert.Equal(t, "789", d.Id())
+	}.ApplyAndExpectData(t, map[string]any{
+		"id":   "789",
+		"name": "TF SQL task subscriptions",
+	})
 }
 
 func TestResourceJobCreate_RunJobTask(t *testing.T) {
-	d, err := qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:   "POST",
-				Resource: "/api/2.2/jobs/create",
-				ExpectedRequest: JobSettings{
-					Name:              "TF RunJobTask Main Job",
-					MaxConcurrentRuns: 1,
-					Tasks: []JobTaskSettings{
+	qa.ResourceFixture{
+		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
+			e := w.GetMockJobsAPI().EXPECT()
+			e.Create(mock.Anything, mock.MatchedBy(func(req jobs.CreateJob) bool {
+				return req.Name == "TF RunJobTask Main Job" && len(req.Tasks) == 1
+			})).Return(&jobs.CreateResponse{
+				JobId: 123,
+			}, nil)
+			e.Get(mock.Anything, jobs.GetJobRequest{
+				JobId: 123,
+			}).Return(&jobs.Job{
+				JobId: 123,
+				Settings: &jobs.JobSettings{
+					Name: "TF SQL task subscriptions",
+					Tasks: []jobs.Task{
 						{
-							TaskKey: "runJobTask",
-							RunJobTask: &RunJobTask{
-								JobID: 123,
-							},
-						},
-					},
-					Queue: &jobs.QueueSettings{
-						Enabled: false,
-					},
-				},
-				Response: Job{
-					JobID: 123,
-				},
-			},
-			{
-				Method:   "GET",
-				Resource: "/api/2.2/jobs/get?job_id=123",
-				Response: Job{
-					JobID: 123,
-					Settings: &JobSettings{
-						Name: "TF SQL task subscriptions",
-						Tasks: []JobTaskSettings{
-							{
-								TaskKey: "childJobTaskKey",
-								NotebookTask: &NotebookTask{
-									NotebookPath: "/Stuff",
-								},
-							},
+							TaskKey:      "childJobTaskKey",
+							NotebookTask: &jobs.NotebookTask{NotebookPath: "/Stuff"},
 						},
 					},
 				},
-			},
+			}, nil)
 		},
 		Create:   true,
 		Resource: ResourceJob(),
@@ -1530,9 +1162,10 @@ func TestResourceJobCreate_RunJobTask(t *testing.T) {
 				job_id = "123"
 		  }
 		}`,
-	}.Apply(t)
-	assert.NoError(t, err)
-	assert.Equal(t, "123", d.Id())
+	}.ApplyAndExpectData(t, map[string]any{
+		"id":   "123",
+		"name": "TF SQL task subscriptions",
+	})
 }
 
 func TestResourceJobCreate_AlwaysRunning(t *testing.T) {
@@ -2234,57 +1867,25 @@ func TestResourceJobCreateWithWebhooks(t *testing.T) {
 
 func TestResourceJobCreateFromGitSource(t *testing.T) {
 	qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:   "POST",
-				Resource: "/api/2.2/jobs/create",
-				ExpectedRequest: JobSettings{
-					Tasks: []JobTaskSettings{
-						{
-							TaskKey: "b",
-							NotebookTask: &NotebookTask{
-								NotebookPath: "/GitSourcedNotebook",
-							},
-						},
-					},
-					Queue: &jobs.QueueSettings{
-						Enabled: false,
-					},
+		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
+			e := w.GetMockJobsAPI().EXPECT()
+			e.Create(mock.Anything, mock.MatchedBy(func(req jobs.CreateJob) bool {
+				return req.Name == "GitSourceJob" && len(req.Tasks) == 1
+			})).Return(&jobs.CreateResponse{
+				JobId: 789,
+			}, nil)
+			e.Get(mock.Anything, jobs.GetJobRequest{
+				JobId: 789,
+			}).Return(&jobs.Job{
+				JobId: 789,
+				Settings: &jobs.JobSettings{
 					Name:              "GitSourceJob",
 					MaxConcurrentRuns: 1,
-					GitSource: &GitSource{
-						Url:      "https://github.com/databricks/terraform-provider-databricks",
-						Tag:      "0.4.8",
-						Provider: "gitHub",
-						JobSource: &jobs.JobSource{
-							JobConfigPath:       "a/b/c/databricks.yml",
-							ImportFromGitBranch: "main",
-							DirtyState:          "NOT_SYNCED",
-						},
+					Tasks: []jobs.Task{
+						{TaskKey: "b"},
 					},
 				},
-				Response: Job{
-					JobID: 789,
-				},
-			},
-			{
-				Method:   "GET",
-				Resource: "/api/2.2/jobs/get?job_id=789",
-				Response: Job{
-					JobID: 789,
-					Settings: &JobSettings{
-						// good enough for mock
-						ExistingClusterID: "abc",
-						Tasks: []JobTaskSettings{
-							{
-								TaskKey: "b",
-							},
-						},
-						Name:              "GitSourceJob",
-						MaxConcurrentRuns: 1,
-					},
-				},
-			},
+			}, nil)
 		},
 		Create:   true,
 		Resource: ResourceJob(),
@@ -2309,7 +1910,10 @@ func TestResourceJobCreateFromGitSource(t *testing.T) {
 				notebook_path = "/GitSourcedNotebook"
 			}
 		}`,
-	}.ApplyNoError(t)
+	}.ApplyAndExpectData(t, map[string]any{
+		"id":   "789",
+		"name": "GitSourceJob",
+	})
 }
 
 func resourceJobCreateFromGitSourceConflict(t *testing.T, conflictingArgs []string, gitSource string) {
@@ -2612,75 +2216,38 @@ func TestResourceJobUpdate(t *testing.T) {
 }
 
 func TestResourceJobUpdate_RunIfSuppressesDiffIfAllSuccess(t *testing.T) {
-	_, err := qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:   "POST",
-				Resource: "/api/2.2/jobs/reset",
-				ExpectedRequest: UpdateJobRequest{
-					JobID: 789,
-					NewSettings: &JobSettings{
-						MaxConcurrentRuns: 1,
-						Queue: &jobs.QueueSettings{
-							Enabled: false,
+	qa.ResourceFixture{
+		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
+			e := w.GetMockJobsAPI().EXPECT()
+			e.Reset(mock.Anything, mock.MatchedBy(func(req jobs.ResetJob) bool {
+				return req.JobId == 789 && req.NewSettings.Name == "My job" && len(req.NewSettings.Tasks) == 2
+			})).Return(nil)
+			e.Get(mock.Anything, jobs.GetJobRequest{
+				JobId: 789,
+			}).Return(&jobs.Job{
+				JobId: 789,
+				Settings: &jobs.JobSettings{
+					Name: "My job",
+					Tasks: []jobs.Task{
+						{
+							TaskKey:      "task1",
+							NotebookTask: &jobs.NotebookTask{NotebookPath: "/foo/bar"},
+							RunIf:        jobs.RunIfAllSuccess,
 						},
-						Tasks: []JobTaskSettings{
-							{
-								TaskKey: "task1",
-								NotebookTask: &NotebookTask{
-									NotebookPath: "/foo/bar",
-								},
-								// The diff is suppressed here. The API payload
-								// contains the "run_if" value from the terraform
-								// state.
-								RunIf: "ALL_SUCCESS",
-							},
-							{
-								TaskKey: "task2",
-								ForEachTask: &ForEachTask{
-									Inputs: "abc",
-									Task: ForEachNestedTask{
-										TaskKey:      "task3",
-										NotebookTask: &NotebookTask{NotebookPath: "/bar/foo"},
-										// The diff is suppressed here. Value is from
-										// the terraform state.
-										RunIf: "ALL_SUCCESS",
-									},
-								},
-							},
-						},
-						Name: "My job",
-					},
-				},
-			},
-			{
-				Method:   "GET",
-				Resource: "/api/2.2/jobs/get?job_id=789",
-				Response: Job{
-					JobID: 789,
-					Settings: &JobSettings{
-						Name: "My job",
-						Tasks: []JobTaskSettings{
-							{
-								TaskKey:      "task1",
-								NotebookTask: &NotebookTask{NotebookPath: "/foo/bar"},
-								RunIf:        "ALL_SUCCESS",
-							},
-							{
-								TaskKey: "task2",
-								ForEachTask: &ForEachTask{
-									Inputs: "abc",
-									Task: ForEachNestedTask{
-										TaskKey:      "task3",
-										NotebookTask: &NotebookTask{NotebookPath: "/bar/foo"},
-										RunIf:        "ALL_SUCCESS",
-									},
+						{
+							TaskKey: "task2",
+							ForEachTask: &jobs.ForEachTask{
+								Inputs: "abc",
+								Task: jobs.Task{
+									TaskKey:      "task3",
+									NotebookTask: &jobs.NotebookTask{NotebookPath: "/bar/foo"},
+									RunIf:        jobs.RunIfAllSuccess,
 								},
 							},
 						},
 					},
 				},
-			},
+			}, nil)
 		},
 		ID:       "789",
 		Update:   true,
@@ -2709,77 +2276,43 @@ func TestResourceJobUpdate_RunIfSuppressesDiffIfAllSuccess(t *testing.T) {
 				}
 			}
 		}`,
-	}.Apply(t)
-	assert.NoError(t, err)
+	}.ApplyAndExpectData(t, map[string]any{
+		"id":   "789",
+		"name": "My job",
+	})
 }
 
 func TestResourceJobUpdate_RunIfDoesNotSuppressIfNotAllSuccess(t *testing.T) {
-	_, err := qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:   "POST",
-				Resource: "/api/2.2/jobs/reset",
-				ExpectedRequest: UpdateJobRequest{
-					JobID: 789,
-					NewSettings: &JobSettings{
-						MaxConcurrentRuns: 1,
-						Tasks: []JobTaskSettings{
-							{
-								TaskKey: "task1",
-								NotebookTask: &NotebookTask{
-									NotebookPath: "/foo/bar",
-								},
-								// The diff is not suppressed here. Thus the API payload
-								// explicitly does not set run_if here, to unset it in the
-								// job definition.
-								// RunIf is not set, as implied from the HCL config.
-							},
-							{
-								TaskKey: "task2",
-								ForEachTask: &ForEachTask{
-									Inputs: "abc",
-									Task: ForEachNestedTask{
-										TaskKey:      "task3",
-										NotebookTask: &NotebookTask{NotebookPath: "/bar/foo"},
-										// The diff is not suppressed. RunIf is
-										// not set, as implied from the HCL config.
-									},
-								},
-							},
+	qa.ResourceFixture{
+		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
+			e := w.GetMockJobsAPI().EXPECT()
+			e.Reset(mock.Anything, mock.MatchedBy(func(req jobs.ResetJob) bool {
+				return req.JobId == 789 && req.NewSettings.Name == "My job" && len(req.NewSettings.Tasks) == 2
+			})).Return(nil)
+			e.Get(mock.Anything, jobs.GetJobRequest{
+				JobId: 789,
+			}).Return(&jobs.Job{
+				JobId: 789,
+				Settings: &jobs.JobSettings{
+					Name: "My job",
+					Tasks: []jobs.Task{
+						{
+							TaskKey:      "task1",
+							NotebookTask: &jobs.NotebookTask{NotebookPath: "/foo/bar"},
+							RunIf:        jobs.RunIfAtLeastOneFailed,
 						},
-						Name: "My job",
-						Queue: &jobs.QueueSettings{
-							Enabled: false,
-						},
-					},
-				},
-			},
-			{
-				Method:   "GET",
-				Resource: "/api/2.2/jobs/get?job_id=789",
-				Response: Job{
-					JobID: 789,
-					Settings: &JobSettings{
-						Name: "My job",
-						Tasks: []JobTaskSettings{
-							{
-								TaskKey:      "task1",
-								NotebookTask: &NotebookTask{NotebookPath: "/foo/bar"},
-								RunIf:        "AT_LEAST_ONE_FAILED",
-							},
-							{
-								TaskKey: "task2",
-								ForEachTask: &ForEachTask{
-									Task: ForEachNestedTask{
-										TaskKey: "task3",
-										RunIf:   "AT_LEAST_ONE_FAILED",
-									},
+						{
+							TaskKey: "task2",
+							ForEachTask: &jobs.ForEachTask{
+								Task: jobs.Task{
+									TaskKey: "task3",
+									RunIf:   jobs.RunIfAtLeastOneFailed,
 								},
 							},
 						},
 					},
 				},
-			},
+			}, nil)
 		},
 		ID:     "789",
 		Update: true,
@@ -2808,60 +2341,28 @@ func TestResourceJobUpdate_RunIfDoesNotSuppressIfNotAllSuccess(t *testing.T) {
 				}
 			}
 		}`,
-	}.Apply(t)
-	assert.NoError(t, err)
+	}.ApplyAndExpectData(t, map[string]any{
+		"id":   "789",
+		"name": "My job",
+	})
 }
 
 func TestResourceJobUpdate_NodeTypeToInstancePool(t *testing.T) {
-	d, err := qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:   "POST",
-				Resource: "/api/2.2/jobs/reset",
-				ExpectedRequest: jobs.ResetJob{
-					JobId: 789,
-					NewSettings: jobs.JobSettings{
-						JobClusters: []jobs.JobCluster{
-							{
-								JobClusterKey: "job_cluster_1",
-								NewCluster: compute.ClusterSpec{
-									InstancePoolId:       "instance-pool-worker-job",
-									DriverInstancePoolId: "instance-pool-driver-job",
-									SparkVersion:         "spark-3",
-									NumWorkers:           3,
-								},
-							},
-						},
-						Tasks: []jobs.Task{
-							{
-								TaskKey: "task1",
-								NewCluster: &compute.ClusterSpec{
-									InstancePoolId:       "instance-pool-worker-task",
-									DriverInstancePoolId: "instance-pool-driver-task",
-									SparkVersion:         "spark-2",
-									NumWorkers:           2,
-								},
-							},
-						},
-						Name:              "Featurizer New",
-						MaxConcurrentRuns: 1,
-						Queue: &jobs.QueueSettings{
-							Enabled: false,
-						},
-					},
+	qa.ResourceFixture{
+		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
+			e := w.GetMockJobsAPI().EXPECT()
+			e.Reset(mock.Anything, mock.MatchedBy(func(req jobs.ResetJob) bool {
+				return req.JobId == 789 && req.NewSettings.Name == "Featurizer New"
+			})).Return(nil)
+			e.Get(mock.Anything, jobs.GetJobRequest{
+				JobId: 789,
+			}).Return(&jobs.Job{
+				JobId: 789,
+				Settings: &jobs.JobSettings{
+					Name:              "Featurizer New",
+					MaxConcurrentRuns: 1,
 				},
-			},
-			{
-				Method:   "GET",
-				Resource: "/api/2.2/jobs/get?job_id=789",
-				Response: jobs.Job{
-					JobId: 789,
-					Settings: &jobs.JobSettings{
-						Name:              "Featurizer New",
-						MaxConcurrentRuns: 1,
-					},
-				},
-			},
+			}, nil)
 		},
 		ID:       "789",
 		Update:   true,
@@ -2893,60 +2394,28 @@ func TestResourceJobUpdate_NodeTypeToInstancePool(t *testing.T) {
 		}
 		max_concurrent_runs = 1
 		name = "Featurizer New"`,
-	}.Apply(t)
-	assert.NoError(t, err)
-	assert.Equal(t, "789", d.Id(), "Id should be the same as in reading")
-	assert.Equal(t, "Featurizer New", d.Get("name"))
+	}.ApplyAndExpectData(t, map[string]any{
+		"id":   "789",
+		"name": "Featurizer New",
+	})
 }
 
 func TestResourceJobUpdate_InstancePoolToNodeType(t *testing.T) {
-	d, err := qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:   "POST",
-				Resource: "/api/2.2/jobs/reset",
-				ExpectedRequest: jobs.UpdateJob{
-					JobId: 789,
-					NewSettings: &jobs.JobSettings{
-						Tasks: []jobs.Task{
-							{
-								TaskKey: "task1",
-								NewCluster: &compute.ClusterSpec{
-									NodeTypeId:   "node-type-id-2",
-									SparkVersion: "spark-2",
-									NumWorkers:   2,
-								},
-							},
-						},
-						JobClusters: []jobs.JobCluster{
-							{
-								JobClusterKey: "job_cluster_1",
-								NewCluster: compute.ClusterSpec{
-									NodeTypeId:   "node-type-id-3",
-									SparkVersion: "spark-3",
-									NumWorkers:   3,
-								},
-							},
-						},
-						Name:              "Featurizer New",
-						MaxConcurrentRuns: 1,
-						Queue: &jobs.QueueSettings{
-							Enabled: false,
-						},
-					},
+	qa.ResourceFixture{
+		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
+			e := w.GetMockJobsAPI().EXPECT()
+			e.Reset(mock.Anything, mock.MatchedBy(func(req jobs.ResetJob) bool {
+				return req.JobId == 789 && req.NewSettings.Name == "Featurizer New"
+			})).Return(nil)
+			e.Get(mock.Anything, jobs.GetJobRequest{
+				JobId: 789,
+			}).Return(&jobs.Job{
+				JobId: 789,
+				Settings: &jobs.JobSettings{
+					Name:              "Featurizer New",
+					MaxConcurrentRuns: 1,
 				},
-			},
-			{
-				Method:   "GET",
-				Resource: "/api/2.2/jobs/get?job_id=789",
-				Response: jobs.Job{
-					JobId: 789,
-					Settings: &jobs.JobSettings{
-						Name:              "Featurizer New",
-						MaxConcurrentRuns: 1,
-					},
-				},
-			},
+			}, nil)
 		},
 		ID:       "789",
 		Update:   true,
@@ -2978,10 +2447,10 @@ func TestResourceJobUpdate_InstancePoolToNodeType(t *testing.T) {
 		}
 		max_concurrent_runs = 1
 		name = "Featurizer New"`,
-	}.Apply(t)
-	assert.NoError(t, err)
-	assert.Equal(t, "789", d.Id(), "Id should be the same as in reading")
-	assert.Equal(t, "Featurizer New", d.Get("name"))
+	}.ApplyAndExpectData(t, map[string]any{
+		"id":   "789",
+		"name": "Featurizer New",
+	})
 }
 
 func TestResourceJobUpdate_Tasks(t *testing.T) {
@@ -3110,72 +2579,41 @@ func TestResourceJobUpdate_Restart(t *testing.T) {
 
 func TestResourceJobUpdate_ApplyPolicyDefaultValues_Default(t *testing.T) {
 	qa.ResourceFixture{
+		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
+			e := w.GetMockJobsAPI().EXPECT()
+			e.Reset(mock.Anything, mock.MatchedBy(func(req jobs.ResetJob) bool {
+				return req.JobId == 789 && req.NewSettings.Name == "Test Job" && len(req.NewSettings.Tasks) == 1
+			})).Return(nil)
+			e.Get(mock.Anything, jobs.GetJobRequest{
+				JobId: 789,
+			}).Return(&jobs.Job{
+				JobId: 789,
+				Settings: &jobs.JobSettings{
+					Name: "Test Job",
+					Tasks: []jobs.Task{
+						{
+							TaskKey:       "task_1",
+							JobClusterKey: "job_cluster_1",
+						},
+					},
+					JobClusters: []jobs.JobCluster{
+						{
+							JobClusterKey: "job_cluster_1",
+							NewCluster: compute.ClusterSpec{
+								ApplyPolicyDefaultValues: true,
+								GcpAttributes: &compute.GcpAttributes{
+									LocalSsdCount: 2,
+								},
+							},
+						},
+					},
+					MaxConcurrentRuns: 1,
+				},
+			}, nil)
+		},
 		Update:   true,
 		ID:       "789",
 		Resource: ResourceJob(),
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:   "POST",
-				Resource: "/api/2.2/jobs/reset",
-				ExpectedRequest: UpdateJobRequest{
-					JobID: 789,
-					NewSettings: &JobSettings{
-						Name: "Test Job",
-						Tasks: []JobTaskSettings{
-							{
-								TaskKey:       "task_1",
-								JobClusterKey: "job_cluster_1",
-							},
-						},
-						JobClusters: []JobCluster{
-							{
-								JobClusterKey: "job_cluster_1",
-								NewCluster: &clusters.Cluster{
-									ApplyPolicyDefaultValues: true,
-									GcpAttributes: &clusters.GcpAttributes{
-										LocalSsdCount: 2,
-									},
-								},
-							},
-						},
-						MaxConcurrentRuns: 1,
-						Queue: &jobs.QueueSettings{
-							Enabled: false,
-						},
-					},
-				},
-			},
-			{
-				Method:   "GET",
-				Resource: "/api/2.2/jobs/get?job_id=789",
-				Response: Job{
-					JobID: 789,
-					Settings: &JobSettings{
-						Name: "Test Job",
-						Tasks: []JobTaskSettings{
-							{
-								TaskKey:       "task_1",
-								JobClusterKey: "job_cluster_1",
-							},
-						},
-						JobClusters: []JobCluster{
-							{
-								JobClusterKey: "job_cluster_1",
-								NewCluster: &clusters.Cluster{
-									GcpAttributes: &clusters.GcpAttributes{
-										LocalSsdCount: 2,
-									},
-								},
-							},
-						},
-						MaxConcurrentRuns: 1,
-						Queue: &jobs.QueueSettings{
-							Enabled: false,
-						},
-					},
-				},
-			},
-		},
 		InstanceState: map[string]string{
 			"name": "Test Job",
 
@@ -3210,77 +2648,48 @@ func TestResourceJobUpdate_ApplyPolicyDefaultValues_Default(t *testing.T) {
 			}
 		}
 		`,
-	}.ApplyNoError(t)
+	}.ApplyAndExpectData(t, map[string]any{
+		"id":   "789",
+		"name": "Test Job",
+	})
 }
 
 func TestResourceJobUpdate_ApplyPolicyDefaultValues_AllowList_Empty(t *testing.T) {
 	qa.ResourceFixture{
+		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
+			e := w.GetMockJobsAPI().EXPECT()
+			e.Reset(mock.Anything, mock.MatchedBy(func(req jobs.ResetJob) bool {
+				return req.JobId == 789 && req.NewSettings.Name == "Test Job" && len(req.NewSettings.Tasks) == 1
+			})).Return(nil)
+			e.Get(mock.Anything, jobs.GetJobRequest{
+				JobId: 789,
+			}).Return(&jobs.Job{
+				JobId: 789,
+				Settings: &jobs.JobSettings{
+					Name: "Test Job",
+					Tasks: []jobs.Task{
+						{
+							TaskKey:       "task_1",
+							JobClusterKey: "job_cluster_1",
+						},
+					},
+					JobClusters: []jobs.JobCluster{
+						{
+							JobClusterKey: "job_cluster_1",
+							NewCluster: compute.ClusterSpec{
+								GcpAttributes: &compute.GcpAttributes{
+									LocalSsdCount: 2,
+								},
+							},
+						},
+					},
+					MaxConcurrentRuns: 1,
+				},
+			}, nil)
+		},
 		Update:   true,
 		ID:       "789",
 		Resource: ResourceJob(),
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:   "POST",
-				Resource: "/api/2.2/jobs/reset",
-				ExpectedRequest: UpdateJobRequest{
-					JobID: 789,
-					NewSettings: &JobSettings{
-						Name: "Test Job",
-						Tasks: []JobTaskSettings{
-							{
-								TaskKey:       "task_1",
-								JobClusterKey: "job_cluster_1",
-							},
-						},
-						JobClusters: []JobCluster{
-							{
-								JobClusterKey: "job_cluster_1",
-								NewCluster: &clusters.Cluster{
-									ApplyPolicyDefaultValues: true,
-									GcpAttributes: &clusters.GcpAttributes{
-										LocalSsdCount: 2,
-									},
-								},
-							},
-						},
-						MaxConcurrentRuns: 1,
-						Queue: &jobs.QueueSettings{
-							Enabled: false,
-						},
-					},
-				},
-			},
-			{
-				Method:   "GET",
-				Resource: "/api/2.2/jobs/get?job_id=789",
-				Response: Job{
-					JobID: 789,
-					Settings: &JobSettings{
-						Name: "Test Job",
-						Tasks: []JobTaskSettings{
-							{
-								TaskKey:       "task_1",
-								JobClusterKey: "job_cluster_1",
-							},
-						},
-						JobClusters: []JobCluster{
-							{
-								JobClusterKey: "job_cluster_1",
-								NewCluster: &clusters.Cluster{
-									GcpAttributes: &clusters.GcpAttributes{
-										LocalSsdCount: 2,
-									},
-								},
-							},
-						},
-						MaxConcurrentRuns: 1,
-						Queue: &jobs.QueueSettings{
-							Enabled: false,
-						},
-					},
-				},
-			},
-		},
 		InstanceState: map[string]string{
 			"name": "Test Job",
 
@@ -3306,84 +2715,55 @@ func TestResourceJobUpdate_ApplyPolicyDefaultValues_AllowList_Empty(t *testing.T
 			new_cluster {
 				apply_policy_default_values = true
 
-				// An empty allow list does NOT activate payload filtering.
-				__apply_policy_default_values_allow_list = []
-			}
+			// An empty allow list does NOT activate payload filtering.
+			__apply_policy_default_values_allow_list = []
 		}
-		`,
-	}.ApplyNoError(t)
+	}
+	`,
+	}.ApplyAndExpectData(t, map[string]any{
+		"id":   "789",
+		"name": "Test Job",
+	})
 }
 
 func TestResourceJobUpdate_ApplyPolicyDefaultValues_AllowList_GcpAttributes(t *testing.T) {
 	qa.ResourceFixture{
+		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
+			e := w.GetMockJobsAPI().EXPECT()
+			e.Reset(mock.Anything, mock.MatchedBy(func(req jobs.ResetJob) bool {
+				return req.JobId == 789 && req.NewSettings.Name == "Test Job" && len(req.NewSettings.Tasks) == 1
+			})).Return(nil)
+			e.Get(mock.Anything, jobs.GetJobRequest{
+				JobId: 789,
+			}).Return(&jobs.Job{
+				JobId: 789,
+				Settings: &jobs.JobSettings{
+					Name: "Test Job",
+					Tasks: []jobs.Task{
+						{
+							TaskKey:       "task_1",
+							JobClusterKey: "job_cluster_1",
+						},
+					},
+					JobClusters: []jobs.JobCluster{
+						{
+							JobClusterKey: "job_cluster_1",
+							NewCluster: compute.ClusterSpec{
+								GcpAttributes: &compute.GcpAttributes{
+									LocalSsdCount: 2,
+									Availability:  compute.GcpAvailabilityPreemptibleGcp,
+									ZoneId:        "us-central1-a",
+								},
+							},
+						},
+					},
+					MaxConcurrentRuns: 1,
+				},
+			}, nil)
+		},
 		Update:   true,
 		ID:       "789",
 		Resource: ResourceJob(),
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:   "POST",
-				Resource: "/api/2.2/jobs/reset",
-				ExpectedRequest: UpdateJobRequest{
-					JobID: 789,
-					NewSettings: &JobSettings{
-						Name: "Test Job",
-						Tasks: []JobTaskSettings{
-							{
-								TaskKey:       "task_1",
-								JobClusterKey: "job_cluster_1",
-							},
-						},
-						JobClusters: []JobCluster{
-							{
-								JobClusterKey: "job_cluster_1",
-								NewCluster: &clusters.Cluster{
-									ApplyPolicyDefaultValues: true,
-									GcpAttributes: &clusters.GcpAttributes{
-										LocalSsdCount: 2,
-									},
-								},
-							},
-						},
-						MaxConcurrentRuns: 1,
-						Queue: &jobs.QueueSettings{
-							Enabled: false,
-						},
-					},
-				},
-			},
-			{
-				Method:   "GET",
-				Resource: "/api/2.2/jobs/get?job_id=789",
-				Response: Job{
-					JobID: 789,
-					Settings: &JobSettings{
-						Name: "Test Job",
-						Tasks: []JobTaskSettings{
-							{
-								TaskKey:       "task_1",
-								JobClusterKey: "job_cluster_1",
-							},
-						},
-						JobClusters: []JobCluster{
-							{
-								JobClusterKey: "job_cluster_1",
-								NewCluster: &clusters.Cluster{
-									GcpAttributes: &clusters.GcpAttributes{
-										LocalSsdCount: 2,
-										Availability:  "SPOT",
-										ZoneId:        "us-central1-a",
-									},
-								},
-							},
-						},
-						MaxConcurrentRuns: 1,
-						Queue: &jobs.QueueSettings{
-							Enabled: false,
-						},
-					},
-				},
-			},
-		},
 		InstanceState: map[string]string{
 			"name": "Test Job",
 
@@ -3415,13 +2795,16 @@ func TestResourceJobUpdate_ApplyPolicyDefaultValues_AllowList_GcpAttributes(t *t
 					"gcp_attributes.local_ssd_count",
 				]
 
-				gcp_attributes {
-					local_ssd_count = 2
-				}
+			gcp_attributes {
+				local_ssd_count = 2
 			}
 		}
-		`,
-	}.ApplyNoError(t)
+	}
+	`,
+	}.ApplyAndExpectData(t, map[string]any{
+		"id":   "789",
+		"name": "Test Job",
+	})
 }
 
 func TestJobRestarts(t *testing.T) {
@@ -3602,14 +2985,10 @@ func TestJobRestarts(t *testing.T) {
 
 func TestResourceJobDelete(t *testing.T) {
 	d, err := qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:   "POST",
-				Resource: "/api/2.2/jobs/delete",
-				ExpectedRequest: map[string]int{
-					"job_id": 789,
-				},
-			},
+		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
+			w.GetMockJobsAPI().EXPECT().
+				DeleteByJobId(mock.Anything, int64(789)).
+				Return(nil)
 		},
 		ID:       "789",
 		Delete:   true,
@@ -3617,82 +2996,6 @@ func TestResourceJobDelete(t *testing.T) {
 	}.Apply(t)
 	assert.NoError(t, err)
 	assert.Equal(t, "789", d.Id())
-}
-
-func TestJobsAPIList(t *testing.T) {
-	qa.HTTPFixturesApply(t, []qa.HTTPFixture{
-		{
-			Method:   "GET",
-			Resource: "/api/2.1/jobs/list?expand_tasks=false&limit=25",
-			Response: JobListResponse{
-				Jobs: []Job{
-					{
-						JobID: 1,
-					},
-				},
-			},
-		},
-	}, func(ctx context.Context, client *common.DatabricksClient) {
-		a := NewJobsAPI(ctx, client)
-		l, err := a.List()
-		require.NoError(t, err)
-		assert.Len(t, l, 1)
-	})
-}
-
-func TestJobsAPIListMultiplePages(t *testing.T) {
-	qa.HTTPFixturesApply(t, []qa.HTTPFixture{
-		{
-			Method:   "GET",
-			Resource: "/api/2.1/jobs/list?expand_tasks=false&limit=25",
-			Response: JobListResponse{
-				Jobs: []Job{
-					{
-						JobID: 1,
-					},
-				},
-				HasMore:       true,
-				NextPageToken: "aaaa",
-			},
-		},
-		{
-			Method:   "GET",
-			Resource: "/api/2.1/jobs/list?expand_tasks=false&limit=25&page_token=aaaa",
-			Response: JobListResponse{
-				Jobs: []Job{
-					{
-						JobID: 2,
-					},
-				},
-			},
-		},
-	}, func(ctx context.Context, client *common.DatabricksClient) {
-		a := NewJobsAPI(ctx, client)
-		l, err := a.List()
-		require.NoError(t, err)
-		assert.Len(t, l, 2)
-	})
-}
-
-func TestJobsAPIListByName(t *testing.T) {
-	qa.HTTPFixturesApply(t, []qa.HTTPFixture{
-		{
-			Method:   "GET",
-			Resource: "/api/2.1/jobs/list?expand_tasks=false&limit=25&name=test",
-			Response: JobListResponse{
-				Jobs: []Job{
-					{
-						JobID: 1,
-					},
-				},
-			},
-		},
-	}, func(ctx context.Context, client *common.DatabricksClient) {
-		a := NewJobsAPI(ctx, client)
-		l, err := a.ListByName("test", false)
-		require.NoError(t, err)
-		assert.Len(t, l, 1)
-	})
 }
 
 func TestJobsAPIRunsList(t *testing.T) {


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

With this refactoring, we'll fix a problem that occurs when a job has more than 100 tasks - the current implementation does not handle it correctly. Additionally, it won't work in workspaces with a large number of jobs...

Additionally, I refactored job tests to use the Mock API instead of `HTTPFixture`. And started to remove unnecessary functions for legacy Jobs APIs.

## Tests
<!--
How is this tested? Please see the checklist below and also describe any other relevant tests
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] using Go SDK
- [ ] using TF Plugin Framework
- [x] has entry in `NEXT_CHANGELOG.md` file
