### PR TITLE
[Feature] Include column name and types in sql_table column type change error

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -7,6 +7,7 @@
 ### New Features and Improvements
 
 * Add `role_arn` field to `databricks_mws_storage_configurations` resource to support sharing S3 buckets between root storage and Unity Catalog ([#5222](https://github.com/databricks/terraform-provider-databricks/issues/5222))
+* Include column name and type details in `databricks_sql_table` column type change error message ([#5478](https://github.com/databricks/terraform-provider-databricks/pull/5478))
 
 ### Bug Fixes
 

--- a/catalog/resource_sql_table.go
+++ b/catalog/resource_sql_table.go
@@ -578,11 +578,13 @@ func getColumnType(columnType string) string {
 func assertNoColumnTypeDiff(oldCols []interface{}, newColumnInfos []SqlColumnInfo) error {
 	for i, oldCol := range oldCols {
 		oldColMap := oldCol.(map[string]interface{})
-		if getColumnType(oldColMap["type"].(string)) != getColumnType(newColumnInfos[i].Type) {
-			return fmt.Errorf("changing the 'type' of an existing column is not supported")
+		oldType := getColumnType(oldColMap["type"].(string))
+		newType := getColumnType(newColumnInfos[i].Type)
+		if oldType != newType {
+			return fmt.Errorf("changing the 'type' of an existing column is not supported: column '%s' type changed from '%s' to '%s'", oldColMap["name"].(string), oldType, newType)
 		}
 		if oldColMap["identity"].(string) != string(newColumnInfos[i].Identity) {
-			return fmt.Errorf("changing the 'identity' type of an existing column is not supported")
+			return fmt.Errorf("changing the 'identity' type of an existing column is not supported: column '%s' identity changed from '%s' to '%s'", oldColMap["name"].(string), oldColMap["identity"].(string), string(newColumnInfos[i].Identity))
 		}
 	}
 	return nil

--- a/catalog/resource_sql_table_test.go
+++ b/catalog/resource_sql_table_test.go
@@ -1115,7 +1115,7 @@ func TestResourceSqlTableUpdateTable_ColumnsTypeThrowsError(t *testing.T) {
 				},
 			},
 			allowedCommands:  []string{},
-			expectedErrorMsg: "changing the 'type' of an existing column is not supported",
+			expectedErrorMsg: "changing the 'type' of an existing column is not supported: column 'one' type changed from 'string' to 'int'",
 		},
 	)
 }


### PR DESCRIPTION
## Changes
When a `databricks_sql_table` plan fails due to a column type or identity change, the error message now specifies which column is affected and shows the old and new values.

Before: `changing the 'type' of an existing column is not supported`
After: `changing the 'type' of an existing column is not supported: column 'price' type changed from 'string' to 'int'`

Closes #4919

## Tests

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] using Go SDK
- [ ] using TF Plugin Framework
- [x] has entry in `NEXT_CHANGELOG.md` file

### How it was tested

- Updated existing unit test `TestResourceSqlTableUpdateTable_ColumnsTypeThrowsError` to assert the new error message includes column name and old/new types (`column 'one' type changed from 'string' to 'int'`)
- Verified `TestResourceSqlTableUpdateTable_ColumnsTypeUpperLowerCaseThrowsError` still passes (case-insensitive comparison: `string` vs `STRING` should not error)
- All 12 `TestResourceSqlTableUpdateTable*` tests pass (column add, drop, update, membership changes, etc.)
- `make fmt lint ws` passes cleanly