### PR TITLE
Fix URL normalization by backend in UC catalog, schema and external location

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -11,6 +11,8 @@
 
 ### Bug Fixes
 
+* Fix URL normalization by backend in UC catalog, schema and external locations ([#5616](https://github.com/databricks/terraform-provider-databricks/pull/5616)).
+
 ### Documentation
 
 ### Exporter

--- a/catalog/resource_catalog.go
+++ b/catalog/resource_catalog.go
@@ -132,8 +132,23 @@ func ResourceCatalog() common.Resource {
 				string(origCatalogData.EnablePredictiveOptimization) == "" {
 				ci.EnablePredictiveOptimization = origCatalogData.EnablePredictiveOptimization
 			}
+			// Preserve the configured storage_root when the only difference is a trailing slash.
+			// This prevents "inconsistent final plan" errors on first apply (#4136).
+			configuredStorageRoot := d.Get("storage_root").(string)
+			if configuredStorageRoot != "" && ucDirectoryPathSlashOnlySuppressDiff("", configuredStorageRoot, ci.StorageRoot, d) {
+				ci.StorageRoot = configuredStorageRoot
+			}
 
-			return common.StructToData(ci, catalogSchema, d)
+			err = common.StructToData(ci, catalogSchema, d)
+			if err != nil {
+				return err
+			}
+			// For non-new resources, StructToData may skip setting storage_root if GetOk returns false.
+			// Re-apply the normalized value to ensure it's preserved.
+			if configuredStorageRoot != "" && ci.StorageRoot == configuredStorageRoot {
+				d.Set("storage_root", configuredStorageRoot)
+			}
+			return nil
 		},
 		Update: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
 			w, err := c.WorkspaceClientUnifiedProvider(ctx, d)

--- a/catalog/resource_catalog_test.go
+++ b/catalog/resource_catalog_test.go
@@ -735,6 +735,34 @@ func TestCatalogCreateForeignIceberg(t *testing.T) {
 	})
 }
 
