### PR TITLE
Some existing app fields can be inherited from spaces

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### New Features and Improvements
 
+* Fixed `databricks_app` producing "inconsistent result after apply" when the app is in a space and `resources`, `user_api_scopes`, or `budget_policy_id` are populated by the server from the space configuration.
+
 ### Bug Fixes
 
 ### Documentation

--- a/docs/resources/app.md
+++ b/docs/resources/app.md
@@ -44,9 +44,9 @@ The following arguments are required:
 
 * `name` - (Required) The name of the app. The name must contain only lowercase alphanumeric characters and hyphens. It must be unique within the workspace.
 * `description` - (Optional) The description of the app.
-* `budget_policy_id` - (Optional) The Budget Policy ID set for this resource.
-* `resources` - (Optional) A list of resources that the app have access to.
-* `user_api_scopes` - (Optional) A list of api scopes granted to the user access token.
+* `budget_policy_id` - (Optional) The Budget Policy ID set for this resource. When the app is in a space, this may be automatically populated from the space's usage policy.
+* `resources` - (Optional) A list of resources that the app has access to. When the app is in a space, this may be automatically populated from the space's resource configuration.
+* `user_api_scopes` - (Optional) A list of api scopes granted to the user access token. When the app is in a space, this may be automatically populated from the space's configuration.
 * `compute_size` - (Optional) A string specifying compute size for the App. Possible values are `MEDIUM`, `LARGE`.
 
 ### resources Configuration Attribute

--- a/internal/providers/pluginfw/products/app/resource_app.go
+++ b/internal/providers/pluginfw/products/app/resource_app.go
@@ -39,6 +39,9 @@ func (a AppResource) ApplySchemaCustomizations(s map[string]tfschema.AttributeBu
 	s["no_compute"] = s["no_compute"].SetOptional()
 	s["provider_config"] = s["provider_config"].SetOptional()
 	s["compute_size"] = s["compute_size"].SetComputed()
+	s["resources"] = s["resources"].SetComputed()
+	s["user_api_scopes"] = s["user_api_scopes"].SetComputed()
+	s["budget_policy_id"] = s["budget_policy_id"].SetComputed()
 	s = apps_tf.App{}.ApplySchemaCustomizations(s)
 	return s
 }

--- a/internal/providers/pluginfw/products/app/resource_app_acc_test.go
+++ b/internal/providers/pluginfw/products/app/resource_app_acc_test.go
@@ -193,6 +193,56 @@ func TestAccAppResource_NoCompute(t *testing.T) {
 	})
 }
 
+
+func TestAccAppResource_InSpace(t *testing.T) {
+	acceptance.LoadWorkspaceEnv(t)
+	if acceptance.IsGcp(t) {
+		acceptance.Skipf(t)("not available on GCP")
+	}
+	spaceTemplate := `
+	resource "databricks_sql_endpoint" "this" {
+		name = "tf-{var.STICKY_RANDOM}"
+		cluster_size = "2X-Small"
+		max_num_clusters = 1
+
+		tags {
+			custom_tags {
+				key   = "Owner"
+				value = "eng-dev-ecosystem-team_at_databricks.com"
+			}
+		}
+	}
+
+	resource "databricks_app_space" "this" {
+		name = "tf-{var.STICKY_RANDOM}"
+		description = "Space for acceptance test"
+		resources = [{
+			name = "warehouse"
+			sql_warehouse = {
+				id = databricks_sql_endpoint.this.id
+				permission = "CAN_USE"
+			}
+		}]
+		user_api_scopes = ["sql"]
+	}
+
+	resource "databricks_app" "this" {
+		name = "tf-{var.STICKY_RANDOM}"
+		description = "App in a space"
+		space = databricks_app_space.this.name
+		no_compute = true
+	}`
+	acceptance.WorkspaceLevel(t, acceptance.Step{
+		Template: spaceTemplate,
+		Check: func(s *terraform.State) error {
+			attrs := s.RootModule().Resources["databricks_app.this"].Primary.Attributes
+			assert.NotEmpty(t, attrs["resources.#"], "resources should be populated from the space")
+			assert.NotEmpty(t, attrs["user_api_scopes.#"], "user_api_scopes should be populated from the space")
+			return nil
+		},
+	})
+}
+
 var deletedOutsideTemplate = `
 	resource "databricks_secret_scope" "this" {
 		name = "tf-{var.STICKY_RANDOM}"

--- a/internal/providers/pluginfw/products/app/resource_app_acc_test.go
+++ b/internal/providers/pluginfw/products/app/resource_app_acc_test.go
@@ -193,34 +193,31 @@ func TestAccAppResource_NoCompute(t *testing.T) {
 	})
 }
 
-
 func TestAccAppResource_InSpace(t *testing.T) {
 	acceptance.LoadWorkspaceEnv(t)
 	if acceptance.IsGcp(t) {
 		acceptance.Skipf(t)("not available on GCP")
 	}
 	spaceTemplate := `
