### PR TITLE
[Fix] Fix `databricks_external_location` drift for new default variable values

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bug Fixes
 
+* Fixed perpetual drift in `databricks_external_location` for `enable_file_events` and `file_event_queue` when the server defaults file events to enabled ([#5355](https://github.com/databricks/terraform-provider-databricks/issues/5355)).
+
 ### Documentation
 
 ### Exporter

--- a/catalog/resource_external_location.go
+++ b/catalog/resource_external_location.go
@@ -36,6 +36,8 @@ func ResourceExternalLocation() common.Resource {
 			common.CustomizeSchemaPath(m, "isolation_mode").SetComputed()
 			common.CustomizeSchemaPath(m, "owner").SetComputed()
 			common.CustomizeSchemaPath(m, "metastore_id").SetComputed()
+			common.CustomizeSchemaPath(m, "enable_file_events").SetComputed()
+			common.CustomizeSchemaPath(m, "file_event_queue").SetComputed()
 			for _, key := range []string{"created_at", "created_by", "credential_id", "updated_at", "updated_by", "browse_only"} {
 				common.CustomizeSchemaPath(m, key).SetReadOnly()
 			}


### PR DESCRIPTION
Closes #5355

## Changes

The Databricks backend now defaults `enable_file_events` to `true` and auto-creates a managed file event queue when the storage credential has the required permissions. Since these fields were not marked as `Computed`, the provider discarded the default values on every read, causing perpetual drift (`enable_file_events = true -> null`).

The fix marks both `enable_file_events` and `file_event_queue` as `Computed`, which tells Terraform the server may set these values and allows the provider to write them to state. This covers both existing resources (where state has `null` from before the backend change) and new resources (where server-set values were discarded immediately after creation). Affected users will see a one-time state update on their next apply.

---

## Detailed Changes

### Add `SetComputed()` to `enable_file_events` and `file_event_queue` (`catalog/resource_external_location.go:39-40`)

**Before:**
```go
common.CustomizeSchemaPath(m, "metastore_id").SetComputed()
for _, key := range []string{"created_at", "created_by", "credential_id", "updated_at", "updated_by", "browse_only"} {
```

**After:**
```go
common.CustomizeSchemaPath(m, "metastore_id").SetComputed()
common.CustomizeSchemaPath(m, "enable_file_events").SetComputed()
common.CustomizeSchemaPath(m, "file_event_queue").SetComputed()
for _, key := range []string{"created_at", "created_by", "credential_id", "updated_at", "updated_by", "browse_only"} {
```

**Why:** Without `Computed`, `StructToData` (`common/reflect_resource.go:708-713`) skips writing server-returned values for fields not explicitly configured by the user. Marking both fields as `Computed` tells Terraform the server may set these values, so `StructToData` preserves them in state. The Update function already handles `enable_file_events` with `ForceSendFields` (line 139-143), so explicit `false` values continue to work.

---

## Tests

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [x] using Go SDK
- [ ] using TF Plugin Framework
- [x] has entry in `NEXT_CHANGELOG.md` file

- **TestReadExternalLocation_ServerDefaultFileEvents**: Simulates a Read where the API returns `enable_file_events: true` and a `file_event_queue` with `managed_sqs` (including `managed_resource_id` and `queue_url`), while the user config does not specify these fields. Asserts that both values are preserved in state via `ApplyAndExpectData`. Uses `MockWorkspaceClientFunc` per project guidelines.
