### PR TITLE
Pin jd Dependency to Commit SHA

### DIFF
--- a/.github/workflows/schema.yml
+++ b/.github/workflows/schema.yml
@@ -53,7 +53,7 @@ jobs:
           terraform_wrapper: false
 
       - name: "Install jd"
-        run: go install github.com/josephburnett/jd@v1.8.1
+        run: go install github.com/josephburnett/jd@11eae3c9ffb1dd32796ca741691bf4733a27dfa4 # v1.8.1
 
       - run: make diff-schema
         env:


### PR DESCRIPTION
This PR pins the `jd` (JSON diff tool) dependency in `schema.yml` from a
version tag (`@v1.8.1`) to its commit SHA. Part of the supply chain security
hardening effort to pin all direct 3P dependencies to known good SHAs.

Note: Go's module proxy is immutable, so `@v1.8.1` was already effectively
pinned. This change makes the pinning explicit for audit purposes.