### PR TITLE
Add GitHub Actions to Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,15 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    commit-message:
-      prefix: "[Dependency] "
     ignore:
       # Ignore Databricks Go SDK because its upgrade requires code generation
       - dependency-name: github.com/databricks/databricks-sdk-go
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    cooldown:
+      default-days: 7
+    # tagging.yml is generated and maintained externally.
+    exclude-paths:
+      - .github/workflows/tagging.yml


### PR DESCRIPTION
Add the github-actions package ecosystem with a monthly update interval.
Monthly keeps churn low while ensuring deprecation notices and security
fixes flow in through PRs. The 7-day cooldown avoids bumping actions
that were just released, letting them bake first.

Exclude tagging.yml because it is generated and maintained externally.

Remove the commit-message prefix configuration. The `[Dependency]`
prefix was enforced by `.github/workflows/message.yml` which was removed
in #4560 when changelogs moved to manual curation.

Co-authored-by: Isaac

NO_CHANGELOG=true