### PR TITLE
[Fix] Move Spark Version selector defaults to Terraform

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Bug Fixes
 
 * Fix spurious plan diffs in `databricks_model_serving` and `databricks_model_serving_provisioned_throughput` resources due to tag reordering ([#5120](https://github.com/databricks/terraform-provider-databricks/pull/5120))
+* Move Spark Version selector defaults to Terraform ([#5219](https://github.com/databricks/terraform-provider-databricks/pull/5219)).
 
 ### Documentation
 

--- a/clusters/data_spark_version.go
+++ b/clusters/data_spark_version.go
@@ -27,6 +27,9 @@ func DataSourceSparkVersion() common.Resource {
 	}, func(s map[string]*schema.Schema) map[string]*schema.Schema {
 		common.CustomizeSchemaPath(s, "photon").SetDeprecated("Specify runtime_engine=\"PHOTON\" in the cluster configuration")
 		common.CustomizeSchemaPath(s, "graviton").SetDeprecated("Not required anymore - it's automatically enabled on the Graviton-based node types")
+		common.CustomizeSchemaPath(s, "scala").SetDefault("2.12")
+		common.CustomizeSchemaPath(s, "latest").SetDefault(true)
+
 		common.NamespaceCustomizeSchemaMap(s)
 		return s
 	})


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

Move defaults for `databricks_spark_version` data source from Go SDK to the Terraform. First part of #5218 work - after new Go SDK is merged, we'll need to change Scala default to `2.1`.

Related to https://github.com/databricks/databricks-sdk-go/pull/1331

## Tests
<!--
How is this tested? Please see the checklist below and also describe any other relevant tests
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [x] covered with integration tests in `internal/acceptance`
- [x] using Go SDK
- [x] using TF Plugin Framework
- [x] has entry in `NEXT_CHANGELOG.md` file
