### PR TITLE
Doc: `grant_rule` optional for `access_control_rule_set`

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -11,7 +11,7 @@
 * Mark `effective_file_event_queue` as read-only in `databricks_external_location` to prevent Terraform drift.
 ### Documentation
 
-In resource `access_control_rule_set` the field `grant_rule` is marked as optional to match the current behaviour.
+* In resource `access_control_rule_set` the field `grant_rule` is marked as optional to match the current behaviour.
 
 ### Exporter
 

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -11,6 +11,8 @@
 * Mark `effective_file_event_queue` as read-only in `databricks_external_location` to prevent Terraform drift.
 ### Documentation
 
+In resource `access_control_rule_set` the field `grant_rule` is marked as optional to match the current behaviour.
+
 ### Exporter
 
 ### Internal Changes

--- a/docs/resources/access_control_rule_set.md
+++ b/docs/resources/access_control_rule_set.md
@@ -316,13 +316,13 @@ resource "databricks_access_control_rule_set" "tag_policy_usage" {
 
 * `api` - (Optional) Specifies whether to use account-level or workspace-level API. Valid values are `account` and `workspace`. When not set, the API level is inferred from the provider host.
 
-* `grant_rules` - (Required) The access control rules to be granted by this rule set, consisting of a set of principals and roles to be granted to them.
+* `grant_rules` - (Optional) The access control rules to be granted by this rule set, consisting of a set of principals and roles to be granted to them.
 
 !> Name uniquely identifies a rule set resource. Ensure all the grant_rules blocks for a rule set name are present in one `databricks_access_control_rule_set` resource block. Otherwise, after applying changes, users might lose their role assignment even if that was not intended.
 
 ### grant_rules
 
-One or more `grant_rules` blocks are required to actually set access rules.
+One or more `grant_rules` blocks are required to actually set access rules. If you want the rule set to contain no grants (for example to remove all existing grants), omit the `grant_rules` blocks entirely.
 
 ```hcl
 grant_rules {


### PR DESCRIPTION
## Changes
Clarified the `access_control_rule_set` documentation for `grant_rules`.

The docs previously marked `grant_rules` as required, but the provider accepts a configuration without `grant_rules`, which results in removing all grants from the affected entity. This PR updates the resource documentation to reflect the actual behavior and make the effect of omitting `grant_rules` explicit.

Resolves https://github.com/databricks/terraform-provider-databricks/issues/5638 if this is the intended behaviour.

## Tests
<!--
How is this tested? Please see the checklist below and also describe any other relevant tests
-->

- [ ] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] using Go SDK
- [ ] using TF Plugin Framework
- [ ] has entry in `NEXT_CHANGELOG.md` file


NO_CHANGELOG=true
