### PR TITLE
[Internal] Add Jsontypes and Timetypes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,8 @@ require (
 	github.com/hashicorp/hcl v1.0.0
 	github.com/hashicorp/hcl/v2 v2.24.0
 	github.com/hashicorp/terraform-plugin-framework v1.16.1
+        github.com/hashicorp/terraform-plugin-framework-jsontypes v0.2.0
+        github.com/hashicorp/terraform-plugin-framework-timetypes v0.5.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.19.0
 	github.com/hashicorp/terraform-plugin-go v0.29.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
Adds `terraform-plugin-framework-jsontypes` and `terraform-plugin-framework-timetypes` as a forward-fixing patch towards upcoming well-known types support.

## Tests
<!--
How is this tested? Please see the checklist below and also describe any other relevant tests
-->

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] using Go SDK
- [ ] using TF Plugin Framework
- [ ] has entry in `NEXT_CHANGELOG.md` file

NO_CHANGELOG=true