### PR TITLE
[Internal] Decouple library schema used in cluster resource with library resource

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -17,3 +17,4 @@
 * Initial support for resources implemented with plugin framework ([#5176](https://github.com/databricks/terraform-provider-databricks/pull/5176)).
 
 ### Internal Changes
+* Decouple library schema used in cluster resource with library resource ([]()).

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -17,4 +17,4 @@
 * Initial support for resources implemented with plugin framework ([#5176](https://github.com/databricks/terraform-provider-databricks/pull/5176)).
 
 ### Internal Changes
-* Decouple library schema used in cluster resource with library resource ([]()).
+* Decouple library schema used in cluster resource with library resource ([#5189](https://github.com/databricks/terraform-provider-databricks/pull/5189)).

--- a/clusters/resource_cluster.go
+++ b/clusters/resource_cluster.go
@@ -722,5 +722,5 @@ func resourceClusterDelete(ctx context.Context, d *schema.ResourceData, c *commo
 
 func init() {
 	common.RegisterResourceProvider(compute.ClusterSpec{}, ClusterSpec{})
-	common.RegisterResourceProvider(compute.Library{}, LibraryResource{})
+	common.RegisterResourceProvider(compute.Library{}, LibraryResourceWithoutNamespace{})
 }

--- a/clusters/resource_library.go
+++ b/clusters/resource_library.go
@@ -13,6 +13,23 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
+type LibraryResourceWithoutNamespace struct {
+	compute.Library
+}
+
+func (LibraryResourceWithoutNamespace) CustomizeSchemaResourceSpecific(s *common.CustomizableSchema) *common.CustomizableSchema {
+	s.AddNewField("cluster_id", &schema.Schema{
+		Type:     schema.TypeString,
+		Required: true,
+	})
+	return s
+}
+
+func (LibraryResourceWithoutNamespace) CustomizeSchema(s *common.CustomizableSchema) *common.CustomizableSchema {
+	s.SchemaPath("egg").SetDeprecated(EggDeprecationWarning)
+	return s
+}
+
 type LibraryResource struct {
 	compute.Library
 	common.Namespace


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
Cluster resource uses the schema used by library resource. Ref: https://github.com/databricks/terraform-provider-databricks/pull/3347
> Add resource provider registry to avoid redundant alias and customization definitions

This leads to provider_config being showed up under library for clusters. The PR decouples the schema used for library in cluster vs library resource.

## Tests
<!--
How is this tested? Please see the checklist below and also describe any other relevant tests
-->
TODO
