### PR TITLE
[Fix] Permanent permissions drift when `user_name` casing in `databricks_permissions` `access_control` blocks differs from the API response

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -9,6 +9,7 @@
 * Add support for managing permissions of Agent Bricks resources ([#5708](https://github.com/databricks/terraform-provider-databricks/issues/5669)). Reverts [#5582](https://github.com/databricks/terraform-provider-databricks/pull/5708).
 
 ### Bug Fixes
+* Fix permanent permissions drift when `user_name` casing in `databricks_permissions` `access_control` blocks differs from the API response ([#5183](https://github.com/databricks/terraform-provider-databricks/issues/5183))
 
 * Fix `databricks_metastore` so that updating `external_access_enabled` from `true` to `false` is sent in the PATCH request. Previously the field was silently dropped from the request body, so the change never reached the API.
 * Fixed destroying of UC objects when workspace binding removed before actual destroy ([#5581](https://github.com/databricks/terraform-provider-databricks/pull/5581)).

--- a/permissions/entity/permissions_entity.go
+++ b/permissions/entity/permissions_entity.go
@@ -1,6 +1,10 @@
 package entity
 
-import "github.com/databricks/databricks-sdk-go/service/iam"
+import (
+	"strings"
+
+	"github.com/databricks/databricks-sdk-go/service/iam"
+)
 
 // PermissionsEntity is the one used for resource metadata
 type PermissionsEntity struct {
@@ -10,7 +14,7 @@ type PermissionsEntity struct {
 
 func (p PermissionsEntity) ContainsUserOrServicePrincipal(name string) bool {
 	for _, ac := range p.AccessControlList {
-		if ac.UserName == name || ac.ServicePrincipalName == name {
+		if strings.EqualFold(ac.UserName, name) || strings.EqualFold(ac.ServicePrincipalName, name) {
 			return true
 		}
 	}

--- a/permissions/permission_definitions.go
+++ b/permissions/permission_definitions.go
@@ -228,7 +228,7 @@ func (p resourcePermissions) prepareResponse(objectID string, objectACL *iam.Obj
 		// If the user doesn't include an access_control block for themselves, do not include it in the state.
 		// On create/update, the provider will automatically include the current user in the access_control block
 		// for appropriate resources. Otherwise, it must be included in state to prevent configuration drift.
-		if me == accessControl.UserName || me == accessControl.ServicePrincipalName {
+		if strings.EqualFold(me, accessControl.UserName) || strings.EqualFold(me, accessControl.ServicePrincipalName) {
 			if !existing.ContainsUserOrServicePrincipal(me) {
 				continue
 			}
@@ -244,8 +244,8 @@ func (p resourcePermissions) prepareResponse(objectID string, objectACL *iam.Obj
 			}
 			entity.AccessControlList = append(entity.AccessControlList, iam.AccessControlRequest{
 				GroupName:            accessControl.GroupName,
-				UserName:             accessControl.UserName,
-				ServicePrincipalName: accessControl.ServicePrincipalName,
+				UserName:             strings.ToLower(accessControl.UserName),
+				ServicePrincipalName: strings.ToLower(accessControl.ServicePrincipalName),
 				PermissionLevel:      permission.PermissionLevel,
 			})
 		}

--- a/permissions/resource_permissions.go
+++ b/permissions/resource_permissions.go
@@ -188,28 +188,30 @@ func ResourcePermissions() common.Resource {
 		}
 		s["access_control"].MinItems = 1
 
-		// Use a custom hash function that only considers non-empty fields.
-		// This prevents spurious diffs when comparing {group_name: "X", permission_level: "Y"}
-		// with {group_name: "X", permission_level: "Y", service_principal_name: "", user_name: ""}
+		// Use a custom hash function that normalizes case-insensitive identity
+		// fields before hashing. Emails (user_name) and service principal names
+		// are case-insensitive, but the API may return them with different casing
+		// than the user's config, causing permanent drift (#5183).
 		acSchema := s["access_control"].Elem.(*schema.Resource).Schema
 		s["access_control"].Set = func(v interface{}) int {
 			m, ok := v.(map[string]interface{})
 			if !ok {
 				return 0
 			}
-			// Build a normalized map with only non-empty string fields for hashing
 			normalized := make(map[string]interface{})
 			for key, val := range m {
 				if _, exists := acSchema[key]; !exists {
-					continue // Skip fields not in schema
+					continue
 				}
 				if strVal, ok := val.(string); ok {
 					if strVal != "" {
+						if key == "user_name" || key == "service_principal_name" {
+							strVal = strings.ToLower(strVal)
+						}
 						normalized[key] = strVal
 					}
 				}
 			}
-			// Use HashResource with a schema that only includes the fields we care about
 			hashSchema := &schema.Resource{Schema: acSchema}
 			return schema.HashResource(hashSchema)(normalized)
 		}

--- a/permissions/resource_permissions_test.go
+++ b/permissions/resource_permissions_test.go
@@ -2062,3 +2062,188 @@ func TestResourcePermissionsCreate_SupervisorAgent_InvalidLevel(t *testing.T) {
 		`,
 	}.ExpectError(t, "permission_level CAN_VIEW is not supported with supervisor_agent_id objects; allowed levels: CAN_MANAGE, CAN_QUERY")
 }
+
+// TestPermissionsDrift_UserNameNoDriftWithSameCasing simulates an existing resource
+// in state with user_name, then performs a Read where the API returns the same
+// casing. Verifies no drift occurs.
+func TestPermissionsDrift_UserNameNoDriftWithSameCasing(t *testing.T) {
+	r := ResourcePermissions()
+	hashFunc := r.Schema["access_control"].Set
+
+	userHash := hashFunc(map[string]interface{}{
+		"user_name":              "user@example.com",
+		"permission_level":       "CAN_MANAGE",
+		"group_name":             "",
+		"service_principal_name": "",
+	})
+	groupHash := hashFunc(map[string]interface{}{
+		"group_name":             "Engineers",
+		"permission_level":       "CAN_MANAGE",
+		"user_name":              "",
+		"service_principal_name": "",
+	})
+
+	instanceState := map[string]string{
+		"sql_endpoint_id":  "abc",
+		"access_control.#": "2",
+		fmt.Sprintf("access_control.%d.user_name", userHash):               "user@example.com",
+		fmt.Sprintf("access_control.%d.permission_level", userHash):        "CAN_MANAGE",
+		fmt.Sprintf("access_control.%d.group_name", userHash):              "",
+		fmt.Sprintf("access_control.%d.service_principal_name", userHash):  "",
+		fmt.Sprintf("access_control.%d.group_name", groupHash):             "Engineers",
+		fmt.Sprintf("access_control.%d.permission_level", groupHash):       "CAN_MANAGE",
+		fmt.Sprintf("access_control.%d.user_name", groupHash):              "",
+		fmt.Sprintf("access_control.%d.service_principal_name", groupHash): "",
+	}
+
+	d, err := qa.ResourceFixture{
+		MockWorkspaceClientFunc: func(mwc *mocks.MockWorkspaceClient) {
+			mwc.GetMockCurrentUserAPI().EXPECT().Me(mock.Anything, mock.Anything).Return(&iam.User{UserName: "admin"}, nil)
+			mwc.GetMockPermissionsAPI().EXPECT().Get(mock.Anything, iam.GetPermissionRequest{
+				RequestObjectId:   "abc",
+				RequestObjectType: "sql/warehouses",
+			}).Return(&iam.ObjectPermissions{
+				ObjectId:   "/sql/warehouses/abc",
+				ObjectType: "warehouses",
+				AccessControlList: []iam.AccessControlResponse{
+					{
+						GroupName: "Engineers",
+						AllPermissions: []iam.Permission{
+							{PermissionLevel: "CAN_MANAGE", Inherited: false},
+						},
+					},
+					{
+						UserName: "user@example.com",
+						AllPermissions: []iam.Permission{
+							{PermissionLevel: "CAN_MANAGE", Inherited: false},
+						},
+					},
+					{
+						UserName: "admin",
+						AllPermissions: []iam.Permission{
+							{PermissionLevel: "CAN_MANAGE", Inherited: false},
+						},
+					},
+				},
+			}, nil)
+		},
+		Resource:      ResourcePermissions(),
+		InstanceState: instanceState,
+		Read:          true,
+		ID:            "/sql/warehouses/abc",
+		HCL: `
+		sql_endpoint_id = "abc"
+		access_control {
+			group_name       = "Engineers"
+			permission_level = "CAN_MANAGE"
+		}
+		access_control {
+			user_name        = "user@example.com"
+			permission_level = "CAN_MANAGE"
+		}
+		`,
+	}.Apply(t)
+	assert.NoError(t, err)
+	ac := d.Get("access_control").(*schema.Set)
+	require.Equal(t, 2, ac.Len(), "expected 2 access_control entries after read (no drift)")
+}
+
+// TestPermissionsDrift_UserNameNoDriftWithDifferentCasing simulates the drift from
+// issue #5183: InstanceState has user_name="user@example.com" but the API returns
+// "User@Example.com". The different casing causes the Read to store a value with
+// a different hash than the config, leading to permanent drift.
+func TestPermissionsDrift_UserNameNoDriftWithDifferentCasing(t *testing.T) {
+	r := ResourcePermissions()
+	hashFunc := r.Schema["access_control"].Set
+
+	userHash := hashFunc(map[string]interface{}{
+		"user_name":              "user@example.com",
+		"permission_level":       "CAN_MANAGE",
+		"group_name":             "",
+		"service_principal_name": "",
+	})
+	groupHash := hashFunc(map[string]interface{}{
+		"group_name":             "Engineers",
+		"permission_level":       "CAN_MANAGE",
+		"user_name":              "",
+		"service_principal_name": "",
+	})
+
+	instanceState := map[string]string{
+		"sql_endpoint_id":  "abc",
+		"access_control.#": "2",
+		fmt.Sprintf("access_control.%d.user_name", userHash):               "user@example.com",
+		fmt.Sprintf("access_control.%d.permission_level", userHash):        "CAN_MANAGE",
+		fmt.Sprintf("access_control.%d.group_name", userHash):              "",
+		fmt.Sprintf("access_control.%d.service_principal_name", userHash):  "",
+		fmt.Sprintf("access_control.%d.group_name", groupHash):             "Engineers",
+		fmt.Sprintf("access_control.%d.permission_level", groupHash):       "CAN_MANAGE",
+		fmt.Sprintf("access_control.%d.user_name", groupHash):              "",
+		fmt.Sprintf("access_control.%d.service_principal_name", groupHash): "",
+	}
+
+	d, err := qa.ResourceFixture{
+		MockWorkspaceClientFunc: func(mwc *mocks.MockWorkspaceClient) {
+			mwc.GetMockCurrentUserAPI().EXPECT().Me(mock.Anything, mock.Anything).Return(&iam.User{UserName: "admin"}, nil)
+			mwc.GetMockPermissionsAPI().EXPECT().Get(mock.Anything, iam.GetPermissionRequest{
+				RequestObjectId:   "abc",
+				RequestObjectType: "sql/warehouses",
+			}).Return(&iam.ObjectPermissions{
+				ObjectId:   "/sql/warehouses/abc",
+				ObjectType: "warehouses",
+				AccessControlList: []iam.AccessControlResponse{
+					{
+						GroupName: "Engineers",
+						AllPermissions: []iam.Permission{
+							{PermissionLevel: "CAN_MANAGE", Inherited: false},
+						},
+					},
+					{
+						// API returns DIFFERENT casing than config
+						UserName: "User@Example.com",
+						AllPermissions: []iam.Permission{
+							{PermissionLevel: "CAN_MANAGE", Inherited: false},
+						},
+					},
+					{
+						UserName: "admin",
+						AllPermissions: []iam.Permission{
+							{PermissionLevel: "CAN_MANAGE", Inherited: false},
+						},
+					},
+				},
+			}, nil)
+		},
+		Resource:      ResourcePermissions(),
+		InstanceState: instanceState,
+		Read:          true,
+		ID:            "/sql/warehouses/abc",
+		HCL: `
+		sql_endpoint_id = "abc"
+		access_control {
+			group_name       = "Engineers"
+			permission_level = "CAN_MANAGE"
+		}
+		access_control {
+			user_name        = "user@example.com"
+			permission_level = "CAN_MANAGE"
+		}
+		`,
+	}.Apply(t)
+	assert.NoError(t, err)
+	ac := d.Get("access_control").(*schema.Set)
+
+	// After the fix, the Read should normalize user_name casing so that the
+	// state matches the config. The set must have exactly 2 elements (not 3),
+	// and the user_name must be lowercase to match the config.
+	require.Equal(t, 2, ac.Len(),
+		"expected 2 access_control entries; 3 means casing mismatch caused drift (#5183)")
+
+	for _, elem := range ac.List() {
+		m := elem.(map[string]interface{})
+		if m["user_name"] != "" {
+			assert.Equal(t, "user@example.com", m["user_name"],
+				"user_name in state must be normalized to match config casing (#5183)")
+		}
+	}
+}


### PR DESCRIPTION
Closes #5183, Fixes #5712

## Changes

Fixes permanent permissions drift when `user_name` casing in `databricks_permissions` `access_control` blocks differs from the API response.

**Problem:** The Databricks API normalizes user emails to lowercase (e.g. config has `User@Example.com`, API returns `user@example.com`). Because emails are case-insensitive, both refer to the same user, but Terraform treats them as different entries, causing a remove/re-add diff on every plan that never converges.

**Fix:** Normalize `user_name` and `service_principal_name` to lowercase throughout the permissions resource so that casing differences between config and API are ignored. The fix touches three areas:

1. **Hash function**: Lowercase `user_name` and `service_principal_name` before hashing so config and API values produce the same hash.
2. **API response handling**: Lowercase `user_name` and `service_principal_name` when reading the API response into state.
3. **Current-user comparison**: Use case-insensitive comparison (`strings.EqualFold`) when checking if the current user is in the config. Without this, the provider silently dropped the current user's permissions from state when their email casing differed, a second source of drift.

---

## Detailed Changes

### Hash function case normalization (`permissions/resource_permissions.go`, lines 191-217)

**Before:**
```go
if strVal, ok := val.(string); ok {
    if strVal != "" {
        normalized[key] = strVal
    }
}
```

**After:**
```go
if strVal, ok := val.(string); ok {
    if strVal != "" {
        if key == "user_name" || key == "service_principal_name" {
            strVal = strings.ToLower(strVal)
        }
        normalized[key] = strVal
    }
}
```

**Why:** The `access_control` block uses `schema.TypeSet`, which relies on a hash function to determine element identity. If the user's config has `User@Example.com` and the API returns `user@example.com`, they produced different hashes, so Terraform saw them as two different set elements: one to remove and one to add. Lowercasing before hashing ensures both values produce the same hash.

---

### API response lowercasing (`permissions/permission_definitions.go`, lines 247-248)

**Before:**
```go
entity.AccessControlList = append(entity.AccessControlList, iam.AccessControlRequest{
    GroupName:            accessControl.GroupName,
    UserName:             accessControl.UserName,
    ServicePrincipalName: accessControl.ServicePrincipalName,
    PermissionLevel:      permission.PermissionLevel,
})
```

**After:**
```go
entity.AccessControlList = append(entity.AccessControlList, iam.AccessControlRequest{
    GroupName:            accessControl.GroupName,
    UserName:             strings.ToLower(accessControl.UserName),
    ServicePrincipalName: strings.ToLower(accessControl.ServicePrincipalName),
    PermissionLevel:      permission.PermissionLevel,
})
```

**Why:** Even with matching hashes, if the stored string value in state differs from the config value, Terraform detects a diff. Lowercasing the API response ensures the state value matches a lowercase config value.

---

### Case-insensitive current-user comparison (`permissions/permission_definitions.go`, line 231)

**Before:**
```go
if me == accessControl.UserName || me == accessControl.ServicePrincipalName {
```

**After:**
```go
if strings.EqualFold(me, accessControl.UserName) || strings.EqualFold(me, accessControl.ServicePrincipalName) {
```

**Why:** `==` is case-sensitive, so `"Admin@Example.com" == "admin@example.com"` returns `false`. `strings.EqualFold` compares strings case-insensitively, correctly matching the same user regardless of casing.

---

### Case-insensitive lookup in `ContainsUserOrServicePrincipal` (`permissions/entity/permissions_entity.go`, line 17)

**Before:**
```go
if ac.UserName == name || ac.ServicePrincipalName == name {
```

**After:**
```go
if strings.EqualFold(ac.UserName, name) || strings.EqualFold(ac.ServicePrincipalName, name) {
```

**Why:** Same as above. `==` is case-sensitive, so `"Admin@Example.com" == "admin@example.com"` returns `false`. `strings.EqualFold` compares strings case-insensitively, correctly matching the same user regardless of casing.

---

## Tests

- **TestPermissionsDrift_UserNameNoDriftWithSameCasing**: Simulates an existing resource in state with `user_name="user@example.com"`, then performs a Read where the API returns the same casing. Constructs a full `InstanceState` with computed set hashes and verifies that the Read produces exactly 2 `access_control` entries (no drift).

- **TestPermissionsDrift_UserNameNoDriftWithDifferentCasing**: Simulates the exact drift from issue #5183: `InstanceState` has `user_name="user@example.com"` but the API returns `User@Example.com`. Verifies that after the fix, the Read normalizes the casing so that:
  1. The `access_control` set still has exactly 2 entries (not 3, which would indicate drift)
  2. The `user_name` value in state is `"user@example.com"` (lowercase)

Both tests use `MockWorkspaceClientFunc` with mocked `CurrentUser.Me()` and `Permissions.Get()` responses, and construct realistic `InstanceState` maps with pre-computed set hashes to simulate the post-apply state that Terraform would produce.

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [x] using Go SDK
- [ ] using TF Plugin Framework
- [x] has entry in `NEXT_CHANGELOG.md` file

## Notes

- No documentation changes needed. This is a bug fix with no new fields or behavioral changes to document.