### PR TITLE
[Internal] Add `api` field support for `databricks_current_config` data source

### DIFF
--- a/mws/data_current_config.go
+++ b/mws/data_current_config.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/databricks/databricks-sdk-go/config"
 	"github.com/databricks/terraform-provider-databricks/common"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
@@ -31,22 +32,38 @@ func cloudTypeFromConfig(cfg *config.Config) string {
 }
 
 func DataSourceCurrentConfiguration() common.Resource {
-	r := common.DataResource(currentConfig{}, func(ctx context.Context, e any, c *common.DatabricksClient) error {
-		data := e.(*currentConfig)
-		data.IsAccount = false
-		if c.Config.HostType() == config.AccountHost {
-			data.AccountId = c.Config.AccountID
-			data.IsAccount = true
-		}
-		data.Host = c.Config.Host
-		if data.Cloud != "" {
-			data.CloudType = data.Cloud
-		} else {
-			data.CloudType = cloudTypeFromConfig(c.Config)
-		}
-		data.AuthType = c.Config.AuthType
-		return nil
+	s := common.StructToSchema(currentConfig{}, func(
+		s map[string]*schema.Schema) map[string]*schema.Schema {
+		s["cloud"].ValidateFunc = validation.StringInSlice(validCloudValues, false)
+		common.AddApiField(s)
+		return s
 	})
-	r.Schema["cloud"].ValidateFunc = validation.StringInSlice(validCloudValues, false)
-	return r
+	common.AddNamespaceInSchema(s)
+	common.NamespaceCustomizeSchemaMap(s)
+	return common.Resource{
+		Schema: s,
+		Read: func(ctx context.Context, d *schema.ResourceData, m *common.DatabricksClient) error {
+			newClient, err := m.DatabricksClientForUnifiedProvider(ctx, d)
+			if err != nil {
+				return err
+			}
+			var data currentConfig
+			common.DataToStructPointer(d, s, &data)
+			data.IsAccount = false
+			if common.IsAccountLevel(d, newClient) {
+				data.AccountId = newClient.Config.AccountID
+				data.IsAccount = true
+			}
+			data.Host = newClient.Config.Host
+			if data.Cloud != "" {
+				data.CloudType = data.Cloud
+			} else {
+				data.CloudType = cloudTypeFromConfig(newClient.Config)
+			}
+			data.AuthType = newClient.Config.AuthType
+			common.StructToData(&data, s, d)
+			d.SetId("_")
+			return nil
+		},
+	}
 }

--- a/mws/data_current_config_acc_test.go
+++ b/mws/data_current_config_acc_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/databricks/terraform-provider-databricks/internal/acceptance"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -113,5 +114,23 @@ func TestMwsAccDataCurrentConfigCloudOverride(t *testing.T) {
 			cloud = "aws"
 		}`,
 		Check: checkCurrentConfigWithCloud(t, "aws", "true", "aws"),
+	})
+}
+
+func TestAccDataCurrentConfigWithApiField(t *testing.T) {
+	acceptance.WorkspaceLevel(t, acceptance.Step{
+		Template: `data "databricks_current_config" "this" {
+			api = "workspace"
+		}`,
+		Check: resource.TestCheckResourceAttr("data.databricks_current_config.this", "is_account", "false"),
+	})
+}
+
+func TestMwsAccDataCurrentConfigWithApiField(t *testing.T) {
+	acceptance.AccountLevel(t, acceptance.Step{
+		Template: `data "databricks_current_config" "this" {
+			api = "account"
+		}`,
+		Check: resource.TestCheckResourceAttr("data.databricks_current_config.this", "is_account", "true"),
 	})
 }

--- a/mws/data_current_config_test.go
+++ b/mws/data_current_config_test.go
@@ -103,3 +103,49 @@ func TestDataSourceCurrentConfigCloudOverrideAccountLevel(t *testing.T) {
 		"cloud":      "aws",
 	})
 }
+
+func TestDataSourceCurrentConfig_ApiFieldAccount(t *testing.T) {
+	// api = "account" without AccountID → is_account = true, account_id = ""
+	qa.ResourceFixture{
+		Fixtures:    []qa.HTTPFixture{},
+		Read:        true,
+		NonWritable: true,
+		Resource:    DataSourceCurrentConfiguration(),
+		ID:          ".",
+		HCL:         `api = "account"`,
+	}.ApplyAndExpectData(t, map[string]any{
+		"is_account": true,
+		"account_id": "",
+	})
+}
+
+func TestDataSourceCurrentConfig_ApiFieldWorkspace(t *testing.T) {
+	// Cross-override: api = "workspace" WITH AccountID → is_account = false
+	qa.ResourceFixture{
+		Fixtures:    []qa.HTTPFixture{},
+		Read:        true,
+		NonWritable: true,
+		Resource:    DataSourceCurrentConfiguration(),
+		ID:          ".",
+		AccountID:   "acc-123",
+		HCL:         `api = "workspace"`,
+	}.ApplyAndExpectData(t, map[string]any{
+		"is_account": false,
+	})
+}
+
+func TestDataSourceCurrentConfig_ApiFieldAccountWithCloud(t *testing.T) {
+	// api = "account" + cloud = "gcp" → is_account = true, cloud_type = "gcp"
+	qa.ResourceFixture{
+		Fixtures:    []qa.HTTPFixture{},
+		Read:        true,
+		NonWritable: true,
+		Resource:    DataSourceCurrentConfiguration(),
+		ID:          ".",
+		HCL:         "api = \"account\"\ncloud = \"gcp\"",
+	}.ApplyAndExpectData(t, map[string]any{
+		"is_account": true,
+		"cloud_type": "gcp",
+		"cloud":      "gcp",
+	})
+}


### PR DESCRIPTION
  ## Summary
  - Refactor `databricks_current_config` from deprecated `DataResource()` to manual
  `Resource{Schema, Read}` pattern (matching `data_group` approach)
  - Add `api` schema field (`"account"` / `"workspace"`) for dual workspace/account usage
  - Use `IsAccountLevel(d, c)` instead of `HostType`-based inference for explicit control
  - Fully backward compatible — existing configs without `api` fall back to host inference

  ## Test plan
  - [x] Unit tests: `TestDataSourceCurrentConfig_ApiFieldAccount`, `_ApiFieldWorkspace`,
  `_ApiFieldAccountWithCloud` — all pass
  - [x] `make fmt lint ws` — all pass
  - Acceptance tests: `TestAccDataCurrentConfigWithApiField` (workspace),
  `TestMwsAccDataCurrentConfigWithApiField` (account) passed on the integration tests

NO_CHANGELOG=true