### PR TITLE
Fixed child groups collection in `databricks_group` data source

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -12,6 +12,7 @@
 * Fixed destroying of UC objects when workspace binding removed before actual destroy ([#5581](https://github.com/databricks/terraform-provider-databricks/pull/5581)).
 * Fixed handling of the case when library is removed outside of Terraform ([#5678](https://github.com/databricks/terraform-provider-databricks/pull/5678)).
 * Fix `databricks_vector_search_index` hardcoded 15-minute creation timeout: increased default to 75 minutes (consistent with `databricks_vector_search_endpoint`) and made it user-overridable via the `timeouts` block.
+* Fixed child groups collection in `databricks_group` data source ([#5679](https://github.com/databricks/terraform-provider-databricks/pull/5679)).
 
 ### Documentation
 

--- a/scim/data_group.go
+++ b/scim/data_group.go
@@ -81,6 +81,13 @@ func DataSourceGroup() common.Resource {
 					}
 					if strings.HasPrefix(x.Ref, "Groups/") {
 						this.ChildGroups = append(this.ChildGroups, x.Value)
+						if this.Recursive {
+							childGroup, err := groupsAPI.Read(x.Value, groupAttributes)
+							if err != nil {
+								return err
+							}
+							queue = append(queue, childGroup)
+						}
 					}
 					if strings.HasPrefix(x.Ref, "ServicePrincipals/") {
 						this.ServicePrincipals = append(this.ServicePrincipals, x.Value)
@@ -92,13 +99,6 @@ func DataSourceGroup() common.Resource {
 				current.Entitlements.readIntoData(d)
 				for _, x := range current.Groups {
 					this.Groups = append(this.Groups, x.Value)
-					if this.Recursive {
-						childGroup, err := groupsAPI.Read(x.Value, groupAttributes)
-						if err != nil {
-							return err
-						}
-						queue = append(queue, childGroup)
-					}
 				}
 			}
 			this.ExternalID = group.ExternalID

--- a/scim/data_group_test.go
+++ b/scim/data_group_test.go
@@ -51,24 +51,16 @@ func TestDataSourceGroup(t *testing.T) {
 				},
 			},
 			{
+				// Recursive: read child group 1114 to get its members
 				Method:   "GET",
-				Resource: "/api/2.0/preview/scim/v2/Groups/abc?attributes=displayName,members,roles,entitlements,externalId,groups",
+				Resource: "/api/2.0/preview/scim/v2/Groups/1114?attributes=displayName,members,roles,entitlements,externalId,groups",
 				Response: Group{
-					DisplayName: "product",
-					ID:          "abc",
-					Entitlements: []ComplexValue{
-						{
-							Value: "allow-instance-pool-create",
-						},
-					},
-					Roles: []ComplexValue{
-						{
-							Value: "b",
-						},
-					},
+					DisplayName: "child-group",
+					ID:          "1114",
 					Members: []ComplexValue{
 						{
-							Value: "1113",
+							Ref:   "Users/2001",
+							Value: "2001",
 						},
 					},
 				},
@@ -82,16 +74,15 @@ func TestDataSourceGroup(t *testing.T) {
 			"display_name": "ds",
 		},
 	}.ApplyAndExpectData(t, map[string]any{
-		"acl_principal_id":           "groups/ds",
-		"instance_profiles":          []string{"a", "b"},
-		"members":                    []string{"1112", "1113", "1114"},
-		"groups":                     []string{"abc"},
-		"allow_instance_pool_create": true,
-		"allow_cluster_create":       true,
-		"users":                      []string{"1112"},
-		"service_principals":         []string{"1113"},
-		"child_groups":               []string{"1114"},
-		"id":                         "eerste",
+		"acl_principal_id":     "groups/ds",
+		"instance_profiles":    []string{"a"},
+		"members":              []string{"1112", "1113", "1114", "2001"},
+		"groups":               []string{"abc"},
+		"allow_cluster_create": true,
+		"users":                []string{"1112", "2001"},
+		"service_principals":   []string{"1113"},
+		"child_groups":         []string{"1114"},
+		"id":                   "eerste",
 	})
 }
 
@@ -207,14 +198,16 @@ func TestDataSourceGroupAccountClient(t *testing.T) {
 				},
 			},
 			{
+				// Recursive: read child group 1114 to get its members
 				Method:   "GET",
-				Resource: "/api/2.0/accounts/1234567890/scim/v2/Groups/abc?attributes=displayName,members,roles,entitlements,externalId,groups",
+				Resource: "/api/2.0/accounts/1234567890/scim/v2/Groups/1114?attributes=displayName,members,roles,entitlements,externalId,groups",
 				Response: Group{
-					DisplayName: "product",
-					ID:          "abc",
+					DisplayName: "child-group",
+					ID:          "1114",
 					Members: []ComplexValue{
 						{
-							Value: "1113",
+							Ref:   "Users/2001",
+							Value: "2001",
 						},
 					},
 				},
@@ -231,9 +224,9 @@ func TestDataSourceGroupAccountClient(t *testing.T) {
 		},
 	}.ApplyAndExpectData(t, map[string]any{
 		"acl_principal_id":   "groups/ds",
-		"members":            []string{"1112", "1113", "1114"},
+		"members":            []string{"1112", "1113", "1114", "2001"},
 		"groups":             []string{"abc"},
-		"users":              []string{"1112"},
+		"users":              []string{"1112", "2001"},
 		"service_principals": []string{"1113"},
 		"child_groups":       []string{"1114"},
 		"id":                 "eerste",


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

Fixed child groups collection in `databricks_group` data source - we should use only groups from the `Members`, not from `Groups`.

Fixes #5447

## Tests
<!--
How is this tested? Please see the checklist below and also describe any other relevant tests
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [x] using Go SDK
- [x] using TF Plugin Framework
- [x] has entry in `NEXT_CHANGELOG.md` file
