### PR TITLE
[Internal] Fail dual resources at plan time when api is unset on a unified host

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -6,8 +6,6 @@
 
 ### New Features and Improvements
 
-* Fail at plan time with "please set api to account or workspace" for dual workspace/account resources when the provider is configured against a unified host and the resource's `api` field is not set.
-
 ### Bug Fixes
 
 * Mark `effective_file_event_queue` as read-only in `databricks_external_location` to prevent Terraform drift.
@@ -19,3 +17,4 @@
 
 * Update Go SDK to v0.128.0.
 * Bump minimum Go toolchain from 1.24.0 to 1.25.7 to pick up the `crypto/tls` TLS 1.3 session-resumption fix.
+* Fail at plan time with "please set api to account or workspace" for dual workspace/account resources when the provider is configured against a unified host and the resource's `api` field is not set.

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### New Features and Improvements
 
+* Fail at plan time with "please set api to account or workspace" for dual workspace/account resources when the provider is configured against a unified host and the resource's `api` field is not set.
+
 ### Bug Fixes
 
 * Mark `effective_file_event_queue` as read-only in `databricks_external_location` to prevent Terraform drift.

--- a/aws/resource_group_instance_profile.go
+++ b/aws/resource_group_instance_profile.go
@@ -55,7 +55,7 @@ func ResourceGroupInstanceProfile() common.Resource {
 	})
 	r.DeprecationMessage = "Please migrate to `databricks_group_role`"
 	r.CustomizeDiff = func(ctx context.Context, d *schema.ResourceDiff, c *common.DatabricksClient) error {
-		return common.NamespaceCustomizeDiff(ctx, d, c)
+		return common.CustomizeDiffDualResources(ctx, d, c)
 	}
 	return r
 }

--- a/aws/resource_service_principal_role.go
+++ b/aws/resource_service_principal_role.go
@@ -51,7 +51,7 @@ func ResourceServicePrincipalRole() common.Resource {
 		},
 	})
 	r.CustomizeDiff = func(ctx context.Context, d *schema.ResourceDiff, c *common.DatabricksClient) error {
-		return common.NamespaceCustomizeDiff(ctx, d, c)
+		return common.CustomizeDiffDualResources(ctx, d, c)
 	}
 	return r
 }

--- a/aws/resource_user_instance_profile.go
+++ b/aws/resource_user_instance_profile.go
@@ -51,7 +51,7 @@ func ResourceUserInstanceProfile() common.Resource {
 	})
 	r.DeprecationMessage = "Please migrate to `databricks_user_role`. This resource will be removed in v0.5.x"
 	r.CustomizeDiff = func(ctx context.Context, d *schema.ResourceDiff, c *common.DatabricksClient) error {
-		return common.NamespaceCustomizeDiff(ctx, d, c)
+		return common.CustomizeDiffDualResources(ctx, d, c)
 	}
 	return r
 }

--- a/aws/resource_user_role.go
+++ b/aws/resource_user_role.go
@@ -50,7 +50,7 @@ func ResourceUserRole() common.Resource {
 		},
 	})
 	r.CustomizeDiff = func(ctx context.Context, d *schema.ResourceDiff, c *common.DatabricksClient) error {
-		return common.NamespaceCustomizeDiff(ctx, d, c)
+		return common.CustomizeDiffDualResources(ctx, d, c)
 	}
 	return r
 }

