### PR TITLE
[Internal] Skip tests for Markdown-only PRs

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -21,16 +21,29 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+        with:
+          fetch-depth: 0
 
       - name: Detect non-markdown changes
         id: filter
-        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
-        with:
-          # tests_required is true when any non-markdown file is touched.
-          # PRs that only modify *.md files (e.g. docs/, NEXT_CHANGELOG.md) skip integration tests.
-          filters: |
-            tests_required:
-              - '!**/*.md'
+        shell: bash
+        run: |
+          BASE_SHA="${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}"
+          HEAD_SHA="${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha || github.sha }}"
+
+          echo "Comparing $BASE_SHA...$HEAD_SHA"
+          CHANGED=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")
+          echo "Changed files:"
+          echo "$CHANGED"
+
+          NON_MD=$(echo "$CHANGED" | grep -v '\.md$' || true)
+          if [ -z "$NON_MD" ] && [ -n "$CHANGED" ]; then
+            echo "Only markdown files changed — integration tests will be skipped"
+            echo "tests_required=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Non-markdown files changed — integration tests will run"
+            echo "tests_required=true" >> "$GITHUB_OUTPUT"
+          fi
 
   check-token:
     name: Check secrets access
@@ -97,7 +110,7 @@ jobs:
   # * Avoid running integration tests twice, since it was already run at the tip of the branch before squashing.
   # We also auto-approve when a PR only changes markdown files, since in that case the trigger-tests job is
   # skipped and the required "Integration Tests" check would otherwise never be reported.
-  # always() is required so this still runs when the `changes` job's output is consumed by the if condition.
+  # always() is required so this still runs when the upstream `changes` job's output is consumed by the if condition.
   auto-approve:
     needs: changes
     if: always() && (github.event_name == 'merge_group' || (github.event_name == 'pull_request' && needs.changes.outputs.tests_required == 'false'))

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -9,6 +9,29 @@ on:
 
 
 jobs:
+  changes:
+    name: Detect non-markdown changes
+
+    runs-on:
+      group: databricks-deco-testing-runner-group
+      labels: ubuntu-latest-deco
+
+    outputs:
+      tests_required: ${{ steps.filter.outputs.tests_required }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+
+      - name: Detect non-markdown changes
+        id: filter
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        with:
+          # tests_required is true when any non-markdown file is touched.
+          # PRs that only modify *.md files (e.g. docs/, NEXT_CHANGELOG.md) skip integration tests.
+          filters: |
+            tests_required:
+              - '!**/*.md'
+
   check-token:
     name: Check secrets access
 
@@ -38,8 +61,8 @@ jobs:
       group: databricks-release-runner-group-emu-access
       labels: linux-ubuntu-latest-emu-access
 
-    needs: check-token
-    if: github.event_name == 'pull_request'  && needs.check-token.outputs.has_token == 'true'
+    needs: [check-token, changes]
+    if: github.event_name == 'pull_request' && needs.check-token.outputs.has_token == 'true' && needs.changes.outputs.tests_required == 'true'
     environment: "test-trigger-is"
 
     steps:
@@ -72,8 +95,12 @@ jobs:
   # We auto approve the check for the merge queue for two reasons:
   # * Queue times out due to duration of tests.
   # * Avoid running integration tests twice, since it was already run at the tip of the branch before squashing.
+  # We also auto-approve when a PR only changes markdown files, since in that case the trigger-tests job is
+  # skipped and the required "Integration Tests" check would otherwise never be reported.
+  # always() is required so this still runs when the `changes` job's output is consumed by the if condition.
   auto-approve:
-    if: github.event_name == 'merge_group'
+    needs: changes
+    if: always() && (github.event_name == 'merge_group' || (github.event_name == 'pull_request' && needs.changes.outputs.tests_required == 'false'))
 
     runs-on:
       group: databricks-deco-testing-runner-group
@@ -88,6 +115,9 @@ jobs:
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
+            const reason = context.eventName === 'merge_group'
+              ? 'Auto-approved for merge queue (tests already passed on PR)'
+              : 'Auto-approved for docs-only change (no non-markdown files modified)';
             await github.rest.checks.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -97,6 +127,6 @@ jobs:
               conclusion: 'success',
               output: {
                 title: 'Integration Tests',
-                summary: 'Auto-approved for merge queue (tests already passed on PR)'
+                summary: reason
               }
             });

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -27,9 +27,42 @@ jobs:
       - name: Detect non-markdown changes
         id: filter
         shell: bash
