### PR TITLE
[Internal] Verify `disabled` field in job settings task

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -13,3 +13,5 @@
 ### Exporter
 
 ### Internal Changes
+
+* Added unit test verifying `disabled` field is present in job task schema via SDK embedding ([JOBS-27406]).

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -14,4 +14,4 @@
 
 ### Internal Changes
 
-* Added unit test verifying `disabled` field is present in job task schema via SDK embedding ([JOBS-27406]).
+* Added unit test verifying `disabled` field is present in job task schema via SDK embedding.

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -13,5 +13,3 @@
 ### Exporter
 
 ### Internal Changes
-
-* Added unit test verifying `disabled` field is present in job task schema via SDK embedding.

--- a/jobs/resource_job_test.go
+++ b/jobs/resource_job_test.go
@@ -3641,6 +3641,70 @@ func TestJobResource_SparkConfDiffSuppress(t *testing.T) {
 	assert.False(t, scs.DiffSuppressFunc("new_cluster.0.spark_conf.%", "1", "1", nil))
 }
 
+func TestJobResource_TaskDisabledFieldPassedInCreateRequest(t *testing.T) {
+	// The disabled field is present in the schema and serialization via SDK
+	// embedding: JobSettingsResource → jobs.JobSettings → []jobs.Task → Disabled.
+	// This test verifies that setting disabled = true in HCL results in the
+	// field being sent in the API create request.
+	d, err := qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "POST",
+				Resource: "/api/2.2/jobs/create",
+				ExpectedRequest: jobs.CreateJob{
+					Name: "DisabledFieldTest",
+					Tasks: []jobs.Task{
+						{
+							TaskKey:           "a",
+							ExistingClusterId: "abc",
+							Disabled:          true,
+							NotebookTask: &jobs.NotebookTask{
+								NotebookPath: "/test",
+							},
+						},
+					},
+					MaxConcurrentRuns: 1,
+					Queue: &jobs.QueueSettings{
+						Enabled: false,
+					},
+				},
+				Response: Job{
+					JobID: 123,
+				},
+			},
+			{
+				Method:   "GET",
+				Resource: "/api/2.2/jobs/get?job_id=123",
+				Response: Job{
+					Settings: &JobSettings{
+						Tasks: []JobTaskSettings{
+							{
+								TaskKey: "a",
+							},
+						},
+					},
+				},
+			},
+		},
+		Create:   true,
+		Resource: ResourceJob(),
+		HCL: `
+		name = "DisabledFieldTest"
+
+		task {
+			task_key = "a"
+			existing_cluster_id = "abc"
+			disabled = true
+
+			notebook_task {
+				notebook_path = "/test"
+			}
+		}`,
+	}.Apply(t)
+	assert.NoError(t, err)
+	assert.Equal(t, "123", d.Id())
+}
+
 func TestJobResource_TaskDisabledFieldInSchema(t *testing.T) {
 	jr := ResourceJob()
 	taskSchema := common.MustSchemaPath(jr.Schema, "task")

--- a/jobs/resource_job_test.go
+++ b/jobs/resource_job_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/databricks/terraform-provider-databricks/clusters"
 	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/databricks/terraform-provider-databricks/qa"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -3638,4 +3639,13 @@ func TestJobResource_SparkConfDiffSuppress(t *testing.T) {
 	scs := common.MustSchemaPath(jr.Schema, "new_cluster", "spark_conf")
 	assert.True(t, scs.DiffSuppressFunc("new_cluster.0.spark_conf.%", "1", "0", nil))
 	assert.False(t, scs.DiffSuppressFunc("new_cluster.0.spark_conf.%", "1", "1", nil))
+}
+
+func TestJobResource_TaskDisabledFieldInSchema(t *testing.T) {
+	jr := ResourceJob()
+	taskSchema := common.MustSchemaPath(jr.Schema, "task")
+	s, ok := taskSchema.Elem.(*schema.Resource).Schema["disabled"]
+	assert.True(t, ok, "disabled field should be in the task schema via SDK embedding (jobs.JobSettings → []jobs.Task → Disabled)")
+	assert.Equal(t, schema.TypeBool, s.Type)
+	assert.True(t, s.Optional)
 }


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
  - Added unit tests verifying the `disabled` field on job tasks is present in the Terraform schema and correctly serialized to API requests
  - The field flows through automatically via SDK embedding: `JobSettingsResource` embeds `jobs.JobSettings` which contains `[]jobs.Task`, and the SDK's `Task`
  struct includes `Disabled bool`

## Tests
<!--
How is this tested? Please see the checklist below and also describe any other relevant tests
-->
  - [x] `go test -run TestJobResource_TaskDisabledFieldInSchema ./jobs/` — verifies field exists in task schema as optional bool
  - [x] `go test -run TestJobResource_TaskDisabledFieldPassedInCreateRequest ./jobs/` — verifies setting `disabled = true` in HCL sends `"disabled": true` in the API
   create request
NO_CHANGELOG=true