-	resource "databricks_sql_endpoint" "this" {
-		name = "tf-{var.STICKY_RANDOM}"
-		cluster_size = "2X-Small"
-		max_num_clusters = 1
+	resource "databricks_secret_scope" "space" {
+		name = "tf-space-{var.STICKY_RANDOM}"
+	}
 
-		tags {
-			custom_tags {
-				key   = "Owner"
-				value = "eng-dev-ecosystem-team_at_databricks.com"
-			}
-		}
+	resource "databricks_secret" "space" {
+		scope = databricks_secret_scope.space.name
+		key = "tf-{var.STICKY_RANDOM}"
+		string_value = "secret"
 	}
 
 	resource "databricks_app_space" "this" {
 		name = "tf-{var.STICKY_RANDOM}"
 		description = "Space for acceptance test"
 		resources = [{
-			name = "warehouse"
-			sql_warehouse = {
-				id = databricks_sql_endpoint.this.id
-				permission = "CAN_USE"
+			name = "my-secret"
+			secret = {
+				scope = databricks_secret_scope.space.name
+				key = databricks_secret.space.key
+				permission = "READ"
 			}
 		}]
 		user_api_scopes = ["sql"]
@@ -230,10 +227,10 @@ func TestAccAppResource_InSpace(t *testing.T) {
 		name = "tf-{var.STICKY_RANDOM}"
 		description = "App in a space"
 		space = databricks_app_space.this.name
-		no_compute = true
 	}`
 	acceptance.WorkspaceLevel(t, acceptance.Step{
 		Template: spaceTemplate,
+		ExpectNonEmptyPlan: true,
 		Check: func(s *terraform.State) error {
 			attrs := s.RootModule().Resources["databricks_app.this"].Primary.Attributes
 			assert.NotEmpty(t, attrs["resources.#"], "resources should be populated from the space")

--- a/internal/providers/pluginfw/products/app/resource_app_test.go
+++ b/internal/providers/pluginfw/products/app/resource_app_test.go
@@ -1,0 +1,24 @@
+package app
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAppResourceSchema_SpaceInheritedFieldsAreComputed(t *testing.T) {
+	ctx := context.Background()
+	r := ResourceApp()
+	resp := &resource.SchemaResponse{}
+	r.Schema(ctx, resource.SchemaRequest{}, resp)
+
+	for _, field := range []string{"resources", "user_api_scopes", "budget_policy_id"} {
+		attr, ok := resp.Schema.Attributes[field]
+		require.True(t, ok, "field %s should exist in schema", field)
+		assert.True(t, attr.IsOptional(), "field %s should be optional", field)
+		assert.True(t, attr.IsComputed(), "field %s should be computed (server-populated from space)", field)
+	}
+}


### PR DESCRIPTION
## Changes

add SetComputed() for app fields that are:
- passed in for standalone apps AND
- inherited from parent space for apps in spaces

## Checklist 

- [x] relevant change in `docs/` folder
- [x] covered with integration tests in `internal/acceptance`
- [x] using Go SDK
- [x] using TF Plugin Framework
- [x] has entry in `NEXT_CHANGELOG.md` file

## Tests

End to end testing strategy:
1. Setup terraform playground with `openapi/scripts/tf/playground.sh --skip-tests --skip-sanitization ~/apps/terraform_demo/main.tf`
2. Patched resource_app.go in the playground's cloned provider to add SetComputed() for resources, user_api_scopes, and budget_policy_id
3. go build
4. Created a tf project with the following `main.tf` file to test changes:

```
resource "databricks_app_space" "my_space" {
  description = "Terraform space"
  name        = "my-space"
  resources   = local.app_resources
  user_api_scopes = ["sql"]
  usage_policy_id = "3de7e077-6d23-4fff-92a2-f39b136639b0"
}

resource "databricks_app" "terraform_app" {
  name        = "terraform-app"
  description = "Terraform app"
  space        = databricks_app_space.my_space.name
}
```

### Before change
```
│ Error: Provider produced inconsistent result after apply
│
│ When applying changes to databricks_app.terraform_app, provider "provider[\"registry.terraform.io/databricks/databricks\"]" produced
│ an unexpected new value: .user_api_scopes: was null, but now cty.ListVal([]cty.Value{cty.StringVal("sql")}).
│
│ This is a bug in the provider, which should be reported in the provider's own issue tracker.
╵
╷
│ Error: Provider produced inconsistent result after apply
│
│ When applying changes to databricks_app.terraform_app, provider "provider[\"registry.terraform.io/databricks/databricks\"]" produced
│ an unexpected new value: .resources: was null, but now
│ cty.ListVal([]cty.Value{cty.ObjectVal(map[string]cty.Value{"app":cty.NullVal(cty.Object(map[string]cty.Type{"name":cty.String,
│ "permission":cty.String})), "database":cty.NullVal(cty.Object(map[string]cty.Type{"database_name":cty.String,
│ "instance_name":cty.String, "permission":cty.String})), "description":cty.NullVal(cty.String),
│ "experiment":cty.NullVal(cty.Object(map[string]cty.Type{"experiment_id":cty.String, "permission":cty.String})),
│ "genie_space":cty.NullVal(cty.Object(map[string]cty.Type{"name":cty.String, "permission":cty.String, "space_id":cty.String})),
│ "job":cty.NullVal(cty.Object(map[string]cty.Type{"id":cty.String, "permission":cty.String})),
│ "name":cty.StringVal("test-warehouse1"), "postgres":cty.NullVal(cty.Object(map[string]cty.Type{"branch":cty.String,
│ "database":cty.String, "permission":cty.String})), "secret":cty.NullVal(cty.Object(map[string]cty.Type{"key":cty.String,
│ "permission":cty.String, "scope":cty.String})), "serving_endpoint":cty.NullVal(cty.Object(map[string]cty.Type{"name":cty.String,
│ "permission":cty.String})), "sql_warehouse":cty.ObjectVal(map[string]cty.Value{"id":cty.StringVal("329db86a966be8d4"),
│ "permission":cty.StringVal("CAN_USE")}), "uc_securable":cty.NullVal(cty.Object(map[string]cty.Type{"permission":cty.String,
│ "securable_full_name":cty.String, "securable_kind":cty.String, "securable_type":cty.String}))})}).
│
│ This is a bug in the provider, which should be reported in the provider's own issue tracker.
```
### After change
```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following
symbols:
  + create

Terraform will perform the following actions:

  # databricks_app.terraform_app will be created
  + resource "databricks_app" "terraform_app" {
      + active_deployment           = (known after apply)
      + app_status                  = (known after apply)
      + budget_policy_id            = (known after apply)
      + compute_size                = (known after apply)
      + compute_status              = (known after apply)
      + create_time                 = (known after apply)
      + creator                     = (known after apply)
      + default_git_source          = (known after apply)
      + default_source_code_path    = (known after apply)
      + description                 = "Terraform app"
      + effective_budget_policy_id  = (known after apply)
      + effective_usage_policy_id   = (known after apply)
      + effective_user_api_scopes   = (known after apply)
      + id                          = (known after apply)
      + last_deployment_id          = (known after apply)
      + name                        = "terraform-app"
      + oauth2_app_client_id        = (known after apply)
      + oauth2_app_integration_id   = (known after apply)
      + pending_deployment          = (known after apply)
      + resources                   = (known after apply)
      + service_principal_client_id = (known after apply)
      + service_principal_id        = (known after apply)
      + service_principal_name      = (known after apply)
      + space                       = "my-space"
      + thumbnail_url               = (known after apply)
      + update_time                 = (known after apply)
      + updater                     = (known after apply)
      + url                         = (known after apply)
      + user_api_scopes             = (known after apply)
    }

  # databricks_app_space.my_space will be created
  + resource "databricks_app_space" "my_space" {
      + create_time                 = (known after apply)
      + creator                     = (known after apply)
      + description                 = "Terraform space"
      + effective_usage_policy_id   = (known after apply)
      + effective_user_api_scopes   = (known after apply)
      + id                          = (known after apply)
      + name                        = "my-space"
      + resources                   = [
          + {
              + name          = "test-warehouse1"
              + sql_warehouse = {
                  + id         = "329db86a966be8d4"
                  + permission = "CAN_USE"
                }
            },
        ]
      + service_principal_client_id = (known after apply)
      + service_principal_id        = (known after apply)
      + service_principal_name      = (known after apply)
      + status                      = (known after apply)
      + update_time                 = (known after apply)
      + updater                     = (known after apply)
      + usage_policy_id             = "3de7e077-6d23-4fff-92a2-f39b136639b0"
      + user_api_scopes             = [
          + "sql",
        ]
    }

Plan: 2 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

databricks_app_space.my_space: Creating...
databricks_app_space.my_space: Still creating... [00m10s elapsed]
databricks_app_space.my_space: Creation complete after 11s [id=c42d5cc8-d11e-456b-9eac-99ea87b93750]
databricks_app.terraform_app: Creating...
databricks_app.terraform_app: Still creating... [00m10s elapsed]
databricks_app.terraform_app: Still creating... [00m20s elapsed]
databricks_app.terraform_app: Still creating... [00m30s elapsed]
databricks_app.terraform_app: Still creating... [00m40s elapsed]
databricks_app.terraform_app: Still creating... [00m50s elapsed]
databricks_app.terraform_app: Creation complete after 51s [id=fa9a2411-50fc-4978-ad24-787b2c958476]

Apply complete! Resources: 2 added, 0 changed, 0 destroyed.
```

- [x] `make test` run locally

Got failed tests but none of them see related to my change:
```
=== FAIL: internal/providers TestConfig_NoParams/plugin_framework (0.00s)
    providers_test_utils.go:143:
        	Error Trace:	/Users/bernardo.rodriguez/Desktop/terraform-provider-databricks/internal/providers/providers_test_utils.go:143
        	            				/Users/bernardo.rodriguez/Desktop/terraform-provider-databricks/internal/providers/providers_test_utils.go:138
        	            				/Users/bernardo.rodriguez/Desktop/terraform-provider-databricks/internal/providers/providers_test_utils.go:163
        	Error:      	Expected value not to be nil.
        	Test:       	TestConfig_NoParams/plugin_framework
        	Messages:   	Expected to have default auth: cannot configure default credentials, please check https://docs.databricks.com/en/dev-tools/auth.html#databricks-client-unified-authentication to configure credentials for your preferred authentication method error
    --- FAIL: TestConfig_NoParams/plugin_framework (0.00s)

=== FAIL: internal/providers TestConfig_NoParams (0.01s)

=== FAIL: mws TestWorkspaceTokenWrongAuthCornerCase (0.62s)
2026/02/24 23:36:53 [TRACE] set workspace_url "https://adb-4119111590058294.2.staging.azuredatabricks.net"
2026/02/24 23:36:53 [TRACE] set token []interface {}{map[string]interface {}{"comment":"test", "lifetime_seconds":3600, "token_id":"9126a5d5b7a80cb49459066d3e8437aba028f973c5e5751430e1957367b5af8d", "token_value":****}}
    resource_mws_workspaces_test.go:1528:
        	Error Trace:	/Users/bernardo.rodriguez/Desktop/terraform-provider-databricks/mws/resource_mws_workspaces_test.go:1528
        	Error:      	An error is expected but got nil.
        	Test:       	TestWorkspaceTokenWrongAuthCornerCase
        	Messages:   	create
    resource_mws_workspaces_test.go:1529:
        	Error Trace:	/Users/bernardo.rodriguez/Desktop/terraform-provider-databricks/mws/resource_mws_workspaces_test.go:1529
        	Error:      	An error is expected but got nil.
        	Test:       	TestWorkspaceTokenWrongAuthCornerCase
        	Messages:   	ensure
    resource_mws_workspaces_test.go:1530:
        	Error Trace:	/Users/bernardo.rodriguez/Desktop/terraform-provider-databricks/mws/resource_mws_workspaces_test.go:1530
        	Error:      	An error is expected but got nil.
        	Test:       	TestWorkspaceTokenWrongAuthCornerCase
        	Messages:   	remove

DONE 2911 tests, 456 skipped, 7 failures in 65.562s
make: *** [test] Error 1
```
