### PR TITLE
[Fix] Cannot provision `databricks_app` when `description` is omitted despite it being `Optional`

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bug Fixes
 
+* Fixed `databricks_app` producing "inconsistent result after apply" error when `description` is omitted.
+
 ### Documentation
 
 * Added documentation note about whitespace handling in `MAP` column types for `databricks_sql_table`.

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bug Fixes
 
-* Fixed `databricks_app` producing "inconsistent result after apply" error when `description` is omitted.
+* Fixed `databricks_app` producing "inconsistent result after apply" error when `description` is omitted ([#5451](https://github.com/databricks/terraform-provider-databricks/pull/5451)).
 
 ### Documentation
 

--- a/internal/providers/pluginfw/products/app/resource_app.go
+++ b/internal/providers/pluginfw/products/app/resource_app.go
@@ -84,7 +84,6 @@ func (a resourceApp) Schema(ctx context.Context, req resource.SchemaRequest, res
 		for _, field := range []string{
 			"create_time",
 			"creator",
-			"description",
 			"service_principal_client_id",
 			"service_principal_name",
 			"url",

--- a/internal/providers/pluginfw/products/app/resource_app.go
+++ b/internal/providers/pluginfw/products/app/resource_app.go
@@ -40,6 +40,7 @@ func (a AppResource) ApplySchemaCustomizations(s map[string]tfschema.AttributeBu
 	s["provider_config"] = s["provider_config"].SetOptional()
 	s["compute_size"] = s["compute_size"].SetComputed()
 	s = apps_tf.App{}.ApplySchemaCustomizations(s)
+	s["description"] = s["description"].SetComputed()
 	return s
 }
 
@@ -83,6 +84,7 @@ func (a resourceApp) Schema(ctx context.Context, req resource.SchemaRequest, res
 		for _, field := range []string{
 			"create_time",
 			"creator",
+			"description",
 			"service_principal_client_id",
 			"service_principal_name",
 			"url",

--- a/internal/providers/pluginfw/products/app/resource_app_test.go
+++ b/internal/providers/pluginfw/products/app/resource_app_test.go
@@ -1,0 +1,28 @@
+package app
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAppResourceSchema_DescriptionIsOptionalAndComputed(t *testing.T) {
+	r := ResourceApp()
+	resp := &resource.SchemaResponse{}
+	r.Schema(context.Background(), resource.SchemaRequest{}, resp)
+	require.False(t, resp.Diagnostics.HasError(), "schema should not have errors")
+
+	descAttr, ok := resp.Schema.Attributes["description"]
+	require.True(t, ok, "description attribute must exist in schema")
+
+	strAttr, ok := descAttr.(schema.StringAttribute)
+	require.True(t, ok, "description attribute must be a StringAttribute")
+
+	assert.True(t, strAttr.Optional, "description must be Optional")
+	assert.True(t, strAttr.Computed, "description must be Computed")
+	assert.NotEmpty(t, strAttr.PlanModifiers, "description must have plan modifiers (UseStateForUnknown)")
+}

--- a/internal/providers/pluginfw/products/app/resource_app_test.go
+++ b/internal/providers/pluginfw/products/app/resource_app_test.go
@@ -24,5 +24,4 @@ func TestAppResourceSchema_DescriptionIsOptionalAndComputed(t *testing.T) {
 
 	assert.True(t, strAttr.Optional, "description must be Optional")
 	assert.True(t, strAttr.Computed, "description must be Computed")
-	assert.NotEmpty(t, strAttr.PlanModifiers, "description must have plan modifiers (UseStateForUnknown)")
 }


### PR DESCRIPTION
## Changes

When users create a `databricks_app` resource without specifying `description`, Terraform fails with:
```
provider produced inconsistent result after apply: .description: was null, but now cty.StringVal("")
```

The `description` attribute was marked as `Optional` only. When omitted, Terraform planned it as `null`. The Databricks API always returns `"description": ""` in its response, and the SDK unmarshaller + converter pipeline produced `types.StringValue("")` instead of `types.StringNull()`, causing a plan-vs-state mismatch.

This fix marks `description` as `Optional + Computed`, so Terraform treats an omitted description as "unknown" during planning and accepts the API's empty-string response without error.

---

## Detailed Changes

### Mark `description` as Computed (`resource_app.go:43`)

**Before:**
```go
s = apps_tf.App{}.ApplySchemaCustomizations(s)
return s
```

**After:**
```go
s = apps_tf.App{}.ApplySchemaCustomizations(s)
s["description"] = s["description"].SetComputed()
return s
```

**Why:** The auto-generated `ApplySchemaCustomizations` in `apps_tf.App` sets `description` as `Optional` only. Adding `SetComputed()` after that call makes it `Optional + Computed`. When the user omits `description`, Terraform plans it as "unknown" rather than "null", so the API returning `""` is accepted without error.

---

## Tests

- **TestAppResourceSchema_DescriptionIsOptionalAndComputed**: Builds the `databricks_app` resource schema and asserts that the `description` attribute is `Optional` and `Computed`. This test would have caught the original bug by detecting that `description` lacked the `Computed` flag.

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [x] using Go SDK
- [x] using TF Plugin Framework
- [x] has entry in `NEXT_CHANGELOG.md` file
