### PR TITLE
[Internal] Unified Terraform Provider: Add plan validations to check for correct `workspace_id` for plugin framework resources and data sources

### DIFF
--- a/internal/providers/pluginfw/products/sharing/resource_share_acc_test.go
+++ b/internal/providers/pluginfw/products/sharing/resource_share_acc_test.go
@@ -654,6 +654,35 @@ func TestAccShare_ProviderConfig_Mismatched(t *testing.T) {
 				`.*please check the workspace_id provided in ` +
 				`provider_config`,
 		),
+		PlanOnly: true,
+	})
+}
+
+func TestAccShare_ProviderConfig_MismatchedReapply(t *testing.T) {
+	acceptance.LoadUcwsEnv(t)
+	ctx := context.Background()
+	w := databricks.Must(databricks.NewWorkspaceClient())
+	workspaceID, err := w.CurrentWorkspaceID(ctx)
+	require.NoError(t, err)
+	workspaceIDStr := strconv.FormatInt(workspaceID, 10)
+	acceptance.UnityWorkspaceLevel(t, acceptance.Step{
+		Template: preTestTemplateSchema + shareTemplate(`
+			provider_config {
+				workspace_id = "123"
+			}
+		`),
+		ExpectError: regexp.MustCompile(
+			`(?s)failed to get workspace client.*workspace_id mismatch` +
+				`.*please check the workspace_id provided in ` +
+				`provider_config`,
+		),
+		PlanOnly: true,
+	}, acceptance.Step{
+		Template: preTestTemplateSchema + shareTemplate(fmt.Sprintf(`
+			provider_config {
+				workspace_id = "%s"
+			}
+		`, workspaceIDStr)),
 	})
 }
 


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
Validate that the provider is configured for the `workspace_id` specified in `provider_config` during plan phase.

## Tests
<!--
How is this tested? Please see the checklist below and also describe any other relevant tests
-->
Integration tests
NO_CHANGELOG=true
