### PR TITLE
[BLOCKED][Internal] Add HostTypeForTerraform() to decouple host type detection from SDK

### DIFF
--- a/common/client.go
+++ b/common/client.go
@@ -574,6 +574,36 @@ func (c *DatabricksClient) Scim(ctx context.Context, method, path string, reques
 	}, nil, request, response, c.addApiPrefix, c.scimVisitorForLevel(apiLevel))
 }
 
+// HostTypeForTerraform returns the type of host the provider is configured for.
+// This replicates the SDK's Config.HostType() logic so that the Terraform provider
+// can customize host type detection independently from the SDK in the future.
+func (c *DatabricksClient) HostTypeForTerraform() config.HostType {
+	// If host metadata resolved a known host type, use it.
+	if c.Config.ResolvedHostType != config.HostTypeUnknown {
+		return c.Config.ResolvedHostType
+	}
+
+	// Normalize the host to ensure the scheme is present before checking
+	// prefixes. Profiles saved without "https://" (e.g. from user input)
+	// would otherwise fail the prefix check and be misclassified as
+	// workspace hosts.
+	host := c.Config.Host
+	if host != "" && !strings.Contains(host, "://") {
+		host = "https://" + host
+	}
+	accountsPrefixes := []string{
+		"https://accounts.",
+		"https://accounts-dod.",
+	}
+	for _, prefix := range accountsPrefixes {
+		if strings.HasPrefix(host, prefix) {
+			return config.AccountHost
+		}
+	}
+
+	return config.WorkspaceHost
+}
+
 // IsAzure returns true if client is configured for Azure Databricks - either by using AAD auth or with host+token combination
 func (c *DatabricksClient) IsAzure() bool {
 	return c.Config.IsAzure()

--- a/common/client.go
+++ b/common/client.go
@@ -579,8 +579,8 @@ func (c *DatabricksClient) Scim(ctx context.Context, method, path string, reques
 // can customize host type detection independently from the SDK in the future.
 func (c *DatabricksClient) HostTypeForTerraform() config.HostType {
 	// If host metadata resolved a known host type, use it.
-	if c.Config.ResolvedHostType != config.HostTypeUnknown {
-		return c.Config.ResolvedHostType
+	if c.Config.GetResolvedHostType() != config.HostTypeUnknown {
+		return c.Config.GetResolvedHostType()
 	}
 
 	// Normalize the host to ensure the scheme is present before checking

--- a/common/client_test.go
+++ b/common/client_test.go
@@ -499,39 +499,37 @@ func TestGetApiLevel_ReturnsEmptyWhenNotSet(t *testing.T) {
 	assert.Equal(t, "", GetApiLevel(d))
 }
 
-func TestHostTypeForTerraform_ResolvedAccountHost(t *testing.T) {
-	c := &DatabricksClient{
-		DatabricksClient: &client.DatabricksClient{
-			Config: &config.Config{
-				Host:             "https://my-workspace.cloud.databricks.com",
-				ResolvedHostType: config.AccountHost,
-			},
+func newClientWithResolvedHostType(t *testing.T, host string, hostType config.HostType) *DatabricksClient {
+	t.Helper()
+	cfg := &config.Config{
+		Host:  host,
+		Token: "test-token",
+		Loaders: []config.Loader{},
+		HostMetadataResolver: func(ctx context.Context, h string) (*config.HostMetadata, error) {
+			return &config.HostMetadata{HostType: hostType}, nil
 		},
 	}
+	err := cfg.EnsureResolved()
+	require.NoError(t, err)
+	return &DatabricksClient{
+		DatabricksClient: &client.DatabricksClient{
+			Config: cfg,
+		},
+	}
+}
+
+func TestHostTypeForTerraform_ResolvedAccountHost(t *testing.T) {
+	c := newClientWithResolvedHostType(t, "https://my-workspace.cloud.databricks.com", config.AccountHost)
 	assert.Equal(t, config.AccountHost, c.HostTypeForTerraform())
 }
 
 func TestHostTypeForTerraform_ResolvedUnifiedHost(t *testing.T) {
-	c := &DatabricksClient{
-		DatabricksClient: &client.DatabricksClient{
-			Config: &config.Config{
-				Host:             "https://unified.cloud.databricks.com",
-				ResolvedHostType: config.UnifiedHost,
-			},
-		},
-	}
+	c := newClientWithResolvedHostType(t, "https://unified.cloud.databricks.com", config.UnifiedHost)
 	assert.Equal(t, config.UnifiedHost, c.HostTypeForTerraform())
 }
 
 func TestHostTypeForTerraform_ResolvedWorkspaceHost(t *testing.T) {
-	c := &DatabricksClient{
-		DatabricksClient: &client.DatabricksClient{
-			Config: &config.Config{
-				Host:             "https://my-workspace.cloud.databricks.com",
-				ResolvedHostType: config.WorkspaceHost,
-			},
-		},
-	}
+	c := newClientWithResolvedHostType(t, "https://my-workspace.cloud.databricks.com", config.WorkspaceHost)
 	assert.Equal(t, config.WorkspaceHost, c.HostTypeForTerraform())
 }
 
@@ -602,14 +600,7 @@ func TestHostTypeForTerraform_Localhost(t *testing.T) {
 }
 
 func TestHostTypeForTerraform_ResolvedTakesPrecedenceOverURL(t *testing.T) {
-	c := &DatabricksClient{
-		DatabricksClient: &client.DatabricksClient{
-			Config: &config.Config{
-				Host:             "https://my-workspace.cloud.databricks.com",
-				ResolvedHostType: config.AccountHost,
-			},
-		},
-	}
-	// ResolvedHostType takes precedence over URL-based detection
+	// Host URL looks like a workspace, but metadata resolved it as account
+	c := newClientWithResolvedHostType(t, "https://my-workspace.cloud.databricks.com", config.AccountHost)
 	assert.Equal(t, config.AccountHost, c.HostTypeForTerraform())
 }

--- a/common/client_test.go
+++ b/common/client_test.go
@@ -498,3 +498,118 @@ func TestGetApiLevel_ReturnsEmptyWhenNotSet(t *testing.T) {
 	d := schema.TestResourceDataRaw(t, testSchemaWithApiField(), map[string]any{})
 	assert.Equal(t, "", GetApiLevel(d))
 }
+
+func TestHostTypeForTerraform_ResolvedAccountHost(t *testing.T) {
+	c := &DatabricksClient{
+		DatabricksClient: &client.DatabricksClient{
+			Config: &config.Config{
+				Host:             "https://my-workspace.cloud.databricks.com",
+				ResolvedHostType: config.AccountHost,
+			},
+		},
+	}
+	assert.Equal(t, config.AccountHost, c.HostTypeForTerraform())
+}
+
+func TestHostTypeForTerraform_ResolvedUnifiedHost(t *testing.T) {
+	c := &DatabricksClient{
+		DatabricksClient: &client.DatabricksClient{
+			Config: &config.Config{
+				Host:             "https://unified.cloud.databricks.com",
+				ResolvedHostType: config.UnifiedHost,
+			},
+		},
+	}
+	assert.Equal(t, config.UnifiedHost, c.HostTypeForTerraform())
+}
+
+func TestHostTypeForTerraform_ResolvedWorkspaceHost(t *testing.T) {
+	c := &DatabricksClient{
+		DatabricksClient: &client.DatabricksClient{
+			Config: &config.Config{
+				Host:             "https://my-workspace.cloud.databricks.com",
+				ResolvedHostType: config.WorkspaceHost,
+			},
+		},
+	}
+	assert.Equal(t, config.WorkspaceHost, c.HostTypeForTerraform())
+}
+
+func TestHostTypeForTerraform_FallbackAccountsPrefix(t *testing.T) {
+	c := &DatabricksClient{
+		DatabricksClient: &client.DatabricksClient{
+			Config: &config.Config{
+				Host: "https://accounts.cloud.databricks.com",
+			},
+		},
+	}
+	assert.Equal(t, config.AccountHost, c.HostTypeForTerraform())
+}
+
+func TestHostTypeForTerraform_FallbackAccountsDodPrefix(t *testing.T) {
+	c := &DatabricksClient{
+		DatabricksClient: &client.DatabricksClient{
+			Config: &config.Config{
+				Host: "https://accounts-dod.cloud.databricks.com",
+			},
+		},
+	}
+	assert.Equal(t, config.AccountHost, c.HostTypeForTerraform())
+}
+
+func TestHostTypeForTerraform_FallbackWorkspaceHost(t *testing.T) {
+	c := &DatabricksClient{
+		DatabricksClient: &client.DatabricksClient{
+			Config: &config.Config{
+				Host: "https://my-workspace.cloud.databricks.com",
+			},
+		},
+	}
+	assert.Equal(t, config.WorkspaceHost, c.HostTypeForTerraform())
+}
+
+func TestHostTypeForTerraform_NoSchemeAccountsHost(t *testing.T) {
+	c := &DatabricksClient{
+		DatabricksClient: &client.DatabricksClient{
+			Config: &config.Config{
+				Host: "accounts.cloud.databricks.com",
+			},
+		},
+	}
+	assert.Equal(t, config.AccountHost, c.HostTypeForTerraform())
+}
+
+func TestHostTypeForTerraform_EmptyHost(t *testing.T) {
+	c := &DatabricksClient{
+		DatabricksClient: &client.DatabricksClient{
+			Config: &config.Config{
+				Host: "",
+			},
+		},
+	}
+	assert.Equal(t, config.WorkspaceHost, c.HostTypeForTerraform())
+}
+
+func TestHostTypeForTerraform_Localhost(t *testing.T) {
+	c := &DatabricksClient{
+		DatabricksClient: &client.DatabricksClient{
+			Config: &config.Config{
+				Host: "http://localhost:5000",
+			},
+		},
+	}
+	assert.Equal(t, config.WorkspaceHost, c.HostTypeForTerraform())
+}
+
+func TestHostTypeForTerraform_ResolvedTakesPrecedenceOverURL(t *testing.T) {
+	c := &DatabricksClient{
+		DatabricksClient: &client.DatabricksClient{
+			Config: &config.Config{
+				Host:             "https://my-workspace.cloud.databricks.com",
+				ResolvedHostType: config.AccountHost,
+			},
+		},
+	}
+	// ResolvedHostType takes precedence over URL-based detection
+	assert.Equal(t, config.AccountHost, c.HostTypeForTerraform())
+}


### PR DESCRIPTION
  ## Summary
  - Adds `DatabricksClient.HostTypeForTerraform()` method that
  replicates the Go SDK's `Config.HostType()` logic, allowing the
  Terraform provider to customize host type detection independently
  - Uses `ResolvedHostType` from SDK host metadata resolution as the
  primary signal, falling back to URL-prefix matching (`accounts.` /
  `accounts-dod.`) for account host detection
  - Removes dependency on SDK's `Experimental_IsUnifiedHost` and
  `isTesting` checks, which are marked as TODOs for removal in the SDK

  ## Tests
  - 10 unit tests covering:
    - Resolved host type precedence (AccountHost, UnifiedHost,
  WorkspaceHost)
    - URL-prefix fallback for `accounts.` and `accounts-dod.` prefixes
    - Edge cases: no scheme, empty host, localhost
    - ResolvedHostType takes precedence over URL-based detection