### PR TITLE
[Feature] Added support for scoped personal access and obo tokens

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -7,7 +7,7 @@
 ### New Features and Improvements
 * Add resource and data sources for `databricks_ai_search_endpoint`.
 * Add resource and data sources for `databricks_ai_search_index`.
-
+* Added support for scoped personal and ObO access tokens ([#5576](https://github.com/databricks/terraform-provider-databricks/pull/5576)).
 
 ### Bug Fixes
 

--- a/docs/resources/obo_token.md
+++ b/docs/resources/obo_token.md
@@ -74,6 +74,7 @@ The following arguments are required:
 * `application_id` - Application ID of [databricks_service_principal](service_principal.md#application_id) to create a PAT token for.
 * `lifetime_seconds` - (Integer, Optional) The number of seconds before the token expires. Token resource is re-created when it expires. If no lifetime is specified, the token remains valid indefinitely.
 * `comment` - (String, Optional) Comment that describes the purpose of the token.
+* `scopes` - (Optional) list of [API scopes](https://docs.databricks.com/api/azure/workspace/api/scopes) associated with this token.
 * `provider_config` - (Optional) Configure the provider for management through account provider. This block consists of the following fields:
   * `workspace_id` - (Required) Workspace ID which the resource belongs to. This workspace must be part of the account which the provider is configured with.
 

--- a/docs/resources/token.md
+++ b/docs/resources/token.md
@@ -56,6 +56,7 @@ The following arguments are available:
 
 * `lifetime_seconds` - (Optional) (Integer) The lifetime of the token, in seconds. If no lifetime is specified, then expire time will be set to maximum allowed by the workspace configuration or platform.
 * `comment` - (Optional) (String) Comment that will appear on the user's settings page for this token.
+* `scopes` - (Optional) list of [API scopes](https://docs.databricks.com/api/azure/workspace/api/scopes) associated with this token.
 * `provider_config` - (Optional) Configure the provider for management through account provider. This block consists of the following fields:
   * `workspace_id` - (Required) Workspace ID which the resource belongs to. This workspace must be part of the account which the provider is configured with.
 

--- a/mws/resource_mws_workspaces.go
+++ b/mws/resource_mws_workspaces.go
@@ -426,8 +426,10 @@ func CreateTokenIfNeeded(workspacesAPI WorkspacesAPI,
 		return err
 	}
 	tokensAPI := tokens.NewTokensAPI(workspacesAPI.context, client)
-	lifetime := time.Duration(wsToken.Token.LifetimeSeconds) * time.Second
-	token, err := tokensAPI.Create(lifetime, wsToken.Token.Comment)
+	token, err := tokensAPI.Create(tokens.TokenRequest{
+		LifetimeSeconds: wsToken.Token.LifetimeSeconds,
+		Comment:         wsToken.Token.Comment,
+	})
 	if isInvalidClient(err) {
 		return fmt.Errorf("cannot create token: the principal used by Databricks (client ID %s) is not authorized to create a token in this workspace. "+
 			"If this is a UC-enabled workspace, add this client to the workspace, either using databricks_mws_permission_assignment or manually (see https://docs.databricks.com/en/admin/users-groups/service-principals.html#assign-a-service-principal-to-a-workspace-using-the-account-console for instructions). "+

--- a/tokens/api.go
+++ b/tokens/api.go
@@ -1,0 +1,86 @@
+package tokens
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/databricks/databricks-sdk-go/apierr"
+	"github.com/databricks/terraform-provider-databricks/common"
+)
+
+// TokenRequest asks for a token
+type TokenRequest struct {
+	LifetimeSeconds int32    `json:"lifetime_seconds,omitempty"`
+	Comment         string   `json:"comment,omitempty"`
+	Scopes          []string `json:"scopes,omitempty"`
+}
+
+// TokenResponse is a struct that contains information about token that is created from the create tokens api
+type TokenResponse struct {
+	TokenValue string     `json:"token_value,omitempty"`
+	TokenInfo  *TokenInfo `json:"token_info,omitempty"`
+}
+
+// TokenInfo is a struct that contains metadata about a given token
+type TokenInfo struct {
+	TokenID      string `json:"token_id,omitempty"`
+	CreationTime int64  `json:"creation_time,omitempty"`
+	ExpiryTime   int64  `json:"expiry_time,omitempty"`
+	Comment      string `json:"comment,omitempty"`
+}
+
+// TokenList ...
+type TokenList struct {
+	TokenInfos []TokenInfo `json:"token_infos,omitempty"`
+}
+
+// NewTokensAPI creates TokensAPI instance from provider meta
+func NewTokensAPI(ctx context.Context, m any) TokensAPI {
+	return TokensAPI{m.(*common.DatabricksClient), ctx}
+}
+
+// TokensAPI exposes the Secrets API
+type TokensAPI struct {
+	client  *common.DatabricksClient
+	context context.Context
+}
+
+// Create creates a api token given a token request
+func (a TokensAPI) Create(request TokenRequest) (r TokenResponse, err error) {
+	err = a.client.Post(a.context, "/token/create", request, &r)
+	return
+}
+
+// List will list all the token metadata and not the content of the tokens in the workspace
+func (a TokensAPI) List() ([]TokenInfo, error) {
+	var tokenListResult TokenList
+	err := a.client.Get(a.context, "/token/list", nil, &tokenListResult)
+	return tokenListResult.TokenInfos, err
+}
+
+// Read will return the token metadata and not the content of the token
+func (a TokensAPI) Read(tokenID string) (TokenInfo, error) {
+	var tokenInfo TokenInfo
+	tokenList, err := a.List()
+	if err != nil {
+		return tokenInfo, err
+	}
+	for _, tokenInfoRecord := range tokenList {
+		if tokenInfoRecord.TokenID == tokenID {
+			return tokenInfoRecord, nil
+		}
+	}
+	return tokenInfo, &apierr.APIError{
+		ErrorCode:  "NOT_FOUND",
+		StatusCode: 404,
+		Message:    fmt.Sprintf("Unable to locate token: %s", tokenID),
+	}
+}
+
+// Delete will delete the token given a token id
+func (a TokensAPI) Delete(tokenID string) error {
+	err := a.client.Post(a.context, "/token/delete", map[string]string{
+		"token_id": tokenID,
+	}, nil)
+	return common.IgnoreNotFoundError(err) // ignore not found error on delete, as it is idempotent
+}

--- a/tokens/obo_token_test.go
+++ b/tokens/obo_token_test.go
@@ -33,3 +33,30 @@ func TestAccAwsOboTokenResource(t *testing.T) {
 		}`,
 	})
 }
+
+func TestAccAwsOboTokenResource_WithScopes(t *testing.T) {
+	acceptance.UnityWorkspaceLevel(t, acceptance.Step{
+		Template: `
+		// dummy: {env.TEST_GLOBAL_METASTORE_ID}
+		resource "databricks_service_principal" "this" {
+			display_name = "tf-{var.RANDOM}"
+		}
+
+		data "databricks_group" "admins" {
+			display_name = "admins"
+		}
+
+		resource "databricks_group_member" "this" {
+			group_id = data.databricks_group.admins.id
+			member_id = databricks_service_principal.this.id
+		}
+
+		resource "databricks_obo_token" "this" {
+			depends_on = [databricks_group_member.this]
+			application_id = databricks_service_principal.this.application_id
+			comment = "Scoped PAT on behalf of ${databricks_service_principal.this.display_name}"
+			lifetime_seconds = 3600
+			scopes = ["sql", "jobs"]
+		}`,
+	})
+}

--- a/tokens/resource_obo_token.go
+++ b/tokens/resource_obo_token.go
@@ -13,6 +13,8 @@ import (
 
 // OboTokenFields defines the schema fields for OBO token creation.
 type OboTokenFields struct {
+	common.Namespace
+
 	ApplicationID   string   `json:"application_id" tf:"force_new"`
 	LifetimeSeconds int64    `json:"lifetime_seconds,omitempty" tf:"force_new"`
 	Comment         string   `json:"comment,omitempty" tf:"force_new"`
@@ -29,7 +31,6 @@ func ResourceOboToken() common.Resource {
 			}
 			return m
 		})
-	common.AddNamespaceInSchema(oboTokenSchema)
 	common.NamespaceCustomizeSchemaMap(oboTokenSchema)
 	return common.Resource{
 		Schema: oboTokenSchema,

--- a/tokens/resource_obo_token.go
+++ b/tokens/resource_obo_token.go
@@ -2,46 +2,25 @@ package tokens
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"time"
 
+	"github.com/databricks/databricks-sdk-go/apierr"
+	"github.com/databricks/databricks-sdk-go/service/settings"
 	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-type OboToken struct {
-	ApplicationID   string `json:"application_id"`
-	LifetimeSeconds int32  `json:"lifetime_seconds,omitempty"`
-	Comment         string `json:"comment,omitempty"`
-}
-
-func NewTokenManagementAPI(ctx context.Context, m any) TokenManagementAPI {
-	return TokenManagementAPI{m.(*common.DatabricksClient), ctx}
-}
-
-type TokenManagementAPI struct {
-	client  *common.DatabricksClient
-	context context.Context
-}
-
-func (a TokenManagementAPI) CreateTokenOnBehalfOfServicePrincipal(request OboToken) (token TokenResponse, err error) {
-	err = a.client.Post(a.context, "/token-management/on-behalf-of/tokens", request, &token, a.client.AddWorkspaceIdHeader)
-	return
-}
-
-func (a TokenManagementAPI) Delete(tokenID string) error {
-	err := a.client.Delete(a.context, fmt.Sprintf("/token-management/tokens/%s", tokenID), map[string]any{}, a.client.AddWorkspaceIdHeader)
-	return common.IgnoreNotFoundError(err) // ignore not found error on delete, as it is idempotent
-}
-
-func (a TokenManagementAPI) Read(tokenID string) (ti TokenResponse, err error) {
-	err = a.client.Get(a.context, fmt.Sprintf("/token-management/tokens/%s", tokenID), nil, &ti, a.client.AddWorkspaceIdHeader)
-	return
+// OboTokenFields defines the schema fields for OBO token creation.
+type OboTokenFields struct {
+	ApplicationID   string   `json:"application_id" tf:"force_new"`
+	LifetimeSeconds int64    `json:"lifetime_seconds,omitempty" tf:"force_new"`
+	Comment         string   `json:"comment,omitempty" tf:"force_new"`
+	Scopes          []string `json:"scopes,omitempty" tf:"force_new"`
 }
 
 func ResourceOboToken() common.Resource {
-	oboTokenSchema := common.StructToSchema(OboToken{},
+	oboTokenSchema := common.StructToSchema(OboTokenFields{},
 		func(m map[string]*schema.Schema) map[string]*schema.Schema {
 			m["token_value"] = &schema.Schema{
 				Type:      schema.TypeString,
@@ -58,50 +37,66 @@ func ResourceOboToken() common.Resource {
 			return common.NamespaceCustomizeDiff(ctx, d, c)
 		},
 		Create: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
-			newClient, err := c.DatabricksClientForUnifiedProvider(ctx, d)
+			w, err := c.WorkspaceClientUnifiedProvider(ctx, d)
 			if err != nil {
 				return err
 			}
-			var request OboToken
-			common.DataToStructPointer(d, oboTokenSchema, &request)
-			ot, err := NewTokenManagementAPI(ctx, newClient).CreateTokenOnBehalfOfServicePrincipal(request)
+			request := settings.CreateOboTokenRequest{
+				ApplicationId:   d.Get("application_id").(string),
+				LifetimeSeconds: int64(d.Get("lifetime_seconds").(int)),
+				Comment:         d.Get("comment").(string),
+			}
+			scopesRaw := d.Get("scopes").([]any)
+			if len(scopesRaw) > 0 {
+				scopes := make([]string, len(scopesRaw))
+				for i, v := range scopesRaw {
+					scopes[i] = v.(string)
+				}
+				request.Scopes = scopes
+			}
+			ot, err := w.TokenManagement.CreateOboToken(ctx, request)
 			if err != nil {
 				return err
 			}
-			d.SetId(ot.TokenInfo.TokenID)
+			d.SetId(ot.TokenInfo.TokenId)
 			return d.Set("token_value", ot.TokenValue)
 		},
 		Read: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
-			newClient, err := c.DatabricksClientForUnifiedProvider(ctx, d)
+			w, err := c.WorkspaceClientUnifiedProvider(ctx, d)
 			if err != nil {
 				return err
 			}
-			ot, err := NewTokenManagementAPI(ctx, newClient).Read(d.Id())
+			ot, err := w.TokenManagement.Get(ctx, settings.GetTokenManagementRequest{
+				TokenId: d.Id(),
+			})
 			if err != nil {
-				err = common.IgnoreNotFoundError(err)
-				if err != nil {
-					return err
-				}
-				log.Printf("[INFO] OBO token with id %s not found, recreating it", d.Id())
-				d.SetId("")
-			} else { // check if token is expired
-				if ot.TokenInfo.ExpiryTime > 0 && time.Now().UnixMilli() > ot.TokenInfo.ExpiryTime {
-					log.Printf("[INFO] OBO token with id %s is expired, recreating it", d.Id())
+				if apierr.IsMissing(err) {
+					log.Printf("[INFO] OBO token with id %s not found, recreating it", d.Id())
 					d.SetId("")
+					return nil
 				}
+				return err
 			}
-			if d.Id() != "" {
-				// set comment only if token exists
-				d.Set("comment", ot.TokenInfo.Comment)
+			if ot.TokenInfo.ExpiryTime > 0 && time.Now().UnixMilli() > ot.TokenInfo.ExpiryTime {
+				log.Printf("[INFO] OBO token with id %s is expired, recreating it", d.Id())
+				d.SetId("")
+				return nil
 			}
+			d.Set("comment", ot.TokenInfo.Comment)
 			return nil
 		},
 		Delete: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
-			newClient, err := c.DatabricksClientForUnifiedProvider(ctx, d)
+			w, err := c.WorkspaceClientUnifiedProvider(ctx, d)
 			if err != nil {
 				return err
 			}
-			return NewTokenManagementAPI(ctx, newClient).Delete(d.Id())
+			err = w.TokenManagement.Delete(ctx, settings.DeleteTokenManagementRequest{
+				TokenId: d.Id(),
+			})
+			if apierr.IsMissing(err) {
+				return nil
+			}
+			return err
 		},
 	}
 }

--- a/tokens/resource_obo_token_test.go
+++ b/tokens/resource_obo_token_test.go
@@ -5,23 +5,24 @@ import (
 	"time"
 
 	"github.com/databricks/databricks-sdk-go/apierr"
+	"github.com/databricks/databricks-sdk-go/experimental/mocks"
+	"github.com/databricks/databricks-sdk-go/service/settings"
+
 	"github.com/databricks/terraform-provider-databricks/qa"
+	"github.com/stretchr/testify/mock"
 )
 
 func TestResourceOboTokenRead(t *testing.T) {
 	qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:   "GET",
-				Resource: "/api/2.0/token-management/tokens/abc",
-
-				Response: TokenResponse{
-					TokenInfo: &TokenInfo{
-						Comment:    "Hello, world!",
-						ExpiryTime: time.Now().UnixMilli() + 1000,
-					},
+		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
+			w.GetMockTokenManagementAPI().EXPECT().Get(mock.Anything, settings.GetTokenManagementRequest{
+				TokenId: "abc",
+			}).Return(&settings.GetTokenResponse{
+				TokenInfo: &settings.TokenInfo{
+					Comment:    "Hello, world!",
+					ExpiryTime: time.Now().UnixMilli() + 1000,
 				},
-			},
+			}, nil)
 		},
 		Resource: ResourceOboToken(),
 		Read:     true,
@@ -35,18 +36,15 @@ func TestResourceOboTokenRead(t *testing.T) {
 
 func TestResourceOboTokenRead_NoExpire(t *testing.T) {
 	qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:   "GET",
-				Resource: "/api/2.0/token-management/tokens/abc",
-
-				Response: TokenResponse{
-					TokenInfo: &TokenInfo{
-						Comment:    "Hello, world!",
-						ExpiryTime: -1,
-					},
+		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
+			w.GetMockTokenManagementAPI().EXPECT().Get(mock.Anything, settings.GetTokenManagementRequest{
+				TokenId: "abc",
+			}).Return(&settings.GetTokenResponse{
+				TokenInfo: &settings.TokenInfo{
+					Comment:    "Hello, world!",
+					ExpiryTime: -1,
 				},
-			},
+			}, nil)
 		},
 		Resource: ResourceOboToken(),
 		Read:     true,
@@ -60,18 +58,15 @@ func TestResourceOboTokenRead_NoExpire(t *testing.T) {
 
 func TestResourceOboTokenRead_Expired(t *testing.T) {
 	qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:   "GET",
-				Resource: "/api/2.0/token-management/tokens/abc",
-
-				Response: TokenResponse{
-					TokenInfo: &TokenInfo{
-						Comment:    "Hello, world!",
-						ExpiryTime: time.Now().UnixMilli() - 1000,
-					},
+		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
+			w.GetMockTokenManagementAPI().EXPECT().Get(mock.Anything, settings.GetTokenManagementRequest{
+				TokenId: "abc",
+			}).Return(&settings.GetTokenResponse{
+				TokenInfo: &settings.TokenInfo{
+					Comment:    "Hello, world!",
+					ExpiryTime: time.Now().UnixMilli() - 1000,
 				},
-			},
+			}, nil)
 		},
 		Resource: ResourceOboToken(),
 		Read:     true,
@@ -84,35 +79,31 @@ func TestResourceOboTokenRead_Expired(t *testing.T) {
 
 func TestResourceOboTokenRead_Error(t *testing.T) {
 	qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:   "GET",
-				Resource: "/api/2.0/token-management/tokens/abc",
-				Status:   500,
-				Response: apierr.APIError{
-					Message: "nope",
-				},
-			},
+		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
+			w.GetMockTokenManagementAPI().EXPECT().Get(mock.Anything, settings.GetTokenManagementRequest{
+				TokenId: "abc",
+			}).Return(nil, &apierr.APIError{
+				StatusCode: 500,
+				Message:    "nope",
+			})
 		},
 		Resource: ResourceOboToken(),
 		Read:     true,
 		New:      true,
 		ID:       "abc",
 	}.ExpectError(t, "nope")
-
 }
+
 func TestResourceOboTokenRead_NotFound(t *testing.T) {
 	qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:   "GET",
-				Resource: "/api/2.0/token-management/tokens/abc",
-				Response: apierr.APIError{
-					ErrorCode: "NOT_FOUND",
-					Message:   "Token does not exist",
-				},
-				Status: 404,
-			},
+		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
+			w.GetMockTokenManagementAPI().EXPECT().Get(mock.Anything, settings.GetTokenManagementRequest{
+				TokenId: "abc",
+			}).Return(nil, &apierr.APIError{
+				ErrorCode:  "NOT_FOUND",
+				StatusCode: 404,
+				Message:    "Token does not exist",
+			})
 		},
 		Resource: ResourceOboToken(),
 		Read:     true,
@@ -125,15 +116,11 @@ func TestResourceOboTokenRead_NotFound(t *testing.T) {
 
 func TestResourceOboTokenCreate_Error(t *testing.T) {
 	qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:   "POST",
-				Resource: "/api/2.0/token-management/on-behalf-of/tokens",
-				Status:   500,
-				Response: apierr.APIError{
-					Message: "nope",
-				},
-			},
+		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
+			w.GetMockTokenManagementAPI().EXPECT().CreateOboToken(mock.Anything, mock.Anything).Return(nil, &apierr.APIError{
+				StatusCode: 500,
+				Message:    "nope",
+			})
 		},
 		Resource: ResourceOboToken(),
 		Create:   true,
@@ -143,33 +130,27 @@ func TestResourceOboTokenCreate_Error(t *testing.T) {
 
 func TestResourceOboTokenCreate(t *testing.T) {
 	qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:   "POST",
-				Resource: "/api/2.0/token-management/on-behalf-of/tokens",
-				ExpectedRequest: OboToken{
-					ApplicationID:   "abc",
-					LifetimeSeconds: 60,
-					Comment:         "e",
+		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
+			e := w.GetMockTokenManagementAPI().EXPECT()
+			e.CreateOboToken(mock.Anything, settings.CreateOboTokenRequest{
+				ApplicationId:   "abc",
+				LifetimeSeconds: 60,
+				Comment:         "e",
+			}).Return(&settings.CreateOboTokenResponse{
+				TokenValue: "s#Cr3t!11",
+				TokenInfo: &settings.TokenInfo{
+					TokenId:    "bcd",
+					ExpiryTime: time.Now().UnixMilli() + 1000,
 				},
-				Response: TokenResponse{
-					TokenValue: "s#Cr3t!11",
-					TokenInfo: &TokenInfo{
-						TokenID:    "bcd",
-						ExpiryTime: time.Now().UnixMilli() + 1000,
-					},
+			}, nil)
+			e.Get(mock.Anything, settings.GetTokenManagementRequest{
+				TokenId: "bcd",
+			}).Return(&settings.GetTokenResponse{
+				TokenInfo: &settings.TokenInfo{
+					Comment:    "Hello, world!",
+					ExpiryTime: time.Now().UnixMilli() + 1000,
 				},
-			},
-			{
-				Method:   "GET",
-				Resource: "/api/2.0/token-management/tokens/bcd",
-				Response: TokenResponse{
-					TokenInfo: &TokenInfo{
-						Comment:    "Hello, world!",
-						ExpiryTime: time.Now().UnixMilli() + 1000,
-					},
-				},
-			},
+			}, nil)
 		},
 		Resource: ResourceOboToken(),
 		Create:   true,
@@ -187,11 +168,10 @@ func TestResourceOboTokenCreate(t *testing.T) {
 
 func TestResourceOboTokenDelete(t *testing.T) {
 	qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:   "DELETE",
-				Resource: "/api/2.0/token-management/tokens/abc?",
-			},
+		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
+			w.GetMockTokenManagementAPI().EXPECT().Delete(mock.Anything, settings.DeleteTokenManagementRequest{
+				TokenId: "abc",
+			}).Return(nil)
 		},
 		Resource: ResourceOboToken(),
 		Delete:   true,
@@ -202,31 +182,25 @@ func TestResourceOboTokenDelete(t *testing.T) {
 
 func TestResourceOboTokenCreateNoLifetimeOrComment(t *testing.T) {
 	qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:   "POST",
-				Resource: "/api/2.0/token-management/on-behalf-of/tokens",
-				ExpectedRequest: OboToken{
-					ApplicationID: "abc",
+		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
+			e := w.GetMockTokenManagementAPI().EXPECT()
+			e.CreateOboToken(mock.Anything, settings.CreateOboTokenRequest{
+				ApplicationId: "abc",
+			}).Return(&settings.CreateOboTokenResponse{
+				TokenValue: "s#Cr3t!11",
+				TokenInfo: &settings.TokenInfo{
+					TokenId:    "bcd",
+					ExpiryTime: time.Now().UnixMilli() + 1000,
 				},
-				Response: TokenResponse{
-					TokenValue: "s#Cr3t!11",
-					TokenInfo: &TokenInfo{
-						TokenID:    "bcd",
-						ExpiryTime: time.Now().UnixMilli() + 1000,
-					},
+			}, nil)
+			e.Get(mock.Anything, settings.GetTokenManagementRequest{
+				TokenId: "bcd",
+			}).Return(&settings.GetTokenResponse{
+				TokenInfo: &settings.TokenInfo{
+					TokenId:    "bcd",
+					ExpiryTime: time.Now().UnixMilli() + 1000,
 				},
-			},
-			{
-				Method:   "GET",
-				Resource: "/api/2.0/token-management/tokens/bcd",
-				Response: TokenResponse{
-					TokenInfo: &TokenInfo{
-						TokenID:    "bcd",
-						ExpiryTime: time.Now().UnixMilli() + 1000,
-					},
-				},
-			},
+			}, nil)
 		},
 		Resource: ResourceOboToken(),
 		Create:   true,

--- a/tokens/resource_token.go
+++ b/tokens/resource_token.go
@@ -14,8 +14,9 @@ import (
 
 // TokenRequest asks for a token
 type TokenRequest struct {
-	LifetimeSeconds int32  `json:"lifetime_seconds,omitempty"`
-	Comment         string `json:"comment,omitempty"`
+	LifetimeSeconds int32    `json:"lifetime_seconds,omitempty"`
+	Comment         string   `json:"comment,omitempty"`
+	Scopes          []string `json:"scopes,omitempty"`
 }
 
 // TokenResponse is a struct that contains information about token that is created from the create tokens api
@@ -48,17 +49,8 @@ type TokensAPI struct {
 	context context.Context
 }
 
-// Create creates a api token given a expiration duration and a comment
-func (a TokensAPI) Create(tokenLifetime time.Duration, comment string) (r TokenResponse, err error) {
-	request := TokenRequest{}
-	seconds := int32(tokenLifetime.Seconds())
-	if seconds > 0 {
-		request.LifetimeSeconds = seconds
-	}
-	if comment != "" {
-		request.Comment = comment
-	}
-
+// Create creates a api token given a token request
+func (a TokensAPI) Create(request TokenRequest) (r TokenResponse, err error) {
 	err = a.client.Post(a.context, "/token/create", request, &r, a.client.AddWorkspaceIdHeader)
 	return
 }
@@ -110,6 +102,12 @@ func ResourceToken() common.Resource {
 			Optional: true,
 			ForceNew: true,
 		},
+		"scopes": {
+			Type:     schema.TypeList,
+			Optional: true,
+			ForceNew: true,
+			Elem:     &schema.Schema{Type: schema.TypeString},
+		},
 		"token_value": {
 			Type:      schema.TypeString,
 			Computed:  true,
@@ -143,10 +141,9 @@ func ResourceToken() common.Resource {
 			if err != nil {
 				return err
 			}
-			comment := d.Get("comment").(string)
-			lifeTimeSeconds := d.Get("lifetime_seconds").(int)
-			tokenDuration := time.Duration(lifeTimeSeconds) * time.Second
-			tokenResp, err := NewTokensAPI(ctx, newClient).Create(tokenDuration, comment)
+			var request TokenRequest
+			common.DataToStructPointer(d, s, &request)
+			tokenResp, err := NewTokensAPI(ctx, newClient).Create(request)
 			if err != nil {
 				return err
 			}
@@ -168,10 +165,13 @@ func ResourceToken() common.Resource {
 				d.SetId("")
 				return nil
 			}
+			// we need to set the scopes back to the resource data
+			scopes := d.Get("scopes")
 			err = common.StructToData(tokenInfo, s, d)
 			if err != nil {
 				return err
 			}
+			d.Set("scopes", scopes)
 			if tokenInfo.ExpiryTime > 0 && time.Now().UnixMilli() > tokenInfo.ExpiryTime {
 				log.Printf("[INFO] token with id %s is expired, recreating it", d.Id())
 				d.SetId("")

--- a/tokens/resource_token.go
+++ b/tokens/resource_token.go
@@ -2,92 +2,15 @@ package tokens
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"time"
 
 	"github.com/databricks/databricks-sdk-go/apierr"
+	"github.com/databricks/databricks-sdk-go/service/settings"
 	"github.com/databricks/terraform-provider-databricks/common"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
-
-// TokenRequest asks for a token
-type TokenRequest struct {
-	LifetimeSeconds int32    `json:"lifetime_seconds,omitempty"`
-	Comment         string   `json:"comment,omitempty"`
-	Scopes          []string `json:"scopes,omitempty"`
-}
-
-// TokenResponse is a struct that contains information about token that is created from the create tokens api
-type TokenResponse struct {
-	TokenValue string     `json:"token_value,omitempty"`
-	TokenInfo  *TokenInfo `json:"token_info,omitempty"`
-}
-
-// TokenInfo is a struct that contains metadata about a given token
-type TokenInfo struct {
-	TokenID      string `json:"token_id,omitempty"`
-	CreationTime int64  `json:"creation_time,omitempty"`
-	ExpiryTime   int64  `json:"expiry_time,omitempty"`
-	Comment      string `json:"comment,omitempty"`
-}
-
-// TokenList ...
-type TokenList struct {
-	TokenInfos []TokenInfo `json:"token_infos,omitempty"`
-}
-
-// NewTokensAPI creates TokensAPI instance from provider meta
-func NewTokensAPI(ctx context.Context, m any) TokensAPI {
-	return TokensAPI{m.(*common.DatabricksClient), ctx}
-}
-
-// TokensAPI exposes the Secrets API
-type TokensAPI struct {
-	client  *common.DatabricksClient
-	context context.Context
-}
-
-// Create creates a api token given a token request
-func (a TokensAPI) Create(request TokenRequest) (r TokenResponse, err error) {
-	err = a.client.Post(a.context, "/token/create", request, &r, a.client.AddWorkspaceIdHeader)
-	return
-}
-
-// List will list all the token metadata and not the content of the tokens in the workspace
-func (a TokensAPI) List() ([]TokenInfo, error) {
-	var tokenListResult TokenList
-	err := a.client.Get(a.context, "/token/list", nil, &tokenListResult, a.client.AddWorkspaceIdHeader)
-	return tokenListResult.TokenInfos, err
-}
-
-// Read will return the token metadata and not the content of the token
-func (a TokensAPI) Read(tokenID string) (TokenInfo, error) {
-	var tokenInfo TokenInfo
-	tokenList, err := a.List()
-	if err != nil {
-		return tokenInfo, err
-	}
-	for _, tokenInfoRecord := range tokenList {
-		if tokenInfoRecord.TokenID == tokenID {
-			return tokenInfoRecord, nil
-		}
-	}
-	return tokenInfo, &apierr.APIError{
-		ErrorCode:  "NOT_FOUND",
-		StatusCode: 404,
-		Message:    fmt.Sprintf("Unable to locate token: %s", tokenID),
-	}
-}
-
-// Delete will delete the token given a token id
-func (a TokensAPI) Delete(tokenID string) error {
-	err := a.client.Post(a.context, "/token/delete", map[string]string{
-		"token_id": tokenID,
-	}, nil, a.client.AddWorkspaceIdHeader)
-	return common.IgnoreNotFoundError(err) // ignore not found error on delete, as it is idempotent
-}
 
 // ResourceToken refreshes token in case it's expired
 func ResourceToken() common.Resource {
@@ -137,40 +60,56 @@ func ResourceToken() common.Resource {
 			return common.NamespaceCustomizeDiff(ctx, d, c)
 		},
 		Create: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
-			newClient, err := c.DatabricksClientForUnifiedProvider(ctx, d)
+			w, err := c.WorkspaceClientUnifiedProvider(ctx, d)
 			if err != nil {
 				return err
 			}
-			var request TokenRequest
-			common.DataToStructPointer(d, s, &request)
-			tokenResp, err := NewTokensAPI(ctx, newClient).Create(request)
+			request := settings.CreateTokenRequest{
+				LifetimeSeconds: int64(d.Get("lifetime_seconds").(int)),
+				Comment:         d.Get("comment").(string),
+			}
+			scopesRaw := d.Get("scopes").([]any)
+			if len(scopesRaw) > 0 {
+				scopes := make([]string, len(scopesRaw))
+				for i, v := range scopesRaw {
+					scopes[i] = v.(string)
+				}
+				request.Scopes = scopes
+			}
+			tokenResp, err := w.Tokens.Create(ctx, request)
 			if err != nil {
 				return err
 			}
-			d.SetId(tokenResp.TokenInfo.TokenID)
+			d.SetId(tokenResp.TokenInfo.TokenId)
 			return d.Set("token_value", tokenResp.TokenValue)
 		},
 		Read: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
-			newClient, err := c.DatabricksClientForUnifiedProvider(ctx, d)
+			w, err := c.WorkspaceClientUnifiedProvider(ctx, d)
 			if err != nil {
 				return err
 			}
-			tokenInfo, err := NewTokensAPI(ctx, newClient).Read(d.Id())
+			tokenList, err := w.Tokens.ListAll(ctx)
 			if err != nil {
-				err = common.IgnoreNotFoundError(err)
-				if err != nil {
-					return err
+				return err
+			}
+			var tokenInfo *settings.PublicTokenInfo
+			for _, ti := range tokenList {
+				if ti.TokenId == d.Id() {
+					tokenInfo = &ti
+					break
 				}
+			}
+			if tokenInfo == nil {
 				log.Printf("[INFO] token with id %s not found, recreating it", d.Id())
 				d.SetId("")
 				return nil
 			}
 			// we need to set the scopes back to the resource data
 			scopes := d.Get("scopes")
-			err = common.StructToData(tokenInfo, s, d)
-			if err != nil {
-				return err
-			}
+			d.Set("token_id", tokenInfo.TokenId)
+			d.Set("comment", tokenInfo.Comment)
+			d.Set("creation_time", tokenInfo.CreationTime)
+			d.Set("expiry_time", tokenInfo.ExpiryTime)
 			d.Set("scopes", scopes)
 			if tokenInfo.ExpiryTime > 0 && time.Now().UnixMilli() > tokenInfo.ExpiryTime {
 				log.Printf("[INFO] token with id %s is expired, recreating it", d.Id())
@@ -179,11 +118,17 @@ func ResourceToken() common.Resource {
 			return nil
 		},
 		Delete: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
-			newClient, err := c.DatabricksClientForUnifiedProvider(ctx, d)
+			w, err := c.WorkspaceClientUnifiedProvider(ctx, d)
 			if err != nil {
 				return err
 			}
-			return NewTokensAPI(ctx, newClient).Delete(d.Id())
+			err = w.Tokens.Delete(ctx, settings.RevokeTokenRequest{
+				TokenId: d.Id(),
+			})
+			if apierr.IsMissing(err) {
+				return nil
+			}
+			return err
 		},
 	}
 }

--- a/tokens/resource_token_test.go
+++ b/tokens/resource_token_test.go
@@ -5,30 +5,27 @@ import (
 	"time"
 
 	"github.com/databricks/databricks-sdk-go/apierr"
+	"github.com/databricks/databricks-sdk-go/experimental/mocks"
+	"github.com/databricks/databricks-sdk-go/service/settings"
 
 	"github.com/databricks/terraform-provider-databricks/qa"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
 func TestResourceTokenRead(t *testing.T) {
 	creationTime := time.Now().UnixMilli()
 	expiryTime := time.Now().UnixMilli() + 10000
 	d, err := qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:   "GET",
-				Resource: "/api/2.0/token/list",
-				Response: TokenList{
-					TokenInfos: []TokenInfo{
-						{
-							Comment:      "Hello, world!",
-							CreationTime: creationTime,
-							ExpiryTime:   expiryTime,
-							TokenID:      "abc",
-						},
-					},
+		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
+			w.GetMockTokensAPI().EXPECT().ListAll(mock.Anything).Return([]settings.PublicTokenInfo{
+				{
+					Comment:      "Hello, world!",
+					CreationTime: creationTime,
+					ExpiryTime:   expiryTime,
+					TokenId:      "abc",
 				},
-			},
+			}, nil)
 		},
 		Resource: ResourceToken(),
 		Read:     true,
@@ -46,21 +43,15 @@ func TestResourceTokenRead(t *testing.T) {
 func TestResourceTokenRead_NoExpire(t *testing.T) {
 	creationTime := time.Now().UnixMilli()
 	d, err := qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:   "GET",
-				Resource: "/api/2.0/token/list",
-				Response: TokenList{
-					TokenInfos: []TokenInfo{
-						{
-							Comment:      "Hello, world!",
-							CreationTime: creationTime,
-							ExpiryTime:   -1,
-							TokenID:      "abc",
-						},
-					},
+		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
+			w.GetMockTokensAPI().EXPECT().ListAll(mock.Anything).Return([]settings.PublicTokenInfo{
+				{
+					Comment:      "Hello, world!",
+					CreationTime: creationTime,
+					ExpiryTime:   -1,
+					TokenId:      "abc",
 				},
-			},
+			}, nil)
 		},
 		Resource: ResourceToken(),
 		Read:     true,
@@ -77,21 +68,15 @@ func TestResourceTokenRead_NoExpire(t *testing.T) {
 
 func TestResourceTokenRead_NotFound(t *testing.T) {
 	qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:   "GET",
-				Resource: "/api/2.0/token/list",
-				Response: TokenList{
-					TokenInfos: []TokenInfo{
-						{
-							Comment:      "Hello, world!",
-							CreationTime: 10,
-							ExpiryTime:   20,
-							TokenID:      "bcd",
-						},
-					},
+		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
+			w.GetMockTokensAPI().EXPECT().ListAll(mock.Anything).Return([]settings.PublicTokenInfo{
+				{
+					Comment:      "Hello, world!",
+					CreationTime: 10,
+					ExpiryTime:   20,
+					TokenId:      "bcd",
 				},
-			},
+			}, nil)
 		},
 		Resource: ResourceToken(),
 		Read:     true,
@@ -103,21 +88,15 @@ func TestResourceTokenRead_NotFound(t *testing.T) {
 
 func TestResourceTokenRead_Expired(t *testing.T) {
 	qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:   "GET",
-				Resource: "/api/2.0/token/list",
-				Response: TokenList{
-					TokenInfos: []TokenInfo{
-						{
-							Comment:      "Hello, world!",
-							CreationTime: 10,
-							ExpiryTime:   20,
-							TokenID:      "abc",
-						},
-					},
+		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
+			w.GetMockTokensAPI().EXPECT().ListAll(mock.Anything).Return([]settings.PublicTokenInfo{
+				{
+					Comment:      "Hello, world!",
+					CreationTime: 10,
+					ExpiryTime:   20,
+					TokenId:      "abc",
 				},
-			},
+			}, nil)
 		},
 		Resource: ResourceToken(),
 		Read:     true,
@@ -129,16 +108,11 @@ func TestResourceTokenRead_Expired(t *testing.T) {
 
 func TestResourceTokenRead_Error(t *testing.T) {
 	d, err := qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:   "GET",
-				Resource: "/api/2.0/token/list",
-				Response: apierr.APIError{
-					ErrorCode: "INVALID_REQUEST",
-					Message:   "Internal error happened",
-				},
-				Status: 400,
-			},
+		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
+			w.GetMockTokensAPI().EXPECT().ListAll(mock.Anything).Return(nil, &apierr.APIError{
+				ErrorCode: "INVALID_REQUEST",
+				Message:   "Internal error happened",
+			})
 		},
 		Resource: ResourceToken(),
 		Read:     true,
@@ -152,37 +126,26 @@ func TestResourceTokenCreate(t *testing.T) {
 	creationTime := time.Now().UnixMilli()
 	expiryTime := time.Now().UnixMilli() + 10000
 	d, err := qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:   "POST",
-				Resource: "/api/2.0/token/create",
-				ExpectedRequest: TokenRequest{
-					LifetimeSeconds: 300,
-					Comment:         "Hello world!",
-					Scopes:          []string{"scope1", "scope2"},
+		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
+			e := w.GetMockTokensAPI().EXPECT()
+			e.Create(mock.Anything, settings.CreateTokenRequest{
+				LifetimeSeconds: 300,
+				Comment:         "Hello world!",
+				Scopes:          []string{"scope1", "scope2"},
+			}).Return(&settings.CreateTokenResponse{
+				TokenValue: "dapi...",
+				TokenInfo: &settings.PublicTokenInfo{
+					TokenId: "abc",
 				},
-				Response: TokenResponse{
-					TokenValue: "dapi...",
-					TokenInfo: &TokenInfo{
-						TokenID: "abc",
-						// other fields may be irrelevant...
-					},
+			}, nil)
+			e.ListAll(mock.Anything).Return([]settings.PublicTokenInfo{
+				{
+					Comment:      "Hello, world!",
+					CreationTime: creationTime,
+					ExpiryTime:   expiryTime,
+					TokenId:      "abc",
 				},
-			},
-			{
-				Method:   "GET",
-				Resource: "/api/2.0/token/list",
-				Response: TokenList{
-					TokenInfos: []TokenInfo{
-						{
-							Comment:      "Hello, world!",
-							CreationTime: creationTime,
-							ExpiryTime:   expiryTime,
-							TokenID:      "abc",
-						},
-					},
-				},
-			},
+			}, nil)
 		},
 		Resource: ResourceToken(),
 		State: map[string]any{
@@ -201,16 +164,11 @@ func TestResourceTokenCreate(t *testing.T) {
 
 func TestResourceTokenCreate_Error(t *testing.T) {
 	d, err := qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:   "POST",
-				Resource: "/api/2.0/token/create",
-				Response: apierr.APIError{
-					ErrorCode: "INVALID_REQUEST",
-					Message:   "Internal error happened",
-				},
-				Status: 400,
-			},
+		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
+			w.GetMockTokensAPI().EXPECT().Create(mock.Anything, mock.Anything).Return(nil, &apierr.APIError{
+				ErrorCode: "INVALID_REQUEST",
+				Message:   "Internal error happened",
+			})
 		},
 		Resource: ResourceToken(),
 		State: map[string]any{
@@ -227,34 +185,22 @@ func TestResourceTokenCreate_NoExpiration(t *testing.T) {
 	creationTime := time.Now().UnixMilli()
 	expiryTime := time.Now().UnixMilli() + 10000
 	d, err := qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:          "POST",
-				Resource:        "/api/2.0/token/create",
-				ExpectedRequest: TokenRequest{},
-				Response: TokenResponse{
-					TokenValue: "dapi...",
-					TokenInfo: &TokenInfo{
-						TokenID:    "abc",
-						Comment:    "",
-						ExpiryTime: -1,
-					},
+		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
+			e := w.GetMockTokensAPI().EXPECT()
+			e.Create(mock.Anything, settings.CreateTokenRequest{}).Return(&settings.CreateTokenResponse{
+				TokenValue: "dapi...",
+				TokenInfo: &settings.PublicTokenInfo{
+					TokenId:    "abc",
+					ExpiryTime: -1,
 				},
-			},
-			{
-				Method:   "GET",
-				Resource: "/api/2.0/token/list",
-				Response: TokenList{
-					TokenInfos: []TokenInfo{
-						{
-							Comment:      "",
-							CreationTime: creationTime,
-							ExpiryTime:   expiryTime,
-							TokenID:      "abc",
-						},
-					},
+			}, nil)
+			e.ListAll(mock.Anything).Return([]settings.PublicTokenInfo{
+				{
+					CreationTime: creationTime,
+					ExpiryTime:   expiryTime,
+					TokenId:      "abc",
 				},
-			},
+			}, nil)
 		},
 		Resource: ResourceToken(),
 		State:    map[string]any{},
@@ -268,14 +214,10 @@ func TestResourceTokenCreate_NoExpiration(t *testing.T) {
 
 func TestResourceTokenDelete(t *testing.T) {
 	d, err := qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{ // read log output for better stub url...
-				Method:   "POST",
-				Resource: "/api/2.0/token/delete",
-				ExpectedRequest: map[string]string{
-					"token_id": "abc",
-				},
-			},
+		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
+			w.GetMockTokensAPI().EXPECT().Delete(mock.Anything, settings.RevokeTokenRequest{
+				TokenId: "abc",
+			}).Return(nil)
 		},
 		Resource: ResourceToken(),
 		Delete:   true,
@@ -287,17 +229,14 @@ func TestResourceTokenDelete(t *testing.T) {
 
 func TestResourceTokenDelete_NotFoundNoError(t *testing.T) {
 	_, err := qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:   "POST",
-				Resource: "/api/2.0/token/delete",
-				Response: apierr.APIError{
-					ErrorCode:  "NOT_FOUND",
-					StatusCode: 404,
-					Message:    "RESOURCE_DOES_NOT_EXIST secret not found",
-				}, // per documentation this is the error response
-				Status: 404,
-			},
+		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
+			w.GetMockTokensAPI().EXPECT().Delete(mock.Anything, settings.RevokeTokenRequest{
+				TokenId: "abc",
+			}).Return(&apierr.APIError{
+				ErrorCode:  "NOT_FOUND",
+				StatusCode: 404,
+				Message:    "RESOURCE_DOES_NOT_EXIST secret not found",
+			})
 		},
 		Resource: ResourceToken(),
 		Delete:   true,
@@ -308,16 +247,13 @@ func TestResourceTokenDelete_NotFoundNoError(t *testing.T) {
 
 func TestResourceTokenDelete_Error(t *testing.T) {
 	d, err := qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:   "POST",
-				Resource: "/api/2.0/token/delete",
-				Response: apierr.APIError{
-					ErrorCode: "NOT_FOUND",
-					Message:   "Token does not exist",
-				},
-				Status: 400,
-			},
+		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
+			w.GetMockTokensAPI().EXPECT().Delete(mock.Anything, settings.RevokeTokenRequest{
+				TokenId: "abc",
+			}).Return(&apierr.APIError{
+				ErrorCode: "INVALID_REQUEST",
+				Message:   "Internal error happened",
+			})
 		},
 		Resource: ResourceToken(),
 		Delete:   true,

--- a/tokens/resource_token_test.go
+++ b/tokens/resource_token_test.go
@@ -159,6 +159,7 @@ func TestResourceTokenCreate(t *testing.T) {
 				ExpectedRequest: TokenRequest{
 					LifetimeSeconds: 300,
 					Comment:         "Hello world!",
+					Scopes:          []string{"scope1", "scope2"},
 				},
 				Response: TokenResponse{
 					TokenValue: "dapi...",
@@ -187,12 +188,15 @@ func TestResourceTokenCreate(t *testing.T) {
 		State: map[string]any{
 			"comment":          "Hello world!",
 			"lifetime_seconds": 300,
+			"scopes":           []any{"scope1", "scope2"},
 		},
 		Create: true,
 	}.Apply(t)
 	assert.NoError(t, err)
 	assert.Equal(t, "abc", d.Id())
 	assert.Equal(t, "dapi...", d.Get("token_value"))
+	scopes := d.Get("scopes").([]any)
+	assert.Equal(t, []any{"scope1", "scope2"}, scopes)
 }
 
 func TestResourceTokenCreate_Error(t *testing.T) {

--- a/tokens/token_test.go
+++ b/tokens/token_test.go
@@ -14,3 +14,13 @@ func TestAccTokenResource(t *testing.T) {
 		}`,
 	})
 }
+
+func TestAccTokenResource_WithScopes(t *testing.T) {
+	acceptance.WorkspaceLevel(t, acceptance.Step{
+		Template: `resource "databricks_token" "this" {
+			lifetime_seconds = 6000
+			comment = "Testing scoped token"
+			scopes = ["sql", "jobs"]
+		}`,
+	})
+}


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

This feature is now in GA, so it makes sense to add support for it - for both PAT and ObO tokens.
Switched to Go SDK for both resources as well.

`databricks_mws_workspace` still uses the old implementation as it's relatively dangerous changes.

## Tests
<!--
How is this tested? Please see the checklist below and also describe any other relevant tests
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [x] covered with integration tests in `internal/acceptance`
- [x] using Go SDK
- [ ] using TF Plugin Framework
- [x] has entry in `NEXT_CHANGELOG.md` file
