### PR TITLE
[Internal] Remove obsolete disable step from TestAccSQLGlobalConfigServerless

### DIFF
--- a/sql/sql_global_config_test.go
+++ b/sql/sql_global_config_test.go
@@ -77,9 +77,6 @@ func TestAccSQLGlobalConfigServerless(t *testing.T) {
 	}, acceptance.Step{
 		Template: makeSqlGlobalConfig(""),
 		Check:    checkServerlessEnabled(true),
-	}, acceptance.Step{
-		Template: makeSqlGlobalConfig("enable_serverless_compute = false"),
-		Check:    checkServerlessEnabled(false),
 	})
 }
 


### PR DESCRIPTION
  ## Summary

Remove the third step of `TestAccSQLGlobalConfigServerless` which asserts `enable_serverless_compute = false` can be applied successfully. The underlying API (`/api/2.0/sql/config/warehouses`) no longer permits disabling serverless on most workspaces — it returns `INVALID_PARAMETER_VALUE`. The `enable_serverless_compute` attribute on `databricks_sql_global_config` is already marked Deprecated for the same reason.

The first two steps (enabling serverless, and applying a default empty configuration) remain valid coverage.

  ## Changes

  * `sql/sql_global_config_test.go` — drop the disable step (`enable_serverless_compute = false` +
  `checkServerlessEnabled(false)`)

NO_CHANGELOG=true