### PR TITLE
[Internal] Add host agnostic support for databricks_service_principal resource

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -17,3 +17,4 @@
 ### Internal Changes
 
 * Host-agnostic cloud detection via node type patterns, replacing host-URL-based `IsAws()`/`IsAzure()`/`IsGcp()` checks.
+* Made `databricks_service_principal` update host-agnostic by removing `IsAzure()` check for `application_id` inclusion.

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -19,4 +19,4 @@
 * Host-agnostic cloud detection via node type patterns, replacing host-URL-based `IsAws()`/`IsAzure()`/`IsGcp()` checks.
 * Use workspace `GetStatus` API to check parent folder existence before creating Lakeview dashboards, replacing fragile error string matching.
 * Use workspace `GetStatus` API to check parent folder existence before uploading workspace files, replacing fragile error string matching.
-* Made `databricks_service_principal` update host-agnostic by removing `IsAzure()` check for `application_id` inclusion.
+* Remove cloud-specific `IsAzure()` gate from `databricks_service_principal` update — `application_id` is now always included when set, making updates host-agnostic.

--- a/scim/resource_service_principal.go
+++ b/scim/resource_service_principal.go
@@ -176,16 +176,12 @@ func ResourceServicePrincipal() common.Resource {
 			return sp.Entitlements.readIntoData(d)
 		},
 		Update: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
-			var applicationId string
-			if c.Config.AzureResourceID != "" {
-				applicationId = d.Get("application_id").(string)
-			}
 			return NewServicePrincipalsAPI(ctx, c).Update(d.Id(), User{
 				DisplayName:   d.Get("display_name").(string),
 				Active:        d.Get("active").(bool),
 				Entitlements:  readEntitlementsFromData(d),
 				ExternalID:    d.Get("external_id").(string),
-				ApplicationID: applicationId,
+				ApplicationID: d.Get("application_id").(string),
 			})
 		},
 		Delete: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {

--- a/scim/resource_service_principal.go
+++ b/scim/resource_service_principal.go
@@ -176,16 +176,12 @@ func ResourceServicePrincipal() common.Resource {
 			return sp.Entitlements.readIntoData(d)
 		},
 		Update: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
-			var applicationId string
-			if c.IsAzure() {
-				applicationId = d.Get("application_id").(string)
-			}
 			return NewServicePrincipalsAPI(ctx, c).Update(d.Id(), User{
 				DisplayName:   d.Get("display_name").(string),
 				Active:        d.Get("active").(bool),
 				Entitlements:  readEntitlementsFromData(d),
 				ExternalID:    d.Get("external_id").(string),
-				ApplicationID: applicationId,
+				ApplicationID: d.Get("application_id").(string),
 			})
 		},
 		Delete: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {

--- a/scim/resource_service_principal.go
+++ b/scim/resource_service_principal.go
@@ -176,12 +176,16 @@ func ResourceServicePrincipal() common.Resource {
 			return sp.Entitlements.readIntoData(d)
 		},
 		Update: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
+			var applicationId string
+			if c.Config.AzureResourceID != "" {
+				applicationId = d.Get("application_id").(string)
+			}
 			return NewServicePrincipalsAPI(ctx, c).Update(d.Id(), User{
 				DisplayName:   d.Get("display_name").(string),
 				Active:        d.Get("active").(bool),
 				Entitlements:  readEntitlementsFromData(d),
 				ExternalID:    d.Get("external_id").(string),
-				ApplicationID: d.Get("application_id").(string),
+				ApplicationID: applicationId,
 			})
 		},
 		Delete: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {

--- a/scim/resource_service_principal_test.go
+++ b/scim/resource_service_principal_test.go
@@ -330,6 +330,67 @@ func TestResourceServicePrincipalUpdateOnAzure(t *testing.T) {
 	}.ApplyNoError(t)
 }
 
