### PR TITLE
[Feature] Add databricks_workspace_file data source for listing workspace files

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### New Features and Improvements
 
+* Added `databricks_workspace_file` data source to list workspace files under a given path with optional recursive listing ([#3437](https://github.com/databricks/terraform-provider-databricks/issues/3437)).
+
 ### Bug Fixes
 
 ### Documentation

--- a/docs/data-sources/workspace_file.md
+++ b/docs/data-sources/workspace_file.md
@@ -1,0 +1,36 @@
+---
+subcategory: "Workspace"
+---
+# databricks_workspace_file Data Source
+
+This data source allows to list workspace files in the Databricks Workspace.
+
+-> This data source can only be used with a workspace-level provider!
+
+## Example Usage
+
+```hcl
+data "databricks_workspace_file" "all" {
+  path      = "/Production"
+  recursive = true
+}
+```
+
+## Argument Reference
+
+* `path` - (Required) Path to workspace directory.
+* `recursive` - (Optional) Whether to recursively list files under the given path. Defaults to `false`.
+
+## Attribute Reference
+
+This data source exports the following attributes:
+
+* `workspace_files` - list of objects with the following attributes:
+  * `id` - the file path (same as `path`).
+  * `created_at` - the creation UTC timestamp of the file.
+  * `modified_at` - the last modified UTC timestamp of the file.
+  * `object_id` - unique identifier of the workspace object.
+  * `path` - the absolute path of the file.
+  * `resource_id` - a unique identifier for the object that is consistent across all Databricks APIs.
+  * `url` - the URL of the file in the Databricks workspace UI.
+  * `workspace_path` - the absolute path prefixed with `/Workspace`.

--- a/internal/providers/pluginfw/pluginfw_rollout_utils.go
+++ b/internal/providers/pluginfw/pluginfw_rollout_utils.go
@@ -25,6 +25,7 @@ import (
 	"github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/products/sharing"
 	"github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/products/user"
 	"github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/products/volume"
+	"github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/products/workspace_file"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 )
@@ -67,6 +68,7 @@ var pluginFwOnlyDataSources = append(
 		registered_model.DataSourceRegisteredModelVersions,
 		serving.DataSourceServingEndpoints,
 		user.DataSourceUsers,
+		workspace_file.DataSourceWorkspaceFilePaths,
 		// TODO: Add DataSourceCluster into migratedDataSources after fixing unit tests.
 		cluster.DataSourceCluster, // Using the staging name (with pluginframework suffix)
 	},

--- a/internal/providers/pluginfw/products/workspace_file/data_workspace_file.go
+++ b/internal/providers/pluginfw/products/workspace_file/data_workspace_file.go
@@ -1,0 +1,174 @@
+package workspace_file
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	"github.com/databricks/databricks-sdk-go/apierr"
+	sdkworkspace "github.com/databricks/databricks-sdk-go/service/workspace"
+	"github.com/databricks/terraform-provider-databricks/common"
+	pluginfwcommon "github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/common"
+	pluginfwcontext "github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/context"
+	"github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/tfschema"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+const dataSourceName = "workspace_file"
+
+func DataSourceWorkspaceFilePaths() datasource.DataSource {
+	return &WorkspaceFilePathsDataSource{}
+}
+
+var _ datasource.DataSourceWithConfigure = &WorkspaceFilePathsDataSource{}
+
+type WorkspaceFilePathsDataSource struct {
+	Client *common.DatabricksClient
+}
+
+type WorkspaceFileInfo struct {
+	Id            types.String `tfsdk:"id"`
+	CreatedAt     types.Int64  `tfsdk:"created_at"`
+	ModifiedAt    types.Int64  `tfsdk:"modified_at"`
+	ObjectId      types.Int64  `tfsdk:"object_id"`
+	Path          types.String `tfsdk:"path"`
+	ResourceId    types.String `tfsdk:"resource_id"`
+	Url           types.String `tfsdk:"url"`
+	WorkspacePath types.String `tfsdk:"workspace_path"`
+}
+
+func (WorkspaceFileInfo) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
+	attrs["id"] = attrs["id"].SetComputed()
+	attrs["created_at"] = attrs["created_at"].SetComputed()
+	attrs["modified_at"] = attrs["modified_at"].SetComputed()
+	attrs["object_id"] = attrs["object_id"].SetComputed()
+	attrs["path"] = attrs["path"].SetComputed()
+	attrs["resource_id"] = attrs["resource_id"].SetComputed()
+	attrs["url"] = attrs["url"].SetComputed()
+	attrs["workspace_path"] = attrs["workspace_path"].SetComputed()
+	return attrs
+}
+
+func (WorkspaceFileInfo) GetComplexFieldTypes(context.Context) map[string]reflect.Type {
+	return map[string]reflect.Type{}
+}
+
+type WorkspaceFileDataSource struct {
+	Path           types.String `tfsdk:"path"`
+	Recursive      types.Bool   `tfsdk:"recursive"`
+	WorkspaceFiles types.List   `tfsdk:"workspace_files"`
+}
+
+func (WorkspaceFileDataSource) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
+	attrs["path"] = attrs["path"].SetRequired()
+	attrs["recursive"] = attrs["recursive"].SetOptional().SetComputed()
+	attrs["workspace_files"] = attrs["workspace_files"].SetComputed()
+	return attrs
+}
+
+func (WorkspaceFileDataSource) GetComplexFieldTypes(context.Context) map[string]reflect.Type {
+	return map[string]reflect.Type{
+		"workspace_files": reflect.TypeOf(WorkspaceFileInfo{}),
+	}
+}
+
+func (d *WorkspaceFilePathsDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = pluginfwcommon.GetDatabricksProductionName(dataSourceName)
+}
+
+func (d *WorkspaceFilePathsDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	attrs, blocks := tfschema.DataSourceStructToSchemaMap(ctx, WorkspaceFileDataSource{}, nil)
+	resp.Schema = schema.Schema{
+		Attributes: attrs,
+		Blocks:     blocks,
+	}
+}
+
+func (d *WorkspaceFilePathsDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if d.Client == nil {
+		d.Client = pluginfwcommon.ConfigureDataSource(req, resp)
+	}
+}
+
+var workspaceFileInfoAttrTypes = map[string]attr.Type{
+	"id":             types.StringType,
+	"created_at":     types.Int64Type,
+	"modified_at":    types.Int64Type,
+	"object_id":      types.Int64Type,
+	"path":           types.StringType,
+	"resource_id":    types.StringType,
+	"url":            types.StringType,
+	"workspace_path": types.StringType,
+}
+
+func (d *WorkspaceFilePathsDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	ctx = pluginfwcontext.SetUserAgentInDataSourceContext(ctx, dataSourceName)
+
+	var data WorkspaceFileDataSource
+	diags := req.Config.Get(ctx, &data)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	w, err := d.Client.WorkspaceClient()
+	if err != nil {
+		resp.Diagnostics.AddError("failed to get workspace client", err.Error())
+		return
+	}
+
+	path := data.Path.ValueString()
+	recursive := data.Recursive.ValueBool()
+
+	var objects []sdkworkspace.ObjectInfo
+	var listErr error
+	if recursive {
+		objects, listErr = w.Workspace.RecursiveList(ctx, path)
+	} else {
+		objects, listErr = w.Workspace.ListAll(ctx, sdkworkspace.ListWorkspaceRequest{
+			Path: path,
+		})
+	}
+	resp.Diagnostics.Append(checkListError(listErr, path)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	fileInfoType := types.ObjectType{AttrTypes: workspaceFileInfoAttrTypes}
+	fileValues := make([]attr.Value, 0, len(objects))
+	for _, obj := range objects {
+		if obj.ObjectType == sdkworkspace.ObjectTypeDirectory {
+			continue
+		}
+		fileValues = append(fileValues, types.ObjectValueMust(
+			workspaceFileInfoAttrTypes,
+			map[string]attr.Value{
+				"id":             types.StringValue(obj.Path),
+				"created_at":     types.Int64Value(obj.CreatedAt),
+				"modified_at":    types.Int64Value(obj.ModifiedAt),
+				"object_id":      types.Int64Value(obj.ObjectId),
+				"path":           types.StringValue(obj.Path),
+				"resource_id":    types.StringValue(obj.ResourceId),
+				"url":            types.StringValue(d.Client.FormatURL("#workspace", obj.Path)),
+				"workspace_path": types.StringValue("/Workspace" + obj.Path),
+			},
+		))
+	}
+
+	data.WorkspaceFiles = types.ListValueMust(fileInfoType, fileValues)
+	resp.Diagnostics.Append(resp.State.Set(ctx, data)...)
+}
+
+func checkListError(err error, path string) diag.Diagnostics {
+	if err == nil {
+		return nil
+	}
+	if apierr.IsMissing(err) {
+		return diag.Diagnostics{diag.NewErrorDiagnostic(fmt.Sprintf("path '%s' does not exist", path), "")}
+	}
+	return diag.Diagnostics{diag.NewErrorDiagnostic(fmt.Sprintf("failed to list workspace files at path: %s", path), err.Error())}
+}

--- a/internal/providers/pluginfw/products/workspace_file/data_workspace_file_acc_test.go
+++ b/internal/providers/pluginfw/products/workspace_file/data_workspace_file_acc_test.go
@@ -1,0 +1,118 @@
+package workspace_file_test
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/databricks/terraform-provider-databricks/internal/acceptance"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const workspaceFileTemplate = `
+resource "databricks_directory" "this" {
+	path = "/Shared/provider-test/workspace_file_{var.RANDOM}"
+}
+
+resource "databricks_workspace_file" "file_a" {
+	path           = "${databricks_directory.this.path}/file_a.txt"
+	content_base64 = base64encode("Hello World A")
+}
+
+resource "databricks_workspace_file" "file_b" {
+	path           = "${databricks_directory.this.path}/file_b.txt"
+	content_base64 = base64encode("Hello World B")
+}
+
+resource "databricks_directory" "subdir" {
+	path = "${databricks_directory.this.path}/subdir"
+}
+
+resource "databricks_directory" "empty_subdir" {
+	path = "${databricks_directory.this.path}/empty_subdir"
+}
+
+resource "databricks_workspace_file" "file_c" {
+	path           = "${databricks_directory.subdir.path}/file_c.txt"
+	content_base64 = base64encode("Hello World C")
+}
+`
+
+func checkWorkspaceFilesPopulated(t *testing.T) func(s *terraform.State) error {
+	return func(s *terraform.State) error {
+		r, ok := s.Modules[0].Resources["data.databricks_workspace_file.this"]
+		require.True(t, ok, "data.databricks_workspace_file.this has to be there")
+		numFiles, _ := strconv.Atoi(r.Primary.Attributes["workspace_files.#"])
+		assert.Equal(t, 2, numFiles)
+		return nil
+	}
+}
+
+func TestAccWorkspaceFileDataSourceNonRecursive(t *testing.T) {
+	acceptance.WorkspaceLevel(t, acceptance.Step{
+		Template: workspaceFileTemplate + `
+		data "databricks_workspace_file" "this" {
+			depends_on = [
+				databricks_workspace_file.file_a,
+				databricks_workspace_file.file_b,
+				databricks_workspace_file.file_c,
+			]
+
+			path = databricks_directory.this.path
+		}
+		output "num_files" {
+			value = length(data.databricks_workspace_file.this.workspace_files)
+		}
+		`,
+		Check: checkWorkspaceFilesPopulated(t),
+	})
+}
+
+func TestAccWorkspaceFileDataSourceEmptyDirectory(t *testing.T) {
+	acceptance.WorkspaceLevel(t, acceptance.Step{
+		Template: workspaceFileTemplate + `
+		data "databricks_workspace_file" "this" {
+			depends_on = [
+				databricks_directory.empty_subdir,
+			]
+
+			path = databricks_directory.empty_subdir.path
+		}
+		`,
+		Check: func(s *terraform.State) error {
+			r, ok := s.Modules[0].Resources["data.databricks_workspace_file.this"]
+			require.True(t, ok, "data.databricks_workspace_file.this has to be there")
+			numFiles, _ := strconv.Atoi(r.Primary.Attributes["workspace_files.#"])
+			assert.Equal(t, 0, numFiles)
+			return nil
+		},
+	})
+}
+
+func TestAccWorkspaceFileDataSourceRecursive(t *testing.T) {
+	acceptance.WorkspaceLevel(t, acceptance.Step{
+		Template: workspaceFileTemplate + `
+		data "databricks_workspace_file" "this" {
+			depends_on = [
+				databricks_workspace_file.file_a,
+				databricks_workspace_file.file_b,
+				databricks_workspace_file.file_c,
+			]
+
+			path      = databricks_directory.this.path
+			recursive = true
+		}
+		output "num_files" {
+			value = length(data.databricks_workspace_file.this.workspace_files)
+		}
+		`,
+		Check: func(s *terraform.State) error {
+			r, ok := s.Modules[0].Resources["data.databricks_workspace_file.this"]
+			require.True(t, ok, "data.databricks_workspace_file.this has to be there")
+			numFiles, _ := strconv.Atoi(r.Primary.Attributes["workspace_files.#"])
+			assert.Equal(t, 3, numFiles)
+			return nil
+		},
+	})
+}

--- a/internal/providers/pluginfw/products/workspace_file/data_workspace_file_test.go
+++ b/internal/providers/pluginfw/products/workspace_file/data_workspace_file_test.go
@@ -1,0 +1,50 @@
+package workspace_file
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/databricks/databricks-sdk-go/apierr"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDataSourceRegistersCorrectName(t *testing.T) {
+	d := &WorkspaceFilePathsDataSource{}
+	resp := &datasource.MetadataResponse{}
+	d.Metadata(context.Background(), datasource.MetadataRequest{ProviderTypeName: "databricks"}, resp)
+	assert.Equal(t, "databricks_workspace_file", resp.TypeName)
+}
+
+func TestSchemaContainsExpectedAttributes(t *testing.T) {
+	d := &WorkspaceFilePathsDataSource{}
+	resp := &datasource.SchemaResponse{}
+	d.Schema(context.Background(), datasource.SchemaRequest{}, resp)
+	assert.False(t, resp.Diagnostics.HasError())
+	assert.Contains(t, resp.Schema.Attributes, "path")
+	assert.Contains(t, resp.Schema.Attributes, "recursive")
+	assert.Contains(t, resp.Schema.Attributes, "workspace_files")
+}
+
+func TestEmptyDirectory(t *testing.T) {
+	diags := checkListError(nil, "/test/empty")
+	assert.Nil(t, diags)
+}
+
+func TestNonExistentDirectory(t *testing.T) {
+	err := &apierr.APIError{StatusCode: 404, Message: "Path doesn't exist"}
+	diags := checkListError(err, "/test/nonexistent")
+	expected := diag.Diagnostics{diag.NewErrorDiagnostic("path '/test/nonexistent' does not exist", "")}
+	assert.True(t, diags.HasError())
+	assert.Equal(t, expected, diags)
+}
+
+func TestListError(t *testing.T) {
+	err := fmt.Errorf("some real error")
+	diags := checkListError(err, "/test/path")
+	expected := diag.Diagnostics{diag.NewErrorDiagnostic("failed to list workspace files at path: /test/path", "some real error")}
+	assert.True(t, diags.HasError())
+	assert.Equal(t, expected, diags)
+}


### PR DESCRIPTION
## Changes                                                                                                                                                           
                                                                                                                                                                       
Add a new `databricks_workspace_file` data source that lists workspace files at a given path. This enables users to enumerate files (excluding directories) in the Databricks Workspace, with optional recursive listing.                                                                                                               
                                                                                                                                                                     
The data source exposes metadata for each file including path, object ID, resource ID, creation/modification timestamps, workspace URL, and workspace path.          
                                                                                                                                                                     
Implemented using the TF Plugin Framework and the Go SDK's `Workspace.ListAll` / `Workspace.RecursiveList` APIs.                                                     
                                                                                                                                                                     
## Tests                                                                                                                                                             
                                                                                                                                                                     
- [x] `make test` run locally                                                                                                                                        
- [x] relevant change in `docs/` folder                                                                                                                              
- [x] covered with integration tests in `internal/acceptance`                                                                                                        
- [x] using Go SDK                                                                                                                                                   
- [x] using TF Plugin Framework                                                                                                                                      
- [x] has entry in `NEXT_CHANGELOG.md` file   

## Note
There is a discrepancy between the [CONTRIBUTING.md](https://github.com/databricks/terraform-provider-databricks/blob/20fafd67335fc150a2bb871f78f27b751e5b2d90/CONTRIBUTING.md#adding-a-new-resource) file and the internal/acceptance/ directory, as the instructions in CONTRIBUTING.md state: “Create a file named data_resource-name_acc_test.go and add integration tests there.” After reviewing other plugin framework data sources, I followed their convention and kept the _acc_test.go files alongside the source code.

There also seem to be duplicate instructions in CONTRIBUTING.md for adding new resources and data sources. It is clearly stated which instructions apply to the plugin framework, but the section that references placing integration tests in internal/acceptance/ is not labeled, and I assume it is intended for the legacy SDKv2 framework.

Closes [#3437](https://github.com/databricks/terraform-provider-databricks/issues/3437)
