### PR TITLE
Support updating min_qps on vector search endpoints via PatchEndpoint

### DIFF
--- a/vectorsearch/resource_vector_search_endpoint.go
+++ b/vectorsearch/resource_vector_search_endpoint.go
@@ -28,7 +28,7 @@ func ResourceVectorSearchEndpoint() common.Resource {
 			delete(s, "id")
 			delete(s, "custom_tags")
 			for _, field := range []string{"creator", "creation_timestamp", "last_updated_timestamp",
-				"last_updated_user", "endpoint_status", "num_indexes", "effective_budget_policy_id"} {
+				"last_updated_user", "endpoint_status", "num_indexes", "effective_budget_policy_id", "scaling_info"} {
 				common.CustomizeSchemaPath(s, field).SetReadOnly()
 			}
 			common.CustomizeSchemaPath(s).AddNewField("endpoint_id", &schema.Schema{
@@ -37,6 +37,11 @@ func ResourceVectorSearchEndpoint() common.Resource {
 			})
 			common.CustomizeSchemaPath(s).AddNewField("budget_policy_id", &schema.Schema{
 				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			})
+			common.CustomizeSchemaPath(s).AddNewField("min_qps", &schema.Schema{
+				Type:     schema.TypeInt,
 				Optional: true,
 				Computed: true,
 			})
@@ -87,6 +92,9 @@ func ResourceVectorSearchEndpoint() common.Resource {
 			}
 			d.Set("budget_policy_id", endpoint.EffectiveBudgetPolicyId)
 			d.Set("endpoint_id", endpoint.Id)
+			if endpoint.ScalingInfo != nil {
+				d.Set("min_qps", endpoint.ScalingInfo.RequestedMinQps)
+			}
 			return nil
 		},
 		Update: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
@@ -98,6 +106,15 @@ func ResourceVectorSearchEndpoint() common.Resource {
 				_, err := w.VectorSearchEndpoints.UpdateEndpointBudgetPolicy(ctx, vectorsearch.PatchEndpointBudgetPolicyRequest{
 					EndpointName:   d.Id(),
 					BudgetPolicyId: d.Get("budget_policy_id").(string),
+				})
+				if err != nil {
+					return err
+				}
+			}
+			if d.HasChange("min_qps") {
+				_, err := w.VectorSearchEndpoints.PatchEndpoint(ctx, vectorsearch.PatchEndpointRequest{
+					EndpointName: d.Id(),
+					MinQps:       int64(d.Get("min_qps").(int)),
 				})
 				if err != nil {
 					return err

--- a/vectorsearch/resource_vector_search_endpoint_test.go
+++ b/vectorsearch/resource_vector_search_endpoint_test.go
@@ -106,6 +106,48 @@ func TestVectorSearchEndpointCreateTimeoutError(t *testing.T) {
 
 }
 
+func TestVectorSearchEndpointUpdateMinQps(t *testing.T) {
+	qa.ResourceFixture{
+		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
+			e := w.GetMockVectorSearchEndpointsAPI().EXPECT()
+			e.PatchEndpoint(mock.Anything, vectorsearch.PatchEndpointRequest{
+				EndpointName: "abc",
+				MinQps:       10,
+			}).Return(&vectorsearch.EndpointInfo{
+				Id:             "1234-5678",
+				EndpointStatus: &vectorsearch.EndpointStatus{State: "ONLINE"},
+				EndpointType:   "STANDARD",
+				Name:           "abc",
+				ScalingInfo:    &vectorsearch.EndpointScalingInfo{RequestedMinQps: 10},
+			}, nil)
+			e.GetEndpointByEndpointName(mock.Anything, "abc").Return(&vectorsearch.EndpointInfo{
+				Id:             "1234-5678",
+				EndpointStatus: &vectorsearch.EndpointStatus{State: "ONLINE"},
+				EndpointType:   "STANDARD",
+				Name:           "abc",
+				ScalingInfo:    &vectorsearch.EndpointScalingInfo{RequestedMinQps: 10},
+			}, nil)
+		},
+		Resource: ResourceVectorSearchEndpoint(),
+		Update:   true,
+		ID:       "abc",
+		InstanceState: map[string]string{
+			"endpoint_id":   "1234-5678",
+			"name":          "abc",
+			"endpoint_type": "STANDARD",
+			"min_qps":       "5",
+		},
+		HCL: `
+		name          = "abc"
+		endpoint_type = "STANDARD"
+		min_qps       = 10
+		`,
+	}.ApplyAndExpectData(t, map[string]any{
+		"id":      "abc",
+		"min_qps": 10,
+	})
+}
+
 func TestVectorSearchEndpointUpdateBudgetPolicy(t *testing.T) {
 	qa.ResourceFixture{
 		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {


### PR DESCRIPTION
Adds min_qps as an optional+computed field on databricks_vector_search_endpoint. Updates call PatchEndpoint when min_qps changes; reads the value back from ScalingInfo.RequestedMinQps on each read. Also marks scaling_info as read-only to avoid ambiguity. Includes a unit test for the update path.

Co-authored-by: Isaac

## Changes
<!-- Summary of your changes that are easy to understand -->

## Tests
<!--
How is this tested? Please see the checklist below and also describe any other relevant tests
-->

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] using Go SDK
- [ ] using TF Plugin Framework
- [ ] has entry in `NEXT_CHANGELOG.md` file
