### PR TITLE
[Internal] Unified Terraform Provider: BugFix for Notebook Data source

### DIFF
--- a/common/client.go
+++ b/common/client.go
@@ -85,10 +85,6 @@ type DatabricksClient struct {
 	// This is used by legacy SDKv2 resources and data sources not using Go SDK where
 	// a new client is created.
 	muLegacy sync.Mutex
-
-	// isDerivedClient is a flag to indicate if the client is
-	// This fails if the methods for getting
-	isDerivedClient bool
 }
 
 // GetWorkspaceClientForUnifiedProviderWithDiagnostics returns the Databricks


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
Newly generated DatabricksClient is only for resources / data sources not using Go SDK. This data source has some parts some are using Go SDK and some which don't. 

We would have proper fix to prevent this by adding a marker in the newly Generated DatabricksClient which would prevent usage of these clients by other methods. This would first need a change internally. Will create this in a separate PR. 

## Tests
<!--
How is this tested? Please see the checklist below and also describe any other relevant tests
-->
CI Tests
NO_CHANGELOG=true
