### PR TITLE
Replace deprecated ::set-output with $GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -25,10 +25,10 @@ jobs:
         run: |
             if [ -z "${{ secrets.DECO_WORKFLOW_TRIGGER_APP_ID }}" ] || [ -z "${{ secrets.DECO_TEST_APPROVAL_APP_ID }}" ]; then
               echo "Required secrets are missing. User has no access to secrets."
-              echo "::set-output name=has_token::false"
+              echo "has_token=false" >> $GITHUB_OUTPUT
             else
               echo "All required secrets are set. User has access to secrets."
-              echo "::set-output name=has_token::true"
+              echo "has_token=true" >> $GITHUB_OUTPUT
             fi
 
   trigger-tests:


### PR DESCRIPTION
## Changes

Replace the deprecated `::set-output` workflow command with the recommended `>> $GITHUB_OUTPUT` syntax in `.github/workflows/integration-tests.yml`.

The `::set-output` command was [deprecated by GitHub in October 2022](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) because it is vulnerable to log injection attacks. The recommended replacement is to write outputs to the `$GITHUB_OUTPUT` environment file.

## Tests

- No functional changes; CI workflow syntax validated by GitHub Actions on push.

NO_CHANGELOG=true

This pull request was AI-assisted by Isaac.