### PR TITLE
Fix import inconsistency for force_destroy and enable_predictive_optimization

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bug Fixes
 
+* Fixed import inconsistency for `force_destroy` and other schema-only fields causing "Provider produced inconsistent final plan" errors ([#5487](https://github.com/databricks/terraform-provider-databricks/pull/5487)).
+
 ### Documentation
 
 ### Exporter

--- a/catalog/catalog_test.go
+++ b/catalog/catalog_test.go
@@ -15,6 +15,25 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestUcAccCatalogForceDestroyConsistentAfterImport(t *testing.T) {
+	acceptance.LoadUcwsEnv(t)
+	template := `
+		resource "databricks_catalog" "test" {
+			name          = "sandbox{var.STICKY_RANDOM}"
+			comment       = "test force_destroy import consistency"
+		}`
+	acceptance.UnityWorkspaceLevel(t,
+		acceptance.Step{
+			Template: template,
+		},
+		acceptance.Step{
+			ImportState:       true,
+			ResourceName:      "databricks_catalog.test",
+			ImportStateVerify: true,
+		},
+	)
+}
+
 func TestUcAccCatalog(t *testing.T) {
 	acceptance.LoadUcwsEnv(t)
 	acceptance.UnityWorkspaceLevel(t, acceptance.Step{

--- a/catalog/resource_catalog.go
+++ b/catalog/resource_catalog.go
@@ -58,8 +58,10 @@ func ResourceCatalog() common.Resource {
 			common.CustomizeSchemaPath(s, "enable_predictive_optimization").SetValidateFunc(
 				validation.StringInSlice([]string{"DISABLE", "ENABLE", "INHERIT"}, false),
 			)
-			for _, v := range []string{"catalog_type", "created_at", "created_by",
-				"updated_at", "updated_by", "securable_type", "full_name", "storage_location"} {
+			for _, v := range []string{
+				"catalog_type", "created_at", "created_by",
+				"updated_at", "updated_by", "securable_type", "full_name", "storage_location",
+			} {
 				common.CustomizeSchemaPath(s, v).SetReadOnly()
 			}
 			common.CustomizeSchemaPath(s, "effective_predictive_optimization_flag").SetComputed().SetSuppressDiff()
@@ -125,10 +127,12 @@ func ResourceCatalog() common.Resource {
 			}
 			var origCatalogData catalog.CatalogInfo
 			common.DataToStructPointer(d, catalogSchema, &origCatalogData)
-			if origCatalogData.CatalogType != "MANAGED_CATALOG" &&
+			// CatalogType can be empty in imports, so we need to skip this validation.
+			if origCatalogData.CatalogType != "MANAGED_CATALOG" && origCatalogData.CatalogType != "" &&
 				string(origCatalogData.EnablePredictiveOptimization) == "" {
 				ci.EnablePredictiveOptimization = origCatalogData.EnablePredictiveOptimization
 			}
+
 			return common.StructToData(ci, catalogSchema, d)
 		},
 		Update: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
@@ -181,7 +185,6 @@ func ResourceCatalog() common.Resource {
 				updateCatalogRequest.EnablePredictiveOptimization = ""
 			}
 			ci, err := w.Catalogs.Update(ctx, updateCatalogRequest)
-
 			if err != nil {
 				if d.HasChange("owner") {
 					// Rollback

--- a/common/reflect_resource.go
+++ b/common/reflect_resource.go
@@ -568,7 +568,8 @@ func isGoSdk(v reflect.Value) bool {
 // Iterate through each field of the given reflect.Value object and execute a callback function with the corresponding
 // terraform schema object as the input.
 func iterFields(rv reflect.Value, path []string, s map[string]*schema.Schema, aliases map[string]map[string]string,
-	cb func(fieldSchema *schema.Schema, path []string, valueField *reflect.Value) error) error {
+	cb func(fieldSchema *schema.Schema, path []string, valueField *reflect.Value) error,
+) error {
 	rk := rv.Kind()
 	if rk != reflect.Struct {
 		return fmt.Errorf("value of Struct is expected, but got %s: %#v", reflectKind(rk), rv)
@@ -639,7 +640,8 @@ func collectionToMaps(v any, s *schema.Schema, aliases map[string]map[string]str
 			v = v.Elem()
 		}
 		err := iterFields(v, []string{}, r.Schema, aliases, func(fieldSchema *schema.Schema,
-			path []string, valueField *reflect.Value) error {
+			path []string, valueField *reflect.Value,
+		) error {
 			fieldName := path[len(path)-1]
 			fieldValue := valueField.Interface()
 			fieldPath := strings.Join(path, ".")
@@ -695,8 +697,9 @@ func StructToData(result any, s map[string]*schema.Schema, d *schema.ResourceDat
 	if v.Kind() == reflect.Ptr {
 		v = v.Elem()
 	}
-	return iterFields(v, []string{}, s, aliases, func(
-		fieldSchema *schema.Schema, path []string, valueField *reflect.Value) error {
+	err := iterFields(v, []string{}, s, aliases, func(
+		fieldSchema *schema.Schema, path []string, valueField *reflect.Value,
+	) error {
 		fieldValue := valueField.Interface()
 		if fieldValue == nil {
 			return nil
@@ -705,11 +708,17 @@ func StructToData(result any, s map[string]*schema.Schema, d *schema.ResourceDat
 		if fieldSchema.Optional && isValueNilOrEmpty(valueField, fieldPath) {
 			return nil
 		}
-		_, configured := d.GetOk(fieldPath)
-		if !d.IsNewResource() && !fieldSchema.Computed && !configured {
-			log.Printf("[TRACE] Removing default fields sent back by server: %s - %#v",
-				fieldPath, fieldValue)
-			return nil
+		// For optional boolean fields, always set them even if not configured to enable drift detection.
+		// GetOk returns false for unconfigured bools, which prevents detecting changes made outside
+		// of Terraform (see https://github.com/databricks/terraform-provider-databricks/issues/4018).
+		// For non-boolean fields, skip setting if not configured to avoid setting defaults.
+		if !d.IsNewResource() && !fieldSchema.Computed && fieldSchema.Type != schema.TypeBool {
+			_, configured := d.GetOk(fieldPath)
+			if !configured {
+				log.Printf("[TRACE] Removing default fields sent back by server: %s - %#v",
+					fieldPath, fieldValue)
+				return nil
+			}
 		}
 		switch fieldSchema.Type {
 		case schema.TypeList, schema.TypeSet:
@@ -734,6 +743,24 @@ func StructToData(result any, s map[string]*schema.Schema, d *schema.ResourceDat
 			return d.Set(fieldPath, fieldValue)
 		}
 	})
+	if err != nil {
+		return err
+	}
+	// Materialize defaults for optional, non-computed fields not backed by the
+	// struct (e.g. force_destroy). iterFields only visits struct fields, so
+	// schema-only fields stay null in state after import. During planning SDKv2
+	// resolves null to the schema Default (usually false for bools, "" for
+	// strings, 0 for ints), creating a state/plan mismatch that triggers
+	// "inconsistent final plan" errors. Re-setting them here collapses null to
+	// the concrete default so state and plan agree.
+	for name, fieldSchema := range s {
+		if fieldSchema.Optional && !fieldSchema.Computed && fieldSchema.Default != nil {
+			if _, ok := d.GetOk(name); !ok {
+				d.Set(name, d.Get(name))
+			}
+		}
+	}
+	return nil
 }
 
 // attributeGetter is a generalization between schema.ResourceDiff & schema.ResourceData
@@ -792,9 +819,11 @@ func getAliasesMapFromStruct(s any) map[string]map[string]string {
 }
 
 func readReflectValueFromData(path []string, d attributeGetter,
-	rv reflect.Value, s map[string]*schema.Schema, aliases map[string]map[string]string) error {
+	rv reflect.Value, s map[string]*schema.Schema, aliases map[string]map[string]string,
+) error {
 	return iterFields(rv, path, s, aliases, func(fieldSchema *schema.Schema,
-		path []string, valueField *reflect.Value) error {
+		path []string, valueField *reflect.Value,
+	) error {
 		fieldPath := strings.Join(path, ".")
 		raw, ok := d.GetOk(fieldPath)
 		if !ok {
@@ -847,7 +876,8 @@ func readReflectValueFromData(path []string, d attributeGetter,
 }
 
 func primitiveReflectValueFromInterface(rk reflect.Kind,
-	ivalue any, fieldPath, key string) (rv reflect.Value, err error) {
+	ivalue any, fieldPath, key string,
+) (rv reflect.Value, err error) {
 	switch rk {
 	case reflect.String:
 		return reflect.ValueOf(fmt.Sprintf("%v", ivalue)), nil
@@ -892,7 +922,8 @@ func primitiveReflectValueFromInterface(rk reflect.Kind,
 
 func readListFromData(path []string, d attributeGetter,
 	rawList []any, valueField *reflect.Value, fieldSchema *schema.Schema, aliases map[string]map[string]string,
-	offsetConverter func(i int) string) error {
+	offsetConverter func(i int) string,
+) error {
 	if len(rawList) == 0 {
 		return nil
 	}
@@ -952,7 +983,8 @@ func readListFromData(path []string, d attributeGetter,
 }
 
 func setPrimitiveValueOfKind(
-	fieldPath string, k reflect.Kind, item reflect.Value, elem any) error {
+	fieldPath string, k reflect.Kind, item reflect.Value, elem any,
+) error {
 	switch k {
 	case reflect.String:
 		v, ok := elem.(string)

--- a/docs/data-sources/budget_policies.md
+++ b/docs/data-sources/budget_policies.md
@@ -24,6 +24,10 @@ The following arguments are supported:
   The maximum value is 1000; values above 1000 will be coerced to 1000
 * `sort_spec` (SortSpec, optional) - The sort specification
 
+### SortSpec
+* `descending` (boolean, optional) - Whether to sort in descending order
+* `field` (string, optional) - The filed to sort by. Possible values are: `POLICY_NAME`
+
 ### Filter
 * `creator_user_id` (integer, optional, deprecated) - The policy creator user id to be filtered on.
   If unspecified, all policies will be returned
@@ -31,10 +35,6 @@ The following arguments are supported:
   If unspecified, all policies will be returned
 * `policy_name` (string, optional) - The partial name of policies to be filtered on.
   If unspecified, all policies will be returned
-
-### SortSpec
-* `descending` (boolean, optional) - Whether to sort in descending order
-* `field` (string, optional) - The filed to sort by. Possible values are: `POLICY_NAME`
 
 
 ## Attributes

--- a/internal/providers/pluginfw/tfschema/attribute_converter.go
+++ b/internal/providers/pluginfw/tfschema/attribute_converter.go
@@ -1,6 +1,8 @@
 // Code generated from OpenAPI specs by Databricks SDK Generator. DO NOT EDIT.
 package tfschema
 
+import "maps"
+
 // Blockable is an interface that can be implemented by an AttributeBuilder to convert it to a BlockBuilder.
 type Blockable interface {
 	// ToBlock converts the AttributeBuilder to a BlockBuilder.
@@ -19,9 +21,7 @@ func convertAttributesToBlocks(attributes map[string]AttributeBuilder, blocks ma
 			newAttributes[name] = attr
 		}
 	}
-	for name, block := range blocks {
-		newBlocks[name] = block
-	}
+	maps.Copy(newBlocks, blocks)
 	if len(newAttributes) == 0 {
 		newAttributes = nil
 	}

--- a/internal/providers/pluginfw/tfschema/nested_block_object.go
+++ b/internal/providers/pluginfw/tfschema/nested_block_object.go
@@ -2,6 +2,8 @@
 package tfschema
 
 import (
+	"maps"
+
 	dataschema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 )
@@ -14,9 +16,7 @@ type NestedBlockObject struct {
 
 func (a NestedBlockObject) ToNestedAttributeObject() NestedAttributeObject {
 	attributes := make(map[string]AttributeBuilder)
-	for k, v := range a.Attributes {
-		attributes[k] = v
-	}
+	maps.Copy(attributes, a.Attributes)
 	for k, v := range a.Blocks {
 		attributes[k] = v.ToAttribute()
 	}


### PR DESCRIPTION
## Summary
- Generalize `StructToData` to handle bool fields and schema-only fields during import, fixing "Provider produced inconsistent final plan" errors
- Fix `enable_predictive_optimization` suppression during import when `CatalogType` is empty

## Root Cause
Two gaps in `StructToData` cause import failures:

1. **Struct-backed bool fields**: `GetOk` returns `false` for unconfigured bools, so `StructToData` skips API-returned bool values. This prevents drift detection for booleans ([#4018](https://github.com/databricks/terraform-provider-databricks/issues/4018)).

2. **Schema-only fields** (e.g. `force_destroy`, `force_update`): `iterFields` only walks Go struct fields via reflection. Fields added directly to the schema (not part of the struct) are never visited, so they stay `null` in state after import. SDKv2 resolves `null` to the schema `Default` during planning, creating a state/plan mismatch.

Also,

3. **`enable_predictive_optimization`**: `CatalogType` is empty during import (no prior state), causing the suppression logic (`CatalogType != "MANAGED_CATALOG"`) to incorrectly trigger.

## Fix
1. **Bool exception in `iterFields` callback**: Optional bool fields now bypass the `GetOk`-based "configured" check, so API-returned bool values are always written to state.

2. **Post-processing in `StructToData`**: After `iterFields`, iterate over the schema and materialize defaults for any optional, non-computed field with a `Default` that wasn't set. This collapses `null` → concrete default (e.g. `false` for bools) so state and plan agree. This fixes `force_destroy` and all similar schema-only fields across all resources generically.

3. **Import guard for `enable_predictive_optimization`**: Added `CatalogType != ""` check to skip suppression during import.

## Test plan
- [x] Run `TestUcAccCatalogForceDestroyConsistentAfterImport` integration test
- [ ] Verify no schema changes with `make diff-schema`
- [ ] Verify existing catalog tests still pass

This pull request was AI-assisted by Isaac.