### PR TITLE
[Exporter] Add exporting for RFA destinations and Delta Sharing providers

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -16,4 +16,6 @@
 
 ### Exporter
 
+* Add exporting for RFA destinations and Delta Sharing providers ([#5337](https://github.com/databricks/terraform-provider-databricks/pull/5337))
+
 ### Internal Changes

--- a/docs/guides/experimental-exporter.md
+++ b/docs/guides/experimental-exporter.md
@@ -106,11 +106,11 @@ All arguments are optional, and they tune what code is being generated.
     ]
   }
   ```
-  
+
   Node types without mappings will be preserved unchanged with a warning logged.
 
   To generate a mapping file, use the `exporter/generate_node_mappings.py` script:
-  
+
   ```bash
   # Extract node types from each cloud workspace
   databricks api get /api/2.1/clusters/list-node-types --profile aws > node-types-aws.json
@@ -260,8 +260,9 @@ Services could be specified in combination with predefined aliases (`all` - for 
 * `uc-metastores` - **listing** [databricks_metastore](../resources/metastore.md) and [databricks_metastore_assignment](../resource/metastore_assignment.md) (only on account-level).  *Please note that when using workspace-level configuration, only the metastores from the workspace's region are listed!*
 * `uc-models` - **listing** (*we can't list directly, only via dependencies to top-level object*) [databricks_registered_model](../resources/registered_model.md)
 * `uc-online-tables` - **listing** (*we can't list directly, only via dependencies to top-level object*) [databricks_online_table](../resources/online_table.md)
+* `uc-rfa` - [databricks_rfa_access_request_destinations](../resources/rfa_access_request_destinations.md) (*emitted as dependencies from Unity Catalog resources when access request destinations are configured*)
 * `uc-schemas` - **listing** (*we can't list directly, only via dependencies to top-level object*) [databricks_schema](../resources/schema.md)
-* `uc-shares` - **listing** [databricks_share](../resources/share.md) and [databricks_recipient](../resources/recipient.md)
+* `uc-shares` - **listing** [databricks_share](../resources/share.md), [databricks_recipient](../resources/recipient.md) and [databricks_provider](../resources/provider.md)
 * `uc-storage-credentials` - **listing** exports [databricks_storage_credential](../resources/storage_credential.md) resources on workspace or account level.
 * `uc-system-schemas` - **listing** exports [databricks_system_schema](../resources/system_schema.md) resources for the UC metastore of the current workspace.
 * `uc-tags` - **listing** exports [databricks_tag_policy](../resources/tag_policy.md) resources.
@@ -350,11 +351,13 @@ Exporter aims to generate HCL code for most of the resources within the Databric
 | [databricks_permission_assignment](../resources/permission_assignment.md) | Yes | No | Yes | No |
 | [databricks_permissions](../resources/permissions.md) | Yes | No | Yes | No |
 | [databricks_pipeline](../resources/pipeline.md) | Yes | Yes | Yes | No |
+| [databricks_provider](../resources/provider.md) | Yes | Yes | Yes | No |
 | [databricks_quality_monitor_v2](../resources/quality_monitor_v2.md) | Yes | Yes | Yes | No |
 | [databricks_query](../resources/query.md) | Yes | Yes | Yes | No |
 | [databricks_recipient](../resources/recipient.md) | Yes | Yes | Yes | No |
 | [databricks_registered_model](../resources/registered.md) | Yes | Yes | Yes | No |
 | [databricks_repo](../resources/repo.md) | Yes | No | Yes | No |
+| [databricks_rfa_access_request_destinations](../resources/rfa_access_request_destinations.md) | Yes | Yes | Yes | No |
 | [databricks_schema](../resources/schema.md) | Yes | Yes | Yes | No |
 | [databricks_secret](../resources/secret.md) | Yes | No | Yes | No |
 | [databricks_secret_acl](../resources/secret_acl.md) | Yes | No | Yes | No |

--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -350,6 +350,13 @@ var emptyRecipients = qa.HTTPFixture{
 	Response:     sharing.ListRecipientsResponse{},
 }
 
+var emptyProviders = qa.HTTPFixture{
+	Method:       "GET",
+	ReuseRequest: true,
+	Resource:     "/api/2.1/unity-catalog/providers?",
+	Response:     sharing.ListProvidersResponse{},
+}
+
 var emptyGitCredentials = qa.HTTPFixture{
 	Method:   http.MethodGet,
 	Resource: "/api/2.0/git-credentials",
@@ -608,6 +615,7 @@ func TestImportingUsersGroupsSecretScopes(t *testing.T) {
 			emptyConnections,
 			emptyTagPolicies,
 			emptyRecipients,
+			emptyProviders,
 			emptyGitCredentials,
 			emptyWorkspace,
 			emptyIpAccessLIst,
@@ -892,6 +900,7 @@ func TestImportingNoResourcesError(t *testing.T) {
 			emptyConnections,
 			emptyTagPolicies,
 			emptyRecipients,
+			emptyProviders,
 			emptyModelServing,
 			emptyMlflowWebhooks,
 			emptyWorkspaceConf,


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

Add exporting of new resources:

- `databricks_provider`
- `databricks_rfa_access_request_destinations`

## Tests
<!--
How is this tested? Please see the checklist below and also describe any other relevant tests
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [x] using Go SDK
- [ ] using TF Plugin Framework
- [x] has entry in `NEXT_CHANGELOG.md` file
