### PR TITLE
[Internal] Remove obsolete ProviderConfig_Required tests

### DIFF
--- a/catalog/grant_test.go
+++ b/catalog/grant_test.go
@@ -173,17 +173,6 @@ func TestUcAccGrant_ProviderConfig_Invalid(t *testing.T) {
 	})
 }
 
-func TestUcAccGrant_ProviderConfig_Required(t *testing.T) {
-	acceptance.UnityWorkspaceLevel(t, acceptance.Step{
-		Template: grantProviderConfigTemplate(`
-			provider_config {
-			}
-		`),
-		ExpectError: regexp.MustCompile(`The argument "workspace_id" is required, but no definition was found.`),
-		PlanOnly:    true,
-	})
-}
-
 func TestUcAccGrant_ProviderConfig_EmptyID(t *testing.T) {
 	acceptance.UnityWorkspaceLevel(t, acceptance.Step{
 		Template: grantProviderConfigTemplate(`

--- a/catalog/grants_test.go
+++ b/catalog/grants_test.go
@@ -185,17 +185,6 @@ func TestUcAccGrants_ProviderConfig_Invalid(t *testing.T) {
 	})
 }
 
-func TestUcAccGrants_ProviderConfig_Required(t *testing.T) {
-	acceptance.UnityWorkspaceLevel(t, acceptance.Step{
-		Template: grantsProviderConfigTemplate(`
-			provider_config {
-			}
-		`),
-		ExpectError: regexp.MustCompile(`The argument "workspace_id" is required, but no definition was found.`),
-		PlanOnly:    true,
-	})
-}
-
 func TestUcAccGrants_ProviderConfig_EmptyID(t *testing.T) {
 	acceptance.UnityWorkspaceLevel(t, acceptance.Step{
 		Template: grantsProviderConfigTemplate(`


### PR DESCRIPTION
  ## Summary
  Remove obsolete acceptance tests `TestUcAccGrant_ProviderConfig_Required` and
  `TestUcAccGrants_ProviderConfig_Required` — they assert an error that no longer occurs, similar to https://github.com/databricks/terraform-provider-databricks/pull/5492

  ## Changes
  * Delete `TestUcAccGrant_ProviderConfig_Required` from `catalog/grant_test.go`
  * Delete `TestUcAccGrants_ProviderConfig_Required` from `catalog/grants_test.go`

NO_CHANGELOG=true