### PR TITLE
[Internal] Switch to use Go SDK struct in `databricks_schema` resource

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -17,3 +17,5 @@
 ### Exporter
 
 ### Internal Changes
+
+* Switch to use Go SDK struct in `databricks_schema` resource ([#5087](https://github.com/databricks/terraform-provider-databricks/pull/5087))

--- a/catalog/resource_schema.go
+++ b/catalog/resource_schema.go
@@ -10,28 +10,37 @@ import (
 )
 
 type SchemaInfo struct {
-	Name                         string            `json:"name" tf:"force_new"`
-	CatalogName                  string            `json:"catalog_name" tf:"force_new"`
-	StorageRoot                  string            `json:"storage_root,omitempty" tf:"force_new"`
-	Comment                      string            `json:"comment,omitempty"`
-	Properties                   map[string]string `json:"properties,omitempty"`
-	EnablePredictiveOptimization string            `json:"enable_predictive_optimization,omitempty" tf:"computed"`
-	Owner                        string            `json:"owner,omitempty" tf:"computed"`
-	MetastoreID                  string            `json:"metastore_id,omitempty" tf:"computed"`
-	FullName                     string            `json:"full_name,omitempty" tf:"computed"`
-	SchemaID                     string            `json:"schema_id" tf:"computed"`
+	catalog.SchemaInfo
 	common.Namespace
 }
 
 func ResourceSchema() common.Resource {
 	s := common.StructToSchema(SchemaInfo{},
 		func(s map[string]*schema.Schema) map[string]*schema.Schema {
-			delete(s, "full_name")
 			s["force_destroy"] = &schema.Schema{
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  false,
 			}
+
+			// Mark fields as force_new
+			for _, v := range []string{"name", "catalog_name", "storage_root"} {
+				common.CustomizeSchemaPath(s, v).SetForceNew()
+			}
+
+			// Mark optional and computed fields (user can set, but has default from backend)
+			for _, v := range []string{"metastore_id", "enable_predictive_optimization", "owner"} {
+				common.CustomizeSchemaPath(s, v).SetComputed()
+			}
+
+			// Set read-only fields (returned by backend, not settable by user)
+			// Note: SetReadOnly() implies SetComputed(), so no need to call both
+			for _, v := range []string{"schema_id", "browse_only", "catalog_type",
+				"created_at", "created_by", "storage_location", "updated_at", "updated_by",
+				"effective_predictive_optimization_flag", "full_name"} {
+				common.CustomizeSchemaPath(s, v).SetReadOnly()
+			}
+
 			common.CustomizeSchemaPath(s, "storage_root").SetCustomSuppressDiff(ucDirectoryPathSlashOnlySuppressDiff)
 			s["storage_root"].DiffSuppressFunc = ucDirectoryPathSlashOnlySuppressDiff
 			common.CustomizeSchemaPath(s, "name").SetCustomSuppressDiff(common.EqualFoldDiffSuppress)

--- a/catalog/resource_schema_test.go
+++ b/catalog/resource_schema_test.go
@@ -41,7 +41,11 @@ func TestCreateSchema(t *testing.T) {
 		catalog_name = "b"
 		comment = "c"
 		`,
-	}.ApplyNoError(t)
+	}.ApplyAndExpectData(t, map[string]any{
+		"comment":      "c",
+		"owner":        "testers",
+		"metastore_id": "d",
+	})
 }
 
 func TestCreateSchemaWithOwner(t *testing.T) {
@@ -83,7 +87,12 @@ func TestCreateSchemaWithOwner(t *testing.T) {
 		owner = "administrators"
 		enable_predictive_optimization = "ENABLE"
 		`,
-	}.ApplyNoError(t)
+	}.ApplyAndExpectData(t, map[string]any{
+		"comment":                        "c",
+		"owner":                          "administrators",
+		"metastore_id":                   "d",
+		"enable_predictive_optimization": "ENABLE",
+	})
 }
 
 func TestUpdateSchema(t *testing.T) {
@@ -132,7 +141,13 @@ func TestUpdateSchema(t *testing.T) {
 		comment = "d"
 		owner = "administrators"
 		`,
-	}.ApplyNoError(t)
+	}.ApplyAndExpectData(t, map[string]any{
+		"name":         "a",
+		"catalog_name": "b",
+		"comment":      "d",
+		"owner":        "administrators",
+		"metastore_id": "d",
+	})
 }
 
 func TestUpdateSchemaSetEmptyComment(t *testing.T) {
@@ -203,7 +218,13 @@ func TestUpdateSchemaChangeForceDestroy(t *testing.T) {
 		catalog_name = "b"
 		force_destroy = false
 		`,
-	}.ApplyNoError(t)
+	}.ApplyAndExpectData(t, map[string]any{
+		"name":          "a",
+		"catalog_name":  "b",
+		"metastore_id":  "d",
+		"owner":         "administrators",
+		"force_destroy": false,
+	})
 }
 
 func TestUpdateSchemaOwnerWithOtherFields(t *testing.T) {
@@ -249,7 +270,13 @@ func TestUpdateSchemaOwnerWithOtherFields(t *testing.T) {
 		comment = "d"
 		owner = "administrators"
 		`,
-	}.ApplyNoError(t)
+	}.ApplyAndExpectData(t, map[string]any{
+		"name":         "a",
+		"catalog_name": "b",
+		"comment":      "d",
+		"owner":        "administrators",
+		"metastore_id": "d",
+	})
 }
 
 func TestUpdateSchemaRollback(t *testing.T) {
@@ -382,7 +409,12 @@ func TestUpdateSchemaForceNew(t *testing.T) {
 		comment = "c"
 		owner = "administrators"
 		`,
-	}.ApplyNoError(t)
+	}.ApplyAndExpectData(t, map[string]any{
+		"name":         "a",
+		"metastore_id": "d",
+		"comment":      "c",
+		"owner":        "administrators",
+	})
 }
 
 func TestDeleteSchema(t *testing.T) {
@@ -399,7 +431,9 @@ func TestDeleteSchema(t *testing.T) {
 		comment = "c"
 		owner = "administrators"
 		`,
-	}.ApplyNoError(t)
+	}.ApplyAndExpectData(t, map[string]any{
+		"id": "b.a",
+	})
 }
 
 func TestForceDeleteSchema(t *testing.T) {
@@ -417,5 +451,7 @@ func TestForceDeleteSchema(t *testing.T) {
 		owner = "administrators"
 		force_destroy = true
 		`,
-	}.ApplyNoError(t)
+	}.ApplyAndExpectData(t, map[string]any{
+		"id": "b.a",
+	})
 }

