### PR TITLE
[Internal] Run config customizer before EnsureResolved in PrepareDatabricksClient

### DIFF
--- a/internal/acceptance/unified_host_acc_test.go
+++ b/internal/acceptance/unified_host_acc_test.go
@@ -17,9 +17,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 )
 
-func unifiedHostProviderFactories(unifiedHost string) map[string]func() (tfprotov6.ProviderServer, error) {
+func unifiedHostProviderFactories(unifiedHost, accountID string) map[string]func() (tfprotov6.ProviderServer, error) {
 	customizer := func(cfg *config.Config) error {
 		cfg.Host = unifiedHost
+		cfg.AccountID = accountID
 		return nil
 	}
 	return map[string]func() (tfprotov6.ProviderServer, error){
@@ -106,22 +107,21 @@ func TestMwsAccUnifiedHostCreateJobs(t *testing.T) {
 	initUnifiedHostAccountEnv(t)
 	unifiedHost := os.Getenv("UNIFIED_HOST")
 	workspaceID := GetEnvOrSkipTest(t, "TEST_WORKSPACE_ID")
-	createJobWithProviderConfig(t, workspaceID, unifiedHostProviderFactories(unifiedHost))
+	accountID := GetEnvOrSkipTest(t, "DATABRICKS_ACCOUNT_ID")
+	createJobWithProviderConfig(t, workspaceID, unifiedHostProviderFactories(unifiedHost, accountID))
 }
 
 func TestAccUnifiedHostWorkspaceCreateJobs(t *testing.T) {
 	initUnifiedHostWorkspaceEnv(t)
-	if !IsAzure(t) {
-		Skipf(t)("This test is only running on Azure until ACCOUNT_ID is exported in our workspace test environments")
-	}
 	unifiedHost := os.Getenv("UNIFIED_HOST")
+	accountID := GetEnvOrSkipTest(t, "TEST_ACCOUNT_ID")
 	ctx := context.Background()
 	w := databricks.Must(databricks.NewWorkspaceClient())
 	workspaceID, err := w.CurrentWorkspaceID(ctx)
 	if err != nil {
 		t.Fatalf("failed to get current workspace ID: %s", err)
 	}
-	createJobWithProviderConfig(t, strconv.FormatInt(workspaceID, 10), unifiedHostProviderFactories(unifiedHost))
+	createJobWithProviderConfig(t, strconv.FormatInt(workspaceID, 10), unifiedHostProviderFactories(unifiedHost, accountID))
 }
 
 func TestMwsAccAccountHostCreateJobs(t *testing.T) {

--- a/internal/providers/client/databricks_client.go
+++ b/internal/providers/client/databricks_client.go
@@ -36,7 +36,6 @@ func PrepareDatabricksClient(ctx context.Context, cfg *config.Config, configCust
 			cfg.AuthType = newer
 		}
 	}
-	cfg.EnsureResolved()
 	// Unless set explicitly, the provider will retry indefinitely until context is cancelled
 	// by either a timeout or interrupt.
 	if cfg.RetryTimeoutSeconds == 0 {
@@ -53,6 +52,7 @@ func PrepareDatabricksClient(ctx context.Context, cfg *config.Config, configCust
 			return nil, err
 		}
 	}
+	cfg.EnsureResolved()
 	client, err := client.New(cfg)
 	if err != nil {
 		return nil, err

--- a/internal/providers/pluginfw/pluginfw_rollout_utils.go
+++ b/internal/providers/pluginfw/pluginfw_rollout_utils.go
@@ -118,7 +118,8 @@ func (o *configCustomizer) Apply(options *pluginFrameworkOptions) {
 	options.configCustomizer = o.configCustomizer
 }
 
-// WithConfigCustomizer allows the caller to customize the SDK config after config resolution.
+// WithConfigCustomizer allows the caller to customize the SDK config before config resolution,
+// so customizer-set fields (e.g. Host) participate in resolveHostMetadata and auth.
 func WithConfigCustomizer(customizer func(*config.Config) error) PluginFrameworkOption {
 	return &configCustomizer{configCustomizer: customizer}
 }

--- a/internal/providers/sdkv2/sdkv2.go
+++ b/internal/providers/sdkv2/sdkv2.go
@@ -96,7 +96,8 @@ func WithSdkV2DataSourceFallbacks(dataSources []string) SdkV2ProviderOption {
 	}
 }
 
-// WithConfigCustomizer allows the caller to customize the SDK config after config resolution.
+// WithConfigCustomizer allows the caller to customize the SDK config before config resolution,
+// so customizer-set fields (e.g. Host) participate in resolveHostMetadata and auth.
 func WithConfigCustomizer(customizer func(*config.Config) error) SdkV2ProviderOption {
 	return func(o *sdkV2ProviderOptions) {
 		o.configCustomizer = customizer


### PR DESCRIPTION
  ## Changes
  Reorder `PrepareDatabricksClient` so the caller-supplied `configCustomizer`
  runs *before* `cfg.EnsureResolved()` instead of after. Updates the matching
  `WithConfigCustomizer` docstrings in `sdkv2` and `pluginfw` to reflect the
  new "before resolution" contract.

  ## Why
  `EnsureResolved()` is what fetches `/.well-known/databricks-config` and
  populates `resolvedHostType`, `DiscoveryURL`, `AccountID`, `WorkspaceID`,
  `TokenAudience`, etc. from host metadata. With the customizer running
  *after* resolution, any customizer that changes `cfg.Host` (e.g. to point
  at a unified host) ended up in an inconsistent state:

  1. `cfg.Host` = env-provided workspace URL
  2. `EnsureResolved` → metadata resolved against the **workspace** host:
     `resolvedHostType = WORKSPACE_HOST`, `DiscoveryURL` = workspace OIDC
  3. Customizer fires → `cfg.Host` = unified host, but the resolved fields
     from step 2 remain workspace-shaped
  4. Auth → issues a **workspace-scoped** OAuth token (from the stale
     workspace `DiscoveryURL`)
  5. API call → sends that workspace token to the **unified** host →
     `400 Unable to load OAuth Config`

  This was the failure signature for `TestAccUnifiedHostWorkspaceCreateJobs`
  across AWS and GCP. Running the customizer first lets the customizer-set
  `Host` participate in host-metadata resolution, OIDC discovery, and auth
  from the start, so all derived fields stay consistent.

  Existing customizers are compatible with the new order:
  - `DefaultConfigCustomizer` only sets `HTTPTimeoutSeconds` (picked up by
    the refresh client built inside `EnsureResolved`).
  - `OidcConfigCustomizer` sets OIDC/auth fields that are consumed post-resolve
    during `authenticateIfNeeded`.
  - Test customizers that call `cfg.EnsureResolved()` themselves become no-ops
    on the outer call (`resolved == true`).

  ## Tests
  - `TestAccUnifiedHostWorkspaceCreateJobs` now passes locally on
    `aws-prod` workspace (previously failed with
    `Error: cannot create job: Unable to load OAuth Config` during apply).
  - Unit tests and `make fmt lint ws` clean.

  NO_CHANGELOG=true