### PR TITLE
[Internal] Introduce HostTypeForTerraform() wrapper over SDK Config.HostType()

### DIFF
--- a/common/client.go
+++ b/common/client.go
@@ -112,7 +112,7 @@ func (c *DatabricksClient) GetWorkspaceClientForUnifiedProvider(
 	ctx context.Context, workspaceID string,
 ) (*databricks.WorkspaceClient, error) {
 	// The provider can be configured at account level or workspace level.
-	if c.Config.HostType() != config.WorkspaceHost {
+	if c.HostTypeForTerraform() != config.WorkspaceHost {
 		return c.getWorkspaceClientForAccountUnifiedHost(ctx, workspaceID)
 	}
 	return c.getWorkspaceClientForWorkspaceConfiguredProvider(ctx, workspaceID)
@@ -532,7 +532,7 @@ func IsAccountLevel(d *schema.ResourceData, c *DatabricksClient) bool {
 	case ApiLevelWorkspace:
 		return false
 	default:
-		return c.Config.HostType() == config.AccountHost
+		return c.HostTypeForTerraform() == config.AccountHost
 	}
 }
 
@@ -567,7 +567,7 @@ func (c *DatabricksClient) scimVisitorForLevel(apiLevel string) func(*http.Reque
 			// Explicit api field takes precedence over host-based inference
 			isAccount = apiLevel == ApiLevelAccount
 		} else {
-			isAccount = c.Config.HostType() == config.AccountHost
+			isAccount = c.HostTypeForTerraform() == config.AccountHost
 		}
 		if isAccount {
 			// until `/preview` is there for workspace scim,

--- a/common/host_type.go
+++ b/common/host_type.go
@@ -1,0 +1,10 @@
+package common
+
+import "github.com/databricks/databricks-sdk-go/config"
+
+// HostTypeForTerraform is the TF-local bridge over the deprecated SDK
+// Config.HostType() — single chokepoint for future TF-specific host-type logic.
+// Once SDK removes HostType(), this is where TF-local inference lives.
+func (c *DatabricksClient) HostTypeForTerraform() config.HostType {
+	return c.Config.HostType()
+}

--- a/common/unified_provider.go
+++ b/common/unified_provider.go
@@ -113,7 +113,7 @@ func NamespaceValidateWorkspaceID(ctx context.Context, d *schema.ResourceDiff, c
 	if err != nil {
 		return err
 	}
-	if c.Config.HostType() != config.WorkspaceHost {
+	if c.HostTypeForTerraform() != config.WorkspaceHost {
 		_, err := c.WorkspaceClientForWorkspace(ctx, workspaceIDInt)
 		if err != nil {
 			return fmt.Errorf("failed to get workspace client with workspace_id %d: %w", workspaceIDInt, err)

--- a/exporter/context.go
+++ b/exporter/context.go
@@ -456,7 +456,7 @@ func (ic *importContext) Run() error {
 		return fmt.Errorf("the path %s is not a directory", ic.Directory)
 	}
 
-	ic.accountLevel = ic.Client.Config.HostType() == config.AccountHost
+	ic.accountLevel = ic.Client.HostTypeForTerraform() == config.AccountHost
 	if ic.accountLevel {
 		ic.meAdmin = true
 		// TODO: check if we can get the current user from the account client

--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -77,7 +77,7 @@ func workspaceConfKeysToURL() string {
 }
 
 func (ic *importContext) setClientsForTests() {
-	ic.accountLevel = ic.Client.Config.HostType() == config.AccountHost
+	ic.accountLevel = ic.Client.HostTypeForTerraform() == config.AccountHost
 	if ic.accountLevel {
 		ic.meAdmin = true
 		ic.accountClient, _ = ic.Client.AccountClient()

--- a/exporter/importables_test.go
+++ b/exporter/importables_test.go
@@ -77,7 +77,7 @@ func importContextForTestWithClient(ctx context.Context, client *common.Databric
 	ic := importContextForTest()
 	ic.Client = client
 	ic.Context = ctx
-	if client.Config.HostType() == config.AccountHost {
+	if client.HostTypeForTerraform() == config.AccountHost {
 		ic.accountClient, _ = client.AccountClient()
 	} else {
 		ic.workspaceClient, _ = client.WorkspaceClient()

--- a/internal/providers/pluginfw/products/user/data_users.go
+++ b/internal/providers/pluginfw/products/user/data_users.go
@@ -89,7 +89,7 @@ func (d *UsersDataSource) Read(ctx context.Context, req datasource.ReadRequest, 
 	var users []iam.User
 	var err error
 
-	isAccount := d.Client.Config.HostType() == config.AccountHost
+	isAccount := d.Client.HostTypeForTerraform() == config.AccountHost
 	if !usersInfo.Api.IsNull() && !usersInfo.Api.IsUnknown() {
 		apiLevel := usersInfo.Api.ValueString()
 		if apiLevel != "account" && apiLevel != "workspace" {

--- a/scim/resource_entitlement.go
+++ b/scim/resource_entitlement.go
@@ -34,7 +34,7 @@ func ResourceEntitlements() common.Resource {
 			return common.NamespaceCustomizeDiff(ctx, d, c)
 		},
 		Create: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
-			if c.Config.HostType() == config.AccountHost {
+			if c.HostTypeForTerraform() == config.AccountHost {
 				return fmt.Errorf("entitlements can only be managed with a provider configured at the workspace-level")
 			}
 			newClient, err := c.DatabricksClientForUnifiedProvider(ctx, d)

--- a/settings/generic_setting.go
+++ b/settings/generic_setting.go
@@ -282,7 +282,7 @@ func (aw accountWorkspaceSetting[T]) SettingStruct() T {
 	return aw.settingStruct
 }
 func (aw accountWorkspaceSetting[T]) Read(ctx context.Context, c *common.DatabricksClient, etag string) (*T, error) {
-	if c.Config.HostType() == config.AccountHost {
+	if c.HostTypeForTerraform() == config.AccountHost {
 		a, err := c.AccountClient()
 		if err != nil {
 			return nil, err
@@ -297,7 +297,7 @@ func (aw accountWorkspaceSetting[T]) Read(ctx context.Context, c *common.Databri
 	}
 }
 func (aw accountWorkspaceSetting[T]) Update(ctx context.Context, c *common.DatabricksClient, t T) (string, error) {
-	if c.Config.HostType() == config.AccountHost {
+	if c.HostTypeForTerraform() == config.AccountHost {
 		a, err := c.AccountClient()
 		if err != nil {
 			return "", err
@@ -312,7 +312,7 @@ func (aw accountWorkspaceSetting[T]) Update(ctx context.Context, c *common.Datab
 	}
 }
 func (aw accountWorkspaceSetting[T]) Delete(ctx context.Context, c *common.DatabricksClient, etag string) (string, error) {
-	if c.Config.HostType() == config.AccountHost {
+	if c.HostTypeForTerraform() == config.AccountHost {
 		a, err := c.AccountClient()
 		if err != nil {
 			return "", err


### PR DESCRIPTION
  ## Summary
  - Introduce `HostTypeForTerraform()` method on `*common.DatabricksClient` in new file `common/host_type.go`.
  Delegates to deprecated SDK `Config.HostType()`.
  - Migrate all 12 existing `Config.HostType()` call sites to use the wrapper.

  ## Why
  The Databricks Go SDK v0.127.0 deprecates `Config.HostType()` with an explicit `// TODO: Remove this after TF
  updates its code.`. When SDK removes the method, TF needs a single place to reimplement TF-local host-type
  inference. This PR puts that chokepoint in place. It also lets TF inject TF-specific host-type logic (e.g.,
  unified-host handling, test overrides) in one spot going forward.

  ## Test plan
  - [x] `make fmt` clean
  - [x] `make lint` clean (staticcheck)
  - [x] `make ws` clean (1085 checked, 0 failed)
  - [x] `make test` — 3122 tests, 0 failures

NO_CHANGELOG=true