### PR TITLE
Fix registered_model aliases not applied to Unity Catalog

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bug Fixes
 
+* Fixed `databricks_registered_model` aliases not being applied to Unity Catalog by using dedicated `SetAlias`/`DeleteAlias` API calls ([#5448](https://github.com/databricks/terraform-provider-databricks/pull/5448)).
+
 ### Documentation
 
 * Added documentation note about whitespace handling in `MAP` column types for `databricks_sql_table`.

--- a/catalog/resource_registered_model.go
+++ b/catalog/resource_registered_model.go
@@ -2,7 +2,9 @@ package catalog
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/databricks/databricks-sdk-go"
 	"github.com/databricks/databricks-sdk-go/service/catalog"
 	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -38,6 +40,19 @@ func ResourceRegisteredModel() common.Resource {
 					m[field].Computed = true
 				}
 			}
+			// Customize aliases schema
+			if aliasesSchema, ok := m["aliases"]; ok {
+				aliasesSchema.Optional = true
+				aliasesSchema.Computed = true
+				if aliasElem, ok := aliasesSchema.Elem.(*schema.Resource); ok {
+					for _, f := range []string{"catalog_name", "schema_name", "model_name", "id"} {
+						if af, ok := aliasElem.Schema[f]; ok {
+							af.Optional = true
+							af.Computed = true
+						}
+					}
+				}
+			}
 			common.NamespaceCustomizeSchemaMap(m)
 			return m
 		})
@@ -50,31 +65,34 @@ func ResourceRegisteredModel() common.Resource {
 			}
 			var m catalog.CreateRegisteredModelRequest
 			common.DataToStructPointer(d, s, &m)
+			aliases := m.Aliases
+			m.Aliases = nil
 			model, err := w.RegisteredModels.Create(ctx, m)
 			if err != nil {
 				return err
 			}
 			d.SetId(model.FullName)
 			// Don't update owner if it is not provided
-			if d.Get("owner") == "" {
-				return nil
+			if d.Get("owner") != "" {
+				var update catalog.UpdateRegisteredModelRequest
+				common.DataToStructPointer(d, s, &update)
+				update.FullName = d.Id()
+				_, err = w.RegisteredModels.Update(ctx, update)
+				if err != nil {
+					return err
+				}
 			}
-
-			var update catalog.UpdateRegisteredModelRequest
-			common.DataToStructPointer(d, s, &update)
-			update.FullName = d.Id()
-			_, err = w.RegisteredModels.Update(ctx, update)
-			if err != nil {
-				return err
-			}
-			return nil
+			return setRegisteredModelAliases(ctx, d.Id(), aliases, w)
 		},
 		Read: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
 			w, err := c.WorkspaceClientUnifiedProvider(ctx, d)
 			if err != nil {
 				return err
 			}
-			model, err := w.RegisteredModels.GetByFullName(ctx, d.Id())
+			model, err := w.RegisteredModels.Get(ctx, catalog.GetRegisteredModelRequest{
+				FullName:       d.Id(),
+				IncludeAliases: true,
+			})
 			if err != nil {
 				return err
 			}
@@ -100,14 +118,21 @@ func ResourceRegisteredModel() common.Resource {
 				}
 			}
 
