### PR TITLE
[Fix] Copy commandFactory when creating DatabricksClient for unified provider

### DIFF
--- a/common/unified_provider.go
+++ b/common/unified_provider.go
@@ -190,6 +190,7 @@ func (c *DatabricksClient) getDatabricksClientForUnifiedProvider(ctx context.Con
 		if client, ok := c.cachedDatabricksClients[workspaceIDInt]; ok && client != nil {
 			return &DatabricksClient{
 				DatabricksClient: client,
+				commandFactory:   c.commandFactory,
 			}, nil
 		}
 	}
@@ -204,6 +205,7 @@ func (c *DatabricksClient) getDatabricksClientForUnifiedProvider(ctx context.Con
 	// Return the Databricks Client.
 	return &DatabricksClient{
 		DatabricksClient: c.cachedDatabricksClients[workspaceIDInt],
+		commandFactory:   c.commandFactory,
 	}, nil
 }
 

--- a/common/unified_provider_test.go
+++ b/common/unified_provider_test.go
@@ -1023,3 +1023,82 @@ func TestNamespaceCustomizeDiff_ForceNewOnChange(t *testing.T) {
 	require.True(t, ok, "workspace_id should be in diff attributes")
 	assert.True(t, wsAttr.RequiresNew, "changing workspace_id should require new resource")
 }
+
+func TestGetDatabricksClientForUnifiedProvider_CopiesCommandFactory(t *testing.T) {
+	// Setup: parent client with commandFactory set via WithCommandMock
+	parentClient := &DatabricksClient{
+		DatabricksClient: &client.DatabricksClient{
+			Config: &config.Config{
+				Host:  "https://test.cloud.databricks.com",
+				Token: "test-token",
+			},
+		},
+	}
+	parentClient.WithCommandMock(func(commandStr string) CommandResults {
+		return CommandResults{ResultType: "text", Data: "mock"}
+	})
+
+	// Verify parent's CommandExecutor works
+	assert.NotPanics(t, func() {
+		parentClient.CommandExecutor(context.Background())
+	}, "parent client should have a working CommandExecutor")
+
+	// Pre-cache an inner client for workspace ID 123456
+	innerClient := &client.DatabricksClient{
+		Config: &config.Config{
+			Host:  "https://workspace-123456.cloud.databricks.com",
+			Token: "test-token",
+		},
+	}
+	parentClient.cachedDatabricksClients = map[int64]*client.DatabricksClient{
+		123456: innerClient,
+	}
+
+	// Call getDatabricksClientForUnifiedProvider — returned client must have
+	// commandFactory copied from the parent so CommandExecutor works.
+	result, err := parentClient.getDatabricksClientForUnifiedProvider(
+		context.Background(), "123456",
+	)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.NotPanics(t, func() {
+		result.CommandExecutor(context.Background())
+	}, "returned client should have commandFactory copied from parent")
+
+	// Also verify via the public entry point DatabricksClientForUnifiedProvider
+	testSchema := map[string]*schema.Schema{
+		"provider_config": {
+			Type:     schema.TypeList,
+			Optional: true,
+			MaxItems: 1,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"workspace_id": {
+						Type:     schema.TypeString,
+						Optional: true,
+					},
+				},
+			},
+		},
+		"name": {
+			Type:     schema.TypeString,
+			Required: true,
+		},
+	}
+	d := schema.TestResourceDataRaw(t, testSchema, map[string]any{
+		"name": "test",
+		"provider_config": []any{
+			map[string]any{
+				"workspace_id": "123456",
+			},
+		},
+	})
+	result2, err := parentClient.DatabricksClientForUnifiedProvider(
+		context.Background(), d,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, result2)
+	assert.NotPanics(t, func() {
+		result2.CommandExecutor(context.Background())
+	}, "client from DatabricksClientForUnifiedProvider should have commandFactory")
+}

