### PR TITLE
Add legacy release workflow with JFrog proxy

### DIFF
--- a/.github/workflows/release-legacy.yml
+++ b/.github/workflows/release-legacy.yml
@@ -1,10 +1,9 @@
-name: release-build
+name: release-legacy
 
 on:
-  # Enable when disabling the legacy release workflow
-  #push:
-  #  tags:
-  #    - "*"
+  push:
+    tags:
+      - "*"
   merge_group:
     types: [checks_requested]
 
@@ -16,7 +15,7 @@ jobs:
 
     permissions:
       id-token: write
-      contents: read
+      contents: write
 
     steps:
       - name: Checkout
@@ -74,7 +73,9 @@ jobs:
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         with:
           version: ~> v2
-          args: release --clean --skip=publish
+          # Arguments cannot reference environment variables, so we write the release notes
+          # to a well-known location and use that in the goreleaser command.
+          args: release --clean --release-notes=/tmp/release-notes/release-notes.md
         env:
           # use GITHUB_TOKEN that is already available in secrets.GITHUB_TOKEN
           # https://docs.github.com/en/free-pro-team@latest/actions/reference/authentication-in-a-workflow#permissions-for-the-github_token
@@ -92,18 +93,3 @@ jobs:
           # https://docs.github.com/en/free-pro-team@latest/actions/reference/authentication-in-a-workflow#permissions-for-the-github_token
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
-
-      - name: Upload artifacts
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
-        with:
-          name: terraform-provider-databricks
-          path: |
-            dist/*.zip
-            dist/*SHA256SUMS*
-
-      - name: Upload release notes
-        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
-        with:
-          name: release-notes
-          path: /tmp/release-notes/release-notes.md


### PR DESCRIPTION
## Summary
- Recover the original single-job release workflow (pre-#5564) that builds **and** publishes to GitHub via goreleaser
- Apply JFrog proxy (`jf go mod download`) for Go module downloads, using the `setup-go-build-environment` composite action
- Disable the tag push trigger on the new split `release.yml` until it is ready

## Context
PR #5564 split the release workflow into build-only + separate publish steps. This legacy workflow restores the original behavior as a fallback while the new split workflow is finalized.

## Test plan
- [ ] Verify `release-legacy.yml` triggers on tag push and `merge_group`
- [ ] Verify `release.yml` no longer triggers on tag push (commented out)
- [ ] Test a tag push to confirm goreleaser builds and publishes correctly via JFrog proxy

 NO_CHANGELOG=true

This pull request was AI-assisted by Isaac.