### PR TITLE
Remove liquid as a compute type

### DIFF
--- a/docs/resources/app.md
+++ b/docs/resources/app.md
@@ -47,7 +47,7 @@ The following arguments are required:
 * `budget_policy_id` - (Optional) The Budget Policy ID set for this resource.
 * `resources` - (Optional) A list of resources that the app have access to.
 * `user_api_scopes` - (Optional) A list of api scopes granted to the user access token.
-* `compute_size` - (Optional) A string specifying compute size for the App. Possible values are `MEDIUM`, `LARGE`, `LIQUID`.
+* `compute_size` - (Optional) A string specifying compute size for the App. Possible values are `MEDIUM`, `LARGE`.
 
 ### resources Configuration Attribute
 


### PR DESCRIPTION
## Changes
Removed `LIQUID` as a possible value for the `compute_size` parameter in the `databricks_app` resource documentation since its under development. The valid compute sizes are now `MEDIUM` and `LARGE`.

## Tests
<!--
How is this tested? Please see the checklist below and also describe any other relevant tests
-->

- [ ] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] using Go SDK
- [ ] using TF Plugin Framework
- [ ] has entry in `NEXT_CHANGELOG.md` file

NO_CHANGELOG=true
