### PR TITLE
Add documentation note about whitespace in complex column types for d…

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Documentation
 
+* Added documentation note about whitespace handling in complex column types (`MAP`, `STRUCT`, `ARRAY`) for `databricks_sql_table` ([#PRNUM](PRLINK)).
+
 ### Exporter
 
 ### Internal Changes

--- a/docs/resources/sql_table.md
+++ b/docs/resources/sql_table.md
@@ -167,6 +167,33 @@ resource "databricks_sql_table" "thing" {
 }
 ```
 
+## Use complex column types
+
+```hcl
+resource "databricks_sql_table" "thing" {
+  provider     = databricks.workspace
+  name         = "complex_types_table"
+  catalog_name = databricks_catalog.sandbox.name
+  schema_name  = databricks_schema.things.name
+  table_type   = "MANAGED"
+
+  column {
+    name = "id"
+    type = "int"
+  }
+  column {
+    name = "metadata"
+    # Do not add whitespace after commas in complex types
+    type = "MAP<STRING,STRING>"
+  }
+  column {
+    name = "tags"
+    type = "ARRAY<STRING>"
+  }
+  comment = "this table is managed by terraform"
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -197,6 +224,8 @@ Currently, changing the column definitions for a table will require dropping and
 
 * `name` - User-visible name of column
 * `type` - Column type spec (with metadata) as SQL text. Not supported for `VIEW` table_type.
+
+  ~> **Note:** When using parameterized or complex column types such as `MAP`, `STRUCT`, or `ARRAY`, do not include whitespace after commas in the type definition. For example, use `MAP<STRING,STRING>` instead of `MAP<STRING, STRING>`. The Databricks API may return types without whitespace, causing the provider to detect a spurious type change and return an error like "changing the 'type' of an existing column is not supported" even when no actual type change was made.
 * `identity` - (Optional) Whether the field is an identity column. Can be `default`, `always`, or unset. It is unset by default.
 * `comment` - (Optional) User-supplied free-form text.
 * `nullable` - (Optional) Whether field is nullable (Default: `true`)


### PR DESCRIPTION
…atabricks_sql_table

Complex column types like MAP<STRING,STRING>, STRUCT, and ARRAY must not contain whitespace after commas in their type definitions. The API returns types without whitespace, causing the provider to incorrectly detect a type change and error with "changing the 'type' of an existing column is not supported" even when no actual change was made.

## Changes
<!-- Summary of your changes that are easy to understand -->

## Tests
<!--
How is this tested? Please see the checklist below and also describe any other relevant tests
-->

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] using Go SDK
- [ ] using TF Plugin Framework
- [ ] has entry in `NEXT_CHANGELOG.md` file
