### PR TITLE
[Feature] Added data sources for GCP permissions

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### New Features and Improvements
 
+* Added `databricks_gcp_crossaccount_policy`, `databricks_gcp_vpc_policy`, and `databricks_gcp_unity_catalog_policy` data sources to simplify creation of GCP custom IAM roles for Databricks workspaces and Unity Catalog ([#5425](https://github.com/databricks/terraform-provider-databricks/pull/5425)).
+
 ### Bug Fixes
 
 ### Documentation

--- a/docs/data-sources/gcp_crossaccount_policy.md
+++ b/docs/data-sources/gcp_crossaccount_policy.md
@@ -1,0 +1,78 @@
+---
+subcategory: "Deployment"
+---
+# databricks_gcp_crossaccount_policy Data Source
+
+This data source constructs the list of GCP IAM permissions required for the Databricks workspace creator custom role in the **workspace GCP project** (IAM, service accounts, project management, service usage).
+
+For the networking permissions required in the VPC project, use [databricks_gcp_vpc_policy](gcp_vpc_policy.md) instead.
+
+-> This data source has an evolving API, which may change in future versions of the provider. Please always consult [latest documentation](https://docs.databricks.com/gcp/en/admin/cloud-configurations/gcp/permissions) in case of any questions.
+
+## Example Usage
+
+### Single-project workspace (VPC in same project as workspace)
+
+When the VPC resides in the same project as the workspace, merge the permissions from both `databricks_gcp_crossaccount_policy` and `databricks_gcp_vpc_policy` into a single custom role:
+
+```hcl
+data "databricks_gcp_crossaccount_policy" "this" {}
+
+data "databricks_gcp_vpc_policy" "this" {
+  enable_byovpc = true
+}
+
+resource "google_project_iam_custom_role" "workspace_creator" {
+  role_id     = "databricks_workspace_creator"
+  title       = "Databricks Workspace Creator"
+  permissions = tolist(toset(concat(
+    data.databricks_gcp_crossaccount_policy.this.permissions,
+    data.databricks_gcp_vpc_policy.this.permissions,
+  )))
+}
+
+resource "google_project_iam_member" "workspace_creator" {
+  project = var.google_project
+  role    = google_project_iam_custom_role.workspace_creator.id
+  member  = "serviceAccount:${var.databricks_google_service_account}"
+}
+```
+
+### Shared VPC workspace (VPC in a separate host project)
+
+When using a Shared VPC, apply the workspace project role to the service project and the VPC project role to the host project:
+
+```hcl
+data "databricks_gcp_crossaccount_policy" "this" {}
+
+resource "google_project_iam_custom_role" "workspace_creator" {
+  project     = var.workspace_project_id
+  role_id     = "databricks_workspace_creator"
+  title       = "Databricks Workspace Creator"
+  permissions = data.databricks_gcp_crossaccount_policy.this.permissions
+}
+
+resource "google_project_iam_member" "workspace_creator" {
+  project = var.workspace_project_id
+  role    = google_project_iam_custom_role.workspace_creator.id
+  member  = "serviceAccount:${var.databricks_google_service_account}"
+}
+```
+
+## Argument Reference
+
+This data source takes no arguments. All permissions for the workspace project are always included.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `permissions` - List of GCP IAM permissions for the workspace creator custom role in the workspace project, to be used with [google_project_iam_custom_role](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/google_project_iam_custom_role).
+
+## Related Resources
+
+The following resources are used in the same context:
+
+* [Provisioning GCP Databricks workspaces](../guides/gcp-workspace.md) - guide for setting up workspaces on GCP.
+* [databricks_gcp_vpc_policy](gcp_vpc_policy.md) - data source for VPC project permissions on GCP.
+* [databricks_gcp_unity_catalog_policy](gcp_unity_catalog_policy.md) - data source for Unity Catalog permissions on GCP.

--- a/docs/data-sources/gcp_unity_catalog_policy.md
+++ b/docs/data-sources/gcp_unity_catalog_policy.md
@@ -1,0 +1,64 @@
+---
+subcategory: "Deployment"
+---
+# databricks_gcp_unity_catalog_policy Data Source
+
+This data source constructs the list of GCP IAM permissions required for the Unity Catalog file events custom role on GCP.
+
+-> This data source has an evolving API, which may change in future versions of the provider. Please always consult [latest documentation](https://docs.databricks.com/gcp/en/admin/cloud-configurations/gcp/permissions) in case of any questions.
+
+## Example Usage
+
+```hcl
+resource "databricks_storage_credential" "ext" {
+  name = "the-creds"
+  databricks_gcp_service_account {}
+}
+
+data "databricks_gcp_unity_catalog_policy" "this" {
+  databricks_google_service_account = databricks_storage_credential.ext.databricks_gcp_service_account[0].email
+}
+
+resource "google_project_iam_custom_role" "uc_file_events" {
+  role_id     = "uc_file_events"
+  title       = "Unity Catalog File Events"
+  permissions = data.databricks_gcp_unity_catalog_policy.this.permissions
+}
+
+resource "google_project_iam_member" "uc_file_events" {
+  project = var.google_project
+  role    = google_project_iam_custom_role.uc_file_events.id
+  member  = "serviceAccount:${data.databricks_gcp_unity_catalog_policy.this.databricks_google_service_account}"
+}
+
+resource "google_storage_bucket_iam_member" "unity_sa_admin" {
+  bucket = google_storage_bucket.this.name
+  role   = "roles/storage.objectAdmin"
+  member = "serviceAccount:${data.databricks_gcp_unity_catalog_policy.this.databricks_google_service_account}"
+}
+
+resource "google_storage_bucket_iam_member" "unity_sa_reader" {
+  bucket = google_storage_bucket.this.name
+  role   = "roles/storage.legacyBucketReader"
+  member = "serviceAccount:${data.databricks_gcp_unity_catalog_policy.this.databricks_google_service_account}"
+}
+```
+
+## Argument Reference
+
+* `databricks_google_service_account` (Required) - The email of the Databricks-managed GCP service account. Typically obtained from `databricks_storage_credential.*.databricks_gcp_service_account[0].email` or `databricks_metastore_data_access.*.databricks_gcp_service_account[0].email`.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `permissions` - List of GCP IAM permissions for the Unity Catalog file events custom role, to be used with [google_project_iam_custom_role](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/google_project_iam_custom_role).
+* `databricks_google_service_account` - The email of the Databricks-managed GCP service account (same as the input). Exported for use in `google_storage_bucket_iam_member` and similar resources.
+
+## Related Resources
+
+The following resources are used in the same context:
+
+* [Unity Catalog set up on GCP](../guides/unity-catalog-gcp.md) - guide for setting up Unity Catalog on GCP.
+* [databricks_storage_credential](../resources/storage_credential.md) - resource for creating storage credentials.
+* [databricks_gcp_crossaccount_policy](gcp_crossaccount_policy.md) - data source for workspace creator permissions on GCP.

--- a/docs/data-sources/gcp_vpc_policy.md
+++ b/docs/data-sources/gcp_vpc_policy.md
@@ -1,0 +1,60 @@
+---
+subcategory: "Deployment"
+---
+# databricks_gcp_vpc_policy Data Source
+
+This data source constructs the list of GCP IAM permissions required for the Databricks workspace creator custom role in the **VPC GCP project** (compute, networking, firewall management).
+
+In a [Shared VPC](https://docs.databricks.com/gcp/en/security/network/classic/customer-managed-vpc) setup, the VPC resides in a separate host project. This data source covers the permissions needed in that host project. When the VPC is in the same project as the workspace, combine these permissions with [databricks_gcp_crossaccount_policy](gcp_crossaccount_policy.md).
+
+-> This data source has an evolving API, which may change in future versions of the provider. Please always consult [latest documentation](https://docs.databricks.com/gcp/en/admin/cloud-configurations/gcp/permissions) in case of any questions.
+
+## Example Usage
+
+### Shared VPC workspace with all features enabled
+
+```hcl
+data "databricks_gcp_vpc_policy" "this" {
+  enable_byovpc = true
+  enable_cmk    = true
+  enable_psc    = true
+}
+
+resource "google_project_iam_custom_role" "vpc_creator" {
+  project     = var.vpc_project_id
+  role_id     = "databricks_vpc_creator"
+  title       = "Databricks Workspace Creator Role for VPC Project"
+  permissions = data.databricks_gcp_vpc_policy.this.permissions
+}
+
+resource "google_project_iam_member" "vpc_creator" {
+  project = var.vpc_project_id
+  role    = google_project_iam_custom_role.vpc_creator.id
+  member  = "serviceAccount:${var.databricks_google_service_account}"
+}
+```
+
+### Single-project workspace (VPC in same project as workspace)
+
+When the VPC resides in the same project, merge these permissions with `databricks_gcp_crossaccount_policy`. See the [databricks_gcp_crossaccount_policy](gcp_crossaccount_policy.md) documentation for a complete example.
+
+## Argument Reference
+
+* `enable_byovpc` - (Optional) Set to `true` to include additional permissions required for [customer-managed VPC (Bring Your Own VPC)](https://docs.databricks.com/gcp/en/security/network/classic/customer-managed-vpc). Adds `compute.subnetworks.*` permissions. Defaults to `false`.
+* `enable_cmk` - (Optional) Set to `true` to include additional permissions required for [Customer-Managed Keys](https://docs.databricks.com/gcp/en/security/keys/customer-managed-keys). Adds `cloudkms.cryptoKeys.*` permissions. Defaults to `false`.
+* `enable_psc` - (Optional) Set to `true` to include additional permissions required for [Private Service Connect](https://docs.databricks.com/gcp/en/security/network/classic/private-service-connect). Adds `compute.forwardingRules.*` permissions. Defaults to `false`.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `permissions` - List of GCP IAM permissions for the workspace creator custom role in the VPC project, to be used with [google_project_iam_custom_role](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/google_project_iam_custom_role).
+
+## Related Resources
+
+The following resources are used in the same context:
+
+* [Provisioning GCP Databricks workspaces](../guides/gcp-workspace.md) - guide for setting up workspaces on GCP.
+* [Provisioning GCP Databricks workspaces with PSC](../guides/gcp-private-service-connect-workspace.md) - guide for setting up workspaces with Private Service Connect.
+* [databricks_gcp_crossaccount_policy](gcp_crossaccount_policy.md) - data source for workspace project permissions on GCP.
+* [databricks_gcp_unity_catalog_policy](gcp_unity_catalog_policy.md) - data source for Unity Catalog permissions on GCP.

--- a/docs/guides/gcp-workspace.md
+++ b/docs/guides/gcp-workspace.md
@@ -51,46 +51,19 @@ resource "google_service_account_iam_policy" "impersonatable" {
   policy_data        = data.google_iam_policy.this.policy_data
 }
 
+data "databricks_gcp_crossaccount_policy" "this" {}
+
+data "databricks_gcp_vpc_policy" "this" {
+  enable_byovpc = true
+}
+
 resource "google_project_iam_custom_role" "workspace_creator" {
   role_id = "${var.prefix}_workspace_creator"
   title   = "Databricks Workspace Creator"
-  permissions = [
-    # IAM Role Management
-    "iam.roles.create",
-    "iam.roles.delete",
-    "iam.roles.get",
-    "iam.roles.update",
-    # Service Account Management
-    "iam.serviceAccounts.create",
-    "iam.serviceAccounts.get",
-    "iam.serviceAccounts.getIamPolicy",
-    "iam.serviceAccounts.setIamPolicy",
-    # Project Management
-    "resourcemanager.projects.get",
-    "resourcemanager.projects.getIamPolicy",
-    "resourcemanager.projects.setIamPolicy",
-    # Service Usage
-    "serviceusage.services.get",
-    "serviceusage.services.list",
-    "serviceusage.services.enable",
-    # Network Management
-    "compute.networks.get",
-    "compute.networks.updatePolicy",
-    "compute.projects.get",
-    "compute.subnetworks.get",
-    "compute.subnetworks.getIamPolicy",
-    "compute.subnetworks.setIamPolicy",
-    # Firewall Management
-    "compute.firewalls.get",
-    "compute.firewalls.create",
-    # Private Service Connect (required if using PSC)
-    "compute.forwardingRules.get",
-    "compute.forwardingRules.list",
-    # Customer-Managed Keys (required if using CMK)
-    # Uncomment these if you plan to use customer-managed encryption keys:
-    # "cloudkms.cryptoKeys.getIamPolicy",
-    # "cloudkms.cryptoKeys.setIamPolicy",
-  ]
+  permissions = tolist(toset(concat(
+    data.databricks_gcp_crossaccount_policy.this.permissions,
+    data.databricks_gcp_vpc_policy.this.permissions,
+  )))
 }
 
 data "google_client_config" "current" {}

--- a/docs/guides/unity-catalog-gcp.md
+++ b/docs/guides/unity-catalog-gcp.md
@@ -142,25 +142,14 @@ resource "databricks_storage_credential" "ext" {
   depends_on = [databricks_metastore_assignment.this]
 }
 
+data "databricks_gcp_unity_catalog_policy" "this" {
+  databricks_google_service_account = databricks_storage_credential.ext.databricks_gcp_service_account[0].email
+}
+
 resource "google_project_iam_custom_role" "uc_file_events" {
-  role_id = "ucFileEvents"
-  title   = "Unity Catalog file events role"
-  permissions = [
-    "pubsub.subscriptions.consume",
-    "pubsub.subscriptions.create",
-    "pubsub.subscriptions.delete",
-    "pubsub.subscriptions.get",
-    "pubsub.subscriptions.list",
-    "pubsub.subscriptions.update",
-    "pubsub.topics.attachSubscription",
-    "pubsub.topics.detachSubscription",
-    "pubsub.topics.create",
-    "pubsub.topics.delete",
-    "pubsub.topics.get",
-    "pubsub.topics.list",
-    "pubsub.topics.update",
-    "storage.buckets.update"
-  ]
+  role_id     = "ucFileEvents"
+  title       = "Unity Catalog file events role"
+  permissions = data.databricks_gcp_unity_catalog_policy.this.permissions
 }
 
 data "google_storage_project_service_account" "gcs_account" {}

--- a/internal/providers/pluginfw/pluginfw_rollout_utils.go
+++ b/internal/providers/pluginfw/pluginfw_rollout_utils.go
@@ -17,6 +17,7 @@ import (
 	"github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/products/catalog"
 	"github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/products/cluster"
 	"github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/products/dashboards"
+	"github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/products/gcp"
 	"github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/products/library"
 	"github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/products/notificationdestinations"
 	"github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/products/qualitymonitor"
@@ -62,6 +63,9 @@ var pluginFwOnlyDataSources = append(
 		app.DataSourceApps,
 		catalog.DataSourceFunctions,
 		dashboards.DataSourceDashboards,
+		gcp.DataSourceGcpCrossaccountPolicy,
+		gcp.DataSourceGcpUnityCatalogPolicy,
+		gcp.DataSourceGcpVpcPolicy,
 		notificationdestinations.DataSourceNotificationDestinations,
 		registered_model.DataSourceRegisteredModel,
 		registered_model.DataSourceRegisteredModelVersions,

--- a/internal/providers/pluginfw/products/gcp/data_gcp_crossaccount_policy.go
+++ b/internal/providers/pluginfw/products/gcp/data_gcp_crossaccount_policy.go
@@ -1,0 +1,116 @@
+package gcp
+
+import (
+	"context"
+	"reflect"
+
+	"github.com/databricks/terraform-provider-databricks/common"
+	pluginfwcommon "github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/common"
+	pluginfwcontext "github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/context"
+	"github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/tfschema"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+const crossAccountDataSourceName = "gcp_crossaccount_policy"
+
+func DataSourceGcpCrossaccountPolicy() datasource.DataSource {
+	return &GcpCrossaccountPolicyDataSource{}
+}
+
+var _ datasource.DataSourceWithConfigure = &GcpCrossaccountPolicyDataSource{}
+
+type GcpCrossaccountPolicyDataSource struct {
+	Client *common.DatabricksClient
+}
+
+// GcpCrossaccountPolicyData holds the input/output for the workspace project
+// custom role. Compute/networking permissions belong to databricks_gcp_vpc_policy.
+type GcpCrossaccountPolicyData struct {
+	Permissions types.List `tfsdk:"permissions"`
+	tfschema.Namespace
+}
+
+func (GcpCrossaccountPolicyData) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
+	attrs["permissions"] = attrs["permissions"].SetComputed()
+	attrs["provider_config"] = attrs["provider_config"].SetOptional()
+	return attrs
+}
+
+func (GcpCrossaccountPolicyData) GetComplexFieldTypes(context.Context) map[string]reflect.Type {
+	return map[string]reflect.Type{
+		"permissions":     reflect.TypeOf(types.String{}),
+		"provider_config": reflect.TypeOf(tfschema.ProviderConfigData{}),
+	}
+}
+
+func (d *GcpCrossaccountPolicyDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = pluginfwcommon.GetDatabricksProductionName(crossAccountDataSourceName)
+}
+
+func (d *GcpCrossaccountPolicyDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	attrs, blocks := tfschema.DataSourceStructToSchemaMap(ctx, GcpCrossaccountPolicyData{}, nil)
+	resp.Schema = schema.Schema{
+		Attributes: attrs,
+		Blocks:     blocks,
+	}
+}
+
+func (d *GcpCrossaccountPolicyDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if d.Client == nil {
+		d.Client = pluginfwcommon.ConfigureDataSource(req, resp)
+	}
+}
+
+func (d *GcpCrossaccountPolicyDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	ctx = pluginfwcontext.SetUserAgentInDataSourceContext(ctx, crossAccountDataSourceName)
+
+	var data GcpCrossaccountPolicyData
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	permissions := computeGcpCrossaccountPermissions()
+
+	permValues := make([]attr.Value, len(permissions))
+	for i, p := range permissions {
+		permValues[i] = types.StringValue(p)
+	}
+	data.Permissions = types.ListValueMust(types.StringType, permValues)
+	resp.Diagnostics.Append(resp.State.Set(ctx, data)...)
+}
+
+func computeGcpCrossaccountPermissions() []string {
+	permissions := make([]string, len(gcpWorkspaceCreatorBasePermissions))
+	copy(permissions, gcpWorkspaceCreatorBasePermissions)
+	return permissions
+}
+
+// gcpWorkspaceCreatorBasePermissions is the set of permissions required for the
+// Databricks workspace creator custom role in the workspace GCP project.
+// See https://docs.databricks.com/gcp/en/admin/cloud-configurations/gcp/permissions
+// Compute and networking permissions (needed in the VPC project) are covered by
+// databricks_gcp_vpc_policy.
+var gcpWorkspaceCreatorBasePermissions = []string{
+	// IAM Role Management
+	"iam.roles.create",
+	"iam.roles.delete",
+	"iam.roles.get",
+	"iam.roles.update",
+	// Service Account Management
+	"iam.serviceAccounts.create",
+	"iam.serviceAccounts.get",
+	"iam.serviceAccounts.getIamPolicy",
+	"iam.serviceAccounts.setIamPolicy",
+	// Project Management
+	"resourcemanager.projects.get",
+	"resourcemanager.projects.getIamPolicy",
+	"resourcemanager.projects.setIamPolicy",
+	// Service Usage
+	"serviceusage.services.get",
+	"serviceusage.services.list",
+	"serviceusage.services.enable",
+}

--- a/internal/providers/pluginfw/products/gcp/data_gcp_crossaccount_policy_test.go
+++ b/internal/providers/pluginfw/products/gcp/data_gcp_crossaccount_policy_test.go
@@ -1,0 +1,37 @@
+package gcp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestComputeGcpCrossaccountPermissions_Base(t *testing.T) {
+	perms := computeGcpCrossaccountPermissions()
+	assert.Equal(t, gcpWorkspaceCreatorBasePermissions, perms)
+	assert.Len(t, perms, 14)
+}
+
+func TestComputeGcpCrossaccountPermissions_DoesNotMutateBase(t *testing.T) {
+	originalLen := len(gcpWorkspaceCreatorBasePermissions)
+	computeGcpCrossaccountPermissions()
+	assert.Len(t, gcpWorkspaceCreatorBasePermissions, originalLen)
+}
+
+func TestComputeGcpCrossaccountPermissions_NoComputePermissions(t *testing.T) {
+	perms := computeGcpCrossaccountPermissions()
+	for _, p := range perms {
+		assert.NotContains(t, p, "compute.", "crossaccount policy must not contain compute permissions (use databricks_gcp_vpc_policy instead)")
+	}
+}
+
+func TestComputeGcpCrossaccountPermissions_NoCmkPermissions(t *testing.T) {
+	perms := computeGcpCrossaccountPermissions()
+	assert.NotContains(t, perms, "cloudkms.cryptoKeys.getIamPolicy", "CMK permissions belong to the VPC project (use databricks_gcp_vpc_policy instead)")
+	assert.NotContains(t, perms, "cloudkms.cryptoKeys.setIamPolicy")
+}
+
+func TestComputeGcpCrossaccountPermissions_ContainsIamRoleDelete(t *testing.T) {
+	perms := computeGcpCrossaccountPermissions()
+	assert.Contains(t, perms, "iam.roles.delete", "iam.roles.delete is workspace project only")
+}

--- a/internal/providers/pluginfw/products/gcp/data_gcp_unity_catalog_policy.go
+++ b/internal/providers/pluginfw/products/gcp/data_gcp_unity_catalog_policy.go
@@ -1,0 +1,101 @@
+package gcp
+
+import (
+	"context"
+	"reflect"
+
+	"github.com/databricks/terraform-provider-databricks/common"
+	pluginfwcommon "github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/common"
+	pluginfwcontext "github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/context"
+	"github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/tfschema"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+const unityCatalogDataSourceName = "gcp_unity_catalog_policy"
+
+func DataSourceGcpUnityCatalogPolicy() datasource.DataSource {
+	return &GcpUnityCatalogPolicyDataSource{}
+}
+
+var _ datasource.DataSourceWithConfigure = &GcpUnityCatalogPolicyDataSource{}
+
+type GcpUnityCatalogPolicyDataSource struct {
+	Client *common.DatabricksClient
+}
+
+type GcpUnityCatalogPolicyData struct {
+	DatabricksGoogleServiceAccount types.String `tfsdk:"databricks_google_service_account"`
+	Permissions                    types.List   `tfsdk:"permissions"`
+	tfschema.Namespace
+}
+
+func (GcpUnityCatalogPolicyData) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
+	attrs["databricks_google_service_account"] = attrs["databricks_google_service_account"].SetRequired()
+	attrs["permissions"] = attrs["permissions"].SetComputed()
+	attrs["provider_config"] = attrs["provider_config"].SetOptional()
+	return attrs
+}
+
+func (GcpUnityCatalogPolicyData) GetComplexFieldTypes(context.Context) map[string]reflect.Type {
+	return map[string]reflect.Type{
+		"permissions":     reflect.TypeOf(types.String{}),
+		"provider_config": reflect.TypeOf(tfschema.ProviderConfigData{}),
+	}
+}
+
+func (d *GcpUnityCatalogPolicyDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = pluginfwcommon.GetDatabricksProductionName(unityCatalogDataSourceName)
+}
+
+func (d *GcpUnityCatalogPolicyDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	attrs, blocks := tfschema.DataSourceStructToSchemaMap(ctx, GcpUnityCatalogPolicyData{}, nil)
+	resp.Schema = schema.Schema{
+		Attributes: attrs,
+		Blocks:     blocks,
+	}
+}
+
+func (d *GcpUnityCatalogPolicyDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if d.Client == nil {
+		d.Client = pluginfwcommon.ConfigureDataSource(req, resp)
+	}
+}
+
+func (d *GcpUnityCatalogPolicyDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	ctx = pluginfwcontext.SetUserAgentInDataSourceContext(ctx, unityCatalogDataSourceName)
+
+	var data GcpUnityCatalogPolicyData
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	permValues := make([]attr.Value, len(gcpUnityCatalogPermissions))
+	for i, p := range gcpUnityCatalogPermissions {
+		permValues[i] = types.StringValue(p)
+	}
+	data.Permissions = types.ListValueMust(types.StringType, permValues)
+	resp.Diagnostics.Append(resp.State.Set(ctx, data)...)
+}
+
+// gcpUnityCatalogPermissions are the permissions required for the Unity Catalog
+// file events custom role on GCP.
+var gcpUnityCatalogPermissions = []string{
+	"pubsub.subscriptions.consume",
+	"pubsub.subscriptions.create",
+	"pubsub.subscriptions.delete",
+	"pubsub.subscriptions.get",
+	"pubsub.subscriptions.list",
+	"pubsub.subscriptions.update",
+	"pubsub.topics.attachSubscription",
+	"pubsub.topics.create",
+	"pubsub.topics.delete",
+	"pubsub.topics.detachSubscription",
+	"pubsub.topics.get",
+	"pubsub.topics.list",
+	"pubsub.topics.update",
+	"storage.buckets.update",
+}

--- a/internal/providers/pluginfw/products/gcp/data_gcp_unity_catalog_policy_test.go
+++ b/internal/providers/pluginfw/products/gcp/data_gcp_unity_catalog_policy_test.go
@@ -1,0 +1,17 @@
+package gcp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGcpUnityCatalogPermissions_ContainsExpectedPermissions(t *testing.T) {
+	assert.Contains(t, gcpUnityCatalogPermissions, "pubsub.subscriptions.consume")
+	assert.Contains(t, gcpUnityCatalogPermissions, "pubsub.topics.create")
+	assert.Contains(t, gcpUnityCatalogPermissions, "storage.buckets.update")
+}
+
+func TestGcpUnityCatalogPermissions_Count(t *testing.T) {
+	assert.Len(t, gcpUnityCatalogPermissions, 14)
+}

--- a/internal/providers/pluginfw/products/gcp/data_gcp_vpc_policy.go
+++ b/internal/providers/pluginfw/products/gcp/data_gcp_vpc_policy.go
@@ -1,0 +1,155 @@
+package gcp
+
+import (
+	"context"
+	"reflect"
+
+	"github.com/databricks/terraform-provider-databricks/common"
+	pluginfwcommon "github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/common"
+	pluginfwcontext "github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/context"
+	"github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/tfschema"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+const vpcDataSourceName = "gcp_vpc_policy"
+
+func DataSourceGcpVpcPolicy() datasource.DataSource {
+	return &GcpVpcPolicyDataSource{}
+}
+
+var _ datasource.DataSourceWithConfigure = &GcpVpcPolicyDataSource{}
+
+type GcpVpcPolicyDataSource struct {
+	Client *common.DatabricksClient
+}
+
+// GcpVpcPolicyData holds the input/output for the VPC project custom role.
+// In shared VPC setups, the VPC may reside in a different GCP project than the
+// workspace. This data source covers the permissions required in that VPC project.
+// See https://docs.databricks.com/gcp/en/admin/cloud-configurations/gcp/permissions
+type GcpVpcPolicyData struct {
+	EnableByovpc types.Bool `tfsdk:"enable_byovpc"`
+	EnableCmk    types.Bool `tfsdk:"enable_cmk"`
+	EnablePsc    types.Bool `tfsdk:"enable_psc"`
+	Permissions  types.List `tfsdk:"permissions"`
+	tfschema.Namespace
+}
+
+func (GcpVpcPolicyData) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
+	attrs["enable_byovpc"] = attrs["enable_byovpc"].SetOptional()
+	attrs["enable_cmk"] = attrs["enable_cmk"].SetOptional()
+	attrs["enable_psc"] = attrs["enable_psc"].SetOptional()
+	attrs["permissions"] = attrs["permissions"].SetComputed()
+	attrs["provider_config"] = attrs["provider_config"].SetOptional()
+	return attrs
+}
+
+func (GcpVpcPolicyData) GetComplexFieldTypes(context.Context) map[string]reflect.Type {
+	return map[string]reflect.Type{
+		"permissions":     reflect.TypeOf(types.String{}),
+		"provider_config": reflect.TypeOf(tfschema.ProviderConfigData{}),
+	}
+}
+
+func (d *GcpVpcPolicyDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = pluginfwcommon.GetDatabricksProductionName(vpcDataSourceName)
+}
+
+func (d *GcpVpcPolicyDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	attrs, blocks := tfschema.DataSourceStructToSchemaMap(ctx, GcpVpcPolicyData{}, nil)
+	resp.Schema = schema.Schema{
+		Attributes: attrs,
+		Blocks:     blocks,
+	}
+}
+
+func (d *GcpVpcPolicyDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if d.Client == nil {
+		d.Client = pluginfwcommon.ConfigureDataSource(req, resp)
+	}
+}
+
+func (d *GcpVpcPolicyDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	ctx = pluginfwcontext.SetUserAgentInDataSourceContext(ctx, vpcDataSourceName)
+
+	var data GcpVpcPolicyData
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	enableByovpc := !data.EnableByovpc.IsNull() && data.EnableByovpc.ValueBool()
+	enableCmk := !data.EnableCmk.IsNull() && data.EnableCmk.ValueBool()
+	enablePsc := !data.EnablePsc.IsNull() && data.EnablePsc.ValueBool()
+	permissions := computeGcpVpcPermissions(enableByovpc, enableCmk, enablePsc)
+
+	permValues := make([]attr.Value, len(permissions))
+	for i, p := range permissions {
+		permValues[i] = types.StringValue(p)
+	}
+	data.Permissions = types.ListValueMust(types.StringType, permValues)
+	resp.Diagnostics.Append(resp.State.Set(ctx, data)...)
+}
+
+func computeGcpVpcPermissions(enableByovpc, enableCmk, enablePsc bool) []string {
+	permissions := make([]string, len(gcpVpcBasePermissions))
+	copy(permissions, gcpVpcBasePermissions)
+	if enableByovpc {
+		permissions = append(permissions, gcpByovpcPermissions...)
+	}
+	if enableCmk {
+		permissions = append(permissions, gcpCmkPermissions...)
+	}
+	if enablePsc {
+		permissions = append(permissions, gcpPscPermissions...)
+	}
+	return permissions
+}
+
+// gcpVpcBasePermissions is the set of permissions always required for the Databricks
+// workspace creator custom role in the VPC GCP project.
+// See https://docs.databricks.com/gcp/en/admin/cloud-configurations/gcp/permissions
+var gcpVpcBasePermissions = []string{
+	// IAM Role Management (note: iam.roles.delete is workspace project only)
+	"iam.roles.create",
+	"iam.roles.get",
+	"iam.roles.update",
+	// Firewall Management
+	"compute.firewalls.create",
+	"compute.firewalls.get",
+	// Network Management
+	"compute.networks.get",
+	"compute.networks.updatePolicy",
+	"compute.projects.get",
+	// Project Management (read-only in VPC project)
+	"resourcemanager.projects.get",
+	"resourcemanager.projects.getIamPolicy",
+	// Service Usage (read-only in VPC project)
+	"serviceusage.services.get",
+	"serviceusage.services.list",
+}
+
+// gcpByovpcPermissions are the additional permissions required when using
+// a customer-managed (Bring Your Own) VPC.
+var gcpByovpcPermissions = []string{
+	"compute.subnetworks.get",
+	"compute.subnetworks.getIamPolicy",
+	"compute.subnetworks.setIamPolicy",
+}
+
+// gcpCmkPermissions are the additional permissions required when using
+// Customer-Managed Keys (CMK) for encryption. These belong to the VPC project.
+var gcpCmkPermissions = []string{
+	"cloudkms.cryptoKeys.getIamPolicy",
+	"cloudkms.cryptoKeys.setIamPolicy",
+}
+
+// gcpPscPermissions are the additional permissions required when using
+// Private Service Connect (PSC).
+var gcpPscPermissions = []string{
+	"compute.forwardingRules.get",
+	"compute.forwardingRules.list",
+}

--- a/internal/providers/pluginfw/products/gcp/data_gcp_vpc_policy_test.go
+++ b/internal/providers/pluginfw/products/gcp/data_gcp_vpc_policy_test.go
@@ -1,0 +1,64 @@
+package gcp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestComputeGcpVpcPermissions_Base(t *testing.T) {
+	perms := computeGcpVpcPermissions(false, false, false)
+	assert.Equal(t, gcpVpcBasePermissions, perms)
+	assert.Len(t, perms, 12)
+	assert.NotContains(t, perms, "compute.forwardingRules.get")
+	assert.NotContains(t, perms, "compute.subnetworks.get")
+	assert.NotContains(t, perms, "cloudkms.cryptoKeys.getIamPolicy")
+}
+
+func TestComputeGcpVpcPermissions_WithByovpc(t *testing.T) {
+	perms := computeGcpVpcPermissions(true, false, false)
+	assert.Len(t, perms, len(gcpVpcBasePermissions)+len(gcpByovpcPermissions))
+	assert.Contains(t, perms, "compute.subnetworks.get")
+	assert.Contains(t, perms, "compute.subnetworks.getIamPolicy")
+	assert.Contains(t, perms, "compute.subnetworks.setIamPolicy")
+}
+
+func TestComputeGcpVpcPermissions_WithCmk(t *testing.T) {
+	perms := computeGcpVpcPermissions(false, true, false)
+	assert.Len(t, perms, len(gcpVpcBasePermissions)+len(gcpCmkPermissions))
+	assert.Contains(t, perms, "cloudkms.cryptoKeys.getIamPolicy")
+	assert.Contains(t, perms, "cloudkms.cryptoKeys.setIamPolicy")
+}
+
+func TestComputeGcpVpcPermissions_WithPsc(t *testing.T) {
+	perms := computeGcpVpcPermissions(false, false, true)
+	assert.Len(t, perms, len(gcpVpcBasePermissions)+len(gcpPscPermissions))
+	assert.Contains(t, perms, "compute.forwardingRules.get")
+	assert.Contains(t, perms, "compute.forwardingRules.list")
+}
+
+func TestComputeGcpVpcPermissions_AllFlags(t *testing.T) {
+	perms := computeGcpVpcPermissions(true, true, true)
+	expected := len(gcpVpcBasePermissions) + len(gcpByovpcPermissions) + len(gcpCmkPermissions) + len(gcpPscPermissions)
+	assert.Len(t, perms, expected)
+	assert.Contains(t, perms, "compute.subnetworks.get")
+	assert.Contains(t, perms, "cloudkms.cryptoKeys.getIamPolicy")
+	assert.Contains(t, perms, "compute.forwardingRules.get")
+}
+
+func TestComputeGcpVpcPermissions_DoesNotMutateBase(t *testing.T) {
+	originalLen := len(gcpVpcBasePermissions)
+	computeGcpVpcPermissions(true, true, true)
+	assert.Len(t, gcpVpcBasePermissions, originalLen)
+}
+
+func TestComputeGcpVpcPermissions_ContainsComputePermissions(t *testing.T) {
+	perms := computeGcpVpcPermissions(false, false, false)
+	assert.Contains(t, perms, "compute.networks.get")
+	assert.Contains(t, perms, "compute.firewalls.create")
+}
+
+func TestComputeGcpVpcPermissions_NoIamRolesDelete(t *testing.T) {
+	perms := computeGcpVpcPermissions(false, false, false)
+	assert.NotContains(t, perms, "iam.roles.delete", "iam.roles.delete is workspace project only")
+}


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

Added `databricks_gcp_crossaccount_policy`, `databricks_gcp_vpc_policy`, and `databricks_gcp_unity_catalog_policy` data sources to simplify creation of GCP custom IAM roles for Databricks workspaces and Unity Catalog.

Resolves #5151

## Tests
<!--
How is this tested? Please see the checklist below and also describe any other relevant tests
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] using Go SDK
- [x] using TF Plugin Framework
- [x] has entry in `NEXT_CHANGELOG.md` file
