### PR TITLE
[Internal] Update TestValidateWorkspaceID for HostTypeForTerraform()

### DIFF
--- a/common/unified_provider_test.go
+++ b/common/unified_provider_test.go
@@ -1474,14 +1474,18 @@ func TestValidateWorkspaceID(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			cfg := &config.Config{
-				Host:        tc.host,
-				AccountID:   tc.accountID,
-				Token:       "test-token",
-				WorkspaceID: tc.workspaceID,
+			c := &DatabricksClient{
+				DatabricksClient: &client.DatabricksClient{
+					Config: &config.Config{
+						Host:        tc.host,
+						AccountID:   tc.accountID,
+						Token:       "test-token",
+						WorkspaceID: tc.workspaceID,
+					},
+				},
 			}
 			// Replicate the validation logic from provider init
-			hasError := cfg.WorkspaceID != "" && cfg.HostType() == config.WorkspaceHost
+			hasError := c.Config.WorkspaceID != "" && c.HostTypeForTerraform() == config.WorkspaceHost
 			assert.Equal(t, tc.expectError, hasError)
 		})
 	}


### PR DESCRIPTION
  Summary

  - TestValidateWorkspaceID (added in #5492) called cfg.HostType() directly on a bare config.Config, bypassing the TF-local HostTypeForTerraform() wrapper introduced in #5603.
  - Wraps the test config in a common.DatabricksClient and routes the host-type check through HostTypeForTerraform(), matching the rest of the provider and keeping the single
  chokepoint intact for when the SDK retires HostType().
  - No production code changes; test assertions unchanged.

  Test plan

  - go test -run TestValidateWorkspaceID ./common/ passes

NO_CHANGELOG=true