### PR TITLE
[Internal] Prefix databricks_connection acceptance test names with `tf-test-`

### DIFF
--- a/catalog/catalog_test.go
+++ b/catalog/catalog_test.go
@@ -156,7 +156,7 @@ func TestUcAccCatalogHmsConnectionUpdate(t *testing.T) {
 	otherAuthorizedPath := fmt.Sprintf("s3://%s/path/to/authorized", qa.RandomName("hms-other-bucket-"))
 	otherInfra := fmt.Sprintf(`
 		resource "databricks_connection" "sandbox" {
-			name = "hms_connection{var.STICKY_RANDOM}"
+			name = "tf-test-hms-connection-{var.STICKY_RANDOM}"
 			connection_type = "HIVE_METASTORE"
 			comment         = "created in TestUcAccCatalogHmsConnectionUpdate"
 			options = {

--- a/catalog/connection_test.go
+++ b/catalog/connection_test.go
@@ -10,7 +10,7 @@ import (
 func connectionTemplateWithOwner(host string, owner string) string {
 	return fmt.Sprintf(`
 	resource "databricks_connection" "this" {
-		name = "name-{var.STICKY_RANDOM}"
+		name = "tf-test-connection-{var.STICKY_RANDOM}"
 		connection_type = "MYSQL"
 		comment         = "this is a connection to mysql db"
 		options         = {
@@ -27,7 +27,7 @@ func connectionTemplateWithOwner(host string, owner string) string {
 func connectionTemplateWithoutOwner() string {
 	return `
 	resource "databricks_connection" "this" {
-		name = "name-{var.STICKY_RANDOM}"
+		name = "tf-test-connection-{var.STICKY_RANDOM}"
 		connection_type = "BIGQUERY"
 		comment         = "test"
 		options = {


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
Matches the existing tf-test-* convention used for metastores, storage credentials, and named credentials, so an upstream cleanup sweeper can match leaked connection resources by a single prefix.
## Tests
<!--
How is this tested? Please see the checklist below and also describe any other relevant tests
-->
NO_CHANGELOG=true