+func TestCatalogCreate_StorageRootTrailingSlashPreserved(t *testing.T) {
+	qa.ResourceFixture{
+		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
+			e := w.GetMockCatalogsAPI().EXPECT()
+			e.Create(mock.Anything, catalog.CreateCatalog{
+				Name:        "a",
+				StorageRoot: "s3://my-storage",
+			}).Return(&catalog.CatalogInfo{
+				Name:        "a",
+				StorageRoot: "s3://my-storage/",
+			}, nil)
+			w.GetMockSchemasAPI().EXPECT().DeleteByFullName(mock.Anything, "a.default").Return(nil)
+			e.GetByName(mock.Anything, "a").Return(&catalog.CatalogInfo{
+				Name:        "a",
+				StorageRoot: "s3://my-storage/",
+			}, nil)
+		},
+		Resource: ResourceCatalog(),
+		Create:   true,
+		HCL: `
+		name = "a"
+		storage_root = "s3://my-storage"
+		`,
+	}.ApplyAndExpectData(t, map[string]any{
+		"storage_root": "s3://my-storage",
+	})
+}
+
 func TestCatalogCreateIsolated(t *testing.T) {
 	qa.ResourceFixture{
 		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {

--- a/catalog/resource_external_location.go
+++ b/catalog/resource_external_location.go
@@ -105,6 +105,12 @@ func ResourceExternalLocation() common.Resource {
 			if err != nil {
 				return err
 			}
+			// Preserve the configured url when the only difference is a trailing slash.
+			// This prevents "inconsistent final plan" errors on first apply.
+			configuredUrl := d.Get("url").(string)
+			if configuredUrl != "" && ucDirectoryPathSlashOnlySuppressDiff("", configuredUrl, el.Url, d) {
+				el.Url = configuredUrl
+			}
 			return common.StructToData(el, s, d)
 		},
 		Update: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {

--- a/catalog/resource_external_location_test.go
+++ b/catalog/resource_external_location_test.go
@@ -56,6 +56,39 @@ func TestCreateExternalLocation(t *testing.T) {
 	}.ApplyNoError(t)
 }
 
+func TestCreateExternalLocation_UrlTrailingSlashPreserved(t *testing.T) {
+	qa.ResourceFixture{
+		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
+			e := w.GetMockExternalLocationsAPI().EXPECT()
+			e.Create(mock.Anything, catalog.CreateExternalLocation{
+				Name:           "abc",
+				Url:            "s3://foo/bar",
+				CredentialName: "bcd",
+			}).Return(&catalog.ExternalLocationInfo{
+				Name:           "abc",
+				Url:            "s3://foo/bar/",
+				CredentialName: "bcd",
+			}, nil)
+			e.GetByName(mock.Anything, "abc").Return(&catalog.ExternalLocationInfo{
+				Name:           "abc",
+				Url:            "s3://foo/bar/",
+				CredentialName: "bcd",
+				Owner:          "efg",
+				MetastoreId:    "fgh",
+			}, nil)
+		},
+		Resource: ResourceExternalLocation(),
+		Create:   true,
+		HCL: `
+		name = "abc"
+		url = "s3://foo/bar"
+		credential_name = "bcd"
+		`,
+	}.ApplyAndExpectData(t, map[string]any{
+		"url": "s3://foo/bar",
+	})
+}
+
 func TestCreateIsolatedExternalLocation(t *testing.T) {
 	qa.ResourceFixture{
 		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {

--- a/catalog/resource_schema.go
+++ b/catalog/resource_schema.go
@@ -91,6 +91,12 @@ func ResourceSchema() common.Resource {
 			if err != nil {
 				return err
 			}
+			// Preserve the configured storage_root when the only difference is a trailing slash.
+			// This prevents "inconsistent final plan" errors on first apply.
+			configuredStorageRoot := d.Get("storage_root").(string)
+			if configuredStorageRoot != "" && ucDirectoryPathSlashOnlySuppressDiff("", configuredStorageRoot, schema.StorageRoot, d) {
+				schema.StorageRoot = configuredStorageRoot
+			}
 			return common.StructToData(schema, s, d)
 		},
 		Update: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {

--- a/catalog/resource_schema_test.go
+++ b/catalog/resource_schema_test.go
@@ -44,6 +44,37 @@ func TestCreateSchema(t *testing.T) {
 	}.ApplyNoError(t)
 }
 
+func TestCreateSchema_StorageRootTrailingSlashPreserved(t *testing.T) {
+	qa.ResourceFixture{
+		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
+			e := w.GetMockSchemasAPI().EXPECT()
+			e.Create(mock.Anything, catalog.CreateSchema{
+				Name:        "a",
+				CatalogName: "b",
+				StorageRoot: "s3://my-bucket/schemas",
+			}).Return(&catalog.SchemaInfo{
+				FullName:    "b.a",
+				StorageRoot: "s3://my-bucket/schemas/",
+				Owner:       "testers",
+			}, nil)
+			e.GetByFullName(mock.Anything, "b.a").Return(&catalog.SchemaInfo{
+				MetastoreId: "d",
+				StorageRoot: "s3://my-bucket/schemas/",
+				Owner:       "testers",
+			}, nil)
+		},
+		Resource: ResourceSchema(),
+		Create:   true,
+		HCL: `
+		name = "a"
+		catalog_name = "b"
+		storage_root = "s3://my-bucket/schemas"
+		`,
+	}.ApplyAndExpectData(t, map[string]any{
+		"storage_root": "s3://my-bucket/schemas",
+	})
+}
+
 func TestCreateSchemaWithOwner(t *testing.T) {
 	qa.ResourceFixture{
 		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

The UC backend performs normalization of URLs adding the trailing `/` if it's missing - this causes errors like `Provider produced inconsistent final plan`.  The suppress diff happens too late, so solution is to handle it in the Read implementation, using the original value if the difference only in trailing `/`.

Resolves #3618, resolves #4136


## Tests
<!--
How is this tested? Please see the checklist below and also describe any other relevant tests
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] using Go SDK
- [ ] using TF Plugin Framework
- [x] has entry in `NEXT_CHANGELOG.md` file
