### PR TITLE
[Internal] Skip scim user and group role tests as on non-Aws environments

### DIFF
--- a/aws/user_role_test.go
+++ b/aws/user_role_test.go
@@ -7,6 +7,9 @@ import (
 )
 
 func TestAccUserRole(t *testing.T) {
+	if !acceptance.IsAws(t) {
+		acceptance.Skipf(t)("TestAccUserRole is failing on non-AWS environments, likely due to read-after-write inconsistency.")
+	}
 	acceptance.WorkspaceLevel(t, acceptance.Step{
 		Template: `
 		resource "databricks_user" "this" {

--- a/scim/group_role_test.go
+++ b/scim/group_role_test.go
@@ -7,6 +7,9 @@ import (
 )
 
 func TestAccGroupRole(t *testing.T) {
+	if !acceptance.IsAws(t) {
+		acceptance.Skipf(t)("TestAccGroupRole is failing on non-AWS environments, likely due to read-after-write inconsistency.")
+	}
 	acceptance.WorkspaceLevel(t, acceptance.Step{
 		Template: `
 		resource "databricks_group" "this" {

--- a/test-config.yaml
+++ b/test-config.yaml
@@ -120,9 +120,3 @@ ignored_tests:
     - package: github.com/databricks/terraform-provider-databricks/secrets
       test_name: TestAccSecretAclResourceDefaultPrincipal
       comment: Failures due to 500s in secrets ACLs APIs.
-    - package: github.com/databricks/terraform-provider-databricks/scim
-      test_name: TestAccGroupRole
-      comment: Failures likely due to read-after-write inconsistency.
-    - package: github.com/databricks/terraform-provider-databricks/scim
-      test_name: TestAccUserRole
-      comment: Failures likely due to read-after-write inconsistency.


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
These tests started fail on Saturday (passed on Friday) with no change in resources for Azure and GCP environments. This could be an API issue, running these tests on AWS to unblock PRs to merge since the failure is happening on main branch.

## Tests
<!--
How is this tested? Please see the checklist below and also describe any other relevant tests
-->
CI is green
NO_CHANGELOG=true
