### PR TITLE
[Fix] Provider panic in `databricks_app` when `compute_size` is specified with non-uppercase casing (e.g. `"Medium"`) or an invalid value (e.g. `"test"`)

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bug Fixes
 
+* Fixed provider panic in `databricks_app` when `compute_size` has non-uppercase casing or invalid value by adding case normalization and enum validation ([#5390](https://github.com/databricks/terraform-provider-databricks/pull/5390)).
+
 ### Documentation
 
 ### Exporter

--- a/internal/providers/pluginfw/products/app/resource_app.go
+++ b/internal/providers/pluginfw/products/app/resource_app.go
@@ -18,6 +18,7 @@ import (
 	"github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/tfschema"
 	"github.com/databricks/terraform-provider-databricks/internal/service/apps_tf"
 	"github.com/hashicorp/terraform-plugin-framework-validators/objectvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
@@ -93,6 +94,12 @@ func (a resourceApp) Schema(ctx context.Context, req resource.SchemaRequest, res
 		}
 		cs.AddPlanModifier(int64planmodifier.UseStateForUnknown(), "service_principal_id")
 		cs.AddPlanModifier(uppercasePlanModifier{}, "compute_size")
+		var computeSize apps.ComputeSize
+		computeSizeValues := make([]string, 0)
+		for _, v := range computeSize.Values() {
+			computeSizeValues = append(computeSizeValues, string(v))
+		}
+		cs.AddValidator(stringvalidator.OneOfCaseInsensitive(computeSizeValues...), "compute_size")
 		return cs
 	})
 }

--- a/internal/providers/pluginfw/products/app/resource_app.go
+++ b/internal/providers/pluginfw/products/app/resource_app.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"reflect"
 	"slices"
+	"strings"
 
 	"github.com/databricks/databricks-sdk-go"
 	"github.com/databricks/databricks-sdk-go/apierr"
@@ -20,6 +21,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
@@ -90,6 +92,7 @@ func (a resourceApp) Schema(ctx context.Context, req resource.SchemaRequest, res
 			cs.AddPlanModifier(stringplanmodifier.UseStateForUnknown(), field)
 		}
 		cs.AddPlanModifier(int64planmodifier.UseStateForUnknown(), "service_principal_id")
+		cs.AddPlanModifier(uppercasePlanModifier{}, "compute_size")
 		return cs
 	})
 }
@@ -334,6 +337,26 @@ func (a *resourceApp) Delete(ctx context.Context, req resource.DeleteRequest, re
 
 func (a *resourceApp) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	resource.ImportStatePassthroughID(ctx, path.Root("name"), req, resp)
+}
+
+// uppercasePlanModifier normalizes a string value to uppercase during planning.
+// This is needed for enum fields like compute_size where the API accepts case-insensitive
+// values but the Go SDK enum validation is case-sensitive (e.g. "Medium" vs "MEDIUM").
+type uppercasePlanModifier struct{}
+
+func (m uppercasePlanModifier) Description(ctx context.Context) string {
+	return "Normalizes the string value to uppercase."
+}
+
+func (m uppercasePlanModifier) MarkdownDescription(ctx context.Context) string {
+	return "Normalizes the string value to uppercase."
+}
+
+func (m uppercasePlanModifier) PlanModifyString(ctx context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
+	if req.PlanValue.IsNull() || req.PlanValue.IsUnknown() {
+		return
+	}
+	resp.PlanValue = types.StringValue(strings.ToUpper(req.PlanValue.ValueString()))
 }
 
 var _ resource.ResourceWithConfigure = &resourceApp{}

