### PR TITLE
Document the `enabled` field of `data_classification_config` in `databricks_quality_monitor`

### DIFF
--- a/docs/resources/quality_monitor.md
+++ b/docs/resources/quality_monitor.md
@@ -99,6 +99,7 @@ table.
     * `output_data_type` - The output type of the custom metric.
     * `type` - The type of the custom metric.
 * `data_classification_config` - The data classification config for the monitor
+    * `enabled` - Whether to enable data classification
 * `inference_log` - Configuration for the inference log monitor
     * `granularities` -  List of granularities to use when aggregating data into time windows based on their timestamp.
     * `label_col` - Column of the model label


### PR DESCRIPTION
## Changes
The structure `data_classification_config` in `databricks_quality_monitor` is documented, but its fields are not. Currently it has only one field, `enabled`, which is a boolean. This PR adds documentation for this field. The comment is taken from the internal API specification.

## Tests
<!--
How is this tested? Please see the checklist below and also describe any other relevant tests
-->

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] using Go SDK
- [ ] using TF Plugin Framework
- [ ] has entry in `NEXT_CHANGELOG.md` file

NO_CHANGELOG=true