### PR TITLE
Remove legacy tag-triggered release workflow

### DIFF
--- a/.github/workflows/release-build-check.yml
+++ b/.github/workflows/release-build-check.yml
@@ -1,4 +1,4 @@
-name: release-legacy
+name: Release Build Check
 
 on:
   merge_group:

--- a/.github/workflows/release-legacy.yml
+++ b/.github/workflows/release-legacy.yml
@@ -1,9 +1,6 @@
 name: release-legacy
 
 on:
-  push:
-    tags:
-      - "*"
   merge_group:
     types: [checks_requested]
 
@@ -54,37 +51,8 @@ jobs:
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           PASSPHRASE: ${{ secrets.PASSPHRASE }}
 
-      - name: Write release notes to file
-        run: |
-          if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
-            RELEASE_NOTES_DIR=/tmp/release-notes
-            mkdir -p "$RELEASE_NOTES_DIR"
-            RELEASE_NOTES_FILE="$RELEASE_NOTES_DIR/release-notes.md"
-            git for-each-ref --format='%(body)' ${{ github.ref }} > "$RELEASE_NOTES_FILE"
-            echo "Release notes file: $RELEASE_NOTES_FILE"
-            echo "Release notes contents:"
-            cat "$RELEASE_NOTES_FILE"
-          else
-            echo "Not a release tag, skipping release notes"
-          fi
-
-      - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
-        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
-        with:
-          version: ~> v2
-          # Arguments cannot reference environment variables, so we write the release notes
-          # to a well-known location and use that in the goreleaser command.
-          args: release --clean --release-notes=/tmp/release-notes/release-notes.md
-        env:
-          # use GITHUB_TOKEN that is already available in secrets.GITHUB_TOKEN
-          # https://docs.github.com/en/free-pro-team@latest/actions/reference/authentication-in-a-workflow#permissions-for-the-github_token
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
-
       - name: Run GoReleaser (snapshot)
         uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
-        if: ${{ ! startsWith(github.ref , 'refs/tags/v') }}
         with:
           version: ~> v2
           args: release --clean --snapshot


### PR DESCRIPTION
NO_CHANGELOG=true

## Summary
The legacy tag-triggered release workflow is superseded by the secure release pipeline in
`databricks/secure-public-registry-releases-eng`, which dispatches `tagging.yml` and
`package.yml` here and handles the GitHub release (with zips + SHA256SUMS) externally.
This PR removes the obsolete tag-trigger path while preserving the `merge_group` snapshot build that runs as a build-breakage check in the merge queue.

## What changed
- `.github/workflows/release-legacy.yml`: dropped `push.tags` trigger, removed the strictly tag-gated steps (release-notes extraction and the non-snapshot `goreleaser release` run), and removed the now-redundant `if: ! startsWith(github.ref, 'refs/tags/v')` guard on the snapshot step. The `merge_group` trigger and the `goreleaser release --clean --snapshot` build-check step are preserved.

## What's preserved
- `tagging.yml` (auto-tag entry point dispatched by the secure release pipeline)
- `package.yml` (GPG-signed GoReleaser build dispatched by the secure release workflow)
- `release-legacy.yml`'s `merge_group` GoReleaser snapshot run (catches build breakage in the merge queue)

## Blast radius
Terraform Registry polls the GH Release assets. The secure release pipeline now produces
the exact asset set (`*.zip`, `*_SHA256SUMS`, `*_SHA256SUMS.sig`) that it produced before.