### PR TITLE
[Internal] Pin remaining GitHub Actions

### DIFF
--- a/.github/workflows/external-message.yml
+++ b/.github/workflows/external-message.yml
@@ -21,7 +21,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Delete old comments
         env:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -43,7 +43,7 @@ jobs:
     environment: "test-trigger-is"
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
     - name: Generate GitHub App Token for Workflow Trigger
       id: generate-token


### PR DESCRIPTION
## Summary

- Follow-up to #5508 — pins remaining action references that were missed

## Test plan

- [x] Verified all action references pass the pin scan

This pull request was AI-assisted by Isaac.