### PR TITLE
[Merge Hold][Internal] Re-enable TestMwsAccNetworkConnectivityConfig

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -18,4 +18,5 @@
 
 ### Internal Changes
 
+* Re-enable `TestMwsAccNetworkConnectivityConfig` acceptance test.
 * Use account host check instead of account ID check in `databricks_access_control_rule_set` to determine client type ([#5484](https://github.com/databricks/terraform-provider-databricks/pull/5484)).

--- a/mws/mws_network_connectivity_config_test.go
+++ b/mws/mws_network_connectivity_config_test.go
@@ -8,7 +8,6 @@ import (
 
 func TestMwsAccNetworkConnectivityConfig(t *testing.T) {
 	if acceptance.IsAzure(t) {
-		acceptance.Skipf(t)("Skipping this test to unblock merging PRs as it's failing due to timeout")
 		acceptance.AccountLevel(t, acceptance.Step{
 			Template: `
 			resource "databricks_mws_network_connectivity_config" "this" {


### PR DESCRIPTION
# Merge Hold

## Changes
<!-- Summary of your changes that are easy to understand -->
Re-enabling the test, earlier this was failing because of timeout.
## Tests
<!--
How is this tested? Please see the checklist below and also describe any other relevant tests
-->
Test passes
