### PR TITLE
fix: Accept running as valid wait state

### DIFF
--- a/mws/resource_mws_workspaces.go
+++ b/mws/resource_mws_workspaces.go
@@ -260,6 +260,13 @@ func (a WorkspacesAPI) WaitForExpectedStatus(ws Workspace, expectedStatus string
 			return resource.NonRetryableError(err)
 		}
 
+		// If expected status is PROVISIONING but workspace is already RUNNING,
+		// consider it successful since RUNNING is a more advanced state
+		if expectedStatus == WorkspaceStatusProvisioning && workspace.WorkspaceStatus == WorkspaceStatusRunning {
+			log.Printf("[INFO] Workspace is RUNNING, which is acceptable when expected status is PROVISIONING")
+			return nil
+		}
+
 		switch workspace.WorkspaceStatus {
 		case expectedStatus:
 			log.Printf("[INFO] Workspace is now in expected status %s", expectedStatus)


### PR DESCRIPTION
## Changes
Accepting RUNNING as valid wait state when PROVISIONING is expected
https://github.com/databricks/terraform-provider-databricks/issues/5267

## Tests
<!--
How is this tested? Please see the checklist below and also describe any other relevant tests
-->

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [x] covered with integration tests in `internal/acceptance`
- [x] using Go SDK
- [x] using TF Plugin Framework
- [ ] has entry in `NEXT_CHANGELOG.md` file