--- a/storage/mounts_acc_test.go
+++ b/storage/mounts_acc_test.go
@@ -45,6 +45,50 @@ func TestAccCreateDatabricksMount(t *testing.T) {
 		})
 }
 
+// TestAccCreateDatabricksMountWithProviderConfig creates a mount using
+// provider_config { workspace_id } pointing at the same workspace the provider
+// is configured for. This exercises getDatabricksClientForUnifiedProvider which
+// creates a new DatabricksClient — verifying that commandFactory (needed by
+// mount's CommandExecutor) is correctly copied to the new client.
+func TestAccCreateDatabricksMountWithProviderConfig(t *testing.T) {
+	workspaceID := acceptance.GetEnvOrSkipTest(t, "THIS_WORKSPACE_ID")
+	mountHclWithProviderConfig := `
+data "databricks_spark_version" "latest" {}
+
+resource "databricks_cluster" "this" {
+	cluster_name = "acc-test-mounts-{var.STICKY_RANDOM}"
+	spark_version = data.databricks_spark_version.latest.id
+	instance_pool_id = "{env.TEST_INSTANCE_POOL_ID}"
+	num_workers = 1
+
+	aws_attributes {
+		instance_profile_arn = "{env.TEST_INSTANCE_PROFILE_ARN}"
+	}
+
+	provider_config {
+		workspace_id = "` + workspaceID + `"
+	}
+}
+
+resource "databricks_mount" "my_mount" {
+	name = "test-mount-pc-{var.STICKY_RANDOM}"
+	cluster_id = databricks_cluster.this.id
+
+	s3 {
+		bucket_name = "{env.TEST_S3_BUCKET_NAME}"
+	}
+
+	provider_config {
+		workspace_id = "` + workspaceID + `"
+	}
+}`
+
+	acceptance.WorkspaceLevel(t,
+		acceptance.Step{
+			Template: mountHclWithProviderConfig,
+		})
+}
+
 func TestAccCreateDatabricksMountIsFineOnClusterRecreate(t *testing.T) {
 	clusterId1 := ""
 	clusterId2 := ""


### PR DESCRIPTION
## Changes
Fix getDatabricksClientForUnifiedProvider not copying commandFactory

 ### Summary

  - getDatabricksClientForUnifiedProvider creates a new DatabricksClient when routing to a specific workspace, but only copies the inner
  *client.DatabricksClient — it does not copy commandFactory, causing a nil pointer panic when resources call CommandExecutor()
  - This affects databricks_mount, which executes Python on clusters via the Commands API and is the only resource using CommandExecutor through DatabricksClientForUnifiedProvider
  - The fix copies commandFactory from the parent client, consistent with the existing pattern in ClientForHost (common/client.go:604)

###  Root Cause

  getDatabricksClientForUnifiedProvider constructs the returned client as:

  return &DatabricksClient{
      DatabricksClient: client,
      // commandFactory is missing!
  }, nil

  CommandExecutor() calls c.commandFactory(ctx, c), which panics when commandFactory is nil.

  This bug was latent on main because resources using DatabricksClientForUnifiedProvider with a workspace-level provider always got workspaceID == "" from
  state, short-circuiting to return the original client (which has commandFactory). The bug is only triggered when provider_config { workspace_id } is
  explicitly set, routing through getDatabricksClientForUnifiedProvider.

##  Test plan

  - Unit test: TestGetDatabricksClientForUnifiedProvider_CopiesCommandFactory — verifies CommandExecutor works on the returned client (both direct and via public API)
  - Acceptance test: TestAccCreateDatabricksMountWithProviderConfig — creates a mount with provider_config { workspace_id } on a workspace-level provider, exercising the full code path end-to-end
  - Verified without fix: cannot create mount: panic: runtime error: invalid memory address or nil pointer dereference
  - Verified with fix: test passes
  - All existing common/ unit tests pass

NO_CHANGELOG=true
