### PR TITLE
[Internal] Bump Go toolchain from 1.24 to 1.25.7

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -16,3 +16,4 @@
 ### Internal Changes
 
 * Update Go SDK to v0.128.0.
+* Bump minimum Go toolchain from 1.24.0 to 1.25.7 to pick up the `crypto/tls` TLS 1.3 session-resumption fix.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/databricks/terraform-provider-databricks
 
-go 1.24.0
+go 1.25.7
 
 require (
 	github.com/databricks/databricks-sdk-go v0.128.0


### PR DESCRIPTION
## Changes

Bumps the provider's minimum Go toolchain from 1.24.0 to 1.25.7.

Go 1.24 is affected by a `crypto/tls` vulnerability in TLS 1.3 session resumption: when `Config.ClientCAs` or `Config.RootCAs` are mutated between an initial handshake and a resumed handshake, the resumed session can succeed against the stale CA set when it should have failed. In practice a previously trusted client or server identity may continue to be accepted after the trust material has been revoked, which weakens the TLS guarantees the provider relies on for workspace and account API calls. The fix was backported to Go 1.24.13, Go 1.25.7, and Go 1.26 GA.

Pinning the `go` directive to 1.25.7 (rather than a bare `1.25`) is deliberate: the `go` directive is the floor for the compiler that builds the released binary, and `go 1.25` would still permit 1.25.0 through 1.25.6, which carry the unpatched `crypto/tls`. Pinning the patch version guarantees every released provider binary carries the fix.

- `go.mod`: `go 1.24.0` -> `go 1.25.7`. No other changes; `go.sum` is unaffected since the `go` directive bump doesn't touch module hashes.
- `NEXT_CHANGELOG.md`: Internal Changes entry noting the bump.

No source changes. Every workflow in `.github/workflows/` already resolves the Go version via `go-version-file: go.mod`, so CI, release, CodeQL, and packaging jobs pick up the new toolchain automatically.

## Tests

- [ ] CI green against the new toolchain.
- [ ] The Setup Go step in the build workflow log reports installing a Go 1.25.7+ toolchain.