### PR TITLE
[Feature] Deprecate `databricks_metastore_data_access` resource

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -8,6 +8,7 @@
 
 * Add `databricks_users` data source ([#4028](https://github.com/databricks/terraform-provider-databricks/pull/4028))
 * Improve `databricks_service_principals` data source ([#5164](https://github.com/databricks/terraform-provider-databricks/pull/5164))
+* Deprecate `databricks_metastore_data_access` resource in favor of using `databricks_storage_credential` with `storage_root_credential_id` on `databricks_metastore` ([#5239](https://github.com/databricks/terraform-provider-databricks/issues/5239)).
 
 ### Bug Fixes
 
@@ -18,7 +19,8 @@
 
 * Document tag policies in `databricks_access_control_rule_set` ([#5209](https://github.com/databricks/terraform-provider-databricks/pull/5209)).
 * Document missing `aws_attributes.ebs_*` properties in `databricks_cluster` ([#5196](https://github.com/databricks/terraform-provider-databricks/pull/5196)).
-* Document support for serverless workspaces on GCP ([#5124](https://github.com/databricks/terraform-provider-databricks/pull/5124))
+* Document support for serverless workspaces on GCP ([#5124](https://github.com/databricks/terraform-provider-databricks/pull/5124)).
+* Fix Unity Catalog GCP guide by removing references to non-existent resources ([#2156](https://github.com/databricks/terraform-provider-databricks/issues/2156))
 
 ### Exporter
 

--- a/catalog/resource_metastore_data_access.go
+++ b/catalog/resource_metastore_data_access.go
@@ -109,6 +109,9 @@ func ResourceMetastoreDataAccess() common.Resource {
 	return common.Resource{
 		Schema:        dacSchema,
 		SchemaVersion: 1,
+		DeprecationMessage: "This resource is deprecated. Please use `databricks_storage_credential` " +
+			"and set it as `storage_root_credential_id` on the `databricks_metastore` resource instead. " +
+			"See https://docs.databricks.com/api-explorer/workspace/metastores/create for more details.",
 		StateUpgraders: []schema.StateUpgrader{
 			{
 				Version: 0,

--- a/docs/guides/unity-catalog-gcp.md
+++ b/docs/guides/unity-catalog-gcp.md
@@ -101,18 +101,6 @@ resource "databricks_metastore" "this" {
   force_destroy = true
 }
 
-resource "google_storage_bucket_iam_member" "unity_sa_admin" {
-  bucket = google_storage_bucket.unity_metastore.name
-  role   = "roles/storage.objectAdmin"
-  member = "serviceAccount:${databricks_metastore_data_access.first.databricks_gcp_service_account[0].email}"
-}
-
-resource "google_storage_bucket_iam_member" "unity_sa_reader" {
-  bucket = google_storage_bucket.unity_metastore.name
-  role   = "roles/storage.legacyBucketReader"
-  member = "serviceAccount:${databricks_metastore_data_access.first.databricks_gcp_service_account[0].email}"
-}
-
 resource "databricks_metastore_assignment" "this" {
   provider     = databricks.accounts
   workspace_id = var.databricks_workspace_id
@@ -127,7 +115,7 @@ Unity Catalog introduces two new objects to access and work with external cloud 
 - [databricks_storage_credential](../resources/storage_credential.md) represent authentication methods to access cloud storage. Storage credentials are access-controlled to determine which users can use the credential.
 - [databricks_external_location](../resources/external_location.md) are objects that combine a cloud storage path with a Storage Credential that can be used to access the location.
 
-First, create the required object in GCPs, including granting permissions on the bucket to the Databricks-managed Service Account.
+First, create the required object in GCPs, including granting permissions on the bucket to the Databricks-managed Service Account created by the [databricks_storage_credential](../resources/storage_credential.md).
 
 ```hcl
 resource "google_storage_bucket" "ext_bucket" {
@@ -189,7 +177,7 @@ resource "google_storage_bucket_iam_member" "unity_cred_reader" {
 }
 ```
 
-Then create the [databricks_storage_credential](../resources/storage_credential.md) and [databricks_external_location](../resources/external_location.md) in Unity Catalog.
+Then create [databricks_external_location](../resources/external_location.md) in Unity Catalog.
 
 ```hcl
 resource "databricks_grants" "external_creds" {


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

It's deprecated in favor of using `databricks_storage_credential` with `storage_root_credential_id` on `databricks_metastore`.

Also, fixed issues in GCP UC guide.

Resolves #2156

## Tests
<!--
How is this tested? Please see the checklist below and also describe any other relevant tests
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] using Go SDK
- [ ] using TF Plugin Framework
- [x] has entry in `NEXT_CHANGELOG.md` file
