### PR TITLE
Remove post-generate testing

### DIFF
--- a/.codegen.json
+++ b/.codegen.json
@@ -11,7 +11,7 @@
             "go"
         ],
         "post_generate": [
-            "make test"
+            "make lint"
         ]
     }
 }


### PR DESCRIPTION
## Changes
This PR removes the `make test` command that used to run tests after the generation by the code generation. As the process of generation is automated now and all the tests run on the PR (in a standard test environment), it is no longer necessary to run the tests in local environments, which may lead to inconsistent results depending on machine setup and configurations.

The `make test` command depends on the `make lint` command, so we replace it with just that.

## Tests
N/A

NO_CHANGELOG=true
