### PR TITLE
Fix databricks_cluster to send gcp_attributes.local_ssd_count=0 durin…

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -16,6 +16,9 @@
 * [Fix] `databricks_app` resource fail to read app when deleted outside terraform ([#5365](https://github.com/databricks/terraform-provider-databricks/pull/5365))
 * Fixed `databricks_users` data source `extra_attributes` parameter issues ([#5308](https://github.com/databricks/terraform-provider-databricks/issues/5308)): (1) Single-attribute inputs (e.g., `extra_attributes = "active"`) were silently ignored at account level due to incorrect value quoting. (2) Complex multi-valued attributes like `emails` and `roles` returned null at account level even when explicitly requested in `extra_attributes`. (3) `extra_attributes` were not forwarded to the SCIM API at workspace level.
 * Fix `databricks_app` resource fail to read app when deleted outside terraform ([#5365](https://github.com/databricks/terraform-provider-databricks/pull/5365))
+* Fix `databricks_cluster` resource on GCP to properly send `gcp_attributes.local_ssd_count = 0` during cluster updates.
+
+ When updating a cluster with `gcp_attributes.local_ssd_count = 0`, the value was not being sent to the Databricks API, causing the cluster to fall back to "Default" behavior (at least 1 local SSD). This fix ensures that zero values are explicitly sent during updates, matching the behavior already present for cluster creation.
 
 ### Documentation
 

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -16,9 +16,9 @@
 * [Fix] `databricks_app` resource fail to read app when deleted outside terraform ([#5365](https://github.com/databricks/terraform-provider-databricks/pull/5365))
 * Fixed `databricks_users` data source `extra_attributes` parameter issues ([#5308](https://github.com/databricks/terraform-provider-databricks/issues/5308)): (1) Single-attribute inputs (e.g., `extra_attributes = "active"`) were silently ignored at account level due to incorrect value quoting. (2) Complex multi-valued attributes like `emails` and `roles` returned null at account level even when explicitly requested in `extra_attributes`. (3) `extra_attributes` were not forwarded to the SCIM API at workspace level.
 * Fix `databricks_app` resource fail to read app when deleted outside terraform ([#5365](https://github.com/databricks/terraform-provider-databricks/pull/5365))
-* Fix `databricks_cluster` resource on GCP to properly send `gcp_attributes.local_ssd_count = 0` during cluster updates.
+* Fix `databricks_cluster` and `databricks_job` resources on GCP to properly send `gcp_attributes.local_ssd_count = 0` ([#3631](https://github.com/databricks/terraform-provider-databricks/pull/3631)).
 
- When updating a cluster with `gcp_attributes.local_ssd_count = 0`, the value was not being sent to the Databricks API, causing the cluster to fall back to "Default" behavior (at least 1 local SSD). This fix ensures that zero values are explicitly sent during updates, matching the behavior already present for cluster creation.
+ When creating or updating clusters (both standalone and job clusters) with `gcp_attributes.local_ssd_count = 0`, the value was not being sent to the Databricks API, causing the cluster to fall back to "Default" behavior (at least 1 local SSD). This fix ensures that zero values are explicitly sent to the API for both standalone clusters and job clusters.
 
 ### Documentation
 

--- a/clusters/resource_cluster.go
+++ b/clusters/resource_cluster.go
@@ -620,6 +620,11 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, c *commo
 			})
 		} else {
 			SetForceSendFieldsForCluster(&cluster, d)
+			if cluster.GcpAttributes != nil {
+				if _, ok := d.GetOkExists("gcp_attributes.0.local_ssd_count"); ok {
+					cluster.GcpAttributes.ForceSendFields = []string{"LocalSsdCount"}
+				}
+			}
 
 			err = retry.RetryContext(ctx, 15*time.Minute, func() *retry.RetryError {
 				_, err = clusters.Edit(ctx, cluster)

--- a/jobs/jobs_api_go_sdk.go
+++ b/jobs/jobs_api_go_sdk.go
@@ -209,7 +209,7 @@ func updateJobClusterSpec(d *schema.ResourceData, prefix string, clusterSpec *co
 	if err != nil {
 		return err
 	}
-	err = clusters.SetForceSendFieldsForCluster(clusterSpec, d)
+	err = clusters.SetForceSendFieldsForClusterWithPrefix(clusterSpec, d, prefix)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
…g updates

When updating a cluster with gcp_attributes.local_ssd_count = 0, the value was not being sent to the Databricks API, causing the cluster to fall back to "Default" behavior (at least 1 local SSD). This fix ensures that zero values are explicitly sent during updates, matching the behavior already present for cluster creation (added in PR #3631).

## Changes
<!-- Summary of your changes that are easy to understand -->

## Tests
<!--
How is this tested? Please see the checklist below and also describe any other relevant tests
-->

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] using Go SDK
- [ ] using TF Plugin Framework
- [ ] has entry in `NEXT_CHANGELOG.md` file
