### PR TITLE
Add documentation note about whitespace in MAP column types for databricks_sql_table

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Documentation
 
-* Added documentation note about whitespace handling in complex column types (`MAP`, `STRUCT`, `ARRAY`) for `databricks_sql_table`.
+* Added documentation note about whitespace handling in `MAP` column types for `databricks_sql_table`.
 
 ### Exporter
 

--- a/docs/resources/sql_table.md
+++ b/docs/resources/sql_table.md
@@ -198,7 +198,7 @@ Currently, changing the column definitions for a table will require dropping and
 * `name` - User-visible name of column
 * `type` - Column type spec (with metadata) as SQL text. Not supported for `VIEW` table_type.
 
-  ~> **Note:** When using parameterized or complex column types such as `MAP`, `STRUCT`, or `ARRAY`, do not include whitespace after commas in the type definition. For example, use `MAP<STRING,STRING>` instead of `MAP<STRING, STRING>`. The Databricks API may return types without whitespace, causing the provider to detect a spurious type change and return an error like "changing the 'type' of an existing column is not supported" even when no actual type change was made.
+  ~> **Note:** When using `MAP` column types, do not include whitespace after commas in the type definition. For example, use `MAP<STRING,STRING>` instead of `MAP<STRING, STRING>`.
 * `identity` - (Optional) Whether the field is an identity column. Can be `default`, `always`, or unset. It is unset by default.
 * `comment` - (Optional) User-supplied free-form text.
 * `nullable` - (Optional) Whether field is nullable (Default: `true`)


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
  - Adds a note to the databricks_sql_table column block documentation warning users not to include whitespace after commas in MAP type definitions (e.g., use MAP<STRING,STRING> instead of MAP<STRING, STRING>)
  - Updates NEXT_CHANGELOG.md with the documentation change
## Tests
<!--
How is this tested? Please see the checklist below and also describe any other relevant tests
-->
N/A
