### PR TITLE
Use SetComputed() instead of SetReadOnly() for effective_file_event_queue

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bug Fixes
 
-* Mark `effective_file_event_queue` as read-only in `databricks_external_location` to prevent Terraform drift.
+* Use `SetComputed()` instead of `SetReadOnly()` for `effective_file_event_queue` in `databricks_external_location` to prevent Terraform drift when the field is null.
 ### Documentation
 
 ### Exporter

--- a/catalog/resource_external_location.go
+++ b/catalog/resource_external_location.go
@@ -36,9 +36,10 @@ func ResourceExternalLocation() common.Resource {
 			common.CustomizeSchemaPath(m, "isolation_mode").SetComputed()
 			common.CustomizeSchemaPath(m, "owner").SetComputed()
 			common.CustomizeSchemaPath(m, "metastore_id").SetComputed()
-			for _, key := range []string{"created_at", "created_by", "credential_id", "updated_at", "updated_by", "browse_only", "effective_enable_file_events", "effective_file_event_queue"} {
+			for _, key := range []string{"created_at", "created_by", "credential_id", "updated_at", "updated_by", "browse_only", "effective_enable_file_events"} {
 				common.CustomizeSchemaPath(m, key).SetReadOnly()
 			}
+			common.CustomizeSchemaPath(m, "effective_file_event_queue").SetComputed()
 			// customize file event queue
 			supportedQueues := []string{"managed_pubsub", "managed_aqs", "managed_sqs", "provided_pubsub", "provided_aqs", "provided_sqs"}
 			for _, key := range supportedQueues {

--- a/catalog/resource_external_location_test.go
+++ b/catalog/resource_external_location_test.go
@@ -788,6 +788,49 @@ func TestReadExternalLocationWithEffectiveFileEventQueue(t *testing.T) {
 	assert.Equal(t, "projects/p/subscriptions/s", pubsub[0].(map[string]any)["managed_resource_id"])
 }
 
+
+func TestCreateExternalLocationWithNullEffectiveFileEventQueue(t *testing.T) {
+	qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "POST",
+				Resource: "/api/2.1/unity-catalog/external-locations",
+				ExpectedRequest: catalog.CreateExternalLocation{
+					Name:           "abc",
+					Url:            "s3://foo/bar",
+					CredentialName: "bcd",
+					Comment:        "def",
+				},
+				Response: catalog.ExternalLocationInfo{
+					Name:           "abc",
+					Url:            "s3://foo/bar",
+					CredentialName: "bcd",
+					Comment:        "def",
+				},
+			},
+			{
+				Method:   "GET",
+				Resource: "/api/2.1/unity-catalog/external-locations/abc?",
+				Response: catalog.ExternalLocationInfo{
+					Name:           "abc",
+					Url:            "s3://foo/bar",
+					CredentialName: "bcd",
+					Comment:        "def",
+					Owner:          "efg",
+					MetastoreId:    "fgh",
+				},
+			},
+		},
+		Resource: ResourceExternalLocation(),
+		Create:   true,
+		HCL: `
+		name = "abc"
+		url = "s3://foo/bar"
+		credential_name = "bcd"
+		comment = "def"
+		`,
+	}.ApplyNoError(t)
+}
 func TestUpdateExternalLocationForce(t *testing.T) {
 	qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{


### PR DESCRIPTION
## Changes

Use `SetComputed()` instead of `SetReadOnly()` for `effective_file_event_queue` in `databricks_external_location`.

`SetReadOnly()` sets `Optional=false, Computed=true`. For a `TypeList` block field, when the backend returns `null` (e.g. server-side feature flag is off), Terraform interprets a non-optional computed field with a null value as "unknown" and shows `+ effective_file_event_queue = (known after apply)` drift on every plan.

`SetComputed()` keeps `Optional=true, Computed=true`, allowing `null` to be a valid state without triggering a plan diff. When the backend does populate the field, it is correctly stored in state.

This fixes the CI integration test failures introduced by #5602.

## Tests

- `TestCreateExternalLocationWithEffectiveFileEventQueue` — API returns a populated queue, no drift
- `TestCreateExternalLocationWithNullEffectiveFileEventQueue` — API returns null queue, no drift
- `TestReadExternalLocationWithEffectiveFileEventQueue` — Read path with populated queue