### PR TITLE
Fix spurious plan diffs in model serving resources due to tag reordering

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -11,6 +11,8 @@
 
 ### Bug Fixes
 
+* Fix spurious plan diffs in `databricks_model_serving` and `databricks_model_serving_provisioned_throughput` resources due to tag reordering ([#5120](https://github.com/databricks/terraform-provider-databricks/pull/5120))
+
 ### Documentation
 
 ### Exporter

--- a/serving/resource_model_serving.go
+++ b/serving/resource_model_serving.go
@@ -290,6 +290,9 @@ func ResourceModelServing() common.Resource {
 			// route_optimized cannot be updated.
 			common.CustomizeSchemaPath(m, "route_optimized").SetForceNew()
 
+			// Tags should have Set type
+			m["tags"].Type = schema.TypeSet
+
 			m["serving_endpoint_id"] = &schema.Schema{
 				Computed: true,
 				Type:     schema.TypeString,

--- a/serving/resource_model_serving_provisioned_throughput.go
+++ b/serving/resource_model_serving_provisioned_throughput.go
@@ -52,6 +52,9 @@ func ResourceModelServingProvisionedThroughput() common.Resource {
 			common.CustomizeSchemaPath(m, "ai_gateway", "guardrails", "input", "pii").SetOptional().SetComputed()
 			common.CustomizeSchemaPath(m, "ai_gateway", "guardrails", "input", "pii", "behavior").SetOptional().SetComputed()
 
+			// Tags should have Set type
+			m["tags"].Type = schema.TypeSet
+
 			m["serving_endpoint_id"] = &schema.Schema{
 				Computed: true,
 				Type:     schema.TypeString,


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

Fixes #5119

The Databricks API returns tags as an ordered list, which caused Terraform to show
spurious diffs when tags were returned in different orders, even though the key-value pairs
remained unchanged.  The fix is done by changing `tags` type to `TypeSet`, which is simpler
than the original implementation.

## Tests
<!--
How is this tested? Please see the checklist below and also describe any other relevant tests
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] using Go SDK
- [ ] using TF Plugin Framework
- [x] has entry in `NEXT_CHANGELOG.md` file
