### PR TITLE
Fix catalog name update using NewName field

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -11,6 +11,8 @@
 
 ### Bug Fixes
 
+* Fix `databricks_catalog` name update using NewName field ([#5205](https://github.com/databricks/terraform-provider-databricks/pull/5205))
+
 ### Documentation
 
 ### Exporter

--- a/catalog/resource_catalog.go
+++ b/catalog/resource_catalog.go
@@ -136,10 +136,15 @@ func ResourceCatalog() common.Resource {
 			common.DataToStructPointer(d, catalogSchema, &updateCatalogRequest)
 			updateCatalogRequest.Name = d.Id()
 
+			if d.HasChange("name") {
+				updateCatalogRequest.NewName = d.Get("name").(string)
+			}
+
 			if d.HasChange("owner") {
 				_, err = w.Catalogs.Update(ctx, catalog.UpdateCatalog{
-					Name:  updateCatalogRequest.Name,
-					Owner: updateCatalogRequest.Owner,
+					Name:    updateCatalogRequest.Name,
+					NewName: updateCatalogRequest.NewName,
+					Owner:   updateCatalogRequest.Owner,
 				})
 				if err != nil {
 					return err
@@ -164,7 +169,6 @@ func ResourceCatalog() common.Resource {
 				}
 			}
 			ci, err := w.Catalogs.Update(ctx, updateCatalogRequest)
-
 			if err != nil {
 				if d.HasChange("owner") {
 					// Rollback


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

The catalog Update operation was using the Name field to identify the catalog to be updated, but when the catalog name should be changed, it looks like the API requires using the NewName field instead. This fixes the bug where attempting to rename a catalog would silently fail because the old name was always used.

Also adds a unit test (TestUpdateCatalogName) that reproduces and verifies the fix for this issue.

## Tests
<!--
How is this tested? Please see the checklist below and also describe any other relevant tests
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] using Go SDK
- [ ] using TF Plugin Framework
- [ ] has entry in `NEXT_CHANGELOG.md` file
