### PR TITLE
Poll on Private Endpoint rule creation to keep Terraform behavior synchronous

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Breaking Changes
 
 ### New Features and Improvements
+* Add polling on `databricks_resource_mws_ncc_private_endpoint_rule` so that Terraform also behaves synchronously, even with an async API
 
 ### Bug Fixes
 * Fixed `databricks_dashboard` resource to detect content changes when using the `file_path` attribute. Previously, only changes to the path string itself triggered updates, not changes to the file content.

--- a/docs/resources/mws_ncc_private_endpoint_rule.md
+++ b/docs/resources/mws_ncc_private_endpoint_rule.md
@@ -93,12 +93,15 @@ The possible values are:
   * `REJECTED`: Connection was rejected by the private link resource owner.
   * `DISCONNECTED`: Connection was removed by the private link resource owner, the private endpoint becomes informative and should be deleted for clean-up.
   * `EXPIRED`: If the endpoint was created but not approved in 14 days, it will be EXPIRED.
+  * `CREATING`: The endpoint creation is in progress. Once successfully created, the state will transition to PENDING.
+  * `CREATE_FAILED`: The endpoint creation failed. You can check the error_message field for more details.
 * `deactivated` - Whether this private endpoint is deactivated.
 * `deactivated_at` - Time in epoch milliseconds when this object was deactivated.
 * `creation_time` - Time in epoch milliseconds when this object was created.
 * `updated_time` - Time in epoch milliseconds when this object was updated.
 * `enabled` - Activation status. Only used by private endpoints towards an AWS S3 service.
 * `vpc_endpoint_id` - The AWS VPC endpoint ID. You can use this ID to identify the VPC endpoint created by Databricks.
+* `error_message` - Error message if creation fails with state CREATE_FAILED
 
 ## Import
 


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
https://docs.databricks.com/api/azure/account/networkconnectivity/createprivateendpointrule indicates a CREATING state, but customers expect Terraform to return once creation is successful. This PR ensures Terraform behaves synchronously, even if the API is asynchronous.

## Tests
<!--
How is this tested? Please see the checklist below and also describe any other relevant tests
-->
Additional test - Databricks field engineer will test databricks_mws_ncc_private_endpoint_rule creation using this change.

- [X] `make test` run locally
- [X] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [X] using Go SDK
- [ ] using TF Plugin Framework
- [X] has entry in `NEXT_CHANGELOG.md` file
