### PR TITLE
Bump Go SDK to v0.128.0

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -13,3 +13,5 @@
 ### Exporter
 
 ### Internal Changes
+
+* Update Go SDK to v0.128.0.

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/databricks/terraform-provider-databricks
 go 1.24.0
 
 require (
-	github.com/databricks/databricks-sdk-go v0.127.0
+	github.com/databricks/databricks-sdk-go v0.128.0
 	github.com/golang-jwt/jwt/v4 v4.5.2
 	github.com/hashicorp/go-cty v1.5.0
 	github.com/hashicorp/hcl v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -27,8 +27,8 @@ github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg
 github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
 github.com/cyphar/filepath-securejoin v0.4.1 h1:JyxxyPEaktOD+GAnqIqTf9A8tHyAG22rowi7HkoSU1s=
 github.com/cyphar/filepath-securejoin v0.4.1/go.mod h1:Sdj7gXlvMcPZsbhwhQ33GguGLDGQL7h7bg04C/+u9jI=
-github.com/databricks/databricks-sdk-go v0.127.0 h1:PMM9AVqH+YEMYu55MWg7CWjG/o8esP/4WqskAKxngiQ=
-github.com/databricks/databricks-sdk-go v0.127.0/go.mod h1:C5LNgGe6hGuRrTwoxFmuup3XtQQEaqtq0e+K8IFDIS4=
+github.com/databricks/databricks-sdk-go v0.128.0 h1:4aGI3KkSZHDkxNIgwQL6dn6q6zZKcgyckidcQZNDGGo=
+github.com/databricks/databricks-sdk-go v0.128.0/go.mod h1:C5LNgGe6hGuRrTwoxFmuup3XtQQEaqtq0e+K8IFDIS4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=


### PR DESCRIPTION
## Changes

Update Go SDK to v0.128.0. No OpenAPI spec change (v0.127.0 and v0.128.0 share the same `_openapi_sha`), so no regenerated code is included.

v0.128.0 is an SDK-only release with:
- New experimental `config.DefaultHostMetadataResolverFactory` for installing a shared resolver from an `init()` block.
- Bug fix: `X-Databricks-Org-Id` header added to `Workspace.Download()` / `Workspace.Upload()` / `SharesAPI.internalList()` for SPOG host compatibility.
- Bug fix: `WorkspaceClient.CurrentWorkspaceID()` returns `Config.WorkspaceID` directly when set, removing an API round-trip and fixing a failure on SPOG hosts.

## Tests

Existing unit tests. `make fmt lint ws` and `make test` pass locally (one unrelated failure in `TestAccProviderPlanShouldSucceedWithIncompleteConfiguration` due to an expired PGP key in the Terraform CLI installer, unrelated to this SDK bump).