### PR TITLE
[Internal] Remove `effective_file_event_queue` as read only

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -8,7 +8,6 @@
 
 ### Bug Fixes
 
-* Mark `effective_file_event_queue` as read-only in `databricks_external_location` to prevent Terraform drift.
 ### Documentation
 
 ### Exporter

--- a/catalog/resource_external_location.go
+++ b/catalog/resource_external_location.go
@@ -36,7 +36,7 @@ func ResourceExternalLocation() common.Resource {
 			common.CustomizeSchemaPath(m, "isolation_mode").SetComputed()
 			common.CustomizeSchemaPath(m, "owner").SetComputed()
 			common.CustomizeSchemaPath(m, "metastore_id").SetComputed()
-			for _, key := range []string{"created_at", "created_by", "credential_id", "updated_at", "updated_by", "browse_only", "effective_enable_file_events", "effective_file_event_queue"} {
+			for _, key := range []string{"created_at", "created_by", "credential_id", "updated_at", "updated_by", "browse_only", "effective_enable_file_events"} {
 				common.CustomizeSchemaPath(m, key).SetReadOnly()
 			}
 			// customize file event queue

--- a/catalog/resource_external_location_test.go
+++ b/catalog/resource_external_location_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/databricks/databricks-sdk-go/service/catalog"
 
 	"github.com/databricks/terraform-provider-databricks/qa"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -692,100 +691,6 @@ func TestCreateExternalLocationWithEffectiveEnableFileEvents(t *testing.T) {
 		comment = "def"
 		`,
 	}.ApplyNoError(t)
-}
-
-func TestCreateExternalLocationWithEffectiveFileEventQueue(t *testing.T) {
-	qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:   "POST",
-				Resource: "/api/2.1/unity-catalog/external-locations",
-				ExpectedRequest: catalog.CreateExternalLocation{
-					Name:           "abc",
-					Url:            "s3://foo/bar",
-					CredentialName: "bcd",
-					Comment:        "def",
-				},
-				Response: catalog.ExternalLocationInfo{
-					Name:           "abc",
-					Url:            "s3://foo/bar",
-					CredentialName: "bcd",
-					Comment:        "def",
-				},
-			},
-			{
-				Method:   "GET",
-				Resource: "/api/2.1/unity-catalog/external-locations/abc?",
-				Response: catalog.ExternalLocationInfo{
-					Name:           "abc",
-					Url:            "s3://foo/bar",
-					CredentialName: "bcd",
-					Comment:        "def",
-					Owner:          "efg",
-					MetastoreId:    "fgh",
-					EffectiveFileEventQueue: &catalog.FileEventQueue{
-						ManagedSqs: &catalog.AwsSqsQueue{},
-					},
-				},
-			},
-		},
-		Resource: ResourceExternalLocation(),
-		Create:   true,
-		HCL: `
-		name = "abc"
-		url = "s3://foo/bar"
-		credential_name = "bcd"
-		comment = "def"
-		`,
-	}.ApplyNoError(t)
-}
-
-func TestReadExternalLocationWithEffectiveFileEventQueue(t *testing.T) {
-	d, err := qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:   "GET",
-				Resource: "/api/2.1/unity-catalog/external-locations/abc?",
-				Response: catalog.ExternalLocationInfo{
-					Name:           "abc",
-					Url:            "s3://foo/bar",
-					CredentialName: "bcd",
-					Comment:        "def",
-					Owner:          "efg",
-					MetastoreId:    "fgh",
-					EffectiveFileEventQueue: &catalog.FileEventQueue{
-						ManagedPubsub: &catalog.GcpPubsub{
-							ManagedResourceId: "projects/p/subscriptions/s",
-						},
-					},
-					EffectiveEnableFileEvents: true,
-				},
-			},
-		},
-		Resource: ResourceExternalLocation(),
-		Read:     true,
-		ID:       "abc",
-		HCL: `
-		name = "abc"
-		url = "s3://foo/bar"
-		credential_name = "bcd"
-		comment = "def"
-		`,
-	}.Apply(t)
-	assert.NoError(t, err)
-	assert.Equal(t, "abc", d.Id())
-	assert.Equal(t, "abc", d.Get("name"))
-	assert.Equal(t, "s3://foo/bar", d.Get("url"))
-	assert.Equal(t, "bcd", d.Get("credential_name"))
-	assert.Equal(t, "def", d.Get("comment"))
-	assert.Equal(t, "efg", d.Get("owner"))
-	assert.Equal(t, "fgh", d.Get("metastore_id"))
-	assert.Equal(t, true, d.Get("effective_enable_file_events"))
-	effective := d.Get("effective_file_event_queue").([]any)
-	assert.Len(t, effective, 1)
-	pubsub := effective[0].(map[string]any)["managed_pubsub"].([]any)
-	assert.Len(t, pubsub, 1)
-	assert.Equal(t, "projects/p/subscriptions/s", pubsub[0].(map[string]any)["managed_resource_id"])
 }
 
 func TestUpdateExternalLocationForce(t *testing.T) {


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
The change is leading to integration test failures. Reverting to restore a green main.

Previous changes: https://github.com/databricks/terraform-provider-databricks/pull/5507, https://github.com/databricks/terraform-provider-databricks/pull/5602

## Tests
<!--
How is this tested? Please see the checklist below and also describe any other relevant tests
-->
Integration tests are passing now

NO_CHANGELOG=true
