### PR TITLE
Fix `databricks_instance_pool` ignoring `enable_elastic_disk = false`

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bug Fixes
 
 * Mark `effective_file_event_queue` as read-only in `databricks_external_location` to prevent Terraform drift.
+* Fixed `databricks_instance_pool` ignoring `enable_elastic_disk = false` due to `omitempty` JSON tag ([#5454](https://github.com/databricks/terraform-provider-databricks/pull/5454)).
 ### Documentation
 
 ### Exporter

--- a/pools/resource_instance_pool.go
+++ b/pools/resource_instance_pool.go
@@ -89,7 +89,7 @@ type InstancePool struct {
 	GcpAttributes                      *InstancePoolGcpAttributes      `json:"gcp_attributes,omitempty" tf:"force_new,suppress_diff"`
 	NodeTypeID                         string                          `json:"node_type_id,omitempty" tf:"suppress_diff,force_new,conflicts:instance_pool_fleet_attributes"`
 	CustomTags                         map[string]string               `json:"custom_tags" tf:"optional"`
-	EnableElasticDisk                  bool                            `json:"enable_elastic_disk,omitempty" tf:"force_new,suppress_diff"`
+	EnableElasticDisk                  bool                            `json:"enable_elastic_disk" tf:"optional,force_new,suppress_diff"`
 	DiskSpec                           *InstancePoolDiskSpec           `json:"disk_spec,omitempty" tf:"force_new"`
 	PreloadedSparkVersions             []string                        `json:"preloaded_spark_versions,omitempty" tf:"force_new"`
 	PreloadedDockerImages              []clusters.DockerImage          `json:"preloaded_docker_images,omitempty" tf:"force_new,slice_set,alias:preloaded_docker_image"`
@@ -118,7 +118,7 @@ type InstancePoolAndStats struct {
 	DefaultTags                        map[string]string                `json:"default_tags,omitempty" tf:"computed"`
 	CustomTags                         map[string]string                `json:"custom_tags,omitempty"`
 	IdleInstanceAutoTerminationMinutes int32                            `json:"idle_instance_autotermination_minutes"`
-	EnableElasticDisk                  bool                             `json:"enable_elastic_disk,omitempty"`
+	EnableElasticDisk                  bool                             `json:"enable_elastic_disk"`
 	DiskSpec                           *InstancePoolDiskSpec            `json:"disk_spec,omitempty"`
 	PreloadedSparkVersions             []string                         `json:"preloaded_spark_versions,omitempty"`
 	State                              string                           `json:"state,omitempty"`

--- a/pools/resource_instance_pool_test.go
+++ b/pools/resource_instance_pool_test.go
@@ -280,3 +280,56 @@ func TestResourceInstancePoolDelete_Error(t *testing.T) {
 	qa.AssertErrorStartsWith(t, err, "Internal error happened")
 	assert.Equal(t, "abc", d.Id())
 }
+
+// Regression test: the Create request body must carry
+// "enable_elastic_disk": false when the user opts out. A map[string]any
+// ExpectedRequest is used so the comparison does not depend on the
+// InstancePool struct's own JSON tags.
+func TestResourceInstancePoolCreate_ElasticDiskDisabled(t *testing.T) {
+	qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "POST",
+				Resource: "/api/2.0/instance-pools/create",
+				ExpectedRequest: map[string]any{
+					"custom_tags":                           nil,
+					"enable_elastic_disk":                   false,
+					"idle_instance_autotermination_minutes": 15,
+					"instance_pool_name":                    "Shared Pool",
+					"max_capacity":                          1000,
+					"min_idle_instances":                    10,
+					"node_type_id":                          "i3.xlarge",
+				},
+				Response: InstancePoolAndStats{
+					InstancePoolID: "abc",
+				},
+			},
+			{
+				Method:   "GET",
+				Resource: "/api/2.0/instance-pools/get?instance_pool_id=abc",
+				Response: InstancePoolAndStats{
+					InstancePoolID:                     "abc",
+					InstancePoolName:                   "Shared Pool",
+					MinIdleInstances:                   10,
+					MaxCapacity:                        1000,
+					NodeTypeID:                         "i3.xlarge",
+					IdleInstanceAutoTerminationMinutes: 15,
+					EnableElasticDisk:                  false,
+				},
+			},
+		},
+		Resource: ResourceInstancePool(),
+		State: map[string]any{
+			"enable_elastic_disk":                   false,
+			"idle_instance_autotermination_minutes": 15,
+			"instance_pool_name":                    "Shared Pool",
+			"max_capacity":                          1000,
+			"min_idle_instances":                    10,
+			"node_type_id":                          "i3.xlarge",
+		},
+		Create: true,
+	}.ApplyAndExpectData(t, map[string]any{
+		"id":                  "abc",
+		"enable_elastic_disk": false,
+	})
+}


### PR DESCRIPTION
## Summary

`enable_elastic_disk = false` on `databricks_instance_pool` is silently ignored, causing an infinite plan/replace cycle.

Fixes https://github.com/databricks/terraform-provider-databricks/issues/5462

## Root Cause

The `EnableElasticDisk` field in both `InstancePool` and `InstancePoolAndStats` structs uses `json:"enable_elastic_disk,omitempty"`. Since `false` is the zero value for `bool` in Go, `omitempty` omits it from the serialized JSON. The API never receives `enable_elastic_disk: false` and defaults to `true`.

Combined with `tf:"force_new"`, this creates an infinite cycle:
1. User sets `enable_elastic_disk = false`
2. Terraform creates pool — but `omitempty` drops the field from the request
3. API defaults to `true`
4. Next `terraform plan` sees drift (`true → false`), wants to recreate
5. Repeat forever

## Verification

Direct REST API call confirms Databricks **does** support `enable_elastic_disk: false`:

```bash
# Create with false
curl -X POST ".../api/2.0/instance-pools/create" \
  -d '{"instance_pool_name":"test","node_type_id":"Standard_F4","enable_elastic_disk":false,...}'

# Read back — confirmed false
curl ".../api/2.0/instance-pools/get?instance_pool_id=..."
# Returns: "enable_elastic_disk": false
```

## Fix

Remove `omitempty` from the JSON tag on `EnableElasticDisk` in both structs so that `false` is explicitly sent to the API.

## Test plan

- [ ] Existing unit tests pass (`go test ./pools/...`)
- [ ] Create instance pool with `enable_elastic_disk = false` — verify API receives the value
- [ ] Subsequent `terraform plan` shows no changes