+        env:
+          PR_BEFORE_SHA: ${{ github.event.before }}
+          PR_AFTER_SHA: ${{ github.event.after }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          MQ_BASE_SHA: ${{ github.event.merge_group.base_sha }}
+          MQ_HEAD_SHA: ${{ github.event.merge_group.head_sha }}
         run: |
-          BASE_SHA="${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}"
-          HEAD_SHA="${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha || github.sha }}"
+          # Pick the SHA range to diff:
+          #  - pull_request.synchronize: only the newly-pushed commits
+          #    (before...after). A docs-only follow-up commit on a code PR
+          #    can skip integration tests without re-running the suite.
+          #    Falls back to full PR diff if `before` is unreachable
+          #    (force-push).
+          #  - pull_request.opened: the entire PR diff (base...head).
+          #  - merge_group: the queue's base_sha...head_sha.
+          case "${{ github.event_name }}" in
+            pull_request)
+              if [ "${{ github.event.action }}" = "synchronize" ] \
+                 && [ -n "$PR_BEFORE_SHA" ] \
+                 && [ "$PR_BEFORE_SHA" != "0000000000000000000000000000000000000000" ] \
+                 && git cat-file -e "$PR_BEFORE_SHA^{commit}" 2>/dev/null; then
+                BASE_SHA="$PR_BEFORE_SHA"
+                HEAD_SHA="$PR_AFTER_SHA"
+                echo "synchronize: comparing only newly-pushed commits"
+              else
+                BASE_SHA="$PR_BASE_SHA"
+                HEAD_SHA="$PR_HEAD_SHA"
+                echo "first run / unreachable before SHA: comparing full PR"
+              fi
+              ;;
+            merge_group)
+              BASE_SHA="$MQ_BASE_SHA"
+              HEAD_SHA="$MQ_HEAD_SHA"
+              ;;
+          esac
 
           echo "Comparing $BASE_SHA...$HEAD_SHA"
           CHANGED=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -20,9 +20,41 @@ jobs:
       - name: Detect non-markdown changes
         id: filter
         shell: bash
+        env:
+          PR_BEFORE_SHA: ${{ github.event.before }}
+          PR_AFTER_SHA: ${{ github.event.after }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          MQ_BASE_SHA: ${{ github.event.merge_group.base_sha }}
+          MQ_HEAD_SHA: ${{ github.event.merge_group.head_sha }}
         run: |
-          BASE_SHA="${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}"
-          HEAD_SHA="${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha || github.sha }}"
+          # Pick the SHA range to diff:
+          #  - pull_request.synchronize: only the newly-pushed commits
+          #    (before...after). A docs-only follow-up commit on a code PR
+          #    can skip tests without re-running the suite. Falls back to
+          #    full PR diff if `before` is unreachable (force-push).
+          #  - pull_request.opened: the entire PR diff (base...head).
+          #  - merge_group: the queue's base_sha...head_sha.
+          case "${{ github.event_name }}" in
+            pull_request)
+              if [ "${{ github.event.action }}" = "synchronize" ] \
+                 && [ -n "$PR_BEFORE_SHA" ] \
+                 && [ "$PR_BEFORE_SHA" != "0000000000000000000000000000000000000000" ] \
+                 && git cat-file -e "$PR_BEFORE_SHA^{commit}" 2>/dev/null; then
+                BASE_SHA="$PR_BEFORE_SHA"
+                HEAD_SHA="$PR_AFTER_SHA"
+                echo "synchronize: comparing only newly-pushed commits"
+              else
+                BASE_SHA="$PR_BASE_SHA"
+                HEAD_SHA="$PR_HEAD_SHA"
+                echo "first run / unreachable before SHA: comparing full PR"
+              fi
+              ;;
+            merge_group)
+              BASE_SHA="$MQ_BASE_SHA"
+              HEAD_SHA="$MQ_HEAD_SHA"
+              ;;
+          esac
 
           echo "Comparing $BASE_SHA...$HEAD_SHA"
           CHANGED=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -14,20 +14,35 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 0
 
       - name: Detect non-markdown changes
         id: filter
-        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
-        with:
-          # tests_required is true when any non-markdown file is touched.
-          # PRs that only modify *.md files (e.g. docs/, NEXT_CHANGELOG.md) skip tests.
-          filters: |
-            tests_required:
-              - '!**/*.md'
+        shell: bash
+        run: |
+          BASE_SHA="${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}"
+          HEAD_SHA="${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha || github.sha }}"
 
