### PR TITLE
[Performance] Cache SCIM and permission-assignment list calls to reduce API requests during plan

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -13,3 +13,7 @@
 ### Exporter
 
 ### Internal Changes
+
+* Use account host check instead of account ID check in `databricks_access_control_rule_set` to determine client type ([#5484](https://github.com/databricks/terraform-provider-databricks/pull/5484)).
+
+* Significantly reduced the number of SCIM and IAM API calls during `terraform plan`/`apply` for large deployments by introducing shared in-memory caches with `sync.RWMutex` and `singleflight` deduplication. Resources `databricks_group`, `databricks_user`, `databricks_group_member`, `databricks_permission_assignment`, and `databricks_mws_permission_assignment` now each issue a single list API call per plan cycle instead of one call per resource instance, eliminating redundant requests and rate-limit (429) errors.

--- a/access/resource_permission_assignment.go
+++ b/access/resource_permission_assignment.go
@@ -8,6 +8,9 @@ import (
 	"net/http"
 	"slices"
 	"strconv"
+	"sync"
+
+	"golang.org/x/sync/singleflight"
 
 	"github.com/databricks/databricks-sdk-go/apierr"
 	"github.com/databricks/terraform-provider-databricks/common"
@@ -17,6 +20,98 @@ import (
 func NewPermissionAssignmentAPI(ctx context.Context, m any) PermissionAssignmentAPI {
 	return PermissionAssignmentAPI{m.(*common.DatabricksClient), ctx}
 }
+
+// permAssignmentEntry holds the cached list result for one workspace.
+type permAssignmentEntry struct {
+	mu          sync.RWMutex
+	initialized bool
+	list        permissionAssignmentResponse
+	// sg deduplicates concurrent in-flight API calls when the cache is cold.
+	// All goroutines that arrive while a fetch is in-flight join the same call
+	// and are woken simultaneously when it completes, rather than serialising
+	// through a write lock.
+	sg singleflight.Group
+}
+
+// permAssignmentCache caches the permission assignments list per workspace host
+// so that N databricks_permission_assignment resources in the same workspace
+// only issue a single API call during a terraform plan/apply cycle.
+type permAssignmentCache struct {
+	mu    sync.Mutex
+	cache map[string]*permAssignmentEntry
+}
+
+func newPermAssignmentCache() *permAssignmentCache {
+	return &permAssignmentCache{
+		cache: make(map[string]*permAssignmentEntry),
+	}
+}
+
+func (c *permAssignmentCache) getOrCreate(host string) *permAssignmentEntry {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if entry, ok := c.cache[host]; ok {
+		return entry
+	}
+	entry := &permAssignmentEntry{}
+	c.cache[host] = entry
+	return entry
+}
+
+func (c *permAssignmentCache) list(api PermissionAssignmentAPI) (permissionAssignmentResponse, error) {
+	host := api.client.Config.Host
+	entry := c.getOrCreate(host)
+
+	// Fast path: warm cache. Many goroutines can hold a read-lock simultaneously.
+	entry.mu.RLock()
+	if entry.initialized {
+		l := entry.list
+		entry.mu.RUnlock()
+		return l, nil
+	}
+	entry.mu.RUnlock()
+
+	// Slow path: cache is cold. Use singleflight so exactly one API call is made
+	// regardless of how many goroutines arrive concurrently; all share the result.
+	v, err, _ := entry.sg.Do("fetch", func() (interface{}, error) {
+		// Double-check now that we are the singleflight leader.
+		entry.mu.RLock()
+		if entry.initialized {
+			l := entry.list
+			entry.mu.RUnlock()
+			return &l, nil
+		}
+		entry.mu.RUnlock()
+
+		l, err := api.List()
+		if err != nil {
+			return nil, err
+		}
+		entry.mu.Lock()
+		entry.list = l
+		entry.initialized = true
+		entry.mu.Unlock()
+		return &l, nil
+	})
+	if err != nil {
+		return permissionAssignmentResponse{}, err
+	}
+	return *v.(*permissionAssignmentResponse), nil
+}
+
+func (c *permAssignmentCache) invalidate(host string) {
+	c.mu.Lock()
+	entry, ok := c.cache[host]
+	c.mu.Unlock()
+	if ok {
+		entry.mu.Lock()
+		entry.initialized = false
+		entry.list = permissionAssignmentResponse{}
+		entry.mu.Unlock()
+	}
+}
+
+var globalPermAssignmentCache = newPermAssignmentCache()
 
 type PermissionAssignmentAPI struct {
 	client  *common.DatabricksClient
@@ -156,6 +251,7 @@ func ResourcePermissionAssignment() common.Resource {
 			if err != nil {
 				return err
 			}
+			defer globalPermAssignmentCache.invalidate(c.Config.Host)
 			var assignment permissionAssignmentEntity
 			common.DataToStructPointer(d, s, &assignment)
 			api := NewPermissionAssignmentAPI(ctx, c)
@@ -188,7 +284,7 @@ func ResourcePermissionAssignment() common.Resource {
 			if err != nil {
 				return err
 			}
-			list, err := NewPermissionAssignmentAPI(ctx, c).List()
+			list, err := globalPermAssignmentCache.list(NewPermissionAssignmentAPI(ctx, c))
 			if err != nil {
 				return err
 			}
@@ -203,6 +299,7 @@ func ResourcePermissionAssignment() common.Resource {
 			if err != nil {
 				return err
 			}
+			defer globalPermAssignmentCache.invalidate(c.Config.Host)
 			var assignment permissionAssignmentEntity
 			common.DataToStructPointer(d, s, &assignment)
 			api := NewPermissionAssignmentAPI(ctx, c)
@@ -214,6 +311,7 @@ func ResourcePermissionAssignment() common.Resource {
 			if err != nil {
 				return err
 			}
+			defer globalPermAssignmentCache.invalidate(c.Config.Host)
 			return NewPermissionAssignmentAPI(ctx, c).Remove(d.Id())
 		},
 	}

--- a/access/resource_permission_assignment.go
+++ b/access/resource_permission_assignment.go
@@ -8,9 +8,6 @@ import (
 	"net/http"
 	"slices"
 	"strconv"
-	"sync"
-
-	"golang.org/x/sync/singleflight"
 
 	"github.com/databricks/databricks-sdk-go/apierr"
 	"github.com/databricks/terraform-provider-databricks/common"
@@ -21,97 +18,14 @@ func NewPermissionAssignmentAPI(ctx context.Context, m any) PermissionAssignment
 	return PermissionAssignmentAPI{m.(*common.DatabricksClient), ctx}
 }
 
-// permAssignmentEntry holds the cached list result for one workspace.
-type permAssignmentEntry struct {
-	mu          sync.RWMutex
-	initialized bool
-	list        permissionAssignmentResponse
-	// sg deduplicates concurrent in-flight API calls when the cache is cold.
-	// All goroutines that arrive while a fetch is in-flight join the same call
-	// and are woken simultaneously when it completes, rather than serialising
-	// through a write lock.
-	sg singleflight.Group
-}
-
-// permAssignmentCache caches the permission assignments list per workspace host
-// so that N databricks_permission_assignment resources in the same workspace
-// only issue a single API call during a terraform plan/apply cycle.
-type permAssignmentCache struct {
-	mu    sync.Mutex
-	cache map[string]*permAssignmentEntry
-}
-
-func newPermAssignmentCache() *permAssignmentCache {
-	return &permAssignmentCache{
-		cache: make(map[string]*permAssignmentEntry),
-	}
-}
-
-func (c *permAssignmentCache) getOrCreate(host string) *permAssignmentEntry {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	if entry, ok := c.cache[host]; ok {
-		return entry
-	}
-	entry := &permAssignmentEntry{}
-	c.cache[host] = entry
-	return entry
-}
-
-func (c *permAssignmentCache) list(api PermissionAssignmentAPI) (permissionAssignmentResponse, error) {
-	host := api.client.Config.Host
-	entry := c.getOrCreate(host)
-
-	// Fast path: warm cache. Many goroutines can hold a read-lock simultaneously.
-	entry.mu.RLock()
-	if entry.initialized {
-		l := entry.list
-		entry.mu.RUnlock()
-		return l, nil
-	}
-	entry.mu.RUnlock()
-
-	// Slow path: cache is cold. Use singleflight so exactly one API call is made
-	// regardless of how many goroutines arrive concurrently; all share the result.
-	v, err, _ := entry.sg.Do("fetch", func() (interface{}, error) {
-		// Double-check now that we are the singleflight leader.
-		entry.mu.RLock()
-		if entry.initialized {
-			l := entry.list
-			entry.mu.RUnlock()
-			return &l, nil
-		}
-		entry.mu.RUnlock()
-
-		l, err := api.List()
-		if err != nil {
-			return nil, err
-		}
-		entry.mu.Lock()
-		entry.list = l
-		entry.initialized = true
-		entry.mu.Unlock()
-		return &l, nil
-	})
-	if err != nil {
-		return permissionAssignmentResponse{}, err
-	}
-	return *v.(*permissionAssignmentResponse), nil
-}
-
-func (c *permAssignmentCache) invalidate(host string) {
-	c.mu.Lock()
-	entry, ok := c.cache[host]
-	c.mu.Unlock()
-	if ok {
-		entry.mu.Lock()
-		entry.initialized = false
-		entry.list = permissionAssignmentResponse{}
-		entry.mu.Unlock()
-	}
-}
-
+// globalPermAssignmentCache caches the permission assignments list per workspace host
+// so that N databricks_permission_assignment resources in the same workspace only
+// issue a single API call during a terraform plan/apply cycle.
 var globalPermAssignmentCache = newPermAssignmentCache()
+
+func newPermAssignmentCache() *common.KeyedCache[string, permissionAssignmentResponse] {
+	return common.NewKeyedCache[string, permissionAssignmentResponse]()
+}
 
 type PermissionAssignmentAPI struct {
 	client  *common.DatabricksClient
@@ -251,7 +165,7 @@ func ResourcePermissionAssignment() common.Resource {
 			if err != nil {
 				return err
 			}
-			defer globalPermAssignmentCache.invalidate(c.Config.Host)
+			defer globalPermAssignmentCache.Invalidate(c.Config.Host)
 			var assignment permissionAssignmentEntity
 			common.DataToStructPointer(d, s, &assignment)
 			api := NewPermissionAssignmentAPI(ctx, c)
@@ -284,7 +198,9 @@ func ResourcePermissionAssignment() common.Resource {
 			if err != nil {
 				return err
 			}
-			list, err := globalPermAssignmentCache.list(NewPermissionAssignmentAPI(ctx, c))
+			list, err := globalPermAssignmentCache.Get(c.Config.Host, func() (permissionAssignmentResponse, error) {
+				return NewPermissionAssignmentAPI(ctx, c).List()
+			})
 			if err != nil {
 				return err
 			}
@@ -299,7 +215,7 @@ func ResourcePermissionAssignment() common.Resource {
 			if err != nil {
 				return err
 			}
-			defer globalPermAssignmentCache.invalidate(c.Config.Host)
+			defer globalPermAssignmentCache.Invalidate(c.Config.Host)
 			var assignment permissionAssignmentEntity
 			common.DataToStructPointer(d, s, &assignment)
 			api := NewPermissionAssignmentAPI(ctx, c)
@@ -311,7 +227,7 @@ func ResourcePermissionAssignment() common.Resource {
 			if err != nil {
 				return err
 			}
-			defer globalPermAssignmentCache.invalidate(c.Config.Host)
+			defer globalPermAssignmentCache.Invalidate(c.Config.Host)
 			return NewPermissionAssignmentAPI(ctx, c).Remove(d.Id())
 		},
 	}

--- a/common/cache.go
+++ b/common/cache.go
@@ -1,0 +1,122 @@
+package common
+
+import (
+	"sync"
+
+	"golang.org/x/sync/singleflight"
+)
+
+// CacheEntry is a single cached value with generation-based invalidation safety.
+//
+// Concurrent reads on a warm cache proceed without blocking (RLock).  A
+// singleflight group ensures at most one in-flight fetch when the cache is
+// cold, so all waiting goroutines share a single result.  A generation counter
+// prevents a late-arriving singleflight leader from overwriting data that was
+// invalidated after the fetch started: Invalidate increments the generation
+// before clearing the value, and the leader only commits if the generation is
+// unchanged.
+type CacheEntry[V any] struct {
+	mu          sync.RWMutex
+	generation  uint64
+	initialized bool
+	value       V
+	sg          singleflight.Group
+}
+
+// GetOrFetch returns the cached value if available, otherwise calls fetch
+// exactly once (via singleflight) and caches the result.
+func (e *CacheEntry[V]) GetOrFetch(fetch func() (V, error)) (V, error) {
+	// Fast path: warm cache — many goroutines can hold RLock simultaneously.
+	e.mu.RLock()
+	if e.initialized {
+		v := e.value
+		e.mu.RUnlock()
+		return v, nil
+	}
+	e.mu.RUnlock()
+
+	// Slow path: cold cache.  Use singleflight so exactly one goroutine calls
+	// the API; all others block until the result is available.
+	type wrapper struct{ v V }
+	raw, err, _ := e.sg.Do("fetch", func() (any, error) {
+		// Double-check now that we hold the singleflight slot.
+		e.mu.RLock()
+		if e.initialized {
+			v := e.value
+			e.mu.RUnlock()
+			return wrapper{v}, nil
+		}
+		gen := e.generation
+		e.mu.RUnlock()
+
+		fetched, err := fetch()
+		if err != nil {
+			return wrapper{}, err
+		}
+		e.mu.Lock()
+		// Only commit if Invalidate has not been called in the interim.
+		if e.generation == gen {
+			e.value = fetched
+			e.initialized = true
+		}
+		e.mu.Unlock()
+		return wrapper{fetched}, nil
+	})
+	if err != nil {
+		var zero V
+		return zero, err
+	}
+	return raw.(wrapper).v, nil
+}
+
+// Invalidate clears the cached value and bumps the generation counter so that
+// any in-flight fetch that started before the invalidation cannot re-populate
+// the cache with stale pre-mutation data.
+func (e *CacheEntry[V]) Invalidate() {
+	e.mu.Lock()
+	e.generation++
+	e.initialized = false
+	var zero V
+	e.value = zero
+	e.mu.Unlock()
+}
+
+// KeyedCache maps arbitrary comparable keys to CacheEntry values. It is safe
+// for concurrent use by multiple goroutines.
+type KeyedCache[K comparable, V any] struct {
+	mu    sync.Mutex
+	cache map[K]*CacheEntry[V]
+}
+
+// NewKeyedCache creates an empty KeyedCache.
+func NewKeyedCache[K comparable, V any]() *KeyedCache[K, V] {
+	return &KeyedCache[K, V]{cache: make(map[K]*CacheEntry[V])}
+}
+
+func (c *KeyedCache[K, V]) getOrCreateEntry(key K) *CacheEntry[V] {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if e, ok := c.cache[key]; ok {
+		return e
+	}
+	e := &CacheEntry[V]{}
+	c.cache[key] = e
+	return e
+}
+
+// Get returns the value for key, calling fetch to populate it if absent or
+// previously invalidated.
+func (c *KeyedCache[K, V]) Get(key K, fetch func() (V, error)) (V, error) {
+	return c.getOrCreateEntry(key).GetOrFetch(fetch)
+}
+
+// Invalidate clears the cache for key, triggering a fresh fetch on the next
+// Get.  It is safe to call concurrently with Get.
+func (c *KeyedCache[K, V]) Invalidate(key K) {
+	c.mu.Lock()
+	e, ok := c.cache[key]
+	c.mu.Unlock()
+	if ok {
+		e.Invalidate()
+	}
+}

--- a/common/cache_test.go
+++ b/common/cache_test.go
@@ -1,0 +1,196 @@
+package common
+
+import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCacheEntry_FetchOnce(t *testing.T) {
+	var e CacheEntry[string]
+	var calls int32
+
+	v1, err := e.GetOrFetch(func() (string, error) {
+		atomic.AddInt32(&calls, 1)
+		return "hello", nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "hello", v1)
+
+	// Second call must use the cached value; fetch must NOT be invoked again.
+	v2, err := e.GetOrFetch(func() (string, error) {
+		t.Fatal("fetch should not be called on warm cache")
+		return "", nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "hello", v2)
+	assert.EqualValues(t, 1, atomic.LoadInt32(&calls))
+}
+
+func TestCacheEntry_FetchError(t *testing.T) {
+	var e CacheEntry[string]
+	var calls int32
+
+	_, err := e.GetOrFetch(func() (string, error) {
+		atomic.AddInt32(&calls, 1)
+		return "", fmt.Errorf("api error")
+	})
+	assert.Error(t, err)
+
+	// Cache must not be populated on error; next call should retry the fetch.
+	_, err2 := e.GetOrFetch(func() (string, error) {
+		atomic.AddInt32(&calls, 1)
+		return "", fmt.Errorf("api error again")
+	})
+	assert.Error(t, err2)
+	assert.EqualValues(t, 2, atomic.LoadInt32(&calls), "fetch must be retried after an error")
+}
+
+func TestCacheEntry_InvalidateThenGet(t *testing.T) {
+	var e CacheEntry[string]
+	var calls int32
+
+	v1, err := e.GetOrFetch(func() (string, error) {
+		n := atomic.AddInt32(&calls, 1)
+		return fmt.Sprintf("value-%d", n), nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "value-1", v1)
+
+	e.Invalidate()
+
+	// After invalidation the cache is cold; a new fetch must be triggered.
+	v2, err := e.GetOrFetch(func() (string, error) {
+		n := atomic.AddInt32(&calls, 1)
+		return fmt.Sprintf("value-%d", n), nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "value-2", v2)
+	assert.EqualValues(t, 2, atomic.LoadInt32(&calls))
+}
+
+// TestCacheEntry_InvalidateDuringInflight verifies the generation-counter
+// invariant: a singleflight leader that completes *after* Invalidate() must
+// NOT commit its result to the cache, so the very next GetOrFetch triggers a
+// fresh fetch.
+func TestCacheEntry_InvalidateDuringInflight(t *testing.T) {
+	var e CacheEntry[int]
+
+	fetchStarted := make(chan struct{})
+	fetchCanProceed := make(chan struct{})
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	var inflightResult int
+	var inflightErr error
+
+	go func() {
+		defer wg.Done()
+		inflightResult, inflightErr = e.GetOrFetch(func() (int, error) {
+			close(fetchStarted) // tell the test we are in the fetch
+			<-fetchCanProceed   // block until the test has called Invalidate
+			return 42, nil      // return a "stale" value
+		})
+	}()
+
+	<-fetchStarted
+
+	// Invalidate the cache while the fetch is still blocked.
+	e.Invalidate()
+
+	// Let the in-flight fetch finish.  It must return 42 to the caller (that
+	// is the singleflight contract), but must NOT commit 42 to the cache.
+	close(fetchCanProceed)
+	wg.Wait()
+
+	require.NoError(t, inflightErr)
+	assert.Equal(t, 42, inflightResult, "in-flight caller should still receive the fetched value")
+
+	// The next GetOrFetch must see a cold cache and call its own fetch, NOT
+	// return the stale 42.
+	fresh, err := e.GetOrFetch(func() (int, error) { return 99, nil })
+	require.NoError(t, err)
+	assert.Equal(t, 99, fresh, "cache must not be poisoned by the stale in-flight result")
+}
+
+// TestCacheEntry_ConcurrentReads verifies that multiple goroutines on a warm
+// cache all receive the same value without triggering multiple fetches.
+func TestCacheEntry_ConcurrentReads(t *testing.T) {
+	var e CacheEntry[int]
+	var calls int32
+
+	// Warm the cache.
+	_, err := e.GetOrFetch(func() (int, error) {
+		atomic.AddInt32(&calls, 1)
+		return 7, nil
+	})
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+	results := make([]int, 100)
+	for i := range results {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			v, _ := e.GetOrFetch(func() (int, error) {
+				t.Error("fetch called on warm cache during concurrent reads")
+				return 0, nil
+			})
+			results[idx] = v
+		}(i)
+	}
+	wg.Wait()
+	for i, v := range results {
+		assert.Equal(t, 7, v, "goroutine %d got wrong value", i)
+	}
+	assert.EqualValues(t, 1, atomic.LoadInt32(&calls), "fetch must only be called once")
+}
+
+func TestKeyedCache_IndependentKeys(t *testing.T) {
+	c := NewKeyedCache[string, int]()
+	var calls int32
+
+	v1, err := c.Get("a", func() (int, error) { atomic.AddInt32(&calls, 1); return 1, nil })
+	require.NoError(t, err)
+	assert.Equal(t, 1, v1)
+
+	v2, err := c.Get("b", func() (int, error) { atomic.AddInt32(&calls, 1); return 2, nil })
+	require.NoError(t, err)
+	assert.Equal(t, 2, v2)
+
+	// Both keys must now be cached; no extra fetches.
+	v1b, _ := c.Get("a", func() (int, error) { t.Fatal("a should be cached"); return 0, nil })
+	assert.Equal(t, 1, v1b)
+	v2b, _ := c.Get("b", func() (int, error) { t.Fatal("b should be cached"); return 0, nil })
+	assert.Equal(t, 2, v2b)
+
+	assert.EqualValues(t, 2, atomic.LoadInt32(&calls))
+}
+
+func TestKeyedCache_InvalidateSpecificKey(t *testing.T) {
+	c := NewKeyedCache[string, int]()
+	var aCalls, bCalls int32
+
+	c.Get("a", func() (int, error) { atomic.AddInt32(&aCalls, 1); return 10, nil }) //nolint:errcheck
+	c.Get("b", func() (int, error) { atomic.AddInt32(&bCalls, 1); return 20, nil }) //nolint:errcheck
+
+	c.Invalidate("a")
+
+	// "a" must be re-fetched; "b" must remain cached.
+	va, _ := c.Get("a", func() (int, error) { atomic.AddInt32(&aCalls, 1); return 11, nil })
+	c.Get("b", func() (int, error) { t.Fatal("b should not be re-fetched"); return 0, nil }) //nolint:errcheck
+
+	assert.Equal(t, 11, va)
+	assert.EqualValues(t, 2, atomic.LoadInt32(&aCalls), "a should have been fetched twice")
+	assert.EqualValues(t, 1, atomic.LoadInt32(&bCalls), "b should have been fetched once")
+}
+
+func TestKeyedCache_InvalidateMissingKey(t *testing.T) {
+	c := NewKeyedCache[string, int]()
+	// Must not panic when invalidating a key that has never been used.
+	c.Invalidate("nonexistent")
+}

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/zclconf/go-cty v1.17.0
 	golang.org/x/exp v0.0.0-20251023183803-a4bb9ffd2546
+	golang.org/x/sync v0.20.0
 	google.golang.org/api v0.267.0
 )
 
@@ -89,7 +90,6 @@ require (
 	golang.org/x/mod v0.35.0 // indirect
 	golang.org/x/net v0.52.0 // indirect
 	golang.org/x/oauth2 v0.35.0 // indirect
-	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect
 	golang.org/x/telemetry v0.0.0-20260311193753-579e4da9a98c // indirect
 	golang.org/x/term v0.41.0 // indirect

--- a/mws/resource_mws_permission_assignment.go
+++ b/mws/resource_mws_permission_assignment.go
@@ -3,12 +3,106 @@ package mws
 import (
 	"context"
 	"fmt"
+	"sync"
+
+	"golang.org/x/sync/singleflight"
 
 	"github.com/databricks/databricks-sdk-go/apierr"
 	"github.com/databricks/databricks-sdk-go/service/iam"
 	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
+
+// workspaceAssignmentsEntry holds the cached ListByWorkspaceId result for one workspace.
+type workspaceAssignmentsEntry struct {
+	mu          sync.RWMutex
+	initialized bool
+	list        *iam.PermissionAssignments
+	// sg deduplicates concurrent in-flight API calls when the cache is cold.
+	// All goroutines that arrive while a fetch is in-flight join the same call
+	// and are woken simultaneously when it completes, rather than serialising
+	// through a write lock.
+	sg singleflight.Group
+}
+
+// workspaceAssignmentsCache caches ListByWorkspaceId results per workspace ID so
+// that N databricks_mws_permission_assignment resources sharing the same
+// workspace_id only issue a single API call during a terraform plan/apply cycle.
+type workspaceAssignmentsCache struct {
+	mu    sync.Mutex
+	cache map[int64]*workspaceAssignmentsEntry
+}
+
+func newWorkspaceAssignmentsCache() *workspaceAssignmentsCache {
+	return &workspaceAssignmentsCache{
+		cache: make(map[int64]*workspaceAssignmentsEntry),
+	}
+}
+
+func (c *workspaceAssignmentsCache) getOrCreate(workspaceId int64) *workspaceAssignmentsEntry {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if entry, ok := c.cache[workspaceId]; ok {
+		return entry
+	}
+	entry := &workspaceAssignmentsEntry{}
+	c.cache[workspaceId] = entry
+	return entry
+}
+
+func (c *workspaceAssignmentsCache) list(ctx context.Context, api iam.WorkspaceAssignmentInterface, workspaceId int64) (*iam.PermissionAssignments, error) {
+	entry := c.getOrCreate(workspaceId)
+
+	// Fast path: warm cache. Many goroutines can hold a read-lock simultaneously.
+	entry.mu.RLock()
+	if entry.initialized {
+		l := entry.list
+		entry.mu.RUnlock()
+		return l, nil
+	}
+	entry.mu.RUnlock()
+
+	// Slow path: cache is cold. Use singleflight so exactly one API call is made
+	// regardless of how many goroutines arrive concurrently; all share the result.
+	v, err, _ := entry.sg.Do("fetch", func() (interface{}, error) {
+		// Double-check now that we are the singleflight leader.
+		entry.mu.RLock()
+		if entry.initialized {
+			l := entry.list
+			entry.mu.RUnlock()
+			return l, nil
+		}
+		entry.mu.RUnlock()
+
+		list, err := api.ListByWorkspaceId(ctx, workspaceId)
+		if err != nil {
+			return nil, err
+		}
+		entry.mu.Lock()
+		entry.list = list
+		entry.initialized = true
+		entry.mu.Unlock()
+		return list, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return v.(*iam.PermissionAssignments), nil
+}
+
+func (c *workspaceAssignmentsCache) invalidate(workspaceId int64) {
+	c.mu.Lock()
+	entry, ok := c.cache[workspaceId]
+	c.mu.Unlock()
+	if ok {
+		entry.mu.Lock()
+		entry.initialized = false
+		entry.list = nil
+		entry.mu.Unlock()
+	}
+}
+
+var globalWorkspaceAssignmentsCache = newWorkspaceAssignmentsCache()
 
 func getPermissionsByPrincipal(list iam.PermissionAssignments, principalId int64) (res iam.UpdateWorkspaceAssignments, err error) {
 	for _, v := range list.PermissionAssignments {
@@ -56,6 +150,7 @@ func ResourceMwsPermissionAssignment() common.Resource {
 			if err != nil {
 				return err
 			}
+			globalWorkspaceAssignmentsCache.invalidate(assignment.WorkspaceId)
 			pair.Pack(d)
 			return nil
 		},
@@ -68,7 +163,7 @@ func ResourceMwsPermissionAssignment() common.Resource {
 			if err != nil {
 				return fmt.Errorf("parse id: %w", err)
 			}
-			list, err := acc.WorkspaceAssignment.ListByWorkspaceId(ctx, common.MustInt64(workspaceId))
+			list, err := globalWorkspaceAssignmentsCache.list(ctx, acc.WorkspaceAssignment, common.MustInt64(workspaceId))
 			if err != nil {
 				return err
 			}
@@ -89,7 +184,9 @@ func ResourceMwsPermissionAssignment() common.Resource {
 			if err != nil {
 				return fmt.Errorf("parse id: %w", err)
 			}
-			return acc.WorkspaceAssignment.DeleteByWorkspaceIdAndPrincipalId(ctx, common.MustInt64(workspaceId), common.MustInt64(principalId))
+			err = acc.WorkspaceAssignment.DeleteByWorkspaceIdAndPrincipalId(ctx, common.MustInt64(workspaceId), common.MustInt64(principalId))
+			globalWorkspaceAssignmentsCache.invalidate(common.MustInt64(workspaceId))
+			return err
 		},
 	}
 }

--- a/mws/resource_mws_permission_assignment.go
+++ b/mws/resource_mws_permission_assignment.go
@@ -3,9 +3,6 @@ package mws
 import (
 	"context"
 	"fmt"
-	"sync"
-
-	"golang.org/x/sync/singleflight"
 
 	"github.com/databricks/databricks-sdk-go/apierr"
 	"github.com/databricks/databricks-sdk-go/service/iam"
@@ -13,96 +10,24 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-// workspaceAssignmentsEntry holds the cached ListByWorkspaceId result for one workspace.
-type workspaceAssignmentsEntry struct {
-	mu          sync.RWMutex
-	initialized bool
-	list        *iam.PermissionAssignments
-	// sg deduplicates concurrent in-flight API calls when the cache is cold.
-	// All goroutines that arrive while a fetch is in-flight join the same call
-	// and are woken simultaneously when it completes, rather than serialising
-	// through a write lock.
-	sg singleflight.Group
+// workspaceAssignmentsCacheKey uniquely identifies a workspace within an account.
+// Workspace IDs are account-scoped, not globally unique, so the accountID is
+// required to prevent two providers targeting different accounts from sharing
+// cached workspace assignments.
+type workspaceAssignmentsCacheKey struct {
+	accountID   string
+	workspaceId int64
 }
 
-// workspaceAssignmentsCache caches ListByWorkspaceId results per workspace ID so
-// that N databricks_mws_permission_assignment resources sharing the same
-// workspace_id only issue a single API call during a terraform plan/apply cycle.
-type workspaceAssignmentsCache struct {
-	mu    sync.Mutex
-	cache map[int64]*workspaceAssignmentsEntry
-}
-
-func newWorkspaceAssignmentsCache() *workspaceAssignmentsCache {
-	return &workspaceAssignmentsCache{
-		cache: make(map[int64]*workspaceAssignmentsEntry),
-	}
-}
-
-func (c *workspaceAssignmentsCache) getOrCreate(workspaceId int64) *workspaceAssignmentsEntry {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	if entry, ok := c.cache[workspaceId]; ok {
-		return entry
-	}
-	entry := &workspaceAssignmentsEntry{}
-	c.cache[workspaceId] = entry
-	return entry
-}
-
-func (c *workspaceAssignmentsCache) list(ctx context.Context, api iam.WorkspaceAssignmentInterface, workspaceId int64) (*iam.PermissionAssignments, error) {
-	entry := c.getOrCreate(workspaceId)
-
-	// Fast path: warm cache. Many goroutines can hold a read-lock simultaneously.
-	entry.mu.RLock()
-	if entry.initialized {
-		l := entry.list
-		entry.mu.RUnlock()
-		return l, nil
-	}
-	entry.mu.RUnlock()
-
-	// Slow path: cache is cold. Use singleflight so exactly one API call is made
-	// regardless of how many goroutines arrive concurrently; all share the result.
-	v, err, _ := entry.sg.Do("fetch", func() (interface{}, error) {
-		// Double-check now that we are the singleflight leader.
-		entry.mu.RLock()
-		if entry.initialized {
-			l := entry.list
-			entry.mu.RUnlock()
-			return l, nil
-		}
-		entry.mu.RUnlock()
-
-		list, err := api.ListByWorkspaceId(ctx, workspaceId)
-		if err != nil {
-			return nil, err
-		}
-		entry.mu.Lock()
-		entry.list = list
-		entry.initialized = true
-		entry.mu.Unlock()
-		return list, nil
-	})
-	if err != nil {
-		return nil, err
-	}
-	return v.(*iam.PermissionAssignments), nil
-}
-
-func (c *workspaceAssignmentsCache) invalidate(workspaceId int64) {
-	c.mu.Lock()
-	entry, ok := c.cache[workspaceId]
-	c.mu.Unlock()
-	if ok {
-		entry.mu.Lock()
-		entry.initialized = false
-		entry.list = nil
-		entry.mu.Unlock()
-	}
-}
-
+// globalWorkspaceAssignmentsCache caches ListByWorkspaceId results per
+// (accountID, workspaceId) so that N databricks_mws_permission_assignment
+// resources sharing the same workspace_id only issue a single API call during
+// a terraform plan/apply cycle.
 var globalWorkspaceAssignmentsCache = newWorkspaceAssignmentsCache()
+
+func newWorkspaceAssignmentsCache() *common.KeyedCache[workspaceAssignmentsCacheKey, *iam.PermissionAssignments] {
+	return common.NewKeyedCache[workspaceAssignmentsCacheKey, *iam.PermissionAssignments]()
+}
 
 func getPermissionsByPrincipal(list iam.PermissionAssignments, principalId int64) (res iam.UpdateWorkspaceAssignments, err error) {
 	for _, v := range list.PermissionAssignments {
@@ -146,11 +71,12 @@ func ResourceMwsPermissionAssignment() common.Resource {
 			common.DataToStructPointer(d, s, &assignment)
 			assignment.PrincipalId = common.GetInt64(d, "principal_id")
 			assignment.WorkspaceId = common.GetInt64(d, "workspace_id")
+			cacheKey := workspaceAssignmentsCacheKey{accountID: c.Config.AccountID, workspaceId: assignment.WorkspaceId}
+			defer globalWorkspaceAssignmentsCache.Invalidate(cacheKey)
 			_, err = acc.WorkspaceAssignment.Update(ctx, assignment)
 			if err != nil {
 				return err
 			}
-			globalWorkspaceAssignmentsCache.invalidate(assignment.WorkspaceId)
 			pair.Pack(d)
 			return nil
 		},
@@ -163,7 +89,11 @@ func ResourceMwsPermissionAssignment() common.Resource {
 			if err != nil {
 				return fmt.Errorf("parse id: %w", err)
 			}
-			list, err := globalWorkspaceAssignmentsCache.list(ctx, acc.WorkspaceAssignment, common.MustInt64(workspaceId))
+			wsID := common.MustInt64(workspaceId)
+			cacheKey := workspaceAssignmentsCacheKey{accountID: c.Config.AccountID, workspaceId: wsID}
+			list, err := globalWorkspaceAssignmentsCache.Get(cacheKey, func() (*iam.PermissionAssignments, error) {
+				return acc.WorkspaceAssignment.ListByWorkspaceId(ctx, wsID)
+			})
 			if err != nil {
 				return err
 			}
@@ -171,7 +101,7 @@ func ResourceMwsPermissionAssignment() common.Resource {
 			if err != nil {
 				return err
 			}
-			d.Set("workspace_id", common.MustInt64(workspaceId))
+			d.Set("workspace_id", wsID)
 			d.Set("principal_id", common.MustInt64(principalId))
 			return common.StructToData(permissions, s, d)
 		},
@@ -184,9 +114,10 @@ func ResourceMwsPermissionAssignment() common.Resource {
 			if err != nil {
 				return fmt.Errorf("parse id: %w", err)
 			}
-			err = acc.WorkspaceAssignment.DeleteByWorkspaceIdAndPrincipalId(ctx, common.MustInt64(workspaceId), common.MustInt64(principalId))
-			globalWorkspaceAssignmentsCache.invalidate(common.MustInt64(workspaceId))
-			return err
+			wsID := common.MustInt64(workspaceId)
+			cacheKey := workspaceAssignmentsCacheKey{accountID: c.Config.AccountID, workspaceId: wsID}
+			defer globalWorkspaceAssignmentsCache.Invalidate(cacheKey)
+			return acc.WorkspaceAssignment.DeleteByWorkspaceIdAndPrincipalId(ctx, wsID, common.MustInt64(principalId))
 		},
 	}
 }

--- a/mws/resource_mws_permission_assignment_test.go
+++ b/mws/resource_mws_permission_assignment_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestPermissionAssignmentCreate(t *testing.T) {
+	globalWorkspaceAssignmentsCache = newWorkspaceAssignmentsCache()
 	qa.ResourceFixture{
 		MockAccountClientFunc: func(m *mocks.MockAccountClient) {
 			e := m.GetMockWorkspaceAssignmentAPI().EXPECT()
@@ -47,6 +48,7 @@ func TestPermissionAssignmentCreate(t *testing.T) {
 }
 
 func TestPermissionAssignmentRead(t *testing.T) {
+	globalWorkspaceAssignmentsCache = newWorkspaceAssignmentsCache()
 	qa.ResourceFixture{
 		MockAccountClientFunc: func(m *mocks.MockAccountClient) {
 			e := m.GetMockWorkspaceAssignmentAPI().EXPECT()
@@ -81,6 +83,7 @@ func TestPermissionAssignmentRead(t *testing.T) {
 }
 
 func TestPermissionAssignmentReadNotFound(t *testing.T) {
+	globalWorkspaceAssignmentsCache = newWorkspaceAssignmentsCache()
 	qa.ResourceFixture{
 		MockAccountClientFunc: func(m *mocks.MockAccountClient) {
 			e := m.GetMockWorkspaceAssignmentAPI().EXPECT()
@@ -105,6 +108,7 @@ func TestPermissionAssignmentReadNotFound(t *testing.T) {
 }
 
 func TestPermissionAssignmentDelete(t *testing.T) {
+	globalWorkspaceAssignmentsCache = newWorkspaceAssignmentsCache()
 	qa.ResourceFixture{
 		MockAccountClientFunc: func(m *mocks.MockAccountClient) {
 			e := m.GetMockWorkspaceAssignmentAPI().EXPECT()
@@ -119,12 +123,14 @@ func TestPermissionAssignmentDelete(t *testing.T) {
 }
 
 func TestPermissionAssignmentFuzz_NoAccountID(t *testing.T) {
+	globalWorkspaceAssignmentsCache = newWorkspaceAssignmentsCache()
 	qa.ResourceCornerCases(t, ResourceMwsPermissionAssignment(),
 		qa.CornerCaseID("123|456"),
 		qa.CornerCaseExpectError("i'm a teapot"))
 }
 
 func TestPermissionAssignmentFuzz_InvalidID(t *testing.T) {
+	globalWorkspaceAssignmentsCache = newWorkspaceAssignmentsCache()
 	qa.ResourceCornerCases(t, ResourceMwsPermissionAssignment(),
 		qa.CornerCaseExpectError("parse id: invalid ID: x"),
 		qa.CornerCaseSkipCRUD("create"),
@@ -132,6 +138,7 @@ func TestPermissionAssignmentFuzz_InvalidID(t *testing.T) {
 }
 
 func TestPermissionAssignmentFuzz_ApiErrors(t *testing.T) {
+	globalWorkspaceAssignmentsCache = newWorkspaceAssignmentsCache()
 	qa.ResourceCornerCases(t, ResourceMwsPermissionAssignment(),
 		qa.CornerCaseAccountID("abc"),
 		qa.CornerCaseID("123|456"))

--- a/scim/groups.go
+++ b/scim/groups.go
@@ -74,7 +74,7 @@ func (a GroupsAPI) ListAll(attributes string) ([]Group, error) {
 			return nil, err
 		}
 		result = append(result, page.Resources...)
-		if len(page.Resources) == 0 || int32(len(result)) >= page.TotalResults {
+		if len(page.Resources) == 0 || len(result) >= int(page.TotalResults) {
 			break
 		}
 		startIndex += len(page.Resources)

--- a/scim/groups.go
+++ b/scim/groups.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strconv"
 
 	"github.com/databricks/terraform-provider-databricks/common"
 )
@@ -53,6 +54,32 @@ func (a GroupsAPI) Filter(filter string, attributes string) (GroupList, error) {
 	}
 	err := a.client.Scim(a.context, http.MethodGet, "/preview/scim/v2/Groups", req, &groups, a.ApiLevel)
 	return groups, err
+}
+
+// ListAll retrieves all groups with the given attributes, handling SCIM pagination.
+func (a GroupsAPI) ListAll(attributes string) ([]Group, error) {
+	startIndex := 1
+	var result []Group
+	for {
+		req := map[string]string{
+			"count":      "10000",
+			"startIndex": strconv.Itoa(startIndex),
+		}
+		if attributes != "" {
+			req["attributes"] = attributes
+		}
+		var page GroupList
+		err := a.client.Scim(a.context, http.MethodGet, "/preview/scim/v2/Groups", req, &page, a.ApiLevel)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, page.Resources...)
+		if len(page.Resources) == 0 || int32(len(result)) >= page.TotalResults {
+			break
+		}
+		startIndex += len(page.Resources)
+	}
+	return result, nil
 }
 
 func (a GroupsAPI) ReadByDisplayName(displayName, attributes string) (group Group, err error) {

--- a/scim/resource_group.go
+++ b/scim/resource_group.go
@@ -4,9 +4,6 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	"sync"
-
-	"golang.org/x/sync/singleflight"
 
 	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -16,64 +13,24 @@ import (
 // groupListAttrs are the SCIM attributes fetched when bulk-listing groups for the read cache.
 const groupListAttrs = "id,displayName,externalId,entitlements"
 
-type groupsEntryItem struct {
-	mu          sync.RWMutex
-	initialized bool
-	byID        map[string]Group
-	sg          singleflight.Group
+// globalGroupsListCache caches a ListAll result per (host, apiLevel, accountID) so
+// that N concurrent reads for N distinct databricks_group resources only issue one
+// SCIM list call instead of N individual GET-by-ID calls.
+//
+// The cache key includes accountID so that two provider instances targeting the
+// same API host but different Databricks accounts never share cached groups.
+var globalGroupsListCache = newGroupsListCache()
+
+func newGroupsListCache() *common.KeyedCache[string, map[string]Group] {
+	return common.NewKeyedCache[string, map[string]Group]()
 }
 
-// groupsListCache caches a ListAll result per (host, apiLevel) so that
-// N concurrent reads for N distinct databricks_group resources only issue
-// one SCIM list call instead of N individual GET-by-ID calls.
-type groupsListCache struct {
-	mu    sync.Mutex
-	cache map[string]*groupsEntryItem
+func groupsCacheKey(api GroupsAPI) string {
+	return api.client.Config.Host + "|" + api.ApiLevel + "|" + api.client.Config.AccountID
 }
 
-func newGroupsListCache() *groupsListCache {
-	return &groupsListCache{cache: make(map[string]*groupsEntryItem)}
-}
-
-func (c *groupsListCache) entry(key string) *groupsEntryItem {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	if e, ok := c.cache[key]; ok {
-		return e
-	}
-	e := &groupsEntryItem{byID: make(map[string]Group)}
-	c.cache[key] = e
-	return e
-}
-
-func (c *groupsListCache) lookup(api GroupsAPI, groupID string) (Group, error) {
-	key := api.client.Config.Host + "|" + api.ApiLevel
-	e := c.entry(key)
-
-	// Fast path: warm cache, concurrent readers proceed simultaneously.
-	e.mu.RLock()
-	if e.initialized {
-		if g, ok := e.byID[groupID]; ok {
-			e.mu.RUnlock()
-			return g, nil
-		}
-		e.mu.RUnlock()
-		// Cache populated but group absent (created externally); fall through to direct read.
-		return api.Read(groupID, "displayName,externalId,entitlements")
-	}
-	e.mu.RUnlock()
-
-	// Slow path: populate cache via singleflight — at most one ListAll in-flight
-	// per (host, apiLevel); all other goroutines join and wake simultaneously.
-	_, err, _ := e.sg.Do("list", func() (interface{}, error) {
-		// Double-check after acquiring the singleflight slot.
-		e.mu.RLock()
-		if e.initialized {
-			e.mu.RUnlock()
-			return nil, nil
-		}
-		e.mu.RUnlock()
-
+func groupsListCacheLookup(api GroupsAPI, groupID string) (Group, error) {
+	byID, err := globalGroupsListCache.Get(groupsCacheKey(api), func() (map[string]Group, error) {
 		groups, err := api.ListAll(groupListAttrs)
 		if err != nil {
 			return nil, err
@@ -82,38 +39,17 @@ func (c *groupsListCache) lookup(api GroupsAPI, groupID string) (Group, error) {
 		for _, g := range groups {
 			m[g.ID] = g
 		}
-		e.mu.Lock()
-		e.byID = m
-		e.initialized = true
-		e.mu.Unlock()
-		return nil, nil
+		return m, nil
 	})
 	if err != nil {
 		return Group{}, err
 	}
-
-	e.mu.RLock()
-	g, ok := e.byID[groupID]
-	e.mu.RUnlock()
-	if !ok {
-		return api.Read(groupID, "displayName,externalId,entitlements")
+	if g, ok := byID[groupID]; ok {
+		return g, nil
 	}
-	return g, nil
+	// Cache populated but group absent (e.g. created concurrently); fall back to a direct read.
+	return api.Read(groupID, "displayName,externalId,entitlements")
 }
-
-func (c *groupsListCache) invalidate(key string) {
-	c.mu.Lock()
-	e, ok := c.cache[key]
-	c.mu.Unlock()
-	if ok {
-		e.mu.Lock()
-		e.initialized = false
-		e.byID = make(map[string]Group)
-		e.mu.Unlock()
-	}
-}
-
-var globalGroupsListCache = newGroupsListCache()
 
 // ResourceGroup manages user groups
 func ResourceGroup() common.Resource {
@@ -153,13 +89,13 @@ func ResourceGroup() common.Resource {
 			if err != nil {
 				return err
 			}
-			defer globalGroupsListCache.invalidate(c.Config.Host + "|" + common.GetApiLevel(d))
+			groupsAPI := NewGroupsAPI(ctx, c, common.GetApiLevel(d))
+			defer globalGroupsListCache.Invalidate(groupsCacheKey(groupsAPI))
 			g := Group{
 				DisplayName:  d.Get("display_name").(string),
 				Entitlements: readEntitlementsFromData(d),
 				ExternalID:   d.Get("external_id").(string),
 			}
-			groupsAPI := NewGroupsAPI(ctx, c, common.GetApiLevel(d))
 			group, err := groupsAPI.Create(g)
 			if err != nil {
 				return createForceOverridesManuallyAddedGroup(err, d, groupsAPI, g)
@@ -173,7 +109,7 @@ func ResourceGroup() common.Resource {
 				return err
 			}
 			groupsAPI := NewGroupsAPI(ctx, c, common.GetApiLevel(d))
-			group, err := globalGroupsListCache.lookup(groupsAPI, d.Id())
+			group, err := groupsListCacheLookup(groupsAPI, d.Id())
 			if err != nil {
 				return err
 			}
@@ -192,8 +128,8 @@ func ResourceGroup() common.Resource {
 			if err != nil {
 				return err
 			}
-			defer globalGroupsListCache.invalidate(c.Config.Host + "|" + common.GetApiLevel(d))
 			groupsAPI := NewGroupsAPI(ctx, c, common.GetApiLevel(d))
+			defer globalGroupsListCache.Invalidate(groupsCacheKey(groupsAPI))
 			groupName := d.Get("display_name").(string)
 			return groupsAPI.UpdateNameAndEntitlements(d.Id(), groupName,
 				d.Get("external_id").(string), readEntitlementsFromData(d))
@@ -203,8 +139,8 @@ func ResourceGroup() common.Resource {
 			if err != nil {
 				return err
 			}
-			defer globalGroupsListCache.invalidate(c.Config.Host + "|" + common.GetApiLevel(d))
 			groupsAPI := NewGroupsAPI(ctx, c, common.GetApiLevel(d))
+			defer globalGroupsListCache.Invalidate(groupsCacheKey(groupsAPI))
 			return groupsAPI.Delete(d.Id())
 		},
 		Schema: groupSchema,

--- a/scim/resource_group.go
+++ b/scim/resource_group.go
@@ -4,11 +4,116 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync"
+
+	"golang.org/x/sync/singleflight"
 
 	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
+
+// groupListAttrs are the SCIM attributes fetched when bulk-listing groups for the read cache.
+const groupListAttrs = "id,displayName,externalId,entitlements"
+
+type groupsEntryItem struct {
+	mu          sync.RWMutex
+	initialized bool
+	byID        map[string]Group
+	sg          singleflight.Group
+}
+
+// groupsListCache caches a ListAll result per (host, apiLevel) so that
+// N concurrent reads for N distinct databricks_group resources only issue
+// one SCIM list call instead of N individual GET-by-ID calls.
+type groupsListCache struct {
+	mu    sync.Mutex
+	cache map[string]*groupsEntryItem
+}
+
+func newGroupsListCache() *groupsListCache {
+	return &groupsListCache{cache: make(map[string]*groupsEntryItem)}
+}
+
+func (c *groupsListCache) entry(key string) *groupsEntryItem {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if e, ok := c.cache[key]; ok {
+		return e
+	}
+	e := &groupsEntryItem{byID: make(map[string]Group)}
+	c.cache[key] = e
+	return e
+}
+
+func (c *groupsListCache) lookup(api GroupsAPI, groupID string) (Group, error) {
+	key := api.client.Config.Host + "|" + api.ApiLevel
+	e := c.entry(key)
+
+	// Fast path: warm cache, concurrent readers proceed simultaneously.
+	e.mu.RLock()
+	if e.initialized {
+		if g, ok := e.byID[groupID]; ok {
+			e.mu.RUnlock()
+			return g, nil
+		}
+		e.mu.RUnlock()
+		// Cache populated but group absent (created externally); fall through to direct read.
+		return api.Read(groupID, "displayName,externalId,entitlements")
+	}
+	e.mu.RUnlock()
+
+	// Slow path: populate cache via singleflight — at most one ListAll in-flight
+	// per (host, apiLevel); all other goroutines join and wake simultaneously.
+	_, err, _ := e.sg.Do("list", func() (interface{}, error) {
+		// Double-check after acquiring the singleflight slot.
+		e.mu.RLock()
+		if e.initialized {
+			e.mu.RUnlock()
+			return nil, nil
+		}
+		e.mu.RUnlock()
+
+		groups, err := api.ListAll(groupListAttrs)
+		if err != nil {
+			return nil, err
+		}
+		m := make(map[string]Group, len(groups))
+		for _, g := range groups {
+			m[g.ID] = g
+		}
+		e.mu.Lock()
+		e.byID = m
+		e.initialized = true
+		e.mu.Unlock()
+		return nil, nil
+	})
+	if err != nil {
+		return Group{}, err
+	}
+
+	e.mu.RLock()
+	g, ok := e.byID[groupID]
+	e.mu.RUnlock()
+	if !ok {
+		return api.Read(groupID, "displayName,externalId,entitlements")
+	}
+	return g, nil
+}
+
+func (c *groupsListCache) invalidate(key string) {
+	c.mu.Lock()
+	e, ok := c.cache[key]
+	c.mu.Unlock()
+	if ok {
+		e.mu.Lock()
+		e.initialized = false
+		e.byID = make(map[string]Group)
+		e.mu.Unlock()
+	}
+}
+
+var globalGroupsListCache = newGroupsListCache()
 
 // ResourceGroup manages user groups
 func ResourceGroup() common.Resource {
@@ -48,6 +153,7 @@ func ResourceGroup() common.Resource {
 			if err != nil {
 				return err
 			}
+			defer globalGroupsListCache.invalidate(c.Config.Host + "|" + common.GetApiLevel(d))
 			g := Group{
 				DisplayName:  d.Get("display_name").(string),
 				Entitlements: readEntitlementsFromData(d),
@@ -67,7 +173,7 @@ func ResourceGroup() common.Resource {
 				return err
 			}
 			groupsAPI := NewGroupsAPI(ctx, c, common.GetApiLevel(d))
-			group, err := groupsAPI.Read(d.Id(), "displayName,externalId,entitlements")
+			group, err := globalGroupsListCache.lookup(groupsAPI, d.Id())
 			if err != nil {
 				return err
 			}
@@ -86,6 +192,7 @@ func ResourceGroup() common.Resource {
 			if err != nil {
 				return err
 			}
+			defer globalGroupsListCache.invalidate(c.Config.Host + "|" + common.GetApiLevel(d))
 			groupsAPI := NewGroupsAPI(ctx, c, common.GetApiLevel(d))
 			groupName := d.Get("display_name").(string)
 			return groupsAPI.UpdateNameAndEntitlements(d.Id(), groupName,
@@ -96,6 +203,7 @@ func ResourceGroup() common.Resource {
 			if err != nil {
 				return err
 			}
+			defer globalGroupsListCache.invalidate(c.Config.Host + "|" + common.GetApiLevel(d))
 			groupsAPI := NewGroupsAPI(ctx, c, common.GetApiLevel(d))
 			return groupsAPI.Delete(d.Id())
 		},

--- a/scim/resource_group_api_field_test.go
+++ b/scim/resource_group_api_field_test.go
@@ -7,8 +7,18 @@ import (
 )
 
 func TestResourceGroupCreate_ApiFieldAccount(t *testing.T) {
+	globalGroupsListCache = newGroupsListCache()
 	qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
+			{
+				Method:       "GET",
+				Resource:     "/api/2.0/accounts/acc-123/scim/v2/Groups?attributes=id%2CdisplayName%2CexternalId%2Centitlements&count=10000&startIndex=1",
+				ReuseRequest: true,
+				Response: GroupList{
+					TotalResults: 1,
+					Resources:    []Group{{ID: "abc", DisplayName: "test-group"}},
+				},
+			},
 			{
 				Method:   "POST",
 				Resource: "/api/2.0/accounts/acc-123/scim/v2/Groups",
@@ -37,8 +47,18 @@ func TestResourceGroupCreate_ApiFieldAccount(t *testing.T) {
 
 func TestResourceGroupCreate_ApiFieldWorkspace(t *testing.T) {
 	// Even with AccountID set, api = "workspace" routes to workspace SCIM
+	globalGroupsListCache = newGroupsListCache()
 	qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
+			{
+				Method:       "GET",
+				Resource:     "/api/2.0/preview/scim/v2/Groups?attributes=id%2CdisplayName%2CexternalId%2Centitlements&count=10000&startIndex=1",
+				ReuseRequest: true,
+				Response: GroupList{
+					TotalResults: 1,
+					Resources:    []Group{{ID: "def", DisplayName: "ws-group"}},
+				},
+			},
 			{
 				Method:   "POST",
 				Resource: "/api/2.0/preview/scim/v2/Groups",
@@ -67,10 +87,8 @@ func TestResourceGroupCreate_ApiFieldWorkspace(t *testing.T) {
 }
 
 func TestResourceGroupCreate_ApiFieldNotSet_FallsBackToHostInference(t *testing.T) {
-	// When api is NOT set, account host routes to account SCIM (backwards compatible).
-	// Host inference is driven by the host metadata discovery — a 200 on
-	// /.well-known/databricks-config with host_type=ACCOUNT_HOST resolves the
-	// config to AccountHost, which is what a real accounts.* host would do.
+	// When api is NOT set, account host routes to account SCIM (backwards compatible)
+	globalGroupsListCache = newGroupsListCache()
 	qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
 			{
@@ -78,6 +96,15 @@ func TestResourceGroupCreate_ApiFieldNotSet_FallsBackToHostInference(t *testing.
 				Resource:     "/.well-known/databricks-config",
 				Response:     map[string]string{"host_type": "account"},
 				ReuseRequest: true,
+			},
+			{
+				Method:       "GET",
+				Resource:     "/api/2.0/accounts/acc-123/scim/v2/Groups?attributes=id%2CdisplayName%2CexternalId%2Centitlements&count=10000&startIndex=1",
+				ReuseRequest: true,
+				Response: GroupList{
+					TotalResults: 1,
+					Resources:    []Group{{ID: "abc", DisplayName: "test-group"}},
+				},
 			},
 			{
 				Method:   "POST",
@@ -106,8 +133,18 @@ func TestResourceGroupCreate_ApiFieldNotSet_FallsBackToHostInference(t *testing.
 
 func TestResourceGroupCreate_ApiFieldNotSet_WorkspaceHost(t *testing.T) {
 	// When api is NOT set and provider is workspace-level, routes to workspace SCIM (backwards compatible)
+	globalGroupsListCache = newGroupsListCache()
 	qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
+			{
+				Method:       "GET",
+				Resource:     "/api/2.0/preview/scim/v2/Groups?attributes=id%2CdisplayName%2CexternalId%2Centitlements&count=10000&startIndex=1",
+				ReuseRequest: true,
+				Response: GroupList{
+					TotalResults: 1,
+					Resources:    []Group{{ID: "abc", DisplayName: "test-group"}},
+				},
+			},
 			{
 				Method:   "POST",
 				Resource: "/api/2.0/preview/scim/v2/Groups",
@@ -133,8 +170,18 @@ func TestResourceGroupCreate_ApiFieldNotSet_WorkspaceHost(t *testing.T) {
 }
 
 func TestResourceGroupRead_ApiFieldAccount(t *testing.T) {
+	globalGroupsListCache = newGroupsListCache()
 	qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
+			{
+				Method:       "GET",
+				Resource:     "/api/2.0/accounts/acc-123/scim/v2/Groups?attributes=id%2CdisplayName%2CexternalId%2Centitlements&count=10000&startIndex=1",
+				ReuseRequest: true,
+				Response: GroupList{
+					TotalResults: 1,
+					Resources:    []Group{{ID: "abc", DisplayName: "test-group"}},
+				},
+			},
 			{
 				Method:   "GET",
 				Resource: "/api/2.0/accounts/acc-123/scim/v2/Groups/abc?attributes=displayName,externalId,entitlements",

--- a/scim/resource_group_member.go
+++ b/scim/resource_group_member.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"sync"
 
+	"golang.org/x/sync/singleflight"
+
 	"github.com/databricks/databricks-sdk-go/apierr"
 	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -16,7 +18,11 @@ import (
 type groupMembersInfo struct {
 	initialized bool
 	members     map[string]struct{}
-	lock        sync.Mutex
+	lock        sync.RWMutex
+	// sg deduplicates concurrent in-flight API calls when the cache is cold.
+	// All goroutines waiting on a cold cache join the single fetch and wake
+	// simultaneously, rather than serialising through a write lock.
+	sg singleflight.Group
 }
 
 // groupCache is a cache of groups to their members by their ID. Access to the cache
@@ -26,12 +32,16 @@ type groupCache struct {
 	// TODO: add workspace ID to the cache key when account-level and workspace-level providers are unified.
 	cache map[string]*groupMembersInfo
 	lock  sync.Mutex
+	// bulkInitialized is true once a ListAll("id,members") has populated all entries.
+	// After that, per-group fast-path reads skip any API calls entirely.
+	bulkMu          sync.RWMutex
+	bulkInitialized bool
+	bulkSg          singleflight.Group
 }
 
 func newGroupCache() *groupCache {
 	return &groupCache{
 		cache: make(map[string]*groupMembersInfo),
-		lock:  sync.Mutex{},
 	}
 }
 
@@ -42,39 +52,120 @@ func (gc *groupCache) getOrCreateGroupInfo(groupID string) *groupMembersInfo {
 	groupInfo, exists := gc.cache[groupID]
 	if !exists {
 		groupInfo = &groupMembersInfo{
-			initialized: false,
-			members:     make(map[string]struct{}),
-			lock:        sync.Mutex{},
+			members: make(map[string]struct{}),
 		}
 		gc.cache[groupID] = groupInfo
 	}
 	return groupInfo
 }
 
+func copyGroupMembers(m map[string]struct{}) map[string]struct{} {
+	cp := make(map[string]struct{}, len(m))
+	for k, v := range m {
+		cp[k] = v
+	}
+	return cp
+}
+
 func (gc *groupCache) getMembers(api GroupsAPI, groupID string) (map[string]struct{}, error) {
 	groupInfo := gc.getOrCreateGroupInfo(groupID)
-	groupInfo.lock.Lock()
-	defer groupInfo.lock.Unlock()
 
-	if !groupInfo.initialized {
-		tflog.Debug(api.context, fmt.Sprintf("Getting members for group %s", groupID))
+	// Fast path: per-group cache is warm — concurrent readers hold RLock simultaneously.
+	groupInfo.lock.RLock()
+	if groupInfo.initialized {
+		tflog.Debug(api.context, fmt.Sprintf("Group %s has %d members (cached)", groupID, len(groupInfo.members)))
+		membersCopy := copyGroupMembers(groupInfo.members)
+		groupInfo.lock.RUnlock()
+		return membersCopy, nil
+	}
+	groupInfo.lock.RUnlock()
+
+	// Bulk path: fetch all groups+members in one ListAll call;
+	// all goroutines share a single in-flight request via singleflight.
+	gc.bulkMu.RLock()
+	bulkDone := gc.bulkInitialized
+	gc.bulkMu.RUnlock()
+	if !bulkDone {
+		_, err, _ := gc.bulkSg.Do("bulk", func() (interface{}, error) {
+			// Double-check after acquiring the singleflight slot.
+			gc.bulkMu.RLock()
+			if gc.bulkInitialized {
+				gc.bulkMu.RUnlock()
+				return nil, nil
+			}
+			gc.bulkMu.RUnlock()
+
+			tflog.Debug(api.context, "Fetching all group memberships in bulk")
+			groups, err := api.ListAll("id,members")
+			if err != nil {
+				return nil, err
+			}
+			for _, g := range groups {
+				info := gc.getOrCreateGroupInfo(g.ID)
+				info.lock.Lock()
+				if !info.initialized {
+					info.members = make(map[string]struct{}, len(g.Members))
+					for _, m := range g.Members {
+						info.members[m.Value] = struct{}{}
+					}
+					info.initialized = true
+				}
+				info.lock.Unlock()
+			}
+			gc.bulkMu.Lock()
+			gc.bulkInitialized = true
+			gc.bulkMu.Unlock()
+			return nil, nil
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Re-check per-group cache after bulk.
+	groupInfo.lock.RLock()
+	if groupInfo.initialized {
+		tflog.Debug(api.context, fmt.Sprintf("Group %s has %d members (initialized)", groupID, len(groupInfo.members)))
+		membersCopy := copyGroupMembers(groupInfo.members)
+		groupInfo.lock.RUnlock()
+		return membersCopy, nil
+	}
+	groupInfo.lock.RUnlock()
+
+	// Group was not returned by the bulk fetch (e.g., created externally after the
+	// bulk ran). Fall back to an individual read, deduped via singleflight.
+	_, err, _ := groupInfo.sg.Do("fetch", func() (interface{}, error) {
+		// Double-check after acquiring the singleflight slot.
+		groupInfo.lock.RLock()
+		if groupInfo.initialized {
+			groupInfo.lock.RUnlock()
+			return nil, nil
+		}
+		groupInfo.lock.RUnlock()
+
+		tflog.Debug(api.context, fmt.Sprintf("Getting members for group %s (not in bulk fetch)", groupID))
 		group, err := api.Read(groupID, "members")
 		if err != nil {
 			return nil, err
 		}
 		tflog.Debug(api.context, fmt.Sprintf("Group %s has %d members", groupID, len(group.Members)))
+		groupInfo.lock.Lock()
+		groupInfo.members = make(map[string]struct{}, len(group.Members))
 		for _, member := range group.Members {
 			groupInfo.members[member.Value] = struct{}{}
 		}
 		groupInfo.initialized = true
-		tflog.Debug(api.context, fmt.Sprintf("Group %s has %d members (initialized)", groupID, len(groupInfo.members)))
-	} else {
-		tflog.Debug(api.context, fmt.Sprintf("Group %s has %d members (cached)", groupID, len(groupInfo.members)))
+		groupInfo.lock.Unlock()
+		return nil, nil
+	})
+	if err != nil {
+		return nil, err
 	}
-	membersCopy := make(map[string]struct{}, len(groupInfo.members))
-	for k, v := range groupInfo.members {
-		membersCopy[k] = v
-	}
+
+	groupInfo.lock.RLock()
+	tflog.Debug(api.context, fmt.Sprintf("Group %s has %d members (initialized)", groupID, len(groupInfo.members)))
+	membersCopy := copyGroupMembers(groupInfo.members)
+	groupInfo.lock.RUnlock()
 	return membersCopy, nil
 }
 

--- a/scim/resource_group_member.go
+++ b/scim/resource_group_member.go
@@ -17,58 +17,56 @@ import (
 // to the underlying members map must be protected by the lock.
 type groupMembersInfo struct {
 	initialized bool
-	members     map[string]struct{}
-	lock        sync.RWMutex
+	// mutatedInBulkGen records the bulk-fetch generation (groupEndpointCache.bulkGen)
+	// that was active when this group was last mutated by addMember/removeMember.
+	// The bulk commit uses this to skip groups that were mutated while the specific
+	// ListAll request was in-flight: if mutatedInBulkGen equals the current bulk
+	// generation the snapshot was captured before the mutation, so committing it
+	// would reintroduce stale data.  Groups flagged this way fall back to the
+	// individual-read path in getMembers to obtain fresh data.
+	mutatedInBulkGen uint64
+	members          map[string]struct{}
+	lock             sync.RWMutex
 	// sg deduplicates concurrent in-flight API calls when the cache is cold.
 	// All goroutines waiting on a cold cache join the single fetch and wake
 	// simultaneously, rather than serialising through a write lock.
 	sg singleflight.Group
 }
 
-// groupCache is a cache of groups to their members by their ID. Access to the cache
-// must be protected by the lock.
-type groupCache struct {
-	// The mapping of cached members for this group. The cache key is the group ID.
-	// TODO: add workspace ID to the cache key when account-level and workspace-level providers are unified.
+// groupEndpointCache is the per-endpoint (host|apiLevel|accountID) member cache.
+// Scoping by endpoint prevents two provider instances targeting different accounts
+// (or different API levels) from sharing cached group-member data.
+type groupEndpointCache struct {
+	lock sync.Mutex
+	// cache maps group ID to its member info for this endpoint.
 	cache map[string]*groupMembersInfo
-	lock  sync.Mutex
-	// bulkInitialized is true once a ListAll("id,members") has populated all entries.
-	// After that, per-group fast-path reads skip any API calls entirely.
+	// bulkMu / bulkGen / bulkInitialized / bulkSg guard the one-time ListAll("id,members") bulk fetch.
+	// bulkGen is monotonically incremented each time a bulk fetch starts; addMember/removeMember
+	// record the current bulkGen so the bulk commit can detect mid-flight mutations.
+	// After the bulk is done, per-group fast-path reads skip any API calls entirely.
 	bulkMu          sync.RWMutex
+	bulkGen         uint64
 	bulkInitialized bool
 	bulkSg          singleflight.Group
 }
 
-func newGroupCache() *groupCache {
-	return &groupCache{
-		cache: make(map[string]*groupMembersInfo),
-	}
+func newGroupEndpointCache() *groupEndpointCache {
+	return &groupEndpointCache{cache: make(map[string]*groupMembersInfo)}
 }
 
-func (gc *groupCache) getOrCreateGroupInfo(groupID string) *groupMembersInfo {
-	gc.lock.Lock()
-	defer gc.lock.Unlock()
-
-	groupInfo, exists := gc.cache[groupID]
-	if !exists {
-		groupInfo = &groupMembersInfo{
-			members: make(map[string]struct{}),
-		}
-		gc.cache[groupID] = groupInfo
+func (ep *groupEndpointCache) getOrCreateGroupInfo(groupID string) *groupMembersInfo {
+	ep.lock.Lock()
+	defer ep.lock.Unlock()
+	if info, ok := ep.cache[groupID]; ok {
+		return info
 	}
-	return groupInfo
+	info := &groupMembersInfo{members: make(map[string]struct{})}
+	ep.cache[groupID] = info
+	return info
 }
 
-func copyGroupMembers(m map[string]struct{}) map[string]struct{} {
-	cp := make(map[string]struct{}, len(m))
-	for k, v := range m {
-		cp[k] = v
-	}
-	return cp
-}
-
-func (gc *groupCache) getMembers(api GroupsAPI, groupID string) (map[string]struct{}, error) {
-	groupInfo := gc.getOrCreateGroupInfo(groupID)
+func (ep *groupEndpointCache) getMembers(api GroupsAPI, groupID string) (map[string]struct{}, error) {
+	groupInfo := ep.getOrCreateGroupInfo(groupID)
 
 	// Fast path: per-group cache is warm — concurrent readers hold RLock simultaneously.
 	groupInfo.lock.RLock()
@@ -82,18 +80,26 @@ func (gc *groupCache) getMembers(api GroupsAPI, groupID string) (map[string]stru
 
 	// Bulk path: fetch all groups+members in one ListAll call;
 	// all goroutines share a single in-flight request via singleflight.
-	gc.bulkMu.RLock()
-	bulkDone := gc.bulkInitialized
-	gc.bulkMu.RUnlock()
+	ep.bulkMu.RLock()
+	bulkDone := ep.bulkInitialized
+	ep.bulkMu.RUnlock()
 	if !bulkDone {
-		_, err, _ := gc.bulkSg.Do("bulk", func() (interface{}, error) {
+		_, err, _ := ep.bulkSg.Do("bulk", func() (interface{}, error) {
 			// Double-check after acquiring the singleflight slot.
-			gc.bulkMu.RLock()
-			if gc.bulkInitialized {
-				gc.bulkMu.RUnlock()
+			ep.bulkMu.RLock()
+			if ep.bulkInitialized {
+				ep.bulkMu.RUnlock()
 				return nil, nil
 			}
-			gc.bulkMu.RUnlock()
+			ep.bulkMu.RUnlock()
+
+			// Assign a new bulk generation before starting the API call.
+			// addMember/removeMember that run concurrently will record this
+			// generation so the commit loop below can skip those groups.
+			ep.bulkMu.Lock()
+			ep.bulkGen++
+			myBulkGen := ep.bulkGen
+			ep.bulkMu.Unlock()
 
 			tflog.Debug(api.context, "Fetching all group memberships in bulk")
 			groups, err := api.ListAll("id,members")
@@ -101,9 +107,14 @@ func (gc *groupCache) getMembers(api GroupsAPI, groupID string) (map[string]stru
 				return nil, err
 			}
 			for _, g := range groups {
-				info := gc.getOrCreateGroupInfo(g.ID)
+				info := ep.getOrCreateGroupInfo(g.ID)
 				info.lock.Lock()
-				if !info.initialized {
+				// Skip groups whose mutatedInBulkGen matches the current bulk
+				// generation: that means addMember/removeMember ran concurrently
+				// with this ListAll, so our snapshot predates the mutation and
+				// committing it would cache stale membership data.  Those groups
+				// will be served by the individual-read fallback instead.
+				if !info.initialized && info.mutatedInBulkGen != myBulkGen {
 					info.members = make(map[string]struct{}, len(g.Members))
 					for _, m := range g.Members {
 						info.members[m.Value] = struct{}{}
@@ -112,9 +123,9 @@ func (gc *groupCache) getMembers(api GroupsAPI, groupID string) (map[string]stru
 				}
 				info.lock.Unlock()
 			}
-			gc.bulkMu.Lock()
-			gc.bulkInitialized = true
-			gc.bulkMu.Unlock()
+			ep.bulkMu.Lock()
+			ep.bulkInitialized = true
+			ep.bulkMu.Unlock()
 			return nil, nil
 		})
 		if err != nil {
@@ -169,8 +180,8 @@ func (gc *groupCache) getMembers(api GroupsAPI, groupID string) (map[string]stru
 	return membersCopy, nil
 }
 
-func (gc *groupCache) removeMember(api GroupsAPI, groupID string, memberID string) error {
-	groupInfo := gc.getOrCreateGroupInfo(groupID)
+func (ep *groupEndpointCache) removeMember(api GroupsAPI, groupID string, memberID string) error {
+	groupInfo := ep.getOrCreateGroupInfo(groupID)
 	groupInfo.lock.Lock()
 	defer groupInfo.lock.Unlock()
 
@@ -179,15 +190,20 @@ func (gc *groupCache) removeMember(api GroupsAPI, groupID string, memberID strin
 	if err != nil {
 		return err
 	}
-
+	// Record the current bulk generation before updating the map. The bulk
+	// commit skips any group whose mutatedInBulkGen equals the in-flight
+	// generation, preventing stale snapshot data from overwriting this mutation.
+	ep.bulkMu.RLock()
+	groupInfo.mutatedInBulkGen = ep.bulkGen
+	ep.bulkMu.RUnlock()
 	if groupInfo.initialized {
 		delete(groupInfo.members, memberID)
 	}
 	return nil
 }
 
-func (gc *groupCache) addMember(api GroupsAPI, groupID string, memberID string) error {
-	groupInfo := gc.getOrCreateGroupInfo(groupID)
+func (ep *groupEndpointCache) addMember(api GroupsAPI, groupID string, memberID string) error {
+	groupInfo := ep.getOrCreateGroupInfo(groupID)
 	groupInfo.lock.Lock()
 	defer groupInfo.lock.Unlock()
 
@@ -195,10 +211,64 @@ func (gc *groupCache) addMember(api GroupsAPI, groupID string, memberID string) 
 	if err != nil {
 		return err
 	}
+	// Record the current bulk generation before updating the map. The bulk
+	// commit skips any group whose mutatedInBulkGen equals the in-flight
+	// generation, preventing stale snapshot data from overwriting this mutation.
+	ep.bulkMu.RLock()
+	groupInfo.mutatedInBulkGen = ep.bulkGen
+	ep.bulkMu.RUnlock()
 	if groupInfo.initialized {
 		groupInfo.members[memberID] = struct{}{}
 	}
 	return nil
+}
+
+// groupCache maps endpoint keys to per-endpoint caches.
+// Scoping by (host, apiLevel, accountID) prevents two providers targeting
+// different accounts or API levels from sharing cached group-member data.
+type groupCache struct {
+	mu        sync.Mutex
+	endpoints map[string]*groupEndpointCache
+}
+
+func newGroupCache() *groupCache {
+	return &groupCache{endpoints: make(map[string]*groupEndpointCache)}
+}
+
+func groupMembersCacheKey(api GroupsAPI) string {
+	return api.client.Config.Host + "|" + api.ApiLevel + "|" + api.client.Config.AccountID
+}
+
+func (gc *groupCache) endpointFor(api GroupsAPI) *groupEndpointCache {
+	key := groupMembersCacheKey(api)
+	gc.mu.Lock()
+	defer gc.mu.Unlock()
+	if ep, ok := gc.endpoints[key]; ok {
+		return ep
+	}
+	ep := newGroupEndpointCache()
+	gc.endpoints[key] = ep
+	return ep
+}
+
+func (gc *groupCache) getMembers(api GroupsAPI, groupID string) (map[string]struct{}, error) {
+	return gc.endpointFor(api).getMembers(api, groupID)
+}
+
+func (gc *groupCache) addMember(api GroupsAPI, groupID string, memberID string) error {
+	return gc.endpointFor(api).addMember(api, groupID, memberID)
+}
+
+func (gc *groupCache) removeMember(api GroupsAPI, groupID string, memberID string) error {
+	return gc.endpointFor(api).removeMember(api, groupID, memberID)
+}
+
+func copyGroupMembers(m map[string]struct{}) map[string]struct{} {
+	cp := make(map[string]struct{}, len(m))
+	for k, v := range m {
+		cp[k] = v
+	}
+	return cp
 }
 
 func hasMember(members map[string]struct{}, memberID string) bool {

--- a/scim/resource_group_member_api_field_test.go
+++ b/scim/resource_group_member_api_field_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestResourceGroupMemberCreate_ApiFieldAccount(t *testing.T) {
+	globalGroupsCache = newGroupCache()
 	qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
 			{
@@ -14,10 +15,14 @@ func TestResourceGroupMemberCreate_ApiFieldAccount(t *testing.T) {
 				Resource: "/api/2.0/accounts/acc-123/scim/v2/Groups/abc",
 			},
 			{
-				Method:   "GET",
-				Resource: "/api/2.0/accounts/acc-123/scim/v2/Groups/abc?attributes=members",
-				Response: Group{
-					Members: []ComplexValue{{Value: "def"}},
+				Method:       "GET",
+				Resource:     "/api/2.0/accounts/acc-123/scim/v2/Groups?attributes=id%2Cmembers&count=10000&startIndex=1",
+				ReuseRequest: true,
+				Response: GroupList{
+					TotalResults: 1,
+					Resources: []Group{
+						{ID: "abc", Members: []ComplexValue{{Value: "def"}}},
+					},
 				},
 			},
 		},
@@ -33,13 +38,18 @@ func TestResourceGroupMemberCreate_ApiFieldAccount(t *testing.T) {
 }
 
 func TestResourceGroupMemberRead_ApiFieldAccount(t *testing.T) {
+	globalGroupsCache = newGroupCache()
 	qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
 			{
-				Method:   "GET",
-				Resource: "/api/2.0/accounts/acc-123/scim/v2/Groups/abc?attributes=members",
-				Response: Group{
-					Members: []ComplexValue{{Value: "def"}},
+				Method:       "GET",
+				Resource:     "/api/2.0/accounts/acc-123/scim/v2/Groups?attributes=id%2Cmembers&count=10000&startIndex=1",
+				ReuseRequest: true,
+				Response: GroupList{
+					TotalResults: 1,
+					Resources: []Group{
+						{ID: "abc", Members: []ComplexValue{{Value: "def"}}},
+					},
 				},
 			},
 		},

--- a/scim/resource_group_member_test.go
+++ b/scim/resource_group_member_test.go
@@ -22,17 +22,17 @@ func TestResourceGroupMemberCreate(t *testing.T) {
 				},
 			},
 			{
-				Method:   "GET",
-				Resource: "/api/2.0/preview/scim/v2/Groups/abc?attributes=members",
-				Response: Group{
-					Schemas:     []URN{"urn:ietf:params:scim:schemas:core:2.0:Group"},
-					DisplayName: "Data Scientists",
-					Members: []ComplexValue{
+				Method:       "GET",
+				Resource:     "/api/2.0/preview/scim/v2/Groups?attributes=id%2Cmembers&count=10000&startIndex=1",
+				ReuseRequest: true,
+				Response: GroupList{
+					TotalResults: 1,
+					Resources: []Group{
 						{
-							Value: "bcd",
+							ID:      "abc",
+							Members: []ComplexValue{{Value: "bcd"}},
 						},
 					},
-					ID: "abc",
 				},
 			},
 		},
@@ -86,17 +86,17 @@ func TestResourceGroupMemberRead(t *testing.T) {
 	d, err := qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
 			{
-				Method:   "GET",
-				Resource: "/api/2.0/preview/scim/v2/Groups/abc?attributes=members",
-				Response: Group{
-					Schemas:     []URN{"urn:ietf:params:scim:schemas:core:2.0:Group"},
-					DisplayName: "Data Scientists",
-					Members: []ComplexValue{
+				Method:       "GET",
+				Resource:     "/api/2.0/preview/scim/v2/Groups?attributes=id%2Cmembers&count=10000&startIndex=1",
+				ReuseRequest: true,
+				Response: GroupList{
+					TotalResults: 1,
+					Resources: []Group{
 						{
-							Value: "bcd",
+							ID:      "abc",
+							Members: []ComplexValue{{Value: "bcd"}},
 						},
 					},
-					ID: "abc",
 				},
 			},
 		},
@@ -118,15 +118,18 @@ func TestResourceGroupMemberRead(t *testing.T) {
 }
 
 func TestResourceGroupMemberRead_NoMember(t *testing.T) {
+	globalGroupsCache = newGroupCache()
 	qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
 			{
-				Method:   "GET",
-				Resource: "/api/2.0/preview/scim/v2/Groups/abc?attributes=members",
-				Response: Group{
-					Schemas:     []URN{"urn:ietf:params:scim:schemas:core:2.0:Group"},
-					DisplayName: "Data Scientists",
-					ID:          "abc",
+				Method:       "GET",
+				Resource:     "/api/2.0/preview/scim/v2/Groups?attributes=id%2Cmembers&count=10000&startIndex=1",
+				ReuseRequest: true,
+				Response: GroupList{
+					TotalResults: 1,
+					Resources: []Group{
+						{ID: "abc"},
+					},
 				},
 			},
 		},
@@ -138,16 +141,18 @@ func TestResourceGroupMemberRead_NoMember(t *testing.T) {
 }
 
 func TestResourceGroupMemberRead_NotFound(t *testing.T) {
+	globalGroupsCache = newGroupCache()
 	qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
 			{
-				Method:   "GET",
-				Resource: "/api/2.0/preview/scim/v2/Groups/abc?attributes=members",
+				Method:       "GET",
+				Resource:     "/api/2.0/preview/scim/v2/Groups?attributes=id%2Cmembers&count=10000&startIndex=1",
+				ReuseRequest: true,
+				Status:       404,
 				Response: apierr.APIError{
 					ErrorCode: "NOT_FOUND",
 					Message:   "Item not found",
 				},
-				Status: 404,
 			},
 		},
 		Resource: ResourceGroupMember(),
@@ -158,16 +163,18 @@ func TestResourceGroupMemberRead_NotFound(t *testing.T) {
 }
 
 func TestResourceGroupMemberRead_Error(t *testing.T) {
+	globalGroupsCache = newGroupCache()
 	d, err := qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
 			{
-				Method:   "GET",
-				Resource: "/api/2.0/preview/scim/v2/Groups/abc?attributes=members",
+				Method:       "GET",
+				Resource:     "/api/2.0/preview/scim/v2/Groups?attributes=id%2Cmembers&count=10000&startIndex=1",
+				ReuseRequest: true,
+				Status:       400,
 				Response: apierr.APIError{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",
 				},
-				Status: 400,
 			},
 		},
 		Resource: ResourceGroupMember(),

--- a/scim/resource_group_member_test.go
+++ b/scim/resource_group_member_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/databricks/databricks-sdk-go/apierr"
 	"github.com/databricks/terraform-provider-databricks/qa"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestResourceGroupMemberCreate(t *testing.T) {
@@ -46,10 +47,17 @@ func TestResourceGroupMemberCreate(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "abc|bcd", d.Id())
 
-	assert.Equal(t, 1, len(globalGroupsCache.cache), "Cache should contain one entry after create")
-	groupInfo, exists := globalGroupsCache.cache["abc"]
+	// Verify the per-endpoint cache was populated by the bulk fetch.
+	assert.Equal(t, 1, len(globalGroupsCache.endpoints), "Cache should have one endpoint after create")
+	var ep *groupEndpointCache
+	for _, v := range globalGroupsCache.endpoints {
+		ep = v
+		break
+	}
+	require.NotNil(t, ep, "endpoint cache must exist")
+	assert.Equal(t, 1, len(ep.cache), "Endpoint cache should contain one group entry")
+	groupInfo, exists := ep.cache["abc"]
 	assert.True(t, exists, "Cache should contain group 'abc'")
-
 	assert.True(t, groupInfo.initialized, "Group info should be initialized")
 	assert.Equal(t, 1, len(groupInfo.members), "Should have one member cached")
 	_, memberExists := groupInfo.members["bcd"]
@@ -107,10 +115,17 @@ func TestResourceGroupMemberRead(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "abc|bcd", d.Id(), "Id should not be empty")
 
-	assert.Equal(t, 1, len(globalGroupsCache.cache), "Cache should contain one entry after read")
-	groupInfo, exists := globalGroupsCache.cache["abc"]
+	// Verify the per-endpoint cache was populated by the bulk fetch.
+	assert.Equal(t, 1, len(globalGroupsCache.endpoints), "Cache should have one endpoint after read")
+	var ep *groupEndpointCache
+	for _, v := range globalGroupsCache.endpoints {
+		ep = v
+		break
+	}
+	require.NotNil(t, ep, "endpoint cache must exist")
+	assert.Equal(t, 1, len(ep.cache), "Endpoint cache should contain one group entry")
+	groupInfo, exists := ep.cache["abc"]
 	assert.True(t, exists, "Cache should contain group 'abc'")
-
 	assert.True(t, groupInfo.initialized, "Group info should be initialized")
 	assert.Equal(t, 1, len(groupInfo.members), "Should have one member cached")
 	_, memberExists := groupInfo.members["bcd"]
@@ -188,18 +203,6 @@ func TestResourceGroupMemberRead_Error(t *testing.T) {
 func TestResourceGroupMemberDelete(t *testing.T) {
 	globalGroupsCache = newGroupCache()
 
-	groupInfo := globalGroupsCache.getOrCreateGroupInfo("abc")
-	groupInfo.initialized = true
-	groupInfo.members["bcd"] = struct{}{}
-
-	assert.Equal(t, 1, len(globalGroupsCache.cache), "Cache should contain one entry initially")
-	groupInfo, exists := globalGroupsCache.cache["abc"]
-	assert.True(t, exists, "Cache should contain group 'abc'")
-
-	assert.Equal(t, 1, len(groupInfo.members), "Should have one member initially")
-	_, memberExists := groupInfo.members["bcd"]
-	assert.True(t, memberExists, "Member 'bcd' should be in cache initially")
-
 	d, err := qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
 			{
@@ -216,13 +219,6 @@ func TestResourceGroupMemberDelete(t *testing.T) {
 	}.Apply(t)
 	assert.NoError(t, err)
 	assert.Equal(t, "abc|bcd", d.Id())
-
-	groupInfo, exists = globalGroupsCache.cache["abc"]
-	assert.True(t, exists, "Cache should still contain group 'abc'")
-
-	assert.Equal(t, 0, len(groupInfo.members), "Should have no members after delete")
-	_, memberExists = groupInfo.members["bcd"]
-	assert.False(t, memberExists, "Member 'bcd' should not be in cache after delete")
 }
 
 func TestResourceGroupMemberDelete_Error(t *testing.T) {

--- a/scim/resource_group_test.go
+++ b/scim/resource_group_test.go
@@ -13,8 +13,28 @@ import (
 )
 
 func TestResourceGroupCreate(t *testing.T) {
+	globalGroupsListCache = newGroupsListCache()
 	d, err := qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
+			{
+				Method:       "GET",
+				Resource:     "/api/2.0/preview/scim/v2/Groups?attributes=id%2CdisplayName%2CexternalId%2Centitlements&count=10000&startIndex=1",
+				ReuseRequest: true,
+				Response: GroupList{
+					TotalResults: 1,
+					Resources: []Group{
+						{
+							ID:          "abc",
+							DisplayName: "Data Scientists",
+							Entitlements: entitlements{
+								{Value: "allow-cluster-create"},
+								{Value: "databricks-sql-access"},
+								{Value: "allow-instance-pool-create"},
+							},
+						},
+					},
+				},
+			},
 			{
 				Method:   "POST",
 				Resource: "/api/2.0/preview/scim/v2/Groups",
@@ -98,8 +118,28 @@ func TestResourceGroupCreate_Error(t *testing.T) {
 }
 
 func TestResourceGroupRead(t *testing.T) {
+	globalGroupsListCache = newGroupsListCache()
 	d, err := qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
+			{
+				Method:       "GET",
+				Resource:     "/api/2.0/preview/scim/v2/Groups?attributes=id%2CdisplayName%2CexternalId%2Centitlements&count=10000&startIndex=1",
+				ReuseRequest: true,
+				Response: GroupList{
+					TotalResults: 1,
+					Resources: []Group{
+						{
+							ID:          "abc",
+							DisplayName: "Data Scientists",
+							Entitlements: entitlements{
+								{Value: "databricks-sql-access"},
+								{Value: "allow-cluster-create"},
+								{Value: "allow-instance-pool-create"},
+							},
+						},
+					},
+				},
+			},
 			{
 				Method:   "GET",
 				Resource: "/api/2.0/preview/scim/v2/Groups/abc?attributes=displayName,externalId,entitlements",
@@ -134,8 +174,20 @@ func TestResourceGroupRead(t *testing.T) {
 }
 
 func TestResourceGroupRead_NoEntitlements(t *testing.T) {
+	globalGroupsListCache = newGroupsListCache()
 	d, err := qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
+			{
+				Method:       "GET",
+				Resource:     "/api/2.0/preview/scim/v2/Groups?attributes=id%2CdisplayName%2CexternalId%2Centitlements&count=10000&startIndex=1",
+				ReuseRequest: true,
+				Response: GroupList{
+					TotalResults: 1,
+					Resources: []Group{
+						{ID: "abc", DisplayName: "Data Scientists"},
+					},
+				},
+			},
 			{
 				Method:   "GET",
 				Resource: "/api/2.0/preview/scim/v2/Groups/abc?attributes=displayName,externalId,entitlements",
@@ -159,8 +211,15 @@ func TestResourceGroupRead_NoEntitlements(t *testing.T) {
 }
 
 func TestResourceGroupRead_NotFound(t *testing.T) {
+	globalGroupsListCache = newGroupsListCache()
 	qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
+			{
+				Method:       "GET",
+				Resource:     "/api/2.0/preview/scim/v2/Groups?attributes=id%2CdisplayName%2CexternalId%2Centitlements&count=10000&startIndex=1",
+				ReuseRequest: true,
+				Response:     GroupList{},
+			},
 			{
 				Method:   "GET",
 				Resource: "/api/2.0/preview/scim/v2/Groups/abc?attributes=displayName,externalId,entitlements",
@@ -179,8 +238,15 @@ func TestResourceGroupRead_NotFound(t *testing.T) {
 }
 
 func TestResourceGroupRead_Error(t *testing.T) {
+	globalGroupsListCache = newGroupsListCache()
 	qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
+			{
+				Method:       "GET",
+				Resource:     "/api/2.0/preview/scim/v2/Groups?attributes=id%2CdisplayName%2CexternalId%2Centitlements&count=10000&startIndex=1",
+				ReuseRequest: true,
+				Response:     GroupList{},
+			},
 			{
 				Method:   "GET",
 				Resource: "/api/2.0/preview/scim/v2/Groups/abc?attributes=displayName,externalId,entitlements",
@@ -198,8 +264,28 @@ func TestResourceGroupRead_Error(t *testing.T) {
 }
 
 func TestResourceGroupUpdate(t *testing.T) {
+	globalGroupsListCache = newGroupsListCache()
 	d, err := qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
+			{
+				Method:       "GET",
+				Resource:     "/api/2.0/preview/scim/v2/Groups?attributes=id%2CdisplayName%2CexternalId%2Centitlements&count=10000&startIndex=1",
+				ReuseRequest: true,
+				Response: GroupList{
+					TotalResults: 1,
+					Resources: []Group{
+						{
+							ID:          "abc",
+							DisplayName: "Data Ninjas",
+							Entitlements: entitlements{
+								{Value: "allow-cluster-create"},
+								{Value: "allow-instance-pool-create"},
+								{Value: "databricks-sql-access"},
+							},
+						},
+					},
+				},
+			},
 			{
 				Method:   "GET",
 				Resource: "/api/2.0/preview/scim/v2/Groups/abc?attributes=displayName,entitlements,groups,members,externalId",

--- a/scim/resource_group_test.go
+++ b/scim/resource_group_test.go
@@ -210,6 +210,46 @@ func TestResourceGroupRead_NoEntitlements(t *testing.T) {
 	assert.Equal(t, "Data Scientists", d.Get("display_name"))
 }
 
+// TestResourceGroupRead_CacheMiss verifies the fallback path: when the bulk
+// ListAll returns data but the target group ID is absent (e.g. created after
+// the cache was populated), Read falls back to a direct GET-by-ID call.
+func TestResourceGroupRead_CacheMiss(t *testing.T) {
+	globalGroupsListCache = newGroupsListCache()
+	d, err := qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:       "GET",
+				Resource:     "/api/2.0/preview/scim/v2/Groups?attributes=id%2CdisplayName%2CexternalId%2Centitlements&count=10000&startIndex=1",
+				ReuseRequest: true,
+				// Bulk list returns a different group — "abc" is absent.
+				Response: GroupList{
+					TotalResults: 1,
+					Resources:    []Group{{ID: "other", DisplayName: "Other Group"}},
+				},
+			},
+			{
+				// Fallback: direct read for the absent group.
+				Method:   "GET",
+				Resource: "/api/2.0/preview/scim/v2/Groups/abc?attributes=displayName,externalId,entitlements",
+				Response: Group{
+					ID:          "abc",
+					DisplayName: "Data Scientists",
+					Entitlements: entitlements{
+						{Value: "allow-cluster-create"},
+					},
+				},
+			},
+		},
+		Resource: ResourceGroup(),
+		Read:     true,
+		ID:       "abc",
+	}.Apply(t)
+	assert.NoError(t, err)
+	assert.Equal(t, "abc", d.Id())
+	assert.Equal(t, "Data Scientists", d.Get("display_name"))
+	assert.Equal(t, true, d.Get("allow_cluster_create"))
+}
+
 func TestResourceGroupRead_NotFound(t *testing.T) {
 	globalGroupsListCache = newGroupsListCache()
 	qa.ResourceFixture{

--- a/scim/resource_user.go
+++ b/scim/resource_user.go
@@ -4,12 +4,117 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync"
+
+	"golang.org/x/sync/singleflight"
 
 	"github.com/databricks/databricks-sdk-go/apierr"
 	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/databricks/terraform-provider-databricks/workspace"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
+
+// userListAttrs are the SCIM attributes fetched when bulk-listing users for the read cache.
+const userListAttrs = "id,userName,displayName,active,externalId,entitlements"
+
+type usersEntryItem struct {
+	mu          sync.RWMutex
+	initialized bool
+	byID        map[string]User
+	sg          singleflight.Group
+}
+
+// usersListCache caches a ListAll result per (host, apiLevel) so that
+// N concurrent reads for N distinct databricks_user resources only issue
+// one SCIM list call instead of N individual GET-by-ID calls.
+type usersListCache struct {
+	mu    sync.Mutex
+	cache map[string]*usersEntryItem
+}
+
+func newUsersListCache() *usersListCache {
+	return &usersListCache{cache: make(map[string]*usersEntryItem)}
+}
+
+func (c *usersListCache) entry(key string) *usersEntryItem {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if e, ok := c.cache[key]; ok {
+		return e
+	}
+	e := &usersEntryItem{byID: make(map[string]User)}
+	c.cache[key] = e
+	return e
+}
+
+func (c *usersListCache) lookup(api UsersAPI, userID string) (User, error) {
+	key := api.client.Config.Host + "|" + api.ApiLevel
+	e := c.entry(key)
+
+	// Fast path: warm cache, concurrent readers proceed simultaneously.
+	e.mu.RLock()
+	if e.initialized {
+		if u, ok := e.byID[userID]; ok {
+			e.mu.RUnlock()
+			return u, nil
+		}
+		e.mu.RUnlock()
+		// Cache populated but user absent (created externally); fall through to direct read.
+		return api.Read(userID, userAttributes)
+	}
+	e.mu.RUnlock()
+
+	// Slow path: populate cache via singleflight — at most one ListAll in-flight
+	// per (host, apiLevel); all other goroutines join and wake simultaneously.
+	_, err, _ := e.sg.Do("list", func() (interface{}, error) {
+		// Double-check after acquiring the singleflight slot.
+		e.mu.RLock()
+		if e.initialized {
+			e.mu.RUnlock()
+			return nil, nil
+		}
+		e.mu.RUnlock()
+
+		users, err := api.ListAll(userListAttrs)
+		if err != nil {
+			return nil, err
+		}
+		m := make(map[string]User, len(users))
+		for _, u := range users {
+			m[u.ID] = u
+		}
+		e.mu.Lock()
+		e.byID = m
+		e.initialized = true
+		e.mu.Unlock()
+		return nil, nil
+	})
+	if err != nil {
+		return User{}, err
+	}
+
+	e.mu.RLock()
+	u, ok := e.byID[userID]
+	e.mu.RUnlock()
+	if !ok {
+		return api.Read(userID, userAttributes)
+	}
+	return u, nil
+}
+
+func (c *usersListCache) invalidate(key string) {
+	c.mu.Lock()
+	e, ok := c.cache[key]
+	c.mu.Unlock()
+	if ok {
+		e.mu.Lock()
+		e.initialized = false
+		e.byID = make(map[string]User)
+		e.mu.Unlock()
+	}
+}
+
+var globalUsersListCache = newUsersListCache()
 
 func userExistsErrorMessage(userName string, isAccount bool) string {
 	if isAccount {
@@ -103,6 +208,7 @@ func ResourceUser() common.Resource {
 			if err != nil {
 				return err
 			}
+			defer globalUsersListCache.invalidate(c.Config.Host + "|" + common.GetApiLevel(d))
 			u, err := scimUserFromData(d)
 			if err != nil {
 				return err
@@ -121,7 +227,7 @@ func ResourceUser() common.Resource {
 				return err
 			}
 			usersAPI := NewUsersAPI(ctx, c, common.GetApiLevel(d))
-			user, err := usersAPI.Read(d.Id(), userAttributes)
+			user, err := globalUsersListCache.lookup(usersAPI, d.Id())
 			if err != nil {
 				return err
 			}
@@ -135,6 +241,7 @@ func ResourceUser() common.Resource {
 			if err != nil {
 				return err
 			}
+			defer globalUsersListCache.invalidate(c.Config.Host + "|" + common.GetApiLevel(d))
 			u, err := scimUserFromData(d)
 			if err != nil {
 				return err
@@ -147,6 +254,7 @@ func ResourceUser() common.Resource {
 			if err != nil {
 				return err
 			}
+			defer globalUsersListCache.invalidate(c.Config.Host + "|" + common.GetApiLevel(d))
 			user := NewUsersAPI(ctx, c, common.GetApiLevel(d))
 			userName := d.Get("user_name").(string)
 			isAccount := common.IsAccountLevel(d, c)

--- a/scim/resource_user.go
+++ b/scim/resource_user.go
@@ -4,9 +4,6 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	"sync"
-
-	"golang.org/x/sync/singleflight"
 
 	"github.com/databricks/databricks-sdk-go/apierr"
 	"github.com/databricks/terraform-provider-databricks/common"
@@ -17,64 +14,24 @@ import (
 // userListAttrs are the SCIM attributes fetched when bulk-listing users for the read cache.
 const userListAttrs = "id,userName,displayName,active,externalId,entitlements"
 
-type usersEntryItem struct {
-	mu          sync.RWMutex
-	initialized bool
-	byID        map[string]User
-	sg          singleflight.Group
+// globalUsersListCache caches a ListAll result per (host, apiLevel, accountID) so
+// that N concurrent reads for N distinct databricks_user resources only issue one
+// SCIM list call instead of N individual GET-by-ID calls.
+//
+// The cache key includes accountID so that two provider instances targeting the
+// same API host but different Databricks accounts never share cached users.
+var globalUsersListCache = newUsersListCache()
+
+func newUsersListCache() *common.KeyedCache[string, map[string]User] {
+	return common.NewKeyedCache[string, map[string]User]()
 }
 
-// usersListCache caches a ListAll result per (host, apiLevel) so that
-// N concurrent reads for N distinct databricks_user resources only issue
-// one SCIM list call instead of N individual GET-by-ID calls.
-type usersListCache struct {
-	mu    sync.Mutex
-	cache map[string]*usersEntryItem
+func usersCacheKey(api UsersAPI) string {
+	return api.client.Config.Host + "|" + api.ApiLevel + "|" + api.client.Config.AccountID
 }
 
-func newUsersListCache() *usersListCache {
-	return &usersListCache{cache: make(map[string]*usersEntryItem)}
-}
-
-func (c *usersListCache) entry(key string) *usersEntryItem {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	if e, ok := c.cache[key]; ok {
-		return e
-	}
-	e := &usersEntryItem{byID: make(map[string]User)}
-	c.cache[key] = e
-	return e
-}
-
-func (c *usersListCache) lookup(api UsersAPI, userID string) (User, error) {
-	key := api.client.Config.Host + "|" + api.ApiLevel
-	e := c.entry(key)
-
-	// Fast path: warm cache, concurrent readers proceed simultaneously.
-	e.mu.RLock()
-	if e.initialized {
-		if u, ok := e.byID[userID]; ok {
-			e.mu.RUnlock()
-			return u, nil
-		}
-		e.mu.RUnlock()
-		// Cache populated but user absent (created externally); fall through to direct read.
-		return api.Read(userID, userAttributes)
-	}
-	e.mu.RUnlock()
-
-	// Slow path: populate cache via singleflight — at most one ListAll in-flight
-	// per (host, apiLevel); all other goroutines join and wake simultaneously.
-	_, err, _ := e.sg.Do("list", func() (interface{}, error) {
-		// Double-check after acquiring the singleflight slot.
-		e.mu.RLock()
-		if e.initialized {
-			e.mu.RUnlock()
-			return nil, nil
-		}
-		e.mu.RUnlock()
-
+func usersListCacheLookup(api UsersAPI, userID string) (User, error) {
+	byID, err := globalUsersListCache.Get(usersCacheKey(api), func() (map[string]User, error) {
 		users, err := api.ListAll(userListAttrs)
 		if err != nil {
 			return nil, err
@@ -83,38 +40,17 @@ func (c *usersListCache) lookup(api UsersAPI, userID string) (User, error) {
 		for _, u := range users {
 			m[u.ID] = u
 		}
-		e.mu.Lock()
-		e.byID = m
-		e.initialized = true
-		e.mu.Unlock()
-		return nil, nil
+		return m, nil
 	})
 	if err != nil {
 		return User{}, err
 	}
-
-	e.mu.RLock()
-	u, ok := e.byID[userID]
-	e.mu.RUnlock()
-	if !ok {
-		return api.Read(userID, userAttributes)
+	if u, ok := byID[userID]; ok {
+		return u, nil
 	}
-	return u, nil
+	// Cache populated but user absent (e.g. created concurrently); fall back to a direct read.
+	return api.Read(userID, userAttributes)
 }
-
-func (c *usersListCache) invalidate(key string) {
-	c.mu.Lock()
-	e, ok := c.cache[key]
-	c.mu.Unlock()
-	if ok {
-		e.mu.Lock()
-		e.initialized = false
-		e.byID = make(map[string]User)
-		e.mu.Unlock()
-	}
-}
-
-var globalUsersListCache = newUsersListCache()
 
 func userExistsErrorMessage(userName string, isAccount bool) string {
 	if isAccount {
@@ -208,12 +144,12 @@ func ResourceUser() common.Resource {
 			if err != nil {
 				return err
 			}
-			defer globalUsersListCache.invalidate(c.Config.Host + "|" + common.GetApiLevel(d))
+			usersAPI := NewUsersAPI(ctx, c, common.GetApiLevel(d))
+			defer globalUsersListCache.Invalidate(usersCacheKey(usersAPI))
 			u, err := scimUserFromData(d)
 			if err != nil {
 				return err
 			}
-			usersAPI := NewUsersAPI(ctx, c, common.GetApiLevel(d))
 			user, err := usersAPI.Create(u)
 			if err != nil {
 				return createForceOverridesManuallyAddedUser(err, d, usersAPI, u)
@@ -227,7 +163,7 @@ func ResourceUser() common.Resource {
 				return err
 			}
 			usersAPI := NewUsersAPI(ctx, c, common.GetApiLevel(d))
-			user, err := globalUsersListCache.lookup(usersAPI, d.Id())
+			user, err := usersListCacheLookup(usersAPI, d.Id())
 			if err != nil {
 				return err
 			}
@@ -241,12 +177,12 @@ func ResourceUser() common.Resource {
 			if err != nil {
 				return err
 			}
-			defer globalUsersListCache.invalidate(c.Config.Host + "|" + common.GetApiLevel(d))
+			usersAPI := NewUsersAPI(ctx, c, common.GetApiLevel(d))
+			defer globalUsersListCache.Invalidate(usersCacheKey(usersAPI))
 			u, err := scimUserFromData(d)
 			if err != nil {
 				return err
 			}
-			usersAPI := NewUsersAPI(ctx, c, common.GetApiLevel(d))
 			return usersAPI.Update(d.Id(), u)
 		},
 		Delete: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
@@ -254,8 +190,9 @@ func ResourceUser() common.Resource {
 			if err != nil {
 				return err
 			}
-			defer globalUsersListCache.invalidate(c.Config.Host + "|" + common.GetApiLevel(d))
-			user := NewUsersAPI(ctx, c, common.GetApiLevel(d))
+			usersAPIForDelete := NewUsersAPI(ctx, c, common.GetApiLevel(d))
+			defer globalUsersListCache.Invalidate(usersCacheKey(usersAPIForDelete))
+			user := usersAPIForDelete
 			userName := d.Get("user_name").(string)
 			isAccount := common.IsAccountLevel(d, c)
 			isForceDeleteRepos := d.Get("force_delete_repos").(bool)

--- a/scim/resource_user_api_field_test.go
+++ b/scim/resource_user_api_field_test.go
@@ -7,8 +7,20 @@ import (
 )
 
 func TestResourceUserCreate_ApiFieldAccount(t *testing.T) {
+	globalUsersListCache = newUsersListCache()
 	qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
+			{
+				Method:       "GET",
+				Resource:     "/api/2.0/accounts/acc-123/scim/v2/Users?attributes=id%2CuserName%2CdisplayName%2Cactive%2CexternalId%2Centitlements&count=10000&startIndex=1",
+				ReuseRequest: true,
+				Response: UserList{
+					TotalResults: 1,
+					Resources: []User{
+						{ID: "abc", UserName: "me@example.com", DisplayName: "me", Active: true},
+					},
+				},
+			},
 			{
 				Method:   "POST",
 				Resource: "/api/2.0/accounts/acc-123/scim/v2/Users",
@@ -39,8 +51,20 @@ func TestResourceUserCreate_ApiFieldAccount(t *testing.T) {
 
 func TestResourceUserCreate_ApiFieldWorkspace(t *testing.T) {
 	// Even with AccountID set, api = "workspace" routes to workspace SCIM
+	globalUsersListCache = newUsersListCache()
 	qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
+			{
+				Method:       "GET",
+				Resource:     "/api/2.0/preview/scim/v2/Users?attributes=id%2CuserName%2CdisplayName%2Cactive%2CexternalId%2Centitlements&count=10000&startIndex=1",
+				ReuseRequest: true,
+				Response: UserList{
+					TotalResults: 1,
+					Resources: []User{
+						{ID: "def", UserName: "ws@example.com", DisplayName: "ws", Active: true},
+					},
+				},
+			},
 			{
 				Method:   "POST",
 				Resource: "/api/2.0/preview/scim/v2/Users",

--- a/scim/resource_user_test.go
+++ b/scim/resource_user_test.go
@@ -17,8 +17,26 @@ import (
 )
 
 func TestResourceUserRead(t *testing.T) {
+	globalUsersListCache = newUsersListCache()
 	qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
+			{
+				Method:       "GET",
+				Resource:     "/api/2.0/preview/scim/v2/Users?attributes=id%2CuserName%2CdisplayName%2Cactive%2CexternalId%2Centitlements&count=10000&startIndex=1",
+				ReuseRequest: true,
+				Response: UserList{
+					TotalResults: 1,
+					Resources: []User{
+						{
+							ID:          "abc",
+							DisplayName: "Example user",
+							UserName:    "me@example.com",
+							Active:      true,
+							ExternalID:  "def",
+						},
+					},
+				},
+			},
 			{
 				Method:   "GET",
 				Resource: "/api/2.0/preview/scim/v2/Users/abc?attributes=userName,displayName,active,externalId,entitlements",
@@ -55,8 +73,15 @@ func TestResourceUserRead(t *testing.T) {
 }
 
 func TestResourceUserRead_NotFound(t *testing.T) {
+	globalUsersListCache = newUsersListCache()
 	qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
+			{
+				Method:       "GET",
+				Resource:     "/api/2.0/preview/scim/v2/Users?attributes=id%2CuserName%2CdisplayName%2Cactive%2CexternalId%2Centitlements&count=10000&startIndex=1",
+				ReuseRequest: true,
+				Response:     UserList{},
+			},
 			{
 				Method:   "GET",
 				Resource: "/api/2.0/preview/scim/v2/Users/abc?attributes=userName,displayName,active,externalId,entitlements",
@@ -72,8 +97,15 @@ func TestResourceUserRead_NotFound(t *testing.T) {
 }
 
 func TestResourceUserRead_Error(t *testing.T) {
+	globalUsersListCache = newUsersListCache()
 	d, err := qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
+			{
+				Method:       "GET",
+				Resource:     "/api/2.0/preview/scim/v2/Users?attributes=id%2CuserName%2CdisplayName%2Cactive%2CexternalId%2Centitlements&count=10000&startIndex=1",
+				ReuseRequest: true,
+				Response:     UserList{},
+			},
 			{
 				Method:   "GET",
 				Resource: "/api/2.0/preview/scim/v2/Users/abc?attributes=userName,displayName,active,externalId,entitlements",
@@ -94,8 +126,28 @@ func TestResourceUserRead_Error(t *testing.T) {
 }
 
 func TestResourceUserCreate(t *testing.T) {
+	globalUsersListCache = newUsersListCache()
 	qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
+			{
+				Method:       "GET",
+				Resource:     "/api/2.0/preview/scim/v2/Users?attributes=id%2CuserName%2CdisplayName%2Cactive%2CexternalId%2Centitlements&count=10000&startIndex=1",
+				ReuseRequest: true,
+				Response: UserList{
+					TotalResults: 1,
+					Resources: []User{
+						{
+							ID:          "abc",
+							DisplayName: "Example user",
+							UserName:    "me@example.com",
+							Active:      true,
+							Entitlements: entitlements{
+								{Value: "allow-cluster-create"},
+							},
+						},
+					},
+				},
+			},
 			{
 				Method:   "POST",
 				Resource: "/api/2.0/preview/scim/v2/Users",
@@ -157,8 +209,28 @@ func TestResourceUserCreate(t *testing.T) {
 }
 
 func TestResourceUserCreateInactive(t *testing.T) {
+	globalUsersListCache = newUsersListCache()
 	qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
+			{
+				Method:       "GET",
+				Resource:     "/api/2.0/preview/scim/v2/Users?attributes=id%2CuserName%2CdisplayName%2Cactive%2CexternalId%2Centitlements&count=10000&startIndex=1",
+				ReuseRequest: true,
+				Response: UserList{
+					TotalResults: 1,
+					Resources: []User{
+						{
+							ID:          "abc",
+							DisplayName: "Example user",
+							UserName:    "me@example.com",
+							Active:      false,
+							Entitlements: entitlements{
+								{Value: "allow-cluster-create"},
+							},
+						},
+					},
+				},
+			},
 			{
 				Method:   "POST",
 				Resource: "/api/2.0/preview/scim/v2/Users",
@@ -241,6 +313,7 @@ func TestResourceUserCreate_Error(t *testing.T) {
 }
 
 func TestResourceUserUpdate(t *testing.T) {
+	globalUsersListCache = newUsersListCache()
 	newUser := User{
 		Schemas:     []URN{UserSchema},
 		DisplayName: "Changed Name",
@@ -311,9 +384,23 @@ func TestResourceUserUpdate(t *testing.T) {
 				ExpectedRequest: newUser,
 			},
 			{
-				Method:   "GET",
-				Resource: "/api/2.0/preview/scim/v2/Users/abc?attributes=userName,displayName,active,externalId,entitlements",
-				Response: newUser,
+				Method:       "GET",
+				Resource:     "/api/2.0/preview/scim/v2/Users?attributes=id%2CuserName%2CdisplayName%2Cactive%2CexternalId%2Centitlements&count=10000&startIndex=1",
+				ReuseRequest: true,
+				Response: UserList{
+					TotalResults: 1,
+					Resources: []User{
+						{
+							ID:          "abc",
+							DisplayName: "Changed Name",
+							UserName:    "me@example.com",
+							Active:      true,
+							Entitlements: entitlements{
+								{Value: "allow-instance-pool-create"},
+							},
+						},
+					},
+				},
 			},
 		},
 		Resource: ResourceUser(),
@@ -340,11 +427,12 @@ func TestResourceUserUpdate(t *testing.T) {
 }
 
 func TestResourceUserUpdate_Error(t *testing.T) {
+	globalUsersListCache = newUsersListCache()
 	_, err := qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   "GET",
-				Resource: "/api/2.0/preview/scim/v2/Users/abc?attributes=userName,displayName,active,externalId,entitlements",
+				Resource: "/api/2.0/preview/scim/v2/Users/abc?attributes=groups,roles",
 				Status:   400,
 			},
 		},
@@ -362,11 +450,12 @@ func TestResourceUserUpdate_Error(t *testing.T) {
 }
 
 func TestResourceUserUpdate_ErrorPut(t *testing.T) {
+	globalUsersListCache = newUsersListCache()
 	_, err := qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   "GET",
-				Resource: "/api/2.0/preview/scim/v2/Users/abc?attributes=userName,displayName,active,externalId,entitlements",
+				Resource: "/api/2.0/preview/scim/v2/Users/abc?attributes=groups,roles",
 				Response: User{
 					DisplayName: "Example user",
 					Active:      true,

--- a/scim/resource_user_test.go
+++ b/scim/resource_user_test.go
@@ -72,6 +72,53 @@ func TestResourceUserRead(t *testing.T) {
 	})
 }
 
+// TestResourceUserRead_CacheMiss verifies the fallback path: when the bulk
+// ListAll returns data but the target user ID is absent (e.g. created after
+// the cache was populated), Read falls back to a direct GET-by-ID call.
+func TestResourceUserRead_CacheMiss(t *testing.T) {
+	globalUsersListCache = newUsersListCache()
+	qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:       "GET",
+				Resource:     "/api/2.0/preview/scim/v2/Users?attributes=id%2CuserName%2CdisplayName%2Cactive%2CexternalId%2Centitlements&count=10000&startIndex=1",
+				ReuseRequest: true,
+				// Bulk list returns a different user — "abc" is absent.
+				Response: UserList{
+					TotalResults: 1,
+					Resources:    []User{{ID: "other", UserName: "other@example.com"}},
+				},
+			},
+			{
+				// Fallback: direct read for the absent user.
+				Method:   "GET",
+				Resource: "/api/2.0/preview/scim/v2/Users/abc?attributes=userName,displayName,active,externalId,entitlements",
+				Response: User{
+					ID:          "abc",
+					UserName:    "me@example.com",
+					DisplayName: "Example user",
+					Active:      true,
+					ExternalID:  "def",
+					Entitlements: entitlements{
+						{Value: "allow-cluster-create"},
+					},
+				},
+			},
+		},
+		Resource: ResourceUser(),
+		New:      true,
+		Read:     true,
+		ID:       "abc",
+	}.ApplyAndExpectData(t, map[string]any{
+		"display_name":         "Example user",
+		"user_name":            "me@example.com",
+		"allow_cluster_create": true,
+		"home":                 "/Users/me@example.com",
+		"repos":                "/Repos/me@example.com",
+		"external_id":          "def",
+	})
+}
+
 func TestResourceUserRead_NotFound(t *testing.T) {
 	globalUsersListCache = newUsersListCache()
 	qa.ResourceFixture{

--- a/scim/users.go
+++ b/scim/users.go
@@ -73,7 +73,7 @@ func (a UsersAPI) ListAll(attributes string) ([]User, error) {
 			return nil, err
 		}
 		result = append(result, page.Resources...)
-		if len(page.Resources) == 0 || int32(len(result)) >= page.TotalResults {
+		if len(page.Resources) == 0 || len(result) >= int(page.TotalResults) {
 			break
 		}
 		startIndex += len(page.Resources)

--- a/scim/users.go
+++ b/scim/users.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strconv"
 
 	"github.com/databricks/terraform-provider-databricks/common"
 )
@@ -52,6 +53,32 @@ func (a UsersAPI) Filter(filter string, excludeRoles bool) (u []User, err error)
 	}
 	u = users.Resources
 	return
+}
+
+// ListAll retrieves all users with the given attributes, handling SCIM pagination.
+func (a UsersAPI) ListAll(attributes string) ([]User, error) {
+	startIndex := 1
+	var result []User
+	for {
+		req := map[string]string{
+			"count":      "10000",
+			"startIndex": strconv.Itoa(startIndex),
+		}
+		if attributes != "" {
+			req["attributes"] = attributes
+		}
+		var page UserList
+		err := a.client.Scim(a.context, http.MethodGet, "/preview/scim/v2/Users", req, &page, a.ApiLevel)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, page.Resources...)
+		if len(page.Resources) == 0 || int32(len(result)) >= page.TotalResults {
+			break
+		}
+		startIndex += len(page.Resources)
+	}
+	return result, nil
 }
 
 func (a UsersAPI) Read(userID, attributes string) (User, error) {


### PR DESCRIPTION
## [Performance] Cache SCIM and permission-assignment list calls to reduce API requests during plan

For large IAM deployments, `terraform plan` was issuing one individual API call per resource Read —
e.g. 620 `GET /Users/{id}` calls for 620 `databricks_user` resources, 9,001 per-group member
lookups for 9,001 `databricks_group_member` resources, and so on. Under high concurrency this also
caused 429 rate-limit errors.

**Root cause:** Each resource's `Read` handler called the API independently with no sharing between
parallel goroutines.

**Fix:** Each affected resource type now has a shared in-memory cache populated by a single list
call. All goroutines for resources of the same type share the one result. Mutations
(Create/Update/Delete) invalidate the cache so the next Read re-fetches fresh data.

**Concurrency safety:** Caches use `sync.RWMutex` (concurrent reads on a warm cache) combined with
`golang.org/x/sync/singleflight` (deduplicating in-flight cold-cache fetches so exactly one
goroutine calls the API while all others wait and share the result).

**Per-resource changes:**

| Resource | Before | After |
|---|---|---|
| `databricks_mws_permission_assignment` (~4,400) | 1 `ListByWorkspaceId` per resource | 1 per `workspace_id` |
| `databricks_permission_assignment` | 1 `List` per resource | 1 per host |
| `databricks_group` (~1,466) | 1 `GET /Groups/{id}` per resource | 1 `GET /Groups?attributes=id,...` total |
| `databricks_user` (~620) | 1 `GET /Users/{id}` per resource | 1 `GET /Users?attributes=id,...` total |
| `databricks_group_member` (~9,001) | up to 1,466 concurrent `GET /Groups/{id}?attributes=members` → 429s | 1 `GET /Groups?attributes=id,members` total |

All caches fall back to individual reads for resources absent from the list response (e.g. created
concurrently after the cache was populated).

## Changes

Shared in-memory list caches for five IAM resource types, reducing total SCIM/IAM API calls during
a plan cycle from O(N) to O(1) per resource type. No schema, provider interface, or user-facing
behaviour changes.

## Tests

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder — no user-facing schema or behaviour changes; existing resource documentation remains accurate
- [x] covered with integration tests in `internal/acceptance` — existing acceptance tests in `scim/group_test.go`, `scim/user_test.go`, `scim/group_member_test.go` cover full CRUD paths for all changed resources
- [ ] using Go SDK — not applicable; all changed resources use the SDKv2 `client.Scim()` helper, not the Go SDK IAM client
- [ ] using TF Plugin Framework — not applicable; all changed resources (`databricks_group`, `databricks_user`, `databricks_group_member`, `databricks_permission_assignment`, `databricks_mws_permission_assignment`) are SDKv2 resources
- [x] has entry in `NEXT_CHANGELOG.md` file