### PR TITLE
Fix integration test by adding validation

### DIFF
--- a/settings/notification_destination_test.go
+++ b/settings/notification_destination_test.go
@@ -154,6 +154,7 @@ func TestAccNDGenericWebhook(t *testing.T) {
 			config {
 				generic_webhook {
 					url = "https://webhook.site/{var.RANDOM}"
+					username = "username"
 					password = "password"
 				}
 			}
@@ -167,6 +168,7 @@ func TestAccNDGenericWebhook(t *testing.T) {
 				generic_webhook {
 					url = "https://webhook.site/{var.RANDOM}"
 					username = "username2"
+					password = "password2"
 				}
 			}
 		}


### PR DESCRIPTION
## Changes
The server side validation for `generic_webhook` type of notification destination changed to enforce either username and password exist together or none exists. 
This PR adds a validation in the schema for the same

## Tests
Unit test

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] using Go SDK
- [ ] using TF Plugin Framework
- [ ] has entry in `NEXT_CHANGELOG.md` file

NO_CHANGELOG=true