+// TestResourceServicePrincipalUpdateWithApplicationId verifies that updates include
+// application_id when set, regardless of cloud provider detection (host-agnostic).
+func TestResourceServicePrincipalUpdateWithApplicationId(t *testing.T) {
+	qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "GET",
+				Resource: "/api/2.0/preview/scim/v2/ServicePrincipals/abc?attributes=groups,roles",
+				Response: User{
+					ApplicationID: "existing-application-id",
+					DisplayName:   "Example Service Principal",
+					Active:        true,
+					ID:            "abc",
+				},
+			},
+			{
+				Method:   "PUT",
+				Resource: "/api/2.0/preview/scim/v2/ServicePrincipals/abc",
+				ExpectedRequest: User{
+					ApplicationID: "existing-application-id",
+					Schemas:       []URN{ServicePrincipalSchema},
+					DisplayName:   "Example Service Principal",
+					Entitlements: entitlements{
+						{
+							Value: "allow-cluster-create",
+						},
+					},
+					Active: true,
+				},
+			},
+			{
+				Method:   "GET",
+				Resource: "/api/2.0/preview/scim/v2/ServicePrincipals/abc?attributes=userName,displayName,active,externalId,entitlements",
+				Response: User{
+					Schemas:       []URN{ServicePrincipalSchema},
+					ApplicationID: "existing-application-id",
+					DisplayName:   "Example Service Principal",
+					Entitlements: entitlements{
+						{
+							Value: "allow-cluster-create",
+						},
+					},
+					Active: true,
+				},
+			},
+		},
+		Resource: ResourceServicePrincipal(),
+		Update:   true,
+		ID:       "abc",
+		InstanceState: map[string]string{
+			"application_id": "existing-application-id",
+			"display_name":   "Example Service Principal",
+		},
+		HCL: `
+		application_id = "existing-application-id"
+		display_name = "Example Service Principal"
+		allow_cluster_create = true
+		`,
+	}.ApplyNoError(t)
+}
+
 func TestResourceServicePrincipalUpdate_Error(t *testing.T) {
 	qa.ResourceFixture{
 		Fixtures: qa.HTTPFailures,

--- a/scim/resource_service_principal_test.go
+++ b/scim/resource_service_principal_test.go
@@ -330,9 +330,9 @@ func TestResourceServicePrincipalUpdateOnAzure(t *testing.T) {
 	}.ApplyNoError(t)
 }
 
-// TestResourceServicePrincipalUpdateWithoutAzureResourceID verifies that updates do NOT include
-// application_id when AzureResourceID is not configured (non-Azure or host-agnostic).
-func TestResourceServicePrincipalUpdateWithoutAzureResourceID(t *testing.T) {
+// TestResourceServicePrincipalUpdateWithApplicationId verifies that updates always include
+// application_id regardless of cloud provider (host-agnostic).
+func TestResourceServicePrincipalUpdateWithApplicationId(t *testing.T) {
 	qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
 			{
@@ -349,8 +349,9 @@ func TestResourceServicePrincipalUpdateWithoutAzureResourceID(t *testing.T) {
 				Method:   "PUT",
 				Resource: "/api/2.0/preview/scim/v2/ServicePrincipals/abc",
 				ExpectedRequest: User{
-					Schemas:     []URN{ServicePrincipalSchema},
-					DisplayName: "Example Service Principal",
+					ApplicationID: "existing-application-id",
+					Schemas:       []URN{ServicePrincipalSchema},
+					DisplayName:   "Example Service Principal",
 					Entitlements: entitlements{
 						{
 							Value: "allow-cluster-create",

--- a/scim/resource_service_principal_test.go
+++ b/scim/resource_service_principal_test.go
@@ -330,9 +330,9 @@ func TestResourceServicePrincipalUpdateOnAzure(t *testing.T) {
 	}.ApplyNoError(t)
 }
 
-// TestResourceServicePrincipalUpdateWithApplicationId verifies that updates include
-// application_id when set, regardless of cloud provider detection (host-agnostic).
-func TestResourceServicePrincipalUpdateWithApplicationId(t *testing.T) {
+// TestResourceServicePrincipalUpdateWithoutAzureResourceID verifies that updates do NOT include
+// application_id when AzureResourceID is not configured (non-Azure or host-agnostic).
+func TestResourceServicePrincipalUpdateWithoutAzureResourceID(t *testing.T) {
 	qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
 			{
@@ -349,9 +349,8 @@ func TestResourceServicePrincipalUpdateWithApplicationId(t *testing.T) {
 				Method:   "PUT",
 				Resource: "/api/2.0/preview/scim/v2/ServicePrincipals/abc",
 				ExpectedRequest: User{
-					ApplicationID: "existing-application-id",
-					Schemas:       []URN{ServicePrincipalSchema},
-					DisplayName:   "Example Service Principal",
+					Schemas:     []URN{ServicePrincipalSchema},
+					DisplayName: "Example Service Principal",
 					Entitlements: entitlements{
 						{
 							Value: "allow-cluster-create",


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
  - Removed host-URL-based c.IsAzure() check from databricks_service_principal Update, replacing it with unconditional d.Get("application_id") so the resource works correctly on
  cloud-agnostic hosts (e.g., SPOG)


## Tests
<!--
How is this tested? Please see the checklist below and also describe any other relevant tests
-->
  - Added unit test TestResourceServicePrincipalUpdateWithApplicationId that verifies application_id is included in the PUT request without relying on Azure cloud detection
