### PR TITLE
[Internal] Simplify workspace client path for host-agnostic unified provider

### DIFF
--- a/common/client.go
+++ b/common/client.go
@@ -115,7 +115,7 @@ func (c *DatabricksClient) GetWorkspaceClientForUnifiedProvider(
 	if c.Config.HostType() != config.WorkspaceHost {
 		return c.getWorkspaceClientForAccountUnifiedHost(ctx, workspaceID)
 	}
-	return c.getWorkspaceClientForWorkspaceConfiguredProvider(ctx, workspaceID)
+	return c.WorkspaceClient()
 }
 
 // getWorkspaceClientForAccountUnifiedHost gets the workspace client for
@@ -142,38 +142,6 @@ func (c *DatabricksClient) getWorkspaceClientForAccountUnifiedHost(
 	if err != nil {
 		return nil, fmt.Errorf("failed to get workspace client with workspace_id %d: %w", workspaceIDInt, err)
 	}
-	return w, nil
-}
-
-// getWorkspaceClientForWorkspaceConfiguredProvider gets the workspace client for
-// the workspace ID specified in the resource when the provider is configured at workspace level.
-func (c *DatabricksClient) getWorkspaceClientForWorkspaceConfiguredProvider(
-	ctx context.Context, workspaceID string,
-) (*databricks.WorkspaceClient, error) {
-	// Provider is configured at workspace level and we get the
-	// workspace client from the provider.
-	if workspaceID == "" {
-		return c.WorkspaceClient()
-	}
-
-	workspaceIDInt, err := parseWorkspaceID(workspaceID)
-	if err != nil {
-		return nil, err
-	}
-
-	// Check if the workspace ID specified in the resource matches
-	// the workspace ID of the provider configured workspace client.
-	w, err := c.WorkspaceClient()
-	if err != nil {
-		return nil, err
-	}
-
-	err = c.validateWorkspaceIDFromProvider(ctx, workspaceIDInt, w)
-	if err != nil {
-		return nil, fmt.Errorf("failed to validate workspace_id: %w", err)
-	}
-	// The provider is configured at the workspace level and the
-	// workspace ID matches
 	return w, nil
 }
 