--- a/internal/providers/pluginfw/products/app/resource_app_test.go
+++ b/internal/providers/pluginfw/products/app/resource_app_test.go
@@ -1,0 +1,132 @@
+package app
+
+import (
+	"context"
+	"testing"
+
+	"github.com/databricks/databricks-sdk-go/service/apps"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUppercasePlanModifier(t *testing.T) {
+	tests := []struct {
+		name          string
+		planValue     types.String
+		expectedValue types.String
+	}{
+		{
+			name:          "lowercase value is uppercased",
+			planValue:     types.StringValue("medium"),
+			expectedValue: types.StringValue("MEDIUM"),
+		},
+		{
+			name:          "mixed case value is uppercased",
+			planValue:     types.StringValue("Medium"),
+			expectedValue: types.StringValue("MEDIUM"),
+		},
+		{
+			name:          "uppercase value remains unchanged",
+			planValue:     types.StringValue("LARGE"),
+			expectedValue: types.StringValue("LARGE"),
+		},
+		{
+			name:          "null value is not modified",
+			planValue:     types.StringNull(),
+			expectedValue: types.StringNull(),
+		},
+		{
+			name:          "unknown value is not modified",
+			planValue:     types.StringUnknown(),
+			expectedValue: types.StringUnknown(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := planmodifier.StringRequest{
+				PlanValue: tt.planValue,
+			}
+			resp := &planmodifier.StringResponse{
+				PlanValue: tt.planValue,
+			}
+
+			m := uppercasePlanModifier{}
+			m.PlanModifyString(context.Background(), req, resp)
+
+			assert.Equal(t, tt.expectedValue, resp.PlanValue)
+		})
+	}
+}
+
+func TestComputeSizeValidation(t *testing.T) {
+	var computeSize apps.ComputeSize
+	values := make([]string, 0)
+	for _, v := range computeSize.Values() {
+		values = append(values, string(v))
+	}
+	v := stringvalidator.OneOfCaseInsensitive(values...)
+
+	tests := []struct {
+		name        string
+		value       types.String
+		expectError bool
+	}{
+		{
+			name:        "valid uppercase MEDIUM",
+			value:       types.StringValue("MEDIUM"),
+			expectError: false,
+		},
+		{
+			name:        "valid uppercase LARGE",
+			value:       types.StringValue("LARGE"),
+			expectError: false,
+		},
+		{
+			name:        "valid mixed case Medium",
+			value:       types.StringValue("Medium"),
+			expectError: false,
+		},
+		{
+			name:        "valid lowercase large",
+			value:       types.StringValue("large"),
+			expectError: false,
+		},
+		{
+			name:        "invalid value FooBar is rejected",
+			value:       types.StringValue("FooBar"),
+			expectError: true,
+		},
+		{
+			name:        "invalid value test is rejected",
+			value:       types.StringValue("test"),
+			expectError: true,
+		},
+		{
+			name:        "null value is accepted",
+			value:       types.StringNull(),
+			expectError: false,
+		},
+		{
+			name:        "unknown value is accepted",
+			value:       types.StringUnknown(),
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := validator.StringRequest{
+				ConfigValue: tt.value,
+			}
+			resp := &validator.StringResponse{}
+
+			v.ValidateString(context.Background(), req, resp)
+
+			assert.Equal(t, tt.expectError, resp.Diagnostics.HasError())
+		})
+	}
+}


### PR DESCRIPTION
Related to #5318

## Changes

The Databricks API accepts `compute_size` case-insensitively and returns the canonical uppercase form (`"MEDIUM"`). On subsequent `terraform apply`, Terraform detects a diff between the config value `"Medium"` and the state value `"MEDIUM"`, triggering an Update. During the Update, `converters.convertToEnumValue` calls `apps.ComputeSize.Set("Medium")`, which rejects the mixed-case value and panics, crashing the provider. Invalid values like `"test"` also cause the same panic.

This PR adds two schema-level fixes to the `compute_size` attribute:

1. **`uppercasePlanModifier`** -- a custom `planmodifier.String` that normalizes `compute_size` to uppercase during planning, preventing case-mismatch diffs and ensuring the converter always receives valid uppercase enum values.
2. **`stringvalidator.OneOfCaseInsensitive`** -- validates that `compute_size` is one of the allowed values derived dynamically from `apps.ComputeSize.Values()`, rejecting invalid values at plan time with a clear error instead of a provider crash at apply time.

<details>
<summary>Stack trace from the crash</summary>

```
╷
│ Error: Request cancelled
│
│ The plugin6.(*GRPCProvider).ApplyResourceChange request was cancelled.
╵
Releasing state lock. This may take a few moments...

Stack trace from the terraform-provider-databricks_v1.106.0 plugin:

panic: value "test" is not one of "LARGE", "MEDIUM". This is a bug. Please report this to the maintainers at github.com/databricks/terraform-provider-databricks.

goroutine 14 [running]:
github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/converters.convertToEnumValue(...)
        .../internal/providers/pluginfw/converters/tf_to_go.go:389
github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/converters.tfsdkToGoSdkStructField(...)
        .../internal/providers/pluginfw/converters/tf_to_go.go:203
github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/converters.TfSdkToGoSdkStruct(...)
        .../internal/providers/pluginfw/converters/tf_to_go.go:85
github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/products/app.(*resourceApp).Update(...)
        .../internal/providers/pluginfw/products/app/resource_app.go:281

Error: The terraform-provider-databricks_v1.106.0 plugin crashed!
```

