### PR TITLE
[Enhancement] Implement caching for workspace permission assignments

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -21,3 +21,4 @@
 ### Internal Changes
 
 * Use account host check instead of account ID check in `databricks_access_control_rule_set` to determine client type ([#5484](https://github.com/databricks/terraform-provider-databricks/pull/5484)).
+* Cache workspace permission assignment list in `databricks_permission_assignment` and `databricks_mws_permission_assignment` to reduce repeated API calls when many assignments belong to the same workspace. Concurrent cache misses are deduplicated via `singleflight` so only one in-flight API call is made per workspace.

--- a/access/resource_permission_assignment.go
+++ b/access/resource_permission_assignment.go
@@ -8,10 +8,12 @@ import (
 	"net/http"
 	"slices"
 	"strconv"
+	"sync"
 
 	"github.com/databricks/databricks-sdk-go/apierr"
 	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"golang.org/x/sync/singleflight"
 )
 
 func NewPermissionAssignmentAPI(ctx context.Context, m any) PermissionAssignmentAPI {
@@ -123,6 +125,15 @@ func (a PermissionAssignmentAPI) List() (list permissionAssignmentResponse, err 
 	return
 }
 
+// wsPermissionAssignmentsCache caches the workspace permission assignment list per
+// workspace to avoid redundant API calls when reading multiple assignments.
+// wsPermissionAssignmentsSF ensures that concurrent cache misses for the same
+// workspace collapse into a single in-flight API call.
+var (
+	wsPermissionAssignmentsCache sync.Map
+	wsPermissionAssignmentsSF    singleflight.Group
+)
+
 type permissionAssignmentEntity struct {
 	PrincipalId          int64    `json:"principal_id,omitempty" tf:"computed,force_new"`
 	ServicePrincipalName string   `json:"service_principal_name,omitempty" tf:"computed,force_new"`
@@ -156,6 +167,7 @@ func ResourcePermissionAssignment() common.Resource {
 			if err != nil {
 				return err
 			}
+			wsPermissionAssignmentsCache.Delete(c.Config.Host)
 			var assignment permissionAssignmentEntity
 			common.DataToStructPointer(d, s, &assignment)
 			api := NewPermissionAssignmentAPI(ctx, c)
@@ -188,9 +200,21 @@ func ResourcePermissionAssignment() common.Resource {
 			if err != nil {
 				return err
 			}
-			list, err := NewPermissionAssignmentAPI(ctx, c).List()
-			if err != nil {
-				return err
+			var list permissionAssignmentResponse
+			if cached, ok := wsPermissionAssignmentsCache.Load(c.Config.Host); ok {
+				list = cached.(permissionAssignmentResponse)
+			} else {
+				v, sfErr, _ := wsPermissionAssignmentsSF.Do(c.Config.Host, func() (any, error) {
+					result, e := NewPermissionAssignmentAPI(ctx, c).List()
+					if e == nil {
+						wsPermissionAssignmentsCache.Store(c.Config.Host, result)
+					}
+					return result, e
+				})
+				if sfErr != nil {
+					return sfErr
+				}
+				list = v.(permissionAssignmentResponse)
 			}
 			data, err := list.ForPrincipal(common.MustInt64(d.Id()))
 			if err != nil {
@@ -203,6 +227,7 @@ func ResourcePermissionAssignment() common.Resource {
 			if err != nil {
 				return err
 			}
+			wsPermissionAssignmentsCache.Delete(c.Config.Host)
 			var assignment permissionAssignmentEntity
 			common.DataToStructPointer(d, s, &assignment)
 			api := NewPermissionAssignmentAPI(ctx, c)
@@ -214,6 +239,7 @@ func ResourcePermissionAssignment() common.Resource {
 			if err != nil {
 				return err
 			}
+			wsPermissionAssignmentsCache.Delete(c.Config.Host)
 			return NewPermissionAssignmentAPI(ctx, c).Remove(d.Id())
 		},
 	}

--- a/access/resource_permission_assignment_acc_test.go
+++ b/access/resource_permission_assignment_acc_test.go
@@ -1,0 +1,42 @@
+package access_test
+
+import (
+	"testing"
+
+	"github.com/databricks/terraform-provider-databricks/internal/acceptance"
+)
+
+func TestAccPermissionAssignmentPrincipalId(t *testing.T) {
+	acceptance.WorkspaceLevel(t, acceptance.Step{
+		Template: `
+		resource "databricks_group" "this" {
+			display_name = "TF {var.RANDOM}"
+		}
+		resource "databricks_permission_assignment" "this" {
+			principal_id = databricks_group.this.id
+			permissions  = ["USER"]
+		}`,
+	}, acceptance.Step{
+		Template: `
+		resource "databricks_group" "this" {
+			display_name = "TF {var.RANDOM}"
+		}
+		resource "databricks_permission_assignment" "this" {
+			principal_id = databricks_group.this.id
+			permissions  = ["ADMIN"]
+		}`,
+	})
+}
+
+func TestAccPermissionAssignmentGroupName(t *testing.T) {
+	acceptance.WorkspaceLevel(t, acceptance.Step{
+		Template: `
+		resource "databricks_group" "this" {
+			display_name = "TF {var.RANDOM}"
+		}
+		resource "databricks_permission_assignment" "this" {
+			group_name  = databricks_group.this.display_name
+			permissions = ["USER"]
+		}`,
+	})
+}

--- a/mws/resource_mws_permission_assignment.go
+++ b/mws/resource_mws_permission_assignment.go
@@ -3,11 +3,30 @@ package mws
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	"github.com/databricks/databricks-sdk-go/apierr"
 	"github.com/databricks/databricks-sdk-go/service/iam"
 	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"golang.org/x/sync/singleflight"
+)
+
+// mwsAssignmentsKey uniquely identifies a cached permission assignment list
+// by the account client pointer and workspace ID.
+type mwsAssignmentsKey struct {
+	acc         any
+	workspaceId int64
+}
+
+// mwsPermissionAssignmentsCache caches workspace permission assignment lists.
+// The cache is keyed by mwsAssignmentsKey so concurrent reads for the same
+// workspace share a single result. mwsPermissionAssignmentsSF ensures that
+// when many goroutines all miss the cache simultaneously, only one in-flight
+// API call is made; the rest block and share the result.
+var (
+	mwsPermissionAssignmentsCache sync.Map
+	mwsPermissionAssignmentsSF    singleflight.Group
 )
 
 func getPermissionsByPrincipal(list iam.PermissionAssignments, principalId int64) (res iam.UpdateWorkspaceAssignments, err error) {
@@ -57,6 +76,7 @@ func ResourceMwsPermissionAssignment() common.Resource {
 				return err
 			}
 			pair.Pack(d)
+			mwsPermissionAssignmentsCache.Delete(mwsAssignmentsKey{acc: acc, workspaceId: assignment.WorkspaceId})
 			return nil
 		},
 		Read: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
@@ -68,9 +88,23 @@ func ResourceMwsPermissionAssignment() common.Resource {
 			if err != nil {
 				return fmt.Errorf("parse id: %w", err)
 			}
-			list, err := acc.WorkspaceAssignment.ListByWorkspaceId(ctx, common.MustInt64(workspaceId))
-			if err != nil {
-				return err
+			key := mwsAssignmentsKey{acc: acc, workspaceId: common.MustInt64(workspaceId)}
+			var list *iam.PermissionAssignments
+			if cached, ok := mwsPermissionAssignmentsCache.Load(key); ok {
+				list = cached.(*iam.PermissionAssignments)
+			} else {
+				sfKey := fmt.Sprintf("%p/%d", acc, common.MustInt64(workspaceId))
+				v, sfErr, _ := mwsPermissionAssignmentsSF.Do(sfKey, func() (any, error) {
+					result, e := acc.WorkspaceAssignment.ListByWorkspaceId(ctx, common.MustInt64(workspaceId))
+					if e == nil {
+						mwsPermissionAssignmentsCache.Store(key, result)
+					}
+					return result, e
+				})
+				if sfErr != nil {
+					return sfErr
+				}
+				list = v.(*iam.PermissionAssignments)
 			}
 			permissions, err := getPermissionsByPrincipal(*list, common.MustInt64(principalId))
 			if err != nil {
@@ -89,7 +123,12 @@ func ResourceMwsPermissionAssignment() common.Resource {
 			if err != nil {
 				return fmt.Errorf("parse id: %w", err)
 			}
-			return acc.WorkspaceAssignment.DeleteByWorkspaceIdAndPrincipalId(ctx, common.MustInt64(workspaceId), common.MustInt64(principalId))
+			err = acc.WorkspaceAssignment.DeleteByWorkspaceIdAndPrincipalId(ctx, common.MustInt64(workspaceId), common.MustInt64(principalId))
+			if err != nil {
+				return err
+			}
+			mwsPermissionAssignmentsCache.Delete(mwsAssignmentsKey{acc: acc, workspaceId: common.MustInt64(workspaceId)})
+			return nil
 		},
 	}
 }


### PR DESCRIPTION
In the current implementation workspace permission assignments are fetched for every [databricks_mws_permission_assignment](https://registry.terraform.io/providers/databricks/databricks/latest/docs/resources/mws_permission_assignment) resource, whereas they could be fetched only once on the first resource and cached locally for subsequent use by other resources.

## Changes
This PR adds the optimization described above by adding a cache.

## Tests
- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [x] covered with integration tests in `internal/acceptance`
- [x] using Go SDK
- [x] using TF Plugin Framework
- [x] has entry in `NEXT_CHANGELOG.md` file