+          echo "Comparing $BASE_SHA...$HEAD_SHA"
+          CHANGED=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")
+          echo "Changed files:"
+          echo "$CHANGED"
+
+          NON_MD=$(echo "$CHANGED" | grep -v '\.md$' || true)
+          if [ -z "$NON_MD" ] && [ -n "$CHANGED" ]; then
+            echo "Only markdown files changed — tests will be skipped"
+            echo "tests_required=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Non-markdown files changed — tests will run"
+            echo "tests_required=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  # The `tests` job is a required status check. It MUST always complete (not be
+  # skipped) so that the required check is satisfied. Step-level `if:` skips
+  # the actual work when only markdown files changed; the job itself succeeds.
   tests:
     needs: changes
-    if: needs.changes.outputs.tests_required == 'true'
     runs-on:
       group: databricks-protected-runner-group
       labels: linux-ubuntu-latest
@@ -37,15 +52,22 @@ jobs:
       contents: read
 
     steps:
-      - name: Checkout
+      - if: needs.changes.outputs.tests_required == 'false'
+        name: Skip tests (markdown-only change)
+        run: echo "Only markdown files changed — skipping tests."
+
+      - if: needs.changes.outputs.tests_required == 'true'
+        name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - name: Setup Go build environment
+      - if: needs.changes.outputs.tests_required == 'true'
+        name: Setup Go build environment
         uses: ./.github/actions/setup-go-build-environment
         with:
           go-version-file: go.mod
 
-      - name: Pull external libraries
+      - if: needs.changes.outputs.tests_required == 'true'
+        name: Pull external libraries
         shell: bash
         run: |
           jf go mod vendor
@@ -57,7 +79,8 @@ jobs:
           echo "GONOSUMCHECK=*" >> $GITHUB_ENV
           echo "GONOSUMDB=*" >> $GITHUB_ENV
 
-      - name: Run tests
+      - if: needs.changes.outputs.tests_required == 'true'
+        name: Run tests
         shell: bash
         run: |
           # Unset OIDC token env vars injected by the id-token: write permission.
@@ -67,7 +90,8 @@ jobs:
           unset ACTIONS_ID_TOKEN_REQUEST_TOKEN
           make test
 
-      - name: Publish test coverage
+      - if: needs.changes.outputs.tests_required == 'true'
+        name: Publish test coverage
         uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -7,7 +7,27 @@ on:
     types: [checks_requested]
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      tests_required: ${{ steps.filter.outputs.tests_required }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Detect non-markdown changes
+        id: filter
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        with:
+          # tests_required is true when any non-markdown file is touched.
+          # PRs that only modify *.md files (e.g. docs/, NEXT_CHANGELOG.md) skip tests.
+          filters: |
+            tests_required:
+              - '!**/*.md'
+
   tests:
+    needs: changes
+    if: needs.changes.outputs.tests_required == 'true'
     runs-on:
       group: databricks-protected-runner-group
       labels: linux-ubuntu-latest


### PR DESCRIPTION
Supersedes #4165

Both workflows (unit/integration tests) now scope the diff dynamically based on the event:

| Event | Diff range |
|---|---|
| `pull_request.opened` (first run) | full PR — `base.sha`...`head.sha` |
| `pull_request.synchronize` (push to PR) | only the newly-pushed commits — `event.before`...`event.after` |
| `pull_request.synchronize` after force-push (`before` SHA unreachable) | falls back to full PR (conservative — tests run) |
| `merge_group` | unchanged — full queue diff |

So the per-push scenario works as follows:
1. PR opened with code changes → `opened` fires → tests run.
2. A docs-only commit is pushed on top → `synchronize` fires → diff covers only the new commit → markdown-only → tests are skipped on the new SHA.
3. The new commit's required check still reports success (the `tests` job completes with all real steps `if:`-skipped; `auto-approve` posts the `Integration Tests` check), so the PR stays mergeable without re-running the suite.

NO_CHANGELOG=true

## Changes
<!-- Summary of your changes that are easy to understand -->

## Tests
<!--
How is this tested? Please see the checklist below and also describe any other relevant tests
-->

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] using Go SDK
- [ ] using TF Plugin Framework
- [ ] has entry in `NEXT_CHANGELOG.md` file
