### PR TITLE
[Internal] Move Experimental_IsUnifiedHost in HostTypeForTerraform()

### DIFF
--- a/common/host_type.go
+++ b/common/host_type.go
@@ -6,5 +6,8 @@ import "github.com/databricks/databricks-sdk-go/config"
 // Config.HostType() — single chokepoint for future TF-specific host-type logic.
 // Once SDK removes HostType(), this is where TF-local inference lives.
 func (c *DatabricksClient) HostTypeForTerraform() config.HostType {
+	if c.Config.Experimental_IsUnifiedHost {
+		return config.UnifiedHost
+	}
 	return c.Config.HostType()
 }


### PR DESCRIPTION
  ## Changes

  Handle `Experimental_IsUnifiedHost` directly in `HostTypeForTerraform()` so the
  wrapper returns `config.UnifiedHost` when the flag is set, independent of the
  SDK's `Config.HostType()` implementation.

  The SDK is dropping `Experimental_IsUnifiedHost` handling from `Config.HostType()`
  as part of its move to host-agnostic behavior. Keeping the check in the TF-local
  chokepoint preserves current provider behavior until TF's callers are migrated
  off `HostType()` entirely.

## Tests
- Existing tests

NO_CHANGELOG=true