### PR TITLE
[internal] Mirror the code changes from generator

### DIFF
--- a/common/client.go
+++ b/common/client.go
@@ -348,6 +348,15 @@ func (c *DatabricksClient) SetAccountClient(a *databricks.AccountClient) {
 	c.cachedAccountClient = a
 }
 
+// SetCachedWorkspaceID sets the cached workspace ID directly.
+// This is used by test infrastructure to pre-populate the cache and prevent
+// lazy CurrentWorkspaceID API calls during unit tests.
+func (c *DatabricksClient) SetCachedWorkspaceID(id int64) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.cachedWorkspaceID = id
+}
+
 // GetProviderWorkspaceID returns the provider-level workspace_id from Config.
 // Satisfies the tfschema.UnifiedProviderClient interface.
 func (c *DatabricksClient) GetProviderWorkspaceID() string {
@@ -359,15 +368,6 @@ func (c *DatabricksClient) GetProviderWorkspaceID() string {
 func (c *DatabricksClient) ValidateWorkspaceAccess(ctx context.Context, workspaceID string) diag.Diagnostics {
 	_, diags := c.GetWorkspaceClientForUnifiedProviderWithDiagnostics(ctx, workspaceID)
 	return diags
-}
-
-// SetCachedWorkspaceID sets the cached workspace ID directly.
-// This is used by test infrastructure to pre-populate the cache and prevent
-// lazy CurrentWorkspaceID API calls during unit tests.
-func (c *DatabricksClient) SetCachedWorkspaceID(id int64) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.cachedWorkspaceID = id
 }
 
 func (c *DatabricksClient) setAccountId(accountId string) error {

--- a/common/resource.go
+++ b/common/resource.go
@@ -15,6 +15,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
+// workspaceIDSchemaKey is the key for the workspace ID in schema
+const workspaceIDSchemaKey = "provider_config.0.workspace_id"
+
 func workspaceIDFromRawConfig(d *schema.ResourceData) (string, bool) {
 	path := cty.Path{
 		cty.GetAttrStep{Name: "provider_config"},

--- a/common/unified_provider.go
+++ b/common/unified_provider.go
@@ -13,9 +13,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
-// workspaceIDSchemaKey is the key for the workspace ID in schema
-const workspaceIDSchemaKey = "provider_config.0.workspace_id"
-
 // Namespace stores the provider configurations for unified terraform provider
 // This should be kept in sync with Namespace for plugin framework resources and data sources
 // defined in internal/providers/pluginfw/tfschema/unified_provider.go


### PR DESCRIPTION
## Changes
This PR mirrors the code changes as done on the generator side. This moves a constant to autogenerated file and moves the relative position of function declaration.

## Tests
N/A

NO_CHANGELOG=true