--- a/common/unified_provider.go
+++ b/common/unified_provider.go
@@ -139,11 +139,13 @@ func NamespaceCustomizeDiff(ctx context.Context, d *schema.ResourceDiff, c *Data
 // WorkspaceClientUnifiedProvider returns the WorkspaceClient for the workspace ID from the resource data
 // This is used by resources and data sources that are developed over SDKv2.
 func (c *DatabricksClient) WorkspaceClientUnifiedProvider(ctx context.Context, d *schema.ResourceData) (*databricks.WorkspaceClient, error) {
+	// Check if provider_config is part of resource schema
 	workspaceIDFromSchema := d.Get(workspaceIDSchemaKey)
-	// workspace_id does not exist in the resource data
 	if workspaceIDFromSchema == nil {
 		return c.GetWorkspaceClientForUnifiedProvider(ctx, "")
 	}
+
+	// Get the workspace_id from provider_config
 	var workspaceID string
 	workspaceID, ok := workspaceIDFromSchema.(string)
 	if !ok {

--- a/common/unified_provider.go
+++ b/common/unified_provider.go
@@ -120,11 +120,11 @@ func NamespaceValidateWorkspaceID(ctx context.Context, d *schema.ResourceDiff, c
 		}
 		return nil
 	}
-	_, err = c.getWorkspaceClientForWorkspaceConfiguredProvider(ctx, newWSID)
+	w, err := c.WorkspaceClient()
 	if err != nil {
 		return err
 	}
-	return nil
+	return c.validateWorkspaceIDFromProvider(ctx, workspaceIDInt, w)
 }
 
 // NamespaceCustomizeDiff is used to customize the diff for the provider configuration

--- a/common/unified_provider_test.go
+++ b/common/unified_provider_test.go
@@ -323,29 +323,6 @@ func TestWorkspaceClientUnifiedProvider(t *testing.T) {
 			description: "When workspace_id is explicitly empty, should use cached workspace client",
 		},
 		{
-			name: "workspace_id with different numeric value - no error at CRUD time, validated at plan time",
-			resourceData: map[string]interface{}{
-				"name": "test",
-				"provider_config": []interface{}{
-					map[string]interface{}{
-						"workspace_id": "789012",
-					},
-				},
-			},
-			client: &DatabricksClient{
-				DatabricksClient: &client.DatabricksClient{
-					Config: &config.Config{
-						Host:  "https://test.cloud.databricks.com",
-						Token: "test-token",
-					},
-				},
-				cachedWorkspaceClient: mockWorkspaceClient,
-				cachedWorkspaceID:     1234,
-			},
-			expectError: false,
-			description: "Workspace ID mismatch is validated at plan time via NamespaceValidateWorkspaceID, not at CRUD time",
-		},
-		{
 			name: "account level provider without workspace_id - returns error",
 			resourceData: map[string]interface{}{
 				"name": "test",
@@ -569,40 +546,6 @@ func TestDatabricksClientForUnifiedProvider(t *testing.T) {
 			expectError:      false,
 			expectSameClient: true,
 			description:      "Account-level provider without workspace_id should return current client",
-		},
-		{
-			name: "workspace_id mismatch - no error at CRUD time, validated at plan time",
-			resourceData: map[string]interface{}{
-				"name": "test",
-				"provider_config": []interface{}{
-					map[string]interface{}{
-						"workspace_id": "100",
-					},
-				},
-			},
-			client: func() *DatabricksClient {
-				c := &DatabricksClient{
-					DatabricksClient: &client.DatabricksClient{
-						Config: &config.Config{
-							Host:  "https://test.cloud.databricks.com",
-							Token: "test-token",
-						},
-					},
-				}
-				c.Config = c.Config.WithTesting()
-				mockWorkspaceClient := &databricks.WorkspaceClient{
-					Config: &config.Config{
-						Host:  cachedWorkspaceHost,
-						Token: "test-token",
-					},
-				}
-				mockWorkspaceClient.Config = mockWorkspaceClient.Config.WithTesting()
-				c.SetWorkspaceClient(mockWorkspaceClient)
-				c.cachedWorkspaceID = 200
-				return c
-			}(),
-			expectError: false,
-			description: "Workspace ID mismatch is validated at plan time via NamespaceValidateWorkspaceID, not at CRUD time",
 		},
 	}
 

--- a/common/unified_provider_test.go
+++ b/common/unified_provider_test.go
@@ -323,7 +323,7 @@ func TestWorkspaceClientUnifiedProvider(t *testing.T) {
 			description: "When workspace_id is explicitly empty, should use cached workspace client",
 		},
 		{
-			name: "workspace_id with different numeric value",
+			name: "workspace_id with different numeric value - no error at CRUD time, validated at plan time",
 			resourceData: map[string]interface{}{
 				"name": "test",
 				"provider_config": []interface{}{
@@ -342,9 +342,8 @@ func TestWorkspaceClientUnifiedProvider(t *testing.T) {
 				cachedWorkspaceClient: mockWorkspaceClient,
 				cachedWorkspaceID:     1234,
 			},
-			expectError:   true,
-			errorContains: "failed to validate workspace_id: workspace_id mismatch: provider is configured for workspace 1234 but got 789012 in provider_config",
-			description:   "Should handle different workspace IDs correctly",
+			expectError: false,
+			description: "Workspace ID mismatch is validated at plan time via NamespaceValidateWorkspaceID, not at CRUD time",
 		},
 		{
 			name: "account level provider without workspace_id - returns error",
@@ -572,7 +571,7 @@ func TestDatabricksClientForUnifiedProvider(t *testing.T) {
 			description:      "Account-level provider without workspace_id should return current client",
 		},
 		{
-			name: "workspace_id mismatch - returns error",
+			name: "workspace_id mismatch - no error at CRUD time, validated at plan time",
 			resourceData: map[string]interface{}{
 				"name": "test",
 				"provider_config": []interface{}{
@@ -602,9 +601,8 @@ func TestDatabricksClientForUnifiedProvider(t *testing.T) {
 				c.cachedWorkspaceID = 200
 				return c
 			}(),
-			expectError:   true,
-			errorContains: "workspace_id mismatch",
-			description:   "Should return error when workspace_id doesn't match configured workspace",
+			expectError: false,
+			description: "Workspace ID mismatch is validated at plan time via NamespaceValidateWorkspaceID, not at CRUD time",
 		},
 	}
 


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
As part of moving towards host agnostic unified provider:
  - Simplify `GetWorkspaceClientForUnifiedProvider` to return `c.WorkspaceClient()` directly when the provider is configured at workspace level
  - Consolidate workspace ID mismatch validation into plan time only, via `NamespaceValidateWorkspaceID` in `CustomizeDiff`
  - Remove `getWorkspaceClientForWorkspaceConfiguredProvider` which is no longer needed

## Tests
<!--
How is this tested? Please see the checklist below and also describe any other relevant tests
-->
Manually ran make fmt, make test
Manually ran some integration tests of unified provider and provider config

NO_CHANGELOG=true