### PR TITLE
[Internal] Migrate to Checks API for integration tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -20,14 +20,14 @@ jobs:
     outputs:
       has_token: ${{ steps.set-token-status.outputs.has_token }}
     steps:
-      - name: Check if DECO_WORKFLOW_TRIGGER_APP_ID is set
+      - name: Check if required secrets are set
         id: set-token-status
         run: |
-            if [ -z "${{ secrets.DECO_WORKFLOW_TRIGGER_APP_ID }}" ]; then
-              echo "DECO_WORKFLOW_TRIGGER_APP_ID is empty. User has no access to secrets."
+            if [ -z "${{ secrets.DECO_WORKFLOW_TRIGGER_APP_ID }}" ] || [ -z "${{ secrets.DECO_TEST_APPROVAL_APP_ID }}" ]; then
+              echo "Required secrets are missing. User has no access to secrets."
               echo "::set-output name=has_token::false"
             else
-              echo "DECO_WORKFLOW_TRIGGER_APP_ID is set. User has access to secrets."
+              echo "All required secrets are set. User has access to secrets."
               echo "::set-output name=has_token::true"
             fi
 
@@ -45,7 +45,31 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Generate GitHub App Token
+    - name: Generate GitHub App Token for Check Updates
+      id: generate-check-token
+      uses: actions/create-github-app-token@v1
+      with:
+        app-id: ${{ secrets.DECO_TEST_APPROVAL_APP_ID }}
+        private-key: ${{ secrets.DECO_TEST_APPROVAL_PRIVATE_KEY }}
+        owner: databricks
+
+    - name: Create Check Run
+      id: create-check
+      env:
+        GH_TOKEN: ${{ steps.generate-check-token.outputs.token }}
+      run: |
+        response=$(gh api -X POST \
+          /repos/${{ github.repository }}/check-runs \
+          -f name="Integration Tests" \
+          -f head_sha="${{ github.event.pull_request.head.sha }}" \
+          -f status="queued" \
+          -f output[title]="Integration Tests" \
+          -f output[summary]="Tests queued and will be triggered shortly...")
+
+        check_run_id=$(echo "$response" | jq -r .id)
+        echo "check_run_id=$check_run_id" >> $GITHUB_OUTPUT
+
+    - name: Generate GitHub App Token for Workflow Trigger
       id: generate-token
       uses: actions/create-github-app-token@v1
       with:
@@ -61,7 +85,8 @@ jobs:
         gh workflow run terraform-isolated-pr.yml -R ${{ secrets.ORG_NAME }}/${{secrets.REPO_NAME}} \
         --ref main \
         -f pull_request_number=${{ github.event.pull_request.number }} \
-        -f commit_sha=${{ github.event.pull_request.head.sha }}
+        -f commit_sha=${{ github.event.pull_request.head.sha }} \
+        -f check_run_id=${{ steps.create-check.outputs.check_run_id }}
 
 
 
@@ -79,14 +104,24 @@ jobs:
       group: databricks-deco-testing-runner-group
       labels: ubuntu-latest-deco
 
+    permissions:
+      checks: write
+      contents: read
+
     steps:
-      - name: Mark Check
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        shell: bash
-        run: |
-            gh api -X POST -H "Accept: application/vnd.github+json" \
-              -H "X-GitHub-Api-Version: 2022-11-28" \
-              /repos/${{ github.repository }}/statuses/${{ github.sha }} \
-              -f 'state=success' \
-              -f 'context=Integration Tests Check'
+      - name: Auto-approve Check for Merge Queue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.checks.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: 'Integration Tests',
+              head_sha: context.sha,
+              status: 'completed',
+              conclusion: 'success',
+              output: {
+                title: 'Integration Tests',
+                summary: 'Auto-approved for merge queue (tests already passed on PR)'
+              }
+            });


### PR DESCRIPTION
## Summary

Migrate integration test status reporting from GitHub Statuses API to Checks API, enabling the use of GitHub App authentication and eliminating the need for monthly PAT rotation.

## Changes

- Add validation for `DECO_TEST_APPROVAL_APP_ID` secret in addition to existing `DECO_WORKFLOW_TRIGGER_APP_ID`
- Create check run using `DECO_TEST_APPROVAL_APP` before triggering tests in eng-dev-ecosystem
- Pass `check_run_id` to eng-dev-ecosystem workflow for check updates
- Update merge queue auto-approve to use Checks API instead of Statuses API

## Testing

Tested successfully on databricks-sdk-go with full end-to-end flow working.

NO_CHANGELOG=true