</details>

---

## Detailed Changes

### New imports

```go
"strings"
```

- `strings` is needed for `strings.ToUpper` in the uppercase plan modifier.

```go
"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
```

- `stringvalidator` provides `OneOfCaseInsensitive` for enum validation.
- `planmodifier` provides the `StringRequest`/`StringResponse` types for the custom plan modifier.

---

### Add uppercase plan modifier to `compute_size` (line 96)

```go
cs.AddPlanModifier(uppercasePlanModifier{}, "compute_size")
```

**Why:** Normalizes the user's config value (e.g. `"Medium"`) to uppercase (`"MEDIUM"`) during planning. This prevents a perpetual diff between config and state, and ensures the converter's `ComputeSize.Set()` always receives the expected uppercase value.

---

### Add dynamic enum validator to `compute_size` (lines 97-102)

```go
var computeSize apps.ComputeSize
computeSizeValues := make([]string, 0)
for _, v := range computeSize.Values() {
    computeSizeValues = append(computeSizeValues, string(v))
}
cs.AddValidator(stringvalidator.OneOfCaseInsensitive(computeSizeValues...), "compute_size")
```

**Why:** Instead of hardcoding the accepted values, the validator reads valid `compute_size` values directly from the Go SDK's `apps.ComputeSize.Values()` method. At runtime, this currently returns `["LARGE", "MEDIUM"]`. When new compute sizes are added to the SDK, they are automatically accepted without requiring a provider code change. `OneOfCaseInsensitive` accepts any casing (e.g. `"medium"`, `"Medium"`, `"MEDIUM"`), and invalid values like `"test"` are rejected at plan time with a clear error instead of a provider crash at apply time.

---

### New `uppercasePlanModifier` type (lines 346-360)

```go
type uppercasePlanModifier struct{}

func (m uppercasePlanModifier) Description(ctx context.Context) string {
    return "Normalizes the string value to uppercase."
}

func (m uppercasePlanModifier) MarkdownDescription(ctx context.Context) string {
    return "Normalizes the string value to uppercase."
}

func (m uppercasePlanModifier) PlanModifyString(ctx context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
    if req.PlanValue.IsNull() || req.PlanValue.IsUnknown() {
        return
    }
    resp.PlanValue = types.StringValue(strings.ToUpper(req.PlanValue.ValueString()))
}
```

**Why:** Implements the `planmodifier.String` interface. For non-null/non-unknown values, it uppercases the planned value so it matches the canonical form returned by the API. Null and unknown values (when the user omits `compute_size` and it's computed from the API default) are left untouched.

---

## Tests

### Unit Tests (`resource_app_test.go`)

**TestUppercasePlanModifier** -- Verifies the plan modifier correctly normalizes string values:
- `"medium"` is uppercased to `"MEDIUM"`
- `"Medium"` (mixed case) is uppercased to `"MEDIUM"`
- `"LARGE"` (already uppercase) remains `"LARGE"`
- Null value is not modified
- Unknown value is not modified

**TestComputeSizeValidation** -- Verifies the validator accepts valid values and rejects invalid ones using the dynamic enum values from `apps.ComputeSize.Values()`:
- `"MEDIUM"`, `"LARGE"` (uppercase) are accepted
- `"Medium"`, `"large"` (mixed/lowercase) are accepted (case-insensitive)
- `"FooBar"`, `"test"` (invalid) are rejected with a diagnostic error
- Null and unknown values are accepted (skipped by the validator)

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [x] using Go SDK
- [x] using TF Plugin Framework
- [x] has entry in `NEXT_CHANGELOG.md` file

## Limitations

- This fix is scoped to `compute_size` on `databricks_app` only. The root cause is in `convertToEnumValue` (`tf_to_go.go:389`), which panics on any enum case mismatch across all resources. That file is auto-generated (`DO NOT EDIT`), so the fix cannot be applied there directly.
- The proper upstream fix would be in the code generator that produces `tf_to_go.go` -- either making `convertToEnumValue` case-insensitive or replacing the panic with a diagnostic error. That would fix all enum fields across all resources at once.

## Notes

- No `docs/` change is needed since `compute_size` is already documented; this is a bug fix to validation and planning behavior.