### PR TITLE
[Feature] Add `principal_id` support to `databricks_git_credential` for service principal credential management

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Documentation
 
+* Documented `principal_id` argument for `databricks_git_credential` resource, allowing management of Git credentials on behalf of service principals.
+
 ### Exporter
 
 ### Internal Changes

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -6,13 +6,21 @@
 
 ### New Features and Improvements
 
+* Added `principal_id` argument to `databricks_git_credential` resource, enabling management of Git credentials on behalf of service principals.
+* Add resource and data source for `databricks_postgres_catalog`.
+* Add resource and data source for `databricks_postgres_synced_table`.
+* Add resource and data sources for `databricks_environments_workspace_base_environment`.
+* Add resource and data source for `databricks_environments_default_workspace_base_environment`.
+
+* Added optional `cloud` argument to `databricks_current_config` data source to explicitly set the cloud type (`aws`, `azure`, `gcp`) instead of relying on host-based detection.
+
+* Added `api` field to dual account/workspace resources (`databricks_user`, `databricks_service_principal`, `databricks_group`, `databricks_group_role`, `databricks_group_member`, `databricks_user_role`, `databricks_service_principal_role`, `databricks_user_instance_profile`, `databricks_group_instance_profile`, `databricks_metastore`, `databricks_metastore_assignment`, `databricks_metastore_data_access`, `databricks_storage_credential`, `databricks_service_principal_secret`, `databricks_access_control_rule_set`) to explicitly control whether account-level or workspace-level APIs are used. This enables support for unified hosts like `api.databricks.com` where the API level cannot be inferred from the host ([#5483](https://github.com/databricks/terraform-provider-databricks/pull/5483)).
+
 ### Bug Fixes
 
 * Fix `databricks_metastore` so that updating `external_access_enabled` from `true` to `false` is sent in the PATCH request. Previously the field was silently dropped from the request body, so the change never reached the API.
 
 ### Documentation
-
-* Documented `principal_id` argument for `databricks_git_credential` resource, allowing management of Git credentials on behalf of service principals.
 
 ### Exporter
 

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -22,6 +22,8 @@
 
 ### Documentation
 
+* Documented `principal_id` argument for `databricks_git_credential` resource.
+
 ### Exporter
 
 ### Internal Changes

--- a/docs/resources/git_credential.md
+++ b/docs/resources/git_credential.md
@@ -31,6 +31,19 @@ resource "databricks_git_credential" "ado" {
 }
 ```
 
+### Git credential for a service principal
+
+You can manage Git credentials on behalf of a service principal by specifying `principal_id`:
+
+```hcl
+resource "databricks_git_credential" "spn" {
+  git_provider          = "gitHub"
+  git_username          = "my-service-principal"
+  personal_access_token = var.github_pat
+  principal_id          = var.databricks_spn_id
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -41,6 +54,7 @@ The following arguments are supported:
 * `git_provider` -  (Required) case insensitive name of the Git provider.  Following values are supported right now (could be a subject for a change, consult [Git Credentials API documentation](https://docs.databricks.com/dev-tools/api/latest/gitcredentials.html)): `gitHub`, `gitHubEnterprise`, `bitbucketCloud`, `bitbucketServer`, `azureDevOpsServices`, `gitLab`, `gitLabEnterpriseEdition`, `awsCodeCommit`, `azureDevOpsServicesAad`.
 * `is_default_for_provider` - (Optional) boolean flag specifying if the credential is the default for the given provider type.
 * `name` - (Optional) the name of the git credential, used for identification and ease of lookup.
+* `principal_id` - (Optional) The ID of the service principal whose credentials will be managed. Only service principal managers can use this field. When specified, the git credential is created or updated for the given service principal instead of the calling user.
 * `force` - (Optional) specify if settings need to be enforced (i.e., to overwrite previously set credential for service principals).
 * `provider_config` - (Optional) Configure the provider for management through account provider. This block consists of the following fields:
   * `workspace_id` - (Required) Workspace ID which the resource belongs to. This workspace must be part of the account which the provider is configured with.

--- a/repos/resource_git_credential.go
+++ b/repos/resource_git_credential.go
@@ -60,9 +60,10 @@ func ResourceGitCredential() common.Resource {
 				if !d.Get("force").(bool) || !isOnlyOneGitCredentialForProviderError(err) {
 					return err
 				}
-				var listRequest workspace.ListCredentialsRequest
-				common.DataToStructPointer(d, s, &listRequest)
-				creds, err := w.GitCredentials.ListAll(ctx, listRequest)
+				principalId := int64(d.Get("principal_id").(int))
+				creds, err := w.GitCredentials.ListAll(ctx, workspace.ListCredentialsRequest{
+					PrincipalId: principalId,
+				})
 				if err != nil {
 					return err
 				}
@@ -91,7 +92,11 @@ func ResourceGitCredential() common.Resource {
 			if err != nil {
 				return err
 			}
-			resp, err := w.GitCredentials.Get(ctx, workspace.GetCredentialsRequest{CredentialId: cred_id})
+			principalId := int64(d.Get("principal_id").(int))
+			resp, err := w.GitCredentials.Get(ctx, workspace.GetCredentialsRequest{
+				CredentialId: cred_id,
+				PrincipalId:  principalId,
+			})
 			if err != nil {
 				return err
 			}
@@ -129,7 +134,11 @@ func ResourceGitCredential() common.Resource {
 			if err != nil {
 				return err
 			}
-			return w.GitCredentials.DeleteByCredentialId(ctx, cred_id)
+			principalId := int64(d.Get("principal_id").(int))
+			return w.GitCredentials.Delete(ctx, workspace.DeleteCredentialsRequest{
+				CredentialId: cred_id,
+				PrincipalId:  principalId,
+			})
 		},
 	}
 }

--- a/repos/resource_git_credential_test.go
+++ b/repos/resource_git_credential_test.go
@@ -60,7 +60,9 @@ func TestResourceGitCredentialDelete(t *testing.T) {
 	qa.ResourceFixture{
 		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
 			w.GetMockGitCredentialsAPI().EXPECT().
-				DeleteByCredentialId(mock.Anything, credID).
+				Delete(mock.Anything, workspace.DeleteCredentialsRequest{
+					CredentialId: credID,
+				}).
 				Return(nil)
 		},
 		Resource: ResourceGitCredential(),
@@ -167,7 +169,10 @@ func TestResourceGitCredentialCreateWithPrincipalId(t *testing.T) {
 				PrincipalId:         int64(principalID),
 			}).
 				Return(&resp, nil)
-			gmock.Get(mock.Anything, workspace.GetCredentialsRequest{CredentialId: resp.CredentialId}).
+			gmock.Get(mock.Anything, workspace.GetCredentialsRequest{
+				CredentialId: resp.CredentialId,
+				PrincipalId:  int64(principalID),
+			}).
 				Return(&workspace.GetCredentialsResponse{
 					CredentialId: resp.CredentialId,
 					GitProvider:  provider,
@@ -188,6 +193,32 @@ func TestResourceGitCredentialCreateWithPrincipalId(t *testing.T) {
 		"git_username": user,
 		"principal_id": principalID,
 	})
+}
+
+func TestResourceGitCredentialDeleteWithPrincipalId(t *testing.T) {
+	credID := int64(48155820875912)
+	credIDStr := fmt.Sprintf("%d", credID)
+	principalID := int64(123456789)
+
+	qa.ResourceFixture{
+		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
+			w.GetMockGitCredentialsAPI().EXPECT().
+				Delete(mock.Anything, workspace.DeleteCredentialsRequest{
+					CredentialId: credID,
+					PrincipalId:  principalID,
+				}).
+				Return(nil)
+		},
+		Resource: ResourceGitCredential(),
+		Delete:   true,
+		ID:       credIDStr,
+		HCL: fmt.Sprintf(`
+		git_provider          = "gitHub"
+		git_username          = "test"
+		personal_access_token = "12345"
+		principal_id          = %d
+		`, principalID),
+	}.ApplyAndExpectData(t, map[string]any{"id": credIDStr})
 }
 
 func TestResourceGitCredentialCreate(t *testing.T) {

--- a/repos/resource_git_credential_test.go
+++ b/repos/resource_git_credential_test.go
@@ -146,6 +146,50 @@ func TestResourceGitCredentialUpdate_Error(t *testing.T) {
 	}.ExpectError(t, "Git credential with the given ID could not be found.")
 }
 
+func TestResourceGitCredentialCreateWithPrincipalId(t *testing.T) {
+	provider := "gitHub"
+	user := "test"
+	token := "12345"
+	principalID := 123456789
+	resp := workspace.CreateCredentialsResponse{
+		CredentialId: 121232342,
+		GitProvider:  provider,
+		GitUsername:  user,
+	}
+
+	qa.ResourceFixture{
+		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
+			gmock := w.GetMockGitCredentialsAPI().EXPECT()
+			gmock.Create(mock.Anything, workspace.CreateCredentialsRequest{
+				GitProvider:         provider,
+				GitUsername:         user,
+				PersonalAccessToken: token,
+				PrincipalId:         int64(principalID),
+			}).
+				Return(&resp, nil)
+			gmock.Get(mock.Anything, workspace.GetCredentialsRequest{CredentialId: resp.CredentialId}).
+				Return(&workspace.GetCredentialsResponse{
+					CredentialId: resp.CredentialId,
+					GitProvider:  provider,
+					GitUsername:  user,
+				}, nil)
+		},
+		Resource: ResourceGitCredential(),
+		State: map[string]any{
+			"git_provider":          provider,
+			"git_username":          user,
+			"personal_access_token": token,
+			"principal_id":          principalID,
+		},
+		Create: true,
+	}.ApplyAndExpectData(t, map[string]any{
+		"id":           fmt.Sprintf("%d", resp.CredentialId),
+		"git_provider": provider,
+		"git_username": user,
+		"principal_id": principalID,
+	})
+}
+
 func TestResourceGitCredentialCreate(t *testing.T) {
 	provider := "gitHub"
 	user := "test"


### PR DESCRIPTION
## Changes

The Databricks Go SDK already supports `principal_id` in Git Credentials API requests, but the Terraform resource did not expose it. This meant there was no way to manage Git credentials on behalf of service principals.

This PR adds the `principal_id` argument to `databricks_git_credential` and passes it through all CRUD operations (Create, Read, Delete, and force-List). Without `principal_id` in Read/Delete/List, the API searches the calling user's credentials instead of the target service principal's, resulting in errors like:

```
databricks_git_credential.this: Creating...
╷
│ Error: cannot read git credential: Git credential with id <credential_id> could not be found.
│
│   with databricks_git_credential.this,
│   on main.tf line 20, in resource "databricks_git_credential" "this":
│   20: resource "databricks_git_credential" "this" {
```

Documentation for the `principal_id` argument is also added.

---

## Detailed Changes

### Read: pass `principal_id` to Get (`repos/resource_git_credential.go:92-99`)

**Before:**
```go
resp, err := w.GitCredentials.Get(ctx, workspace.GetCredentialsRequest{CredentialId: cred_id})
```

**After:**
```go
principalId := int64(d.Get("principal_id").(int))
resp, err := w.GitCredentials.Get(ctx, workspace.GetCredentialsRequest{
    CredentialId: cred_id,
    PrincipalId:  principalId,
})
```

**Why:** The Get endpoint requires `principal_id` as a query parameter to retrieve credentials belonging to a service principal. Without it, the API searches the calling user's credentials and returns "not found".

### Delete: pass `principal_id` to Delete (`repos/resource_git_credential.go:134-141`)

**Before:**
```go
return w.GitCredentials.DeleteByCredentialId(ctx, cred_id)
```

**After:**
```go
principalId := int64(d.Get("principal_id").(int))
return w.GitCredentials.Delete(ctx, workspace.DeleteCredentialsRequest{
    CredentialId: cred_id,
    PrincipalId:  principalId,
})
```

**Why:** `DeleteByCredentialId` is a convenience wrapper that omits `principal_id`. Switching to the full `Delete` method allows passing it. Without this, `terraform destroy` fails for service principal credentials.

### Create (force flow): pass `principal_id` to List (`repos/resource_git_credential.go:63-66`)

**Before:**
```go
var listRequest workspace.ListCredentialsRequest
common.DataToStructPointer(d, s, &listRequest)
creds, err := w.GitCredentials.ListAll(ctx, listRequest)
```

**After:**
```go
principalId := int64(d.Get("principal_id").(int))
creds, err := w.GitCredentials.ListAll(ctx, workspace.ListCredentialsRequest{
    PrincipalId: principalId,
})
```

**Why:** `ListCredentialsRequest.PrincipalId` is tagged `json:"-"`, so `DataToStructPointer` (which uses JSON reflection) never populates it. When `force = true` triggers the list-then-update fallback, it lists the calling user's credentials (0 results) instead of the service principal's, causing "list of credentials is either empty or have more than one entry (0)".

### Documentation (`docs/resources/git_credential.md`)

Added `principal_id` to the Argument Reference and a new example section showing service principal credential management.

---

## Tests

**TestResourceGitCredentialCreateWithPrincipalId**: Verifies `principal_id` is sent in Create request and passed through to the subsequent Get call. Asserts `principal_id` persists in state.
**TestResourceGitCredentialDeleteWithPrincipalId**: Verifies Delete passes `principal_id` to the `DeleteCredentialsRequest`.
**TestResourceGitCredentialDelete** (updated): Updated to match new `Delete` call signature (was `DeleteByCredentialId`).

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [x] using Go SDK
- [ ] using TF Plugin Framework
- [x] has entry in `NEXT_CHANGELOG.md` file