### PR TITLE
[Internal] Mark two more DBFS/Legacy settings as flacky

### DIFF
--- a/test-config.yaml
+++ b/test-config.yaml
@@ -127,5 +127,11 @@ ignored_tests:
       test_name: TestAccSecretAclResourceDefaultPrincipal
       comment: Failures due to 500s in secrets ACLs APIs.
     - package: github.com/databricks/terraform-provider-databricks/settings
+      test_name: TestAccDisableLegacyAccessSetting
+      comment: These settings were moved to Settings v2 platform and now flacky
+    - package: github.com/databricks/terraform-provider-databricks/settings
+      test_name: TestAccDisableLegacyDbfsSetting
+      comment: These settings were moved to Settings v2 platform and now flacky
+    - package: github.com/databricks/terraform-provider-databricks/settings
       test_name: TestMwsAccDisableLegacyFeaturesSetting
       comment: These settings were moved to Settings v2 platform and now flacky


### PR DESCRIPTION
NO_CHANGELOG=true

## Changes
<!-- Summary of your changes that are easy to understand -->

## Tests
<!--
How is this tested? Please see the checklist below and also describe any other relevant tests
-->

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] using Go SDK
- [ ] using TF Plugin Framework
- [ ] has entry in `NEXT_CHANGELOG.md` file