--- a/docs/resources/schema.md
+++ b/docs/resources/schema.md
@@ -38,7 +38,10 @@ The following arguments are required:
 
 * `name` - Name of Schema relative to parent catalog. Change forces creation of a new resource.
 * `catalog_name` - Name of parent catalog. Change forces creation of a new resource.
-* `storage_root` - (Optional) Managed location of the schema. Location in cloud storage where data for managed tables will be stored.  If the URL contains special characters, such as space, `&`, etc., they should be percent-encoded (space -> `%20`, etc.). If not specified, the location will default to the catalog root location. Change forces creation of a new resource.
+
+The following arguments are optional:
+
+* `storage_root` - (Optional) Managed location of the schema. Location in cloud storage where data for managed tables will be stored. If the URL contains special characters, such as space, `&`, etc., they should be percent-encoded (space -> `%20`, etc.). If not specified, the location will default to the catalog root location. Change forces creation of a new resource.
 * `owner` - (Optional) Username/groupname/sp application_id of the schema owner.
 * `comment` - (Optional) User-supplied free-form text.
 * `properties` - (Optional) Extensible Schema properties.
@@ -52,7 +55,17 @@ The following arguments are required:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - ID of this schema in form of `<catalog_name>.<name>`.
+* `browse_only` - Whether the principal is limited to retrieving metadata for the schema through the BROWSE privilege.
+* `catalog_type` - The type of the parent catalog.
+* `created_at` - Time at which this schema was created, in epoch milliseconds.
+* `created_by` - Username of schema creator.
+* `effective_predictive_optimization_flag` - Detailed status of the effective predictive optimization flag for this schema.
+* `full_name` - the full name of the schema in form of `<catalog_name>.<name>`.
+* `metastore_id` - Unique identifier of parent metastore.
 * `schema_id` - The unique identifier of the schema.
+* `storage_location` - Storage location for managed tables within schema (read-only).
+* `updated_at` - Time at which this schema was last updated, in epoch milliseconds.
+* `updated_by` - Username of user who last modified schema.
 
 ## Import
 


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

Use the Go struct defined in Go SDK instead of manually defined in the TF source code.

## Tests
<!--
How is this tested? Please see the checklist below and also describe any other relevant tests
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [x] covered with integration tests in `internal/acceptance`
- [x] using Go SDK
- [ ] using TF Plugin Framework
- [x] has entry in `NEXT_CHANGELOG.md` file
