### PR TITLE
Skip TestAccProviderPlanShouldSucceedWithIncompleteConfiguration until 2026-05-08

### DIFF
--- a/internal/acceptance/tf_provider_test.go
+++ b/internal/acceptance/tf_provider_test.go
@@ -2,6 +2,7 @@ package acceptance
 
 import (
 	"testing"
+	"time"
 
 	"github.com/databricks/terraform-provider-databricks/internal/providers/sdkv2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -25,6 +26,13 @@ func NoOpResource() *schema.Resource {
 // This test ensures that, within a single Terraform module, a workspace can be created and that
 // the Databricks provider can be configured to use that workspace.
 func TestAccProviderPlanShouldSucceedWithIncompleteConfiguration(t *testing.T) {
+	// Skip until 2026-05-08: Terraform CLI install fails with
+	// "openpgp: key expired" when verifying checksum signatures.
+	// We are waiting for the new version of Terraform CLI to be released and
+	// be included in the JROG proxy.
+	if time.Now().Before(time.Date(2026, 5, 8, 0, 0, 0, 0, time.UTC)) {
+		t.Skip("temporarily skipped until 2026-05-08: Terraform CLI install fails due to expired openpgp key")
+	}
 	resource.Test(t, resource.TestCase{
 		IsUnitTest: true,
 		ProviderFactories: map[string]func() (*schema.Provider, error){


### PR DESCRIPTION
## Summary
- Skip `TestAccProviderPlanShouldSucceedWithIncompleteConfiguration` until 2026-05-08.
- The test fails because the Terraform CLI install step cannot verify the checksum signature: `openpgp: key expired`. We're waiting for a new Terraform CLI release to propagate through the JFrog proxy.
- The skip uses a date-based `time.Now()` check, so the test auto-re-enables on 2026-05-08 without requiring a follow-up PR.

## Test plan
- [x] `go vet` passes for the file.
- [ ] CI confirms the test is skipped on this branch.

NO_CHANGELOG=true

This pull request and its description were written by Isaac.