### PR TITLE
[Internal] Remove TestUcAccMetastoreDeltaSharingInfiniteLifetime Test

### DIFF
--- a/catalog/metastore_test.go
+++ b/catalog/metastore_test.go
@@ -58,16 +58,6 @@ func TestUcAccMetastoreDeltaSharing(t *testing.T) {
 	})
 }
 
-func TestUcAccMetastoreDeltaSharingInfiniteLifetime(t *testing.T) {
-	acceptance.LoadUcacctEnv(t)
-	runMetastoreTest(t, map[string]any{
-		"storage_root":        getStorageRoot(t),
-		"region":              getRegion(t),
-		"delta_sharing_scope": "INTERNAL",
-		"delta_sharing_recipient_token_lifetime_in_seconds": 0,
-	})
-}
-
 func TestUcAccMetastoreWithOwnerUpdates(t *testing.T) {
 	acceptance.LoadUcacctEnv(t)
 	runMetastoreTestWithOwnerUpdates(t, map[string]any{


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
This PR removes `TestUcAccMetastoreDeltaSharingInfiniteLifetime`, which specifically tests support for sending in 0 in order to indicate an infinite token lifetime. Since this is no longer supported and the maximal lifetime is 1 year, this test is no longer relevant.

NO_CHANGELOG=true