### PR TITLE
[Internal] Add `api` field support for `databricks_user` data source

### DIFF
--- a/scim/data_user.go
+++ b/scim/data_user.go
@@ -71,6 +71,7 @@ func DataSourceUser() common.Resource {
 			Computed: true,
 		},
 	}
+	common.AddApiField(s)
 	common.AddNamespaceInSchema(s)
 	common.NamespaceCustomizeSchemaMap(s)
 	return common.Resource{
@@ -80,7 +81,7 @@ func DataSourceUser() common.Resource {
 			if err != nil {
 				return err
 			}
-			usersAPI := NewUsersAPI(ctx, newClient, "")
+			usersAPI := NewUsersAPI(ctx, newClient, common.GetApiLevel(d))
 			user, err := getUser(usersAPI, d.Get("user_id").(string), d.Get("user_name").(string))
 			if err != nil {
 				return err

--- a/scim/data_user_acc_test.go
+++ b/scim/data_user_acc_test.go
@@ -39,3 +39,33 @@ func TestAccUserData(t *testing.T) {
 		Check:    checkUserDataSourcePopulated(t),
 	})
 }
+
+func TestMwsAccDataUserWithApiField(t *testing.T) {
+	acceptance.AccountLevel(t, acceptance.Step{
+		Template: `
+		resource "databricks_user" "this" {
+			user_name = "tf-{var.RANDOM}@example.com"
+			api = "account"
+		}
+		data "databricks_user" "this" {
+			user_name = databricks_user.this.user_name
+			api = "account"
+		}`,
+		Check: checkUserDataSourcePopulated(t),
+	})
+}
+
+func TestAccDataUserWithApiField(t *testing.T) {
+	acceptance.WorkspaceLevel(t, acceptance.Step{
+		Template: `
+		resource "databricks_user" "this" {
+			user_name = "tf-{var.RANDOM}@example.com"
+			api = "workspace"
+		}
+		data "databricks_user" "this" {
+			user_name = databricks_user.this.user_name
+			api = "workspace"
+		}`,
+		Check: checkUserDataSourcePopulated(t),
+	})
+}

--- a/scim/data_user_test.go
+++ b/scim/data_user_test.go
@@ -45,6 +45,103 @@ func TestDataSourceUser(t *testing.T) {
 	assert.Equal(t, d.Get("active"), true)
 }
 
+func TestDataSourceUser_ApiFieldAccount(t *testing.T) {
+	d, err := qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "GET",
+				Resource: "/api/2.0/accounts/acc-123/scim/v2/Users?excludedAttributes=roles&filter=userName%20eq%20%22ds%22",
+				Response: UserList{
+					Resources: []User{
+						{
+							ID:       "123",
+							UserName: "mr.test@example.com",
+							Active:   true,
+						},
+					},
+				},
+			},
+		},
+		Read:        true,
+		NonWritable: true,
+		Resource:    DataSourceUser(),
+		AccountID:   "acc-123",
+		ID:          ".",
+		State: map[string]any{
+			"user_name": "ds",
+			"api":       "account",
+		},
+	}.Apply(t)
+	require.NoError(t, err)
+	assert.Equal(t, "123", d.Id())
+	assert.Equal(t, "account", d.Get("api"))
+}
+
+func TestDataSourceUser_ApiFieldWorkspace(t *testing.T) {
+	// Even with AccountID set, api = "workspace" routes to workspace SCIM
+	d, err := qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "GET",
+				Resource: "/api/2.0/preview/scim/v2/Users?excludedAttributes=roles&filter=userName%20eq%20%22ds%22",
+				Response: UserList{
+					Resources: []User{
+						{
+							ID:       "123",
+							UserName: "mr.test@example.com",
+							Active:   true,
+						},
+					},
+				},
+			},
+		},
+		Read:        true,
+		NonWritable: true,
+		Resource:    DataSourceUser(),
+		AccountID:   "acc-123",
+		ID:          ".",
+		State: map[string]any{
+			"user_name": "ds",
+			"api":       "workspace",
+		},
+	}.Apply(t)
+	require.NoError(t, err)
+	assert.Equal(t, "123", d.Id())
+	assert.Equal(t, "workspace", d.Get("api"))
+}
+
+func TestDataSourceUser_ApiFieldAccount_ById(t *testing.T) {
+	// api = "account" with user_id lookup routes to account SCIM Read endpoint
+	qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "GET",
+				Resource: "/api/2.0/accounts/acc-123/scim/v2/Users/abc?attributes=userName,displayName,externalId,applicationId,active",
+				Response: User{
+					ID:          "abc",
+					UserName:    "acct@example.com",
+					DisplayName: "Acct User",
+					Active:      true,
+				},
+			},
+		},
+		Read:        true,
+		NonWritable: true,
+		Resource:    DataSourceUser(),
+		AccountID:   "acc-123",
+		ID:          ".",
+		State: map[string]any{
+			"user_id": "abc",
+			"api":     "account",
+		},
+	}.ApplyAndExpectData(t, map[string]any{
+		"id":        "abc",
+		"user_name": "acct@example.com",
+		"home":      "/Users/acct@example.com",
+		"active":    true,
+	})
+}
+
 func TestDataSourceUserGerUser(t *testing.T) {
 	qa.HTTPFixturesApply(t, []qa.HTTPFixture{
 		{


### PR DESCRIPTION

  ## Summary
  - Add `api` schema field (`"account"` / `"workspace"`) to the `databricks_user` data source,
  enabling dual workspace/account usage
  - Follows the established pattern used by other dual resources (`databricks_group`,
  `databricks_service_principal`, etc.)
  - Adds unit tests covering account routing, workspace cross-override, and account-by-ID lookup
  - Adds acceptance tests for both workspace-level and account-level usage

  ## Test plan
  - Unit tests: `TestDataSourceUser_ApiFieldAccount`, `TestDataSourceUser_ApiFieldWorkspace`,
  `TestDataSourceUser_ApiFieldAccount_ById` — all pass
  - `make fmt lint ws` — all pass
  - Acceptance tests: `TestAccDataUserWithApiField` (workspace),
  `TestMwsAccDataUserWithApiField` (account) — passed on integration tests

NO_CHANGELOG=true