### PR TITLE
[Doc] Make external location `file_event_queue` argument description clearer

### DIFF
--- a/docs/resources/external_location.md
+++ b/docs/resources/external_location.md
@@ -156,7 +156,7 @@ The `file_event_queue` block supports the following:
   - `managed_resource_id` - (Computed) The ID of the managed resource.
 - `managed_aqs` - (Optional) Configuration for managed Azure Queue Storage queue.
   - `managed_resource_id` - (Computed) The ID of the managed resource.
-  - `resource_group` - (Required) The Azure resource group.
+  - `resource_group` - (Required) The name of the Azure resource group.
   - `subscription_id` - (Required) The Azure subscription ID.
 - `managed_sqs` - (Optional) Configuration for managed Amazon SQS queue.
   - `managed_resource_id` - (Computed) The ID of the managed resource.


### PR DESCRIPTION
## Changes

Specify that the `resource_group` argument used to configure file events on a `databricks_external_location` resource should take the name of the resource group rather than the id. Being explicit here makes it a lot clearer in my opinion.

## Tests

Confirmed correct rendering at https://registry.terraform.io/tools/doc-preview

NO_CHANGELOG=true