--- a/catalog/resource_metastore.go
+++ b/catalog/resource_metastore.go
@@ -89,7 +89,7 @@ func ResourceMetastore() common.Resource {
 	return common.Resource{
 		Schema: s,
 		CustomizeDiff: func(ctx context.Context, d *schema.ResourceDiff, c *common.DatabricksClient) error {
-			return common.NamespaceCustomizeDiff(ctx, d, c)
+			return common.CustomizeDiffDualResources(ctx, d, c)
 		},
 		Create: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
 			c, err := c.DatabricksClientForUnifiedProvider(ctx, d)

--- a/catalog/resource_metastore_assignment.go
+++ b/catalog/resource_metastore_assignment.go
@@ -29,7 +29,7 @@ func ResourceMetastoreAssignment() common.Resource {
 	return common.Resource{
 		Schema: s,
 		CustomizeDiff: func(ctx context.Context, d *schema.ResourceDiff, c *common.DatabricksClient) error {
-			return common.NamespaceCustomizeDiff(ctx, d, c)
+			return common.CustomizeDiffDualResources(ctx, d, c)
 		},
 		Create: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
 			c, err := c.DatabricksClientForUnifiedProvider(ctx, d)

--- a/catalog/resource_metastore_data_access.go
+++ b/catalog/resource_metastore_data_access.go
@@ -120,7 +120,7 @@ func ResourceMetastoreDataAccess() common.Resource {
 			},
 		},
 		CustomizeDiff: func(ctx context.Context, d *schema.ResourceDiff, c *common.DatabricksClient) error {
-			return common.NamespaceCustomizeDiff(ctx, d, c)
+			return common.CustomizeDiffDualResources(ctx, d, c)
 		},
 		Create: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
 			c, err := c.DatabricksClientForUnifiedProvider(ctx, d)

--- a/catalog/resource_storage_credential.go
+++ b/catalog/resource_storage_credential.go
@@ -79,7 +79,7 @@ func ResourceStorageCredential() common.Resource {
 	return common.Resource{
 		Schema: storageCredentialSchema,
 		CustomizeDiff: func(ctx context.Context, d *schema.ResourceDiff, c *common.DatabricksClient) error {
-			return common.NamespaceCustomizeDiff(ctx, d, c)
+			return common.CustomizeDiffDualResources(ctx, d, c)
 		},
 		Create: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
 			c, err := c.DatabricksClientForUnifiedProvider(ctx, d)

--- a/common/unified_provider.go
+++ b/common/unified_provider.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/databricks/databricks-sdk-go"
 	"github.com/databricks/databricks-sdk-go/client"
+	"github.com/databricks/databricks-sdk-go/config"
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -210,9 +211,29 @@ func workspaceIDFromRawDiffConfig(d *schema.ResourceDiff) (string, bool) {
 	return "", false
 }
 
+// ValidateApiLevelForUnifiedHost fails the plan for dual resources (identified
+// by an `api` field in the schema) when the provider is configured against a
+// UnifiedHost but `api` is not explicitly set. On a unified host the API level
+// cannot be inferred from the host, so the user must declare it.
+func ValidateApiLevelForUnifiedHost(d *schema.ResourceDiff, c *DatabricksClient) error {
+	if d.Get("api") == nil {
+		return nil
+	}
+	if c.HostTypeForTerraform() != config.UnifiedHost {
+		return nil
+	}
+	if GetApiLevelFromDiff(d) != "" {
+		return nil
+	}
+	return fmt.Errorf("please set api to account or workspace")
+}
+
 // NamespaceCustomizeDiff is used to customize the diff for the provider configuration
 // in a resource diff.
 func NamespaceCustomizeDiff(ctx context.Context, d *schema.ResourceDiff, c *DatabricksClient) error {
+	if err := ValidateApiLevelForUnifiedHost(d, c); err != nil {
+		return err
+	}
 	if err := namespaceForceNew(ctx, d, c); err != nil {
 		return err
 	}

--- a/common/unified_provider.go
+++ b/common/unified_provider.go
@@ -211,14 +211,12 @@ func workspaceIDFromRawDiffConfig(d *schema.ResourceDiff) (string, bool) {
 	return "", false
 }
 
-// ValidateApiLevelForUnifiedHost fails the plan for dual resources (identified
-// by an `api` field in the schema) when the provider is configured against a
-// UnifiedHost but `api` is not explicitly set. On a unified host the API level
-// cannot be inferred from the host, so the user must declare it.
+// ValidateApiLevelForUnifiedHost fails the plan when the provider is configured
+// against a UnifiedHost but the resource's `api` field is not set. On a unified
+// host the API level cannot be inferred from the host, so the user must declare
+// it. Intended for dual resources (called via CustomizeDiffDualResources); the
+// `api` field is assumed to exist in the schema.
 func ValidateApiLevelForUnifiedHost(d *schema.ResourceDiff, c *DatabricksClient) error {
-	if d.Get("api") == nil {
-		return nil
-	}
 	if c.HostTypeForTerraform() != config.UnifiedHost {
 		return nil
 	}

--- a/common/unified_provider.go
+++ b/common/unified_provider.go
@@ -231,13 +231,20 @@ func ValidateApiLevelForUnifiedHost(d *schema.ResourceDiff, c *DatabricksClient)
 // NamespaceCustomizeDiff is used to customize the diff for the provider configuration
 // in a resource diff.
 func NamespaceCustomizeDiff(ctx context.Context, d *schema.ResourceDiff, c *DatabricksClient) error {
-	if err := ValidateApiLevelForUnifiedHost(d, c); err != nil {
-		return err
-	}
 	if err := namespaceForceNew(ctx, d, c); err != nil {
 		return err
 	}
 	return NamespaceValidateWorkspaceID(ctx, d, c)
+}
+
+// CustomizeDiffDualResources is the CustomizeDiff entry point for dual
+// workspace/account resources (those that call AddApiField). It runs the
+// unified-host api-level check before delegating to NamespaceCustomizeDiff.
+func CustomizeDiffDualResources(ctx context.Context, d *schema.ResourceDiff, c *DatabricksClient) error {
+	if err := ValidateApiLevelForUnifiedHost(d, c); err != nil {
+		return err
+	}
+	return NamespaceCustomizeDiff(ctx, d, c)
 }
 
 // WorkspaceClientUnifiedProvider returns the WorkspaceClient for the workspace ID from the resource data

--- a/common/unified_provider.go
+++ b/common/unified_provider.go
@@ -217,10 +217,21 @@ func workspaceIDFromRawDiffConfig(d *schema.ResourceDiff) (string, bool) {
 // it. Intended for dual resources (called via CustomizeDiffDualResources); the
 // `api` field is assumed to exist in the schema.
 func ValidateApiLevelForUnifiedHost(d *schema.ResourceDiff, c *DatabricksClient) error {
+	return validateApiLevelForUnifiedHost(GetApiLevelFromDiff(d), c)
+}
+
+// ValidateApiLevelForUnifiedHostFromData is the data-source variant of
+// ValidateApiLevelForUnifiedHost. SDKv2 data sources cannot set CustomizeDiff,
+// so call this at the top of Read to fail the plan for dual data sources.
+func ValidateApiLevelForUnifiedHostFromData(d *schema.ResourceData, c *DatabricksClient) error {
+	return validateApiLevelForUnifiedHost(GetApiLevel(d), c)
+}
+
+func validateApiLevelForUnifiedHost(apiLevel string, c *DatabricksClient) error {
 	if c.HostTypeForTerraform() != config.UnifiedHost {
 		return nil
 	}
-	if GetApiLevelFromDiff(d) != "" {
+	if apiLevel != "" {
 		return nil
 	}
 	return fmt.Errorf("please set api to account or workspace")

--- a/common/unified_provider_test.go
+++ b/common/unified_provider_test.go
@@ -896,24 +896,6 @@ func TestValidateApiLevelForUnifiedHost_PassesWhenApiSet(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestValidateApiLevelForUnifiedHost_IgnoresNonDualResources(t *testing.T) {
-	resource := newTestResourceForCustomizeDiff()
-	c := &DatabricksClient{
-		DatabricksClient: &client.DatabricksClient{
-			Config: unifiedHostConfig(t, "https://unifiedhost.databricks.com"),
-		},
-	}
-	_, err := diffCustomizeDiff(t, resource, nil, map[string]interface{}{
-		"name": "test",
-		"provider_config": []interface{}{
-			map[string]interface{}{
-				"workspace_id": "999",
-			},
-		},
-	}, c)
-	assert.NoError(t, err)
-}
-
 func TestValidateApiLevelForUnifiedHost_IgnoresNonUnifiedHost(t *testing.T) {
 	resource := newDualResourceForCustomizeDiff()
 	c := &DatabricksClient{

--- a/common/unified_provider_test.go
+++ b/common/unified_provider_test.go
@@ -845,6 +845,91 @@ func TestNamespaceCustomizeDiff_UnifiedHost_DirectFallback(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+// newDualResourceForCustomizeDiff builds a test resource with the `api` field
+// (mirroring dual resources that call AddApiField) wired to NamespaceCustomizeDiff.
+func newDualResourceForCustomizeDiff() *schema.Resource {
+	r := Resource{
+		Schema: AddApiField(map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		}),
+		CustomizeDiff: NamespaceCustomizeDiff,
+		Read: func(ctx context.Context, d *schema.ResourceData, c *DatabricksClient) error {
+			return nil
+		},
+		Create: func(ctx context.Context, d *schema.ResourceData, c *DatabricksClient) error {
+			return nil
+		},
+	}
+	AddNamespaceInSchema(r.Schema)
+	NamespaceCustomizeSchemaMap(r.Schema)
+	return r.ToResource()
+}
+
+func TestValidateApiLevelForUnifiedHost_ErrorsWhenApiMissing(t *testing.T) {
+	resource := newDualResourceForCustomizeDiff()
+	c := &DatabricksClient{
+		DatabricksClient: &client.DatabricksClient{
+			Config: unifiedHostConfig(t, "https://unifiedhost.databricks.com"),
+		},
+	}
+	_, err := diffCustomizeDiff(t, resource, nil, map[string]interface{}{
+		"name": "test",
+	}, c)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "please set api to account or workspace")
+}
+
+func TestValidateApiLevelForUnifiedHost_PassesWhenApiSet(t *testing.T) {
+	resource := newDualResourceForCustomizeDiff()
+	c := &DatabricksClient{
+		DatabricksClient: &client.DatabricksClient{
+			Config: unifiedHostConfig(t, "https://unifiedhost.databricks.com"),
+		},
+	}
+	_, err := diffCustomizeDiff(t, resource, nil, map[string]interface{}{
+		"name": "test",
+		"api":  "account",
+	}, c)
+	assert.NoError(t, err)
+}
+
+func TestValidateApiLevelForUnifiedHost_IgnoresNonDualResources(t *testing.T) {
+	resource := newTestResourceForCustomizeDiff()
+	c := &DatabricksClient{
+		DatabricksClient: &client.DatabricksClient{
+			Config: unifiedHostConfig(t, "https://unifiedhost.databricks.com"),
+		},
+	}
+	_, err := diffCustomizeDiff(t, resource, nil, map[string]interface{}{
+		"name": "test",
+		"provider_config": []interface{}{
+			map[string]interface{}{
+				"workspace_id": "999",
+			},
+		},
+	}, c)
+	assert.NoError(t, err)
+}
+
+func TestValidateApiLevelForUnifiedHost_IgnoresNonUnifiedHost(t *testing.T) {
+	resource := newDualResourceForCustomizeDiff()
+	c := &DatabricksClient{
+		DatabricksClient: &client.DatabricksClient{
+			Config: &config.Config{
+				Host:  "https://test.cloud.databricks.com",
+				Token: "test-token",
+			},
+		},
+	}
+	_, err := diffCustomizeDiff(t, resource, nil, map[string]interface{}{
+		"name": "test",
+	}, c)
+	assert.NoError(t, err)
+}
+
 func TestNamespaceCustomizeDiff_ForceNewOnChange(t *testing.T) {
 	resource := newTestResourceForCustomizeDiff()
 	mockWS := &databricks.WorkspaceClient{

--- a/common/unified_provider_test.go
+++ b/common/unified_provider_test.go
@@ -896,6 +896,30 @@ func TestValidateApiLevelForUnifiedHost_PassesWhenApiSet(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestValidateApiLevelForUnifiedHostFromData_ErrorsWhenApiMissing(t *testing.T) {
+	c := &DatabricksClient{
+		DatabricksClient: &client.DatabricksClient{
+			Config: unifiedHostConfig(t, "https://unifiedhost.databricks.com"),
+		},
+	}
+	d := schema.TestResourceDataRaw(t, AddApiField(map[string]*schema.Schema{}), map[string]interface{}{})
+	err := ValidateApiLevelForUnifiedHostFromData(d, c)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "please set api to account or workspace")
+}
+
+func TestValidateApiLevelForUnifiedHostFromData_PassesWhenApiSet(t *testing.T) {
+	c := &DatabricksClient{
+		DatabricksClient: &client.DatabricksClient{
+			Config: unifiedHostConfig(t, "https://unifiedhost.databricks.com"),
+		},
+	}
+	d := schema.TestResourceDataRaw(t, AddApiField(map[string]*schema.Schema{}), map[string]interface{}{
+		"api": "workspace",
+	})
+	assert.NoError(t, ValidateApiLevelForUnifiedHostFromData(d, c))
+}
+
 func TestValidateApiLevelForUnifiedHost_IgnoresNonUnifiedHost(t *testing.T) {
 	resource := newDualResourceForCustomizeDiff()
 	c := &DatabricksClient{

--- a/common/unified_provider_test.go
+++ b/common/unified_provider_test.go
@@ -846,7 +846,7 @@ func TestNamespaceCustomizeDiff_UnifiedHost_DirectFallback(t *testing.T) {
 }
 
 // newDualResourceForCustomizeDiff builds a test resource with the `api` field
-// (mirroring dual resources that call AddApiField) wired to NamespaceCustomizeDiff.
+// (mirroring dual resources that call AddApiField) wired to CustomizeDiffDualResources.
 func newDualResourceForCustomizeDiff() *schema.Resource {
 	r := Resource{
 		Schema: AddApiField(map[string]*schema.Schema{
@@ -855,7 +855,7 @@ func newDualResourceForCustomizeDiff() *schema.Resource {
 				Required: true,
 			},
 		}),
-		CustomizeDiff: NamespaceCustomizeDiff,
+		CustomizeDiff: CustomizeDiffDualResources,
 		Read: func(ctx context.Context, d *schema.ResourceData, c *DatabricksClient) error {
 			return nil
 		},

--- a/internal/acceptance/dual_resource_api_validation_acc_test.go
+++ b/internal/acceptance/dual_resource_api_validation_acc_test.go
@@ -198,3 +198,27 @@ func TestAccDualResource_UnifiedHost_MetastoreAssignment_MissingApi(t *testing.T
 		}
 	`)
 }
+
+func TestAccDualDataSource_UnifiedHost_User_MissingApi(t *testing.T) {
+	dualResourceUnifiedHostPlanTest(t, `
+		data "databricks_user" "this" {
+			user_name = "test@example.com"
+		}
+	`)
+}
+
+func TestAccDualDataSource_UnifiedHost_Group_MissingApi(t *testing.T) {
+	dualResourceUnifiedHostPlanTest(t, `
+		data "databricks_group" "this" {
+			display_name = "test-group"
+		}
+	`)
+}
+
+func TestAccDualDataSource_UnifiedHost_CurrentConfig_MissingApi(t *testing.T) {
+	dualResourceUnifiedHostPlanTest(t, `
+		data "databricks_current_config" "this" {
+			cloud = "aws"
+		}
+	`)
+}

--- a/internal/acceptance/dual_resource_api_validation_acc_test.go
+++ b/internal/acceptance/dual_resource_api_validation_acc_test.go
@@ -1,0 +1,200 @@
+package acceptance
+
+import (
+	"context"
+	"regexp"
+	"testing"
+
+	"github.com/databricks/databricks-sdk-go/config"
+	"github.com/databricks/terraform-provider-databricks/internal/providers"
+	"github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw"
+	"github.com/databricks/terraform-provider-databricks/internal/providers/sdkv2"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+// unifiedHostMockProviderFactories returns provider factories whose resolved
+// host type is UnifiedHost. The customizer resets the config so EnsureResolved
+// runs again with an in-memory HostMetadataResolver that always returns
+// UnifiedHost — no network call, no env dependency.
+func unifiedHostMockProviderFactories() map[string]func() (tfprotov6.ProviderServer, error) {
+	customizer := func(cfg *config.Config) error {
+		*cfg = config.Config{
+			Host:  "https://unifiedhost.databricks.com",
+			Token: "test-token",
+			HostMetadataResolver: func(ctx context.Context, _ string) (*config.HostMetadata, error) {
+				return &config.HostMetadata{HostType: config.UnifiedHost}, nil
+			},
+		}
+		return cfg.EnsureResolved()
+	}
+	return map[string]func() (tfprotov6.ProviderServer, error){
+		"databricks": func() (tfprotov6.ProviderServer, error) {
+			ctx := context.Background()
+			sdkPluginProvider := sdkv2.DatabricksProvider(
+				sdkv2.WithConfigCustomizer(customizer),
+			)
+			pluginFrameworkProvider := pluginfw.GetDatabricksProviderPluginFramework(
+				pluginfw.WithConfigCustomizer(customizer),
+			)
+			return providers.GetProviderServer(ctx,
+				providers.WithSdkV2Provider(sdkPluginProvider),
+				providers.WithPluginFrameworkProvider(pluginFrameworkProvider),
+			)
+		},
+	}
+}
+
+// dualResourceUnifiedHostPlanTest plans the given HCL against a UnifiedHost-
+// mocked provider and asserts it fails with the missing-api error.
+func dualResourceUnifiedHostPlanTest(t *testing.T, hcl string) {
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: unifiedHostMockProviderFactories(),
+		Steps: []resource.TestStep{{
+			Config:      hcl,
+			PlanOnly:    true,
+			ExpectError: regexp.MustCompile(`please set api to account or workspace`),
+		}},
+	})
+}
+
+func TestAccDualResource_UnifiedHost_User_MissingApi(t *testing.T) {
+	dualResourceUnifiedHostPlanTest(t, `
+		resource "databricks_user" "this" {
+			user_name = "test@example.com"
+		}
+	`)
+}
+
+func TestAccDualResource_UnifiedHost_ServicePrincipal_MissingApi(t *testing.T) {
+	dualResourceUnifiedHostPlanTest(t, `
+		resource "databricks_service_principal" "this" {
+			display_name = "test-sp"
+		}
+	`)
+}
+
+func TestAccDualResource_UnifiedHost_Group_MissingApi(t *testing.T) {
+	dualResourceUnifiedHostPlanTest(t, `
+		resource "databricks_group" "this" {
+			display_name = "test-group"
+		}
+	`)
+}
+
+func TestAccDualResource_UnifiedHost_GroupRole_MissingApi(t *testing.T) {
+	dualResourceUnifiedHostPlanTest(t, `
+		resource "databricks_group_role" "this" {
+			group_id = "123"
+			role     = "test-role"
+		}
+	`)
+}
+
+func TestAccDualResource_UnifiedHost_GroupMember_MissingApi(t *testing.T) {
+	dualResourceUnifiedHostPlanTest(t, `
+		resource "databricks_group_member" "this" {
+			group_id  = "123"
+			member_id = "456"
+		}
+	`)
+}
+
+func TestAccDualResource_UnifiedHost_UserRole_MissingApi(t *testing.T) {
+	dualResourceUnifiedHostPlanTest(t, `
+		resource "databricks_user_role" "this" {
+			user_id = "123"
+			role    = "test-role"
+		}
+	`)
+}
+
+func TestAccDualResource_UnifiedHost_ServicePrincipalRole_MissingApi(t *testing.T) {
+	dualResourceUnifiedHostPlanTest(t, `
+		resource "databricks_service_principal_role" "this" {
+			service_principal_id = "123"
+			role                 = "test-role"
+		}
+	`)
+}
+
+func TestAccDualResource_UnifiedHost_UserInstanceProfile_MissingApi(t *testing.T) {
+	dualResourceUnifiedHostPlanTest(t, `
+		resource "databricks_user_instance_profile" "this" {
+			user_id             = "123"
+			instance_profile_id = "arn:aws:iam::123456789012:instance-profile/test"
+		}
+	`)
+}
+
+func TestAccDualResource_UnifiedHost_GroupInstanceProfile_MissingApi(t *testing.T) {
+	dualResourceUnifiedHostPlanTest(t, `
+		resource "databricks_group_instance_profile" "this" {
+			group_id            = "123"
+			instance_profile_id = "arn:aws:iam::123456789012:instance-profile/test"
+		}
+	`)
+}
+
+func TestAccDualResource_UnifiedHost_ServicePrincipalSecret_MissingApi(t *testing.T) {
+	dualResourceUnifiedHostPlanTest(t, `
+		resource "databricks_service_principal_secret" "this" {
+			service_principal_id = "123"
+		}
+	`)
+}
+
+func TestAccDualResource_UnifiedHost_AccessControlRuleSet_MissingApi(t *testing.T) {
+	dualResourceUnifiedHostPlanTest(t, `
+		resource "databricks_access_control_rule_set" "this" {
+			name = "accounts/abc/servicePrincipals/123/ruleSets/default"
+			grant_rules {
+				principals = ["groups/admins"]
+				role       = "roles/servicePrincipal.user"
+			}
+		}
+	`)
+}
+
+func TestAccDualResource_UnifiedHost_Metastore_MissingApi(t *testing.T) {
+	dualResourceUnifiedHostPlanTest(t, `
+		resource "databricks_metastore" "this" {
+			name         = "test-metastore"
+			storage_root = "s3://test-bucket/"
+			region       = "us-east-1"
+		}
+	`)
+}
+
+func TestAccDualResource_UnifiedHost_StorageCredential_MissingApi(t *testing.T) {
+	dualResourceUnifiedHostPlanTest(t, `
+		resource "databricks_storage_credential" "this" {
+			name = "test-credential"
+			aws_iam_role {
+				role_arn = "arn:aws:iam::123456789012:role/test"
+			}
+		}
+	`)
+}
+
+func TestAccDualResource_UnifiedHost_MetastoreDataAccess_MissingApi(t *testing.T) {
+	dualResourceUnifiedHostPlanTest(t, `
+		resource "databricks_metastore_data_access" "this" {
+			metastore_id = "11111111-1111-1111-1111-111111111111"
+			name         = "test-data-access"
+			aws_iam_role {
+				role_arn = "arn:aws:iam::123456789012:role/test"
+			}
+		}
+	`)
+}
+
+func TestAccDualResource_UnifiedHost_MetastoreAssignment_MissingApi(t *testing.T) {
+	dualResourceUnifiedHostPlanTest(t, `
+		resource "databricks_metastore_assignment" "this" {
+			metastore_id = "11111111-1111-1111-1111-111111111111"
+			workspace_id = 123456
+		}
+	`)
+}

--- a/mws/data_current_config.go
+++ b/mws/data_current_config.go
@@ -43,6 +43,9 @@ func DataSourceCurrentConfiguration() common.Resource {
 	return common.Resource{
 		Schema: s,
 		Read: func(ctx context.Context, d *schema.ResourceData, m *common.DatabricksClient) error {
+			if err := common.ValidateApiLevelForUnifiedHostFromData(d, m); err != nil {
+				return err
+			}
 			newClient, err := m.DatabricksClientForUnifiedProvider(ctx, d)
 			if err != nil {
 				return err

--- a/permissions/resource_access_control_rule_set.go
+++ b/permissions/resource_access_control_rule_set.go
@@ -100,7 +100,7 @@ func ResourceAccessControlRuleSet() common.Resource {
 	return common.Resource{
 		Schema: s,
 		CustomizeDiff: func(ctx context.Context, d *schema.ResourceDiff, c *common.DatabricksClient) error {
-			return common.NamespaceCustomizeDiff(ctx, d, c)
+			return common.CustomizeDiffDualResources(ctx, d, c)
 		},
 		CanSkipReadAfterCreateAndUpdate: func(_ *schema.ResourceData) bool {
 			return true

--- a/scim/data_group.go
+++ b/scim/data_group.go
@@ -42,6 +42,9 @@ func DataSourceGroup() common.Resource {
 	return common.Resource{
 		Schema: s,
 		Read: func(ctx context.Context, d *schema.ResourceData, m *common.DatabricksClient) error {
+			if err := common.ValidateApiLevelForUnifiedHostFromData(d, m); err != nil {
+				return err
+			}
 			newClient, err := m.DatabricksClientForUnifiedProvider(ctx, d)
 			if err != nil {
 				return err

--- a/scim/data_user.go
+++ b/scim/data_user.go
@@ -77,6 +77,9 @@ func DataSourceUser() common.Resource {
 	return common.Resource{
 		Schema: s,
 		Read: func(ctx context.Context, d *schema.ResourceData, m *common.DatabricksClient) error {
+			if err := common.ValidateApiLevelForUnifiedHostFromData(d, m); err != nil {
+				return err
+			}
 			newClient, err := m.DatabricksClientForUnifiedProvider(ctx, d)
 			if err != nil {
 				return err

--- a/scim/resource_group.go
+++ b/scim/resource_group.go
@@ -40,7 +40,7 @@ func ResourceGroup() common.Resource {
 	common.NamespaceCustomizeSchemaMap(groupSchema)
 	return common.Resource{
 		CustomizeDiff: func(ctx context.Context, d *schema.ResourceDiff, c *common.DatabricksClient) error {
-			return common.NamespaceCustomizeDiff(ctx, d, c)
+			return common.CustomizeDiffDualResources(ctx, d, c)
 		},
 		Create: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
 			c, err := c.DatabricksClientForUnifiedProvider(ctx, d)

--- a/scim/resource_group_member.go
+++ b/scim/resource_group_member.go
@@ -156,7 +156,7 @@ func ResourceGroupMember() common.Resource {
 		},
 	})
 	r.CustomizeDiff = func(ctx context.Context, d *schema.ResourceDiff, c *common.DatabricksClient) error {
-		return common.NamespaceCustomizeDiff(ctx, d, c)
+		return common.CustomizeDiffDualResources(ctx, d, c)
 	}
 	return r
 }

--- a/scim/resource_group_role.go
+++ b/scim/resource_group_role.go
@@ -50,7 +50,7 @@ func ResourceGroupRole() common.Resource {
 		},
 	})
 	r.CustomizeDiff = func(ctx context.Context, d *schema.ResourceDiff, c *common.DatabricksClient) error {
-		return common.NamespaceCustomizeDiff(ctx, d, c)
+		return common.CustomizeDiffDualResources(ctx, d, c)
 	}
 	return r
 }

--- a/scim/resource_service_principal.go
+++ b/scim/resource_service_principal.go
@@ -161,7 +161,7 @@ func ResourceServicePrincipal() common.Resource {
 	return common.Resource{
 		Schema: servicePrincipalSchema,
 		CustomizeDiff: func(ctx context.Context, d *schema.ResourceDiff, c *common.DatabricksClient) error {
-			return common.NamespaceCustomizeDiff(ctx, d, c)
+			return common.CustomizeDiffDualResources(ctx, d, c)
 		},
 		Create: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
 			c, err := c.DatabricksClientForUnifiedProvider(ctx, d)

--- a/scim/resource_user.go
+++ b/scim/resource_user.go
@@ -95,7 +95,7 @@ func ResourceUser() common.Resource {
 	return common.Resource{
 		Schema: userSchema,
 		CustomizeDiff: func(ctx context.Context, d *schema.ResourceDiff, c *common.DatabricksClient) error {
-			return common.NamespaceCustomizeDiff(ctx, d, c)
+			return common.CustomizeDiffDualResources(ctx, d, c)
 		},
 		Create: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
 			c, err := c.DatabricksClientForUnifiedProvider(ctx, d)

--- a/tokens/resource_service_principal_secret.go
+++ b/tokens/resource_service_principal_secret.go
@@ -48,7 +48,7 @@ func ResourceServicePrincipalSecret() common.Resource {
 	return common.Resource{
 		Schema: spnSecretSchema,
 		CustomizeDiff: func(ctx context.Context, d *schema.ResourceDiff, c *common.DatabricksClient) error {
-			return common.NamespaceCustomizeDiff(ctx, d, c)
+			return common.CustomizeDiffDualResources(ctx, d, c)
 		},
 		CanSkipReadAfterCreateAndUpdate: func(d *schema.ResourceData) bool {
 			return true


### PR DESCRIPTION
 ## Summary

  Dual workspace/account resources (the ones that call common.AddApiField) cannot infer the API level from a unified host, so the user must declare api = "account" or api =
  "workspace" explicitly. Today, if they don't, the provider silently defaults to workspace-level routing and the error only surfaces at apply time (as a misleading API error).

  This PR makes the plan fail fast with a clear message:

  Error: please set api to account or workspace

 ## Changes

  - common/unified_provider.go
    - New ValidateApiLevelForUnifiedHost(d, c) — errors if HostTypeForTerraform() == UnifiedHost and api is unset.
    - New CustomizeDiffDualResources(ctx, d, c) — runs the api-level check, then delegates to NamespaceCustomizeDiff. This is the single CustomizeDiff entry point for dual resources.
    - NamespaceCustomizeDiff is unchanged for pure workspace resources.
  - Wired all 15 dual resources to CustomizeDiffDualResources: databricks_user, databricks_service_principal, databricks_group, databricks_group_role, databricks_group_member,
  databricks_user_role, databricks_service_principal_role, databricks_user_instance_profile, databricks_group_instance_profile, databricks_service_principal_secret,
  databricks_access_control_rule_set, databricks_metastore, databricks_storage_credential, databricks_metastore_data_access, databricks_metastore_assignment.
  - NEXT_CHANGELOG.md — changelog entry under New Features and Improvements.

 ## Tests

  - common/unified_provider_test.go — 3 unit tests for the validator: errors when api missing, passes when set, passes when host isn't unified.
  - internal/acceptance/dual_resource_api_validation_acc_test.go — 15 plan-only acceptance tests (one per dual resource) that mock a UnifiedHost via an in-memory
  HostMetadataResolver, assert PlanOnly: true fails with please set api to account or workspace. No CLOUD_ENV required — runs locally under TF_ACC=1.

  Test plan

  - make fmt lint ws
  - go test ./common/... ./aws/... ./scim/... ./catalog/... ./permissions/... ./tokens/...