-			if !d.HasChangeExcept("owner") {
+			if d.HasChange("aliases") {
+				if err := updateRegisteredModelAliases(ctx, d, w); err != nil {
+					return err
+				}
+			}
+
+			if !d.HasChangeExcept("owner") || !d.HasChange("comment") {
 				return nil
 			}
 
-			if d.HasChange("comment") && u.Comment == "" {
+			if u.Comment == "" {
 				u.ForceSendFields = append(u.ForceSendFields, "Comment")
 			}
 			u.Owner = ""
+			u.Aliases = nil
 			_, err = w.RegisteredModels.Update(ctx, u)
 			if err != nil {
 				if d.HasChange("owner") {
@@ -137,4 +162,66 @@ func ResourceRegisteredModel() common.Resource {
 		Schema:         s,
 		SchemaVersion:  0,
 	}
+}
+
+func setRegisteredModelAliases(ctx context.Context, fullName string, aliases []catalog.RegisteredModelAlias, w *databricks.WorkspaceClient) error {
+	for _, alias := range aliases {
+		_, err := w.RegisteredModels.SetAlias(ctx, catalog.SetRegisteredModelAliasRequest{
+			FullName:   fullName,
+			Alias:      alias.AliasName,
+			VersionNum: alias.VersionNum,
+		})
+		if err != nil {
+			return fmt.Errorf("failed to set alias %q: %w", alias.AliasName, err)
+		}
+	}
+	return nil
+}
+
+func updateRegisteredModelAliases(ctx context.Context, d *schema.ResourceData, w *databricks.WorkspaceClient) error {
+	old, new := d.GetChange("aliases")
+	oldAliases := old.([]interface{})
+	newAliases := new.([]interface{})
+
+	oldMap := make(map[string]int)
+	for _, a := range oldAliases {
+		alias := a.(map[string]interface{})
+		oldMap[alias["alias_name"].(string)] = alias["version_num"].(int)
+	}
+
+	newMap := make(map[string]int)
+	for _, a := range newAliases {
+		alias := a.(map[string]interface{})
+		newMap[alias["alias_name"].(string)] = alias["version_num"].(int)
+	}
+
+	// Delete aliases that were removed
+	for name := range oldMap {
+		if _, exists := newMap[name]; !exists {
+			err := w.RegisteredModels.DeleteAlias(ctx, catalog.DeleteAliasRequest{
+				FullName: d.Id(),
+				Alias:    name,
+			})
+			if err != nil {
+				return fmt.Errorf("failed to delete alias %q: %w", name, err)
+			}
+		}
+	}
+
+	// Set aliases that were added or changed
+	for name, version := range newMap {
+		oldVersion, exists := oldMap[name]
+		if !exists || oldVersion != version {
+			_, err := w.RegisteredModels.SetAlias(ctx, catalog.SetRegisteredModelAliasRequest{
+				FullName:   d.Id(),
+				Alias:      name,
+				VersionNum: version,
+			})
+			if err != nil {
+				return fmt.Errorf("failed to set alias %q: %w", name, err)
+			}
+		}
+	}
+
+	return nil
 }

--- a/catalog/resource_registered_model_test.go
+++ b/catalog/resource_registered_model_test.go
@@ -31,7 +31,10 @@ func TestRegisteredModelCreate(t *testing.T) {
 				FullName:    "catalog.schema.model",
 				Comment:     "comment",
 			}, nil)
-			e.GetByFullName(mock.Anything, "catalog.schema.model").Return(&catalog.RegisteredModelInfo{
+			e.Get(mock.Anything, catalog.GetRegisteredModelRequest{
+				FullName:       "catalog.schema.model",
+				IncludeAliases: true,
+			}).Return(&catalog.RegisteredModelInfo{
 				Name:        "model",
 				CatalogName: "catalog",
 				Owner:       "owner",
@@ -89,7 +92,10 @@ func TestRegisteredModelCreateWithOwner(t *testing.T) {
 				FullName:    "catalog.schema.model",
 				Comment:     "comment",
 			}, nil)
-			e.GetByFullName(mock.Anything, "catalog.schema.model").Return(&catalog.RegisteredModelInfo{
+			e.Get(mock.Anything, catalog.GetRegisteredModelRequest{
+				FullName:       "catalog.schema.model",
+				IncludeAliases: true,
+			}).Return(&catalog.RegisteredModelInfo{
 				Name:        "model",
 				CatalogName: "catalog",
 				Owner:       "owner",
@@ -130,7 +136,10 @@ func TestRegisteredModelRead(t *testing.T) {
 	qa.ResourceFixture{
 		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
 			e := w.GetMockRegisteredModelsAPI().EXPECT()
-			e.GetByFullName(mock.Anything, "catalog.schema.model").Return(&catalog.RegisteredModelInfo{
+			e.Get(mock.Anything, catalog.GetRegisteredModelRequest{
+				FullName:       "catalog.schema.model",
+				IncludeAliases: true,
+			}).Return(&catalog.RegisteredModelInfo{
 				Name:        "model",
 				CatalogName: "catalog",
 				SchemaName:  "schema",
@@ -152,7 +161,10 @@ func TestRegisteredModelRead_Error(t *testing.T) {
 	qa.ResourceFixture{
 		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
 			e := w.GetMockRegisteredModelsAPI().EXPECT()
-			e.GetByFullName(mock.Anything, "catalog.schema.model").Return(nil, errors.New("Internal error happened"))
+			e.Get(mock.Anything, catalog.GetRegisteredModelRequest{
+				FullName:       "catalog.schema.model",
+				IncludeAliases: true,
+			}).Return(nil, errors.New("Internal error happened"))
 		},
 		Resource: ResourceRegisteredModel(),
 		Read:     true,
@@ -177,7 +189,10 @@ func TestRegisteredModelUpdate(t *testing.T) {
 				FullName:    "catalog.schema.model",
 				Comment:     "new comment",
 			}, nil)
-			e.GetByFullName(mock.Anything, "catalog.schema.model").Return(&catalog.RegisteredModelInfo{
+			e.Get(mock.Anything, catalog.GetRegisteredModelRequest{
+				FullName:       "catalog.schema.model",
+				IncludeAliases: true,
+			}).Return(&catalog.RegisteredModelInfo{
 				Name:        "model",
 				CatalogName: "catalog",
 				SchemaName:  "schema",
@@ -221,7 +236,10 @@ func TestRegisteredModelUpdateCommentOnly(t *testing.T) {
 				FullName:    "catalog.schema.model",
 				Comment:     "",
 			}, nil)
-			e.GetByFullName(mock.Anything, "catalog.schema.model").Return(&catalog.RegisteredModelInfo{
+			e.Get(mock.Anything, catalog.GetRegisteredModelRequest{
+				FullName:       "catalog.schema.model",
+				IncludeAliases: true,
+			}).Return(&catalog.RegisteredModelInfo{
 				Name:        "model",
 				CatalogName: "catalog",
 				SchemaName:  "schema",
@@ -275,7 +293,10 @@ func TestRegisteredModelUpdateOwner(t *testing.T) {
 				FullName:    "catalog.schema.model",
 				Comment:     "new comment",
 			}, nil)
-			e.GetByFullName(mock.Anything, "catalog.schema.model").Return(&catalog.RegisteredModelInfo{
+			e.Get(mock.Anything, catalog.GetRegisteredModelRequest{
+				FullName:       "catalog.schema.model",
+				IncludeAliases: true,
+			}).Return(&catalog.RegisteredModelInfo{
 				Name:        "model",
 				CatalogName: "catalog",
 				SchemaName:  "schema",
@@ -418,4 +439,241 @@ func TestRegisteredModelDelete_Error(t *testing.T) {
 		Delete:   true,
 		ID:       "catalog.schema.model",
 	}.ExpectError(t, "Internal error happened")
+}
+
+func TestRegisteredModelCreateWithAliases(t *testing.T) {
+	qa.ResourceFixture{
+		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
+			e := w.GetMockRegisteredModelsAPI().EXPECT()
+			e.Create(mock.Anything, catalog.CreateRegisteredModelRequest{
+				Name:        "model",
+				CatalogName: "catalog",
+				SchemaName:  "schema",
+				Comment:     "comment",
+			}).Return(&catalog.RegisteredModelInfo{
+				Name:        "model",
+				Owner:       "owner",
+				CatalogName: "catalog",
+				SchemaName:  "schema",
+				FullName:    "catalog.schema.model",
+				Comment:     "comment",
+			}, nil)
+			e.SetAlias(mock.Anything, catalog.SetRegisteredModelAliasRequest{
+				FullName:   "catalog.schema.model",
+				Alias:      "champion",
+				VersionNum: 1,
+			}).Return(&catalog.RegisteredModelAlias{
+				AliasName:  "champion",
+				VersionNum: 1,
+			}, nil)
+			e.SetAlias(mock.Anything, catalog.SetRegisteredModelAliasRequest{
+				FullName:   "catalog.schema.model",
+				Alias:      "challenger",
+				VersionNum: 2,
+			}).Return(&catalog.RegisteredModelAlias{
+				AliasName:  "challenger",
+				VersionNum: 2,
+			}, nil)
+			e.Get(mock.Anything, catalog.GetRegisteredModelRequest{
+				FullName:       "catalog.schema.model",
+				IncludeAliases: true,
+			}).Return(&catalog.RegisteredModelInfo{
+				Name:        "model",
+				CatalogName: "catalog",
+				Owner:       "owner",
+				SchemaName:  "schema",
+				FullName:    "catalog.schema.model",
+				Comment:     "comment",
+				Aliases: []catalog.RegisteredModelAlias{
+					{AliasName: "champion", VersionNum: 1},
+					{AliasName: "challenger", VersionNum: 2},
+				},
+			}, nil)
+		},
+		Resource: ResourceRegisteredModel(),
+		HCL: `
+			name = "model"
+			catalog_name = "catalog"
+			schema_name = "schema"
+			comment = "comment"
+			aliases {
+				alias_name = "champion"
+				version_num = 1
+			}
+			aliases {
+				alias_name = "challenger"
+				version_num = 2
+			}
+			`,
+		Create: true,
+	}.ApplyAndExpectData(t,
+		map[string]any{
+			"id":    "catalog.schema.model",
+			"owner": "owner",
+		},
+	)
+}
+
+func TestRegisteredModelReadWithAliases(t *testing.T) {
+	qa.ResourceFixture{
+		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
+			e := w.GetMockRegisteredModelsAPI().EXPECT()
+			e.Get(mock.Anything, catalog.GetRegisteredModelRequest{
+				FullName:       "catalog.schema.model",
+				IncludeAliases: true,
+			}).Return(&catalog.RegisteredModelInfo{
+				Name:        "model",
+				CatalogName: "catalog",
+				SchemaName:  "schema",
+				FullName:    "catalog.schema.model",
+				Comment:     "comment",
+				Aliases: []catalog.RegisteredModelAlias{
+					{AliasName: "champion", VersionNum: 1},
+					{AliasName: "challenger", VersionNum: 2},
+				},
+			}, nil)
+		},
+		Resource: ResourceRegisteredModel(),
+		Read:     true,
+		ID:       "catalog.schema.model",
+	}.ApplyAndExpectData(t,
+		map[string]any{
+			"id":        "catalog.schema.model",
+			"aliases.#": 2,
+		},
+	)
+}
+
+func TestRegisteredModelUpdateAliases(t *testing.T) {
+	qa.ResourceFixture{
+		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
+			e := w.GetMockRegisteredModelsAPI().EXPECT()
+			e.Update(mock.Anything, catalog.UpdateRegisteredModelRequest{
+				FullName:    "catalog.schema.model",
+				Comment:     "new comment",
+				CatalogName: "catalog",
+				SchemaName:  "schema",
+				Name:        "model",
+			}).Return(&catalog.RegisteredModelInfo{
+				Name:        "model",
+				CatalogName: "catalog",
+				SchemaName:  "schema",
+				FullName:    "catalog.schema.model",
+				Comment:     "new comment",
+			}, nil)
+			e.DeleteAlias(mock.Anything, catalog.DeleteAliasRequest{
+				FullName: "catalog.schema.model",
+				Alias:    "old_alias",
+			}).Return(nil)
+			e.SetAlias(mock.Anything, catalog.SetRegisteredModelAliasRequest{
+				FullName:   "catalog.schema.model",
+				Alias:      "new_alias",
+				VersionNum: 3,
+			}).Return(&catalog.RegisteredModelAlias{
+				AliasName:  "new_alias",
+				VersionNum: 3,
+			}, nil)
+			e.SetAlias(mock.Anything, catalog.SetRegisteredModelAliasRequest{
+				FullName:   "catalog.schema.model",
+				Alias:      "champion",
+				VersionNum: 2,
+			}).Return(&catalog.RegisteredModelAlias{
+				AliasName:  "champion",
+				VersionNum: 2,
+			}, nil)
+			e.Get(mock.Anything, catalog.GetRegisteredModelRequest{
+				FullName:       "catalog.schema.model",
+				IncludeAliases: true,
+			}).Return(&catalog.RegisteredModelInfo{
+				Name:        "model",
+				CatalogName: "catalog",
+				SchemaName:  "schema",
+				FullName:    "catalog.schema.model",
+				Comment:     "new comment",
+				Aliases: []catalog.RegisteredModelAlias{
+					{AliasName: "champion", VersionNum: 2},
+					{AliasName: "new_alias", VersionNum: 3},
+				},
+			}, nil)
+		},
+		Resource: ResourceRegisteredModel(),
+		Update:   true,
+		ID:       "catalog.schema.model",
+		InstanceState: map[string]string{
+			"name":                  "model",
+			"catalog_name":          "catalog",
+			"schema_name":           "schema",
+			"comment":               "comment",
+			"aliases.#":             "2",
+			"aliases.0.alias_name":  "champion",
+			"aliases.0.version_num": "1",
+			"aliases.1.alias_name":  "old_alias",
+			"aliases.1.version_num": "5",
+		},
+		HCL: `
+			name = "model"
+			catalog_name = "catalog"
+			schema_name = "schema"
+			comment = "new comment"
+			aliases {
+				alias_name = "champion"
+				version_num = 2
+			}
+			aliases {
+				alias_name = "new_alias"
+				version_num = 3
+			}
+			`,
+	}.ApplyNoError(t)
+}
+
+func TestRegisteredModelUpdateAliasesOnly(t *testing.T) {
+	qa.ResourceFixture{
+		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
+			e := w.GetMockRegisteredModelsAPI().EXPECT()
+			e.SetAlias(mock.Anything, catalog.SetRegisteredModelAliasRequest{
+				FullName:   "catalog.schema.model",
+				Alias:      "champion",
+				VersionNum: 2,
+			}).Return(&catalog.RegisteredModelAlias{
+				AliasName:  "champion",
+				VersionNum: 2,
+			}, nil)
+			e.Get(mock.Anything, catalog.GetRegisteredModelRequest{
+				FullName:       "catalog.schema.model",
+				IncludeAliases: true,
+			}).Return(&catalog.RegisteredModelInfo{
+				Name:        "model",
+				CatalogName: "catalog",
+				SchemaName:  "schema",
+				FullName:    "catalog.schema.model",
+				Comment:     "comment",
+				Aliases: []catalog.RegisteredModelAlias{
+					{AliasName: "champion", VersionNum: 2},
+				},
+			}, nil)
+		},
+		Resource: ResourceRegisteredModel(),
+		Update:   true,
+		ID:       "catalog.schema.model",
+		InstanceState: map[string]string{
+			"name":                  "model",
+			"catalog_name":          "catalog",
+			"schema_name":           "schema",
+			"comment":               "comment",
+			"aliases.#":             "1",
+			"aliases.0.alias_name":  "champion",
+			"aliases.0.version_num": "1",
+		},
+		HCL: `
+			name = "model"
+			catalog_name = "catalog"
+			schema_name = "schema"
+			comment = "comment"
+			aliases {
+				alias_name = "champion"
+				version_num = 2
+			}
+			`,
+	}.ApplyNoError(t)
 }

--- a/docs/resources/registered_model.md
+++ b/docs/resources/registered_model.md
@@ -14,6 +14,17 @@ resource "databricks_registered_model" "this" {
   name         = "my_model"
   catalog_name = "main"
   schema_name  = "default"
+  comment      = "My registered model"
+
+  aliases {
+    alias_name  = "champion"
+    version_num = 1
+  }
+
+  aliases {
+    alias_name  = "challenger"
+    version_num = 2
+  }
 }
 ```
 
@@ -27,6 +38,9 @@ The following arguments are supported:
 * `owner` - (Optional) Name of the registered model owner.
 * `comment` - (Optional) The comment attached to the registered model.
 * `storage_location` - (Optional) The storage location under which model version data files are stored.  If the URL contains special characters, such as space, `&`, etc., they should be percent-encoded (space -> `%20`, etc.). *Change of this parameter forces recreation of the resource.*
+* `aliases` - (Optional) List of aliases associated with the registered model. Each `aliases` block consists of the following fields:
+  * `alias_name` - (Required) The name of the alias, e.g. `champion` or `latest_stable`.
+  * `version_num` - (Required) The version number of the model version to which the alias points.
 * `provider_config` - (Optional) Configure the provider for management through account provider. This block consists of the following fields:
   * `workspace_id` - (Required) Workspace ID which the resource belongs to. This workspace must be part of the account which the provider is configured with.
 


### PR DESCRIPTION
Fixes https://github.com/databricks/cli/issues/4012

## Changes

Aliases on `databricks_registered_model` were silently dropped because the Update API ignores the `aliases` field. This fix manages aliases via dedicated `SetAlias`/`DeleteAlias` API calls and reads them back with `IncludeAliases: true`.

## Tests

- Added `TestRegisteredModelCreateWithAliases`
- Added `TestRegisteredModelReadWithAliases`
- Added `TestRegisteredModelUpdateAliases`
- Added `TestRegisteredModelUpdateAliasesOnly`
- All existing tests updated and passing