### PR TITLE
Fix NCC transient failures during terraform apply and destroy (#5292)

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -9,6 +9,8 @@
 ### Bug Fixes
 
 * Mark `effective_file_event_queue` as read-only in `databricks_external_location` to prevent Terraform drift.
+* Retry `databricks_mws_ncc_private_endpoint_rule` creation on transient HTTP inactivity timeouts ([#<PR>](https://github.com/databricks/terraform-provider-databricks/pull/<PR>)). Fixes spurious "request timed out after 1m5s of inactivity" failures during `terraform apply`.
+* Retry `databricks_mws_network_connectivity_config` deletion while the backend reports that private endpoint rules or workspaces are still attached ([#<PR>](https://github.com/databricks/terraform-provider-databricks/pull/<PR>)). Absorbs eventual-consistency delays during `terraform destroy`.
 ### Documentation
 
 ### Exporter

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -9,8 +9,8 @@
 ### Bug Fixes
 
 * Mark `effective_file_event_queue` as read-only in `databricks_external_location` to prevent Terraform drift.
-* Retry `databricks_mws_ncc_private_endpoint_rule` creation on transient HTTP inactivity timeouts ([#<PR>](https://github.com/databricks/terraform-provider-databricks/pull/<PR>)). Fixes spurious "request timed out after 1m5s of inactivity" failures during `terraform apply`.
-* Retry `databricks_mws_network_connectivity_config` deletion while the backend reports that private endpoint rules or workspaces are still attached ([#<PR>](https://github.com/databricks/terraform-provider-databricks/pull/<PR>)). Absorbs eventual-consistency delays during `terraform destroy`.
+* Retry `databricks_mws_ncc_private_endpoint_rule` creation on transient HTTP inactivity timeouts ([#5648](https://github.com/databricks/terraform-provider-databricks/pull/5648)). Fixes spurious "request timed out after 1m5s of inactivity" failures during `terraform apply`.
+* Retry `databricks_mws_network_connectivity_config` deletion while the backend reports that private endpoint rules or workspaces are still attached ([#5648](https://github.com/databricks/terraform-provider-databricks/pull/5648)). Absorbs eventual-consistency delays during `terraform destroy`.
 ### Documentation
 
 ### Exporter

--- a/mws/resource_mws_ncc_private_endpoint_rule.go
+++ b/mws/resource_mws_ncc_private_endpoint_rule.go
@@ -51,7 +51,13 @@ func ResourceMwsNccPrivateEndpointRule() common.Resource {
 			if err != nil {
 				return err
 			}
-			rule, err := acc.NetworkConnectivity.CreatePrivateEndpointRule(ctx, create)
+			// Retry on "request timed out after ... of inactivity" — the backend
+			// can exceed the SDK's HTTP inactivity timeout on NCC private endpoint
+			// creation. Retries are safe because (resource_id, group_id, ncc_id)
+			// is the natural key and the API returns a conflict on duplicates.
+			rule, err := common.RetryOnTimeout(ctx, func(ctx context.Context) (*settings.NccPrivateEndpointRule, error) {
+				return acc.NetworkConnectivity.CreatePrivateEndpointRule(ctx, create)
+			})
 			if err != nil {
 				return err
 			}

--- a/mws/resource_mws_ncc_private_endpoint_rule_test.go
+++ b/mws/resource_mws_ncc_private_endpoint_rule_test.go
@@ -1,6 +1,7 @@
 package mws
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/databricks/databricks-sdk-go/apierr"
@@ -293,4 +294,39 @@ func TestResourceNccPrivateEndpointRuleDelete_Error(t *testing.T) {
 	}.Apply(t)
 	qa.AssertErrorStartsWith(t, err, "error")
 	assert.Equal(t, "ncc_id/rule_id", d.Id())
+}
+
+func TestResourceNccPrivateEndpointRuleCreate_RetriesOnTimeout(t *testing.T) {
+	qa.ResourceFixture{
+		MockAccountClientFunc: func(a *mocks.MockAccountClient) {
+			e := a.GetMockNetworkConnectivityAPI().EXPECT()
+			call1 := e.CreatePrivateEndpointRule(mock.Anything, settings.CreatePrivateEndpointRuleRequest{
+				NetworkConnectivityConfigId: "ncc_id",
+				PrivateEndpointRule: settings.CreatePrivateEndpointRule{
+					ResourceId: "resource_id",
+					GroupId:    "blob",
+				},
+			}).Return(nil, errors.New("request failed: request timed out after 1m5s of inactivity"))
+			call1.Repeatability = 1
+			e.CreatePrivateEndpointRule(mock.Anything, settings.CreatePrivateEndpointRuleRequest{
+				NetworkConnectivityConfigId: "ncc_id",
+				PrivateEndpointRule: settings.CreatePrivateEndpointRule{
+					ResourceId: "resource_id",
+					GroupId:    "blob",
+				},
+			}).Return(getTestNccRule(), nil)
+			e.GetPrivateEndpointRuleByNetworkConnectivityConfigIdAndPrivateEndpointRuleId(
+				mock.Anything, "ncc_id", "rule_id",
+			).Return(getTestNccRule(), nil)
+		},
+		Resource:  ResourceMwsNccPrivateEndpointRule(),
+		AccountID: "abc",
+		Host:      "https://accounts.cloud.databricks.com",
+		HCL: `
+		network_connectivity_config_id = "ncc_id"
+		resource_id = "resource_id"
+		group_id = "blob"
+		`,
+		Create: true,
+	}.ApplyAndExpectData(t, map[string]any{"id": "ncc_id/rule_id"})
 }

--- a/mws/resource_mws_network_connectivity_config.go
+++ b/mws/resource_mws_network_connectivity_config.go
@@ -2,13 +2,38 @@ package mws
 
 import (
 	"context"
+	"errors"
+	"strings"
+	"time"
 
+	"github.com/databricks/databricks-sdk-go/apierr"
 	"github.com/databricks/databricks-sdk-go/service/settings"
 	"github.com/databricks/terraform-provider-databricks/common"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
+
+// isNccStillInUseError reports whether the given error is the Databricks
+// Accounts API's "NCC is still in use" response — which is expected during
+// teardown when rule/binding deletes haven't yet propagated. These errors
+// are safe to retry; the backend eventually observes the dependent deletes
+// and allows the NCC removal.
+func isNccStillInUseError(err error) bool {
+	var apiErr *apierr.APIError
+	if !errors.As(err, &apiErr) {
+		return false
+	}
+	msg := strings.ToLower(apiErr.Message)
+	if strings.Contains(msg, "has one or more private endpoint rules") {
+		return true
+	}
+	if strings.Contains(msg, "attached to one or more workspaces") {
+		return true
+	}
+	return false
+}
 
 func ResourceMwsNetworkConnectivityConfig() common.Resource {
 	s := common.StructToSchema(settings.NetworkConnectivityConfiguration{}, func(m map[string]*schema.Schema) map[string]*schema.Schema {
@@ -63,7 +88,20 @@ func ResourceMwsNetworkConnectivityConfig() common.Resource {
 			if err != nil {
 				return err
 			}
-			return acc.NetworkConnectivity.DeleteNetworkConnectivityConfigurationByNetworkConnectivityConfigId(ctx, nccId)
+			// Retry while the backend reports the NCC is still in use
+			// (rules still attached, or workspaces still bound). This absorbs
+			// eventual-consistency delays between dependent deletes and the
+			// NCC's own deletion check.
+			return resource.RetryContext(ctx, 15*time.Minute, func() *resource.RetryError {
+				err := acc.NetworkConnectivity.DeleteNetworkConnectivityConfigurationByNetworkConnectivityConfigId(ctx, nccId)
+				if err == nil {
+					return nil
+				}
+				if isNccStillInUseError(err) {
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			})
 		},
 	}
 }

--- a/mws/resource_mws_network_connectivity_config_test.go
+++ b/mws/resource_mws_network_connectivity_config_test.go
@@ -134,3 +134,82 @@ func TestResourceNccDelete_Error(t *testing.T) {
 	qa.AssertErrorStartsWith(t, err, "error")
 	assert.Equal(t, "abc/ncc_id", d.Id())
 }
+
+func TestResourceNccDelete_RetriesOnStillInUseRules(t *testing.T) {
+	qa.ResourceFixture{
+		MockAccountClientFunc: func(a *mocks.MockAccountClient) {
+			e := a.GetMockNetworkConnectivityAPI().EXPECT()
+			call1 := e.DeleteNetworkConnectivityConfigurationByNetworkConnectivityConfigId(
+				mock.Anything, "ncc_id",
+			).Return(&apierr.APIError{
+				Message: "Network Connectivity Config ncc_id is unable to be deleted because it has one or more private endpoint rules.",
+			})
+			call1.Repeatability = 1
+			e.DeleteNetworkConnectivityConfigurationByNetworkConnectivityConfigId(
+				mock.Anything, "ncc_id",
+			).Return(nil)
+		},
+		Resource:  ResourceMwsNetworkConnectivityConfig(),
+		AccountID: "abc",
+		Host:      "https://accounts.cloud.databricks.com",
+		InstanceState: map[string]string{
+			"account_id":                     "abc",
+			"network_connectivity_config_id": "ncc_id",
+			"name":                           "ncc_name",
+			"region":                         "ar",
+		},
+		ID:     "abc/ncc_id",
+		Delete: true,
+	}.ApplyNoError(t)
+}
+
+func TestResourceNccDelete_RetriesOnStillInUseWorkspaces(t *testing.T) {
+	qa.ResourceFixture{
+		MockAccountClientFunc: func(a *mocks.MockAccountClient) {
+			e := a.GetMockNetworkConnectivityAPI().EXPECT()
+			call1 := e.DeleteNetworkConnectivityConfigurationByNetworkConnectivityConfigId(
+				mock.Anything, "ncc_id",
+			).Return(&apierr.APIError{
+				Message: "Network Connectivity Config ncc_id is unable to be deleted because it is attached to one or more workspaces: 12345",
+			})
+			call1.Repeatability = 1
+			e.DeleteNetworkConnectivityConfigurationByNetworkConnectivityConfigId(
+				mock.Anything, "ncc_id",
+			).Return(nil)
+		},
+		Resource:  ResourceMwsNetworkConnectivityConfig(),
+		AccountID: "abc",
+		Host:      "https://accounts.cloud.databricks.com",
+		InstanceState: map[string]string{
+			"account_id":                     "abc",
+			"network_connectivity_config_id": "ncc_id",
+			"name":                           "ncc_name",
+			"region":                         "ar",
+		},
+		ID:     "abc/ncc_id",
+		Delete: true,
+	}.ApplyNoError(t)
+}
+
+func TestResourceNccDelete_NonRetryableErrorFailsFast(t *testing.T) {
+	_, err := qa.ResourceFixture{
+		MockAccountClientFunc: func(a *mocks.MockAccountClient) {
+			e := a.GetMockNetworkConnectivityAPI().EXPECT()
+			e.DeleteNetworkConnectivityConfigurationByNetworkConnectivityConfigId(
+				mock.Anything, "ncc_id",
+			).Return(&apierr.APIError{Message: "permission denied"}).Once()
+		},
+		Resource:  ResourceMwsNetworkConnectivityConfig(),
+		AccountID: "abc",
+		Host:      "https://accounts.cloud.databricks.com",
+		InstanceState: map[string]string{
+			"account_id":                     "abc",
+			"network_connectivity_config_id": "ncc_id",
+			"name":                           "ncc_name",
+			"region":                         "ar",
+		},
+		ID:     "abc/ncc_id",
+		Delete: true,
+	}.Apply(t)
+	qa.AssertErrorStartsWith(t, err, "permission denied")
+}


### PR DESCRIPTION
## Changes

Fixes #5292 — two transient failures in NCC resources that break `terraform apply` / `terraform destroy` even though the backend eventually reaches the desired state.

- **`databricks_mws_ncc_private_endpoint_rule` Create** — wrap `CreatePrivateEndpointRule` in `common.RetryOnTimeout` so the SDK's `"request timed out after X of inactivity"` error retries instead of failing the apply. The backend often completes the create successfully even when the HTTP client gives up. Same pattern already used in `workspace/resource_directory.go`, `workspace/resource_notebook.go`, `workspace/resource_workspace_file.go`.

- **`databricks_mws_network_connectivity_config` Delete** — add `isNccStillInUseError` classifier and wrap Delete in `resource.RetryContext` with a 15-minute timeout. Retries while the backend reports `has one or more private endpoint rules` or `attached to one or more workspaces` — these are propagation races between dependent deletes and the NCC's own deletion check. Non-retryable errors (e.g. permission denied) still fail fast. Same pattern already used in `mws/resource_mws_networks.go`.

No public API or schema change — existing TF configs behave identically, retries happen transparently inside the provider.

Credit: bug + fix proposed by @michael-saltzman-databricks in the issue body.

## Tests

Four new unit tests in `mws/`:

- `TestResourceNccPrivateEndpointRuleCreate_RetriesOnTimeout` — first call returns the inactivity-timeout error, second succeeds.
- `TestResourceNccDelete_RetriesOnStillInUseRules` — first delete returns "has one or more private endpoint rules", second succeeds.
- `TestResourceNccDelete_RetriesOnStillInUseWorkspaces` — first delete returns "attached to one or more workspaces", second succeeds.
- `TestResourceNccDelete_NonRetryableErrorFailsFast` — single "permission denied" response surfaces immediately without retrying.

All pre-existing `TestResourceNcc*` unit tests still pass.

**On integration tests:** intentionally omitted. The retry paths only trigger on transient backend timing (HTTP inactivity cutoffs, eventual-consistency windows on delete) that can't be reliably reproduced in a live acceptance harness. The existing `TestAccDataSourceMwsNetworkConnectivityConfigTest` still exercises the happy path end-to-end, so CI continues to verify no regression in the non-retry code path. Happy to add a happy-path `TestMwsAccNccPrivateEndpointRule…` as a follow-up if reviewers would prefer.

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder — n/a, no public behavior change
- [ ] covered with integration tests in `internal/acceptance` — see note above
- [x] using Go SDK
- [ ] using TF Plugin Framework — n/a, this resource is still SDKv2
- [x] has entry in `NEXT_CHANGELOG.md` file
