### PR TITLE
docs: add note that workspace can only have one NCC binding

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Documentation
 
+* Added note to `databricks_mws_ncc_binding` that a workspace can only have one NCC binding at a time.
+
 ### Exporter
 
 ### Internal Changes

--- a/docs/resources/mws_ncc_binding.md
+++ b/docs/resources/mws_ncc_binding.md
@@ -11,6 +11,8 @@ Allows you to attach a [Network Connectivity Config](mws_network_connectivity_co
 
 The NCC and workspace must be in the same region.
 
+-> A workspace can only be bound to a single NCC. Binding a different NCC to the same workspace will overwrite the previous one. If you need multiple private endpoint rules, add them to a single NCC using [`databricks_mws_ncc_private_endpoint_rule`](mws_ncc_private_endpoint_rule.md).
+
 ## Example Usage
 
 ```hcl


### PR DESCRIPTION
## Changes

Added a note to `databricks_mws_ncc_binding` docs that a workspace can only be bound to a single NCC, and binding a different NCC will overwrite the previous one.

Closes #5400

## Tests

- [x] `docs/` folder has been updated
- [x] Added `NEXT_CHANGELOG.md` entry