### PR TITLE
Fixed handling of the case when library is removed outside of Terraform

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -10,6 +10,7 @@
 
 * Fix `databricks_metastore` so that updating `external_access_enabled` from `true` to `false` is sent in the PATCH request. Previously the field was silently dropped from the request body, so the change never reached the API.
 * Fixed destroying of UC objects when workspace binding removed before actual destroy ([#5581](https://github.com/databricks/terraform-provider-databricks/pull/5581)).
+* Fixed handling of the case when library is removed outside of Terraform ([#5678](https://github.com/databricks/terraform-provider-databricks/pull/5678)).
 
 ### Documentation
 

--- a/internal/providers/pluginfw/products/library/resource_library.go
+++ b/internal/providers/pluginfw/products/library/resource_library.go
@@ -70,7 +70,13 @@ func readLibrary(ctx context.Context, w *databricks.WorkspaceClient, waitParams 
 			return libraryExtended, d
 		}
 	}
-	d.AddError("failed to find the installed library", fmt.Sprintf("failed to find %s on %s", libraryRep, waitParams.ClusterID))
+	if waitParams.IsRefresh {
+		// During Read, the library may have been removed outside of Terraform (e.g. via UI).
+		// Return nil without error so the caller can remove it from state and trigger re-creation.
+		d.AddWarning("library not found", fmt.Sprintf("library %s not found on cluster %s", libraryRep, waitParams.ClusterID))
+	} else {
+		d.AddError("failed to find the installed library", fmt.Sprintf("failed to find %s on %s", libraryRep, waitParams.ClusterID))
+	}
 	return nil, d
 }
 

--- a/internal/providers/pluginfw/products/library/resource_library_test.go
+++ b/internal/providers/pluginfw/products/library/resource_library_test.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"testing"
 
+	"github.com/databricks/databricks-sdk-go/service/compute"
+	"github.com/databricks/terraform-provider-databricks/common"
+	"github.com/databricks/terraform-provider-databricks/qa"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/stretchr/testify/assert"
@@ -73,4 +76,109 @@ func TestResourceLibrary_ModifyPlan_SkipsDestroyAndNilClient(t *testing.T) {
 	resp := &resource.ModifyPlanResponse{}
 	r.ModifyPlan(context.Background(), req, resp)
 	assert.False(t, resp.Diagnostics.HasError(), "should not error on null plan with nil client")
+}
+
+func TestReadLibrary_NotFoundDuringRefresh(t *testing.T) {
+	qa.HTTPFixturesApply(t, []qa.HTTPFixture{
+		{
+			Method:       "GET",
+			Resource:     "/api/2.0/libraries/cluster-status?cluster_id=test-cluster",
+			ReuseRequest: true,
+			Response: compute.ClusterLibraryStatuses{
+				ClusterId: "test-cluster",
+				LibraryStatuses: []compute.LibraryFullStatus{
+					{
+						Status: "INSTALLED",
+						Library: &compute.Library{
+							Jar: "other.jar",
+						},
+					},
+				},
+			},
+		},
+	}, func(ctx context.Context, client *common.DatabricksClient) {
+		w, err := client.WorkspaceClient()
+		require.NoError(t, err)
+
+		// During refresh (Read), a missing library should return nil with a warning, not an error.
+		// This allows Terraform to detect drift and plan re-creation.
+		result, diags := readLibrary(ctx, w, compute.Wait{
+			ClusterID: "test-cluster",
+			IsRefresh: true,
+		}, "mvn:net.snowflake:spark-snowflake_2.12:3.1.0")
+
+		assert.Nil(t, result)
+		assert.False(t, diags.HasError(), "should not return error during refresh when library is not found")
+		assert.True(t, len(diags.Warnings()) > 0, "should return a warning when library is not found")
+		assert.Contains(t, diags.Warnings()[0].Detail(), "not found on cluster")
+	})
+}
+
+func TestReadLibrary_NotFoundDuringCreate(t *testing.T) {
+	qa.HTTPFixturesApply(t, []qa.HTTPFixture{
+		{
+			Method:       "GET",
+			Resource:     "/api/2.0/libraries/cluster-status?cluster_id=test-cluster",
+			ReuseRequest: true,
+			Response: compute.ClusterLibraryStatuses{
+				ClusterId: "test-cluster",
+				LibraryStatuses: []compute.LibraryFullStatus{
+					{
+						Status: "INSTALLED",
+						Library: &compute.Library{
+							Jar: "other.jar",
+						},
+					},
+				},
+			},
+		},
+	}, func(ctx context.Context, client *common.DatabricksClient) {
+		w, err := client.WorkspaceClient()
+		require.NoError(t, err)
+
+		// During create (IsRunning=true), a missing library should return an error.
+		result, diags := readLibrary(ctx, w, compute.Wait{
+			ClusterID: "test-cluster",
+			IsRunning: true,
+		}, "mvn:net.snowflake:spark-snowflake_2.12:3.1.0")
+
+		assert.Nil(t, result)
+		assert.True(t, diags.HasError(), "should return error during create when library is not found")
+		assert.Contains(t, diags.Errors()[0].Detail(), "failed to find")
+	})
+}
+
+func TestReadLibrary_FoundDuringRefresh(t *testing.T) {
+	qa.HTTPFixturesApply(t, []qa.HTTPFixture{
+		{
+			Method:       "GET",
+			Resource:     "/api/2.0/libraries/cluster-status?cluster_id=test-cluster",
+			ReuseRequest: true,
+			Response: compute.ClusterLibraryStatuses{
+				ClusterId: "test-cluster",
+				LibraryStatuses: []compute.LibraryFullStatus{
+					{
+						Status: "INSTALLED",
+						Library: &compute.Library{
+							Maven: &compute.MavenLibrary{
+								Coordinates: "net.snowflake:spark-snowflake_2.12:3.1.0",
+							},
+						},
+					},
+				},
+			},
+		},
+	}, func(ctx context.Context, client *common.DatabricksClient) {
+		w, err := client.WorkspaceClient()
+		require.NoError(t, err)
+
+		result, diags := readLibrary(ctx, w, compute.Wait{
+			ClusterID: "test-cluster",
+			IsRefresh: true,
+		}, "mvn:net.snowflake:spark-snowflake_2.12:3.1.0")
+
+		assert.False(t, diags.HasError())
+		assert.NotNil(t, result)
+		assert.Equal(t, "test-cluster", result.ClusterId.ValueString())
+	})
 }


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

When reading a library state we did return an error directly when library isn't found - in this case it exited immediately, instead of recreating the resource.  That was handled correctly in SDKv2 implementation.

Fixes #5464

## Tests
<!--
How is this tested? Please see the checklist below and also describe any other relevant tests
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] using Go SDK
- [x] using TF Plugin Framework
- [x] has entry in `NEXT_CHANGELOG.md` file
