### PR TITLE
Fixed `databricks_mws_workspaces` failing to update `private_access_settings_id` and other fields on GCP workspaces

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bug Fixes
 
+* Fixed `databricks_mws_workspaces` failing to update `private_access_settings_id` and other fields on GCP workspaces ([#5430](https://github.com/databricks/terraform-provider-databricks/issues/5430)).
+
 ### Documentation
 
 ### Exporter

--- a/mws/resource_mws_workspaces.go
+++ b/mws/resource_mws_workspaces.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"net"
 	"net/url"
+	"sort"
 	"strings"
 	"time"
 
@@ -334,6 +335,13 @@ func (a WorkspacesAPI) UpdateRunning(ws Workspace, timeout time.Duration) error 
 	if len(request) == 0 {
 		return nil
 	}
+
+	updateMaskFields := make([]string, 0, len(request))
+	for field := range request {
+		updateMaskFields = append(updateMaskFields, field)
+	}
+	sort.Strings(updateMaskFields)
+	workspacesAPIPath = fmt.Sprintf("%s?update_mask=%s", workspacesAPIPath, strings.Join(updateMaskFields, ","))
 
 	err := a.client.Patch(a.context, workspacesAPIPath, request)
 	if err != nil {

--- a/mws/resource_mws_workspaces_test.go
+++ b/mws/resource_mws_workspaces_test.go
@@ -734,7 +734,7 @@ func TestResourceWorkspaceUpdate(t *testing.T) {
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   "PATCH",
-				Resource: "/api/2.0/accounts/abc/workspaces/1234",
+				Resource: "/api/2.0/accounts/abc/workspaces/1234?update_mask=credentials_id,managed_services_customer_managed_key_id,network_id,storage_customer_managed_key_id",
 				ExpectedRequest: map[string]any{
 					"credentials_id":                           "bcd",
 					"network_id":                               "fgh",
@@ -896,7 +896,7 @@ func TestResourceWorkspaceUpdate_Error(t *testing.T) {
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   "PATCH",
-				Resource: "/api/2.0/accounts/abc/workspaces/1234",
+				Resource: "/api/2.0/accounts/abc/workspaces/1234?update_mask=credentials_id,managed_services_customer_managed_key_id,network_id,storage_customer_managed_key_id",
 				Response: apierr.APIError{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
@@ -1235,7 +1235,7 @@ func updateWorkspaceScimFixtureWithPatch(t *testing.T, fixtures []qa.HTTPFixture
 	accountsAPI := []qa.HTTPFixture{
 		{
 			Method:   "PATCH",
-			Resource: "/api/2.0/accounts/c/workspaces/0",
+			Resource: "/api/2.0/accounts/c/workspaces/0?update_mask=network_id,storage_customer_managed_key_id",
 		},
 		{
 			Method:       "GET",
@@ -1615,7 +1615,7 @@ func TestResourceWorkspaceUpdatePrivateAccessSettings(t *testing.T) {
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   "PATCH",
-				Resource: "/api/2.0/accounts/abc/workspaces/1234",
+				Resource: "/api/2.0/accounts/abc/workspaces/1234?update_mask=credentials_id,managed_services_customer_managed_key_id,network_id,private_access_settings_id,storage_customer_managed_key_id",
 				ExpectedRequest: map[string]any{
 					"credentials_id":                           "bcd",
 					"network_id":                               "fgh",


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

Fixed by including the required `update_mask` query parameter in PATCH requests. On AWS `update_mask` is ignored - checked with the corresponding team.

Resolves #5426


## Tests
<!--
How is this tested? Please see the checklist below and also describe any other relevant tests
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [x] covered with integration tests in `internal/acceptance`
- [ ] using Go SDK
- [ ] using TF Plugin Framework
- [x] has entry in `NEXT_CHANGELOG.md` file
