### PR TITLE
Add api field to dual data source service principal

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bug Fixes
 
+* Fix `databricks_service_principal` data source failing on account-level provider with `cannot populate provider_config for service principal: failed to resolve workspace_id` ([#5664](https://github.com/databricks/terraform-provider-databricks/issues/5664)). The data source now supports the `api` field and skips workspace-tracking when used at account level.
+
 ### Documentation
 
 ### Exporter

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bug Fixes
 
 * Fix `databricks_service_principal` data source failing on account-level provider with `cannot populate provider_config for service principal: failed to resolve workspace_id` ([#5664](https://github.com/databricks/terraform-provider-databricks/issues/5664)). The data source now supports the `api` field and skips workspace-tracking when used at account level.
+* Fix `databricks_service_principals` data source failing on account-level provider with the same `cannot populate provider_config for service principals: failed to resolve workspace_id` regression ([#5664](https://github.com/databricks/terraform-provider-databricks/issues/5664)). The data source now supports the `api` field and skips workspace-tracking when used at account level.
 
 ### Documentation
 

--- a/scim/data_service_principal.go
+++ b/scim/data_service_principal.go
@@ -29,15 +29,20 @@ func DataSourceServicePrincipal() common.Resource {
 		s["application_id"].ExactlyOneOf = []string{"application_id", "display_name", "scim_id"}
 		s["display_name"].ExactlyOneOf = []string{"application_id", "display_name", "scim_id"}
 		s["scim_id"].ExactlyOneOf = []string{"application_id", "display_name", "scim_id"}
+		common.AddApiField(s)
 		return s
 	})
 	common.AddNamespaceInSchema(s)
 	common.NamespaceCustomizeSchemaMap(s)
 
 	return common.Resource{
+		IsDual: true,
 		Schema: s,
 		Read: func(ctx context.Context, d *schema.ResourceData, m *common.DatabricksClient) error {
-			newClient, err := m.DatabricksClientForUnifiedProvider(ctx, d)
+			if err := common.ValidateApiLevelForUnifiedHostFromData(d, m); err != nil {
+				return err
+			}
+			newClient, err := m.DatabricksClientForDualResource(ctx, d)
 			if err != nil {
 				return err
 			}
@@ -45,7 +50,7 @@ func DataSourceServicePrincipal() common.Resource {
 			var spList []User
 
 			common.DataToStructPointer(d, s, &response)
-			spnAPI := NewServicePrincipalsAPI(ctx, newClient, "")
+			spnAPI := NewServicePrincipalsAPI(ctx, newClient, common.GetApiLevel(d))
 
 			if response.ApplicationID != "" {
 				spList, err = spnAPI.Filter(fmt.Sprintf(`applicationId eq "%s"`, response.ApplicationID), true)

--- a/scim/data_service_principal_acc_test.go
+++ b/scim/data_service_principal_acc_test.go
@@ -48,3 +48,45 @@ func TestAccDataSourceSPNOnAzureBySCIMID(t *testing.T) {
 		Template: azureSpnBySCIMID,
 	})
 }
+
+// Regression test for https://github.com/databricks/terraform-provider-databricks/issues/5664.
+// The data source must work against an account-level provider with no workspace_id
+// configured anywhere. Before adding the `api` field, the post-Read provider_config
+// hook tried to resolve a workspace_id and failed with strconv.ParseInt: parsing "".
+const accountSpnByDisplayName = `
+resource "databricks_service_principal" "this" {
+	display_name = "SPN {var.RANDOM}"
+	api          = "account"
+}
+
+data "databricks_service_principal" "this" {
+	display_name = databricks_service_principal.this.display_name
+	api          = "account"
+	depends_on   = [databricks_service_principal.this]
+}`
+
+func TestMwsAccDataSourceSPNByDisplayNameOnAccount(t *testing.T) {
+	acceptance.AccountLevel(t, acceptance.Step{
+		Template: accountSpnByDisplayName,
+	})
+}
+
+// Same as above but does not set `api` on the data source — exercises the
+// host-based account-level inference path so the regression in 1.114.0 cannot
+// reappear under the no-explicit-api configuration the user originally hit.
+const accountSpnByDisplayNameNoApi = `
+resource "databricks_service_principal" "this" {
+	display_name = "SPN {var.RANDOM}"
+	api          = "account"
+}
+
+data "databricks_service_principal" "this" {
+	display_name = databricks_service_principal.this.display_name
+	depends_on   = [databricks_service_principal.this]
+}`
+
+func TestMwsAccDataSourceSPNByDisplayNameOnAccountNoApi(t *testing.T) {
+	acceptance.AccountLevel(t, acceptance.Step{
+		Template: accountSpnByDisplayNameNoApi,
+	})
+}

--- a/scim/data_service_principals.go
+++ b/scim/data_service_principals.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 
 	"github.com/databricks/terraform-provider-databricks/common"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 // DataSourceServicePrincipals searches for service principals based on display_name
@@ -16,41 +17,63 @@ func DataSourceServicePrincipals() common.Resource {
 		ApplicationIDs      []string               `json:"application_ids,omitempty" tf:"computed,slice_set"`
 		ServicePrincipals   []servicePrincipalData `json:"service_principals,omitempty" tf:"computed"`
 	}
-	return common.DataResource(spnsData{}, func(ctx context.Context, e any, c *common.DatabricksClient) error {
-		response := e.(*spnsData)
-		spnAPI := NewServicePrincipalsAPI(ctx, c, "")
-
-		var filter string
-
-		if response.DisplayNameContains != "" {
-			filter = fmt.Sprintf(`displayName co "%s"`, response.DisplayNameContains)
-		}
-		spList, err := spnAPI.Filter(filter, true)
-		if err != nil {
-			return err
-		}
-		if len(spList) == 0 {
-			log.Printf("[INFO] cannot find SPs with display name containing %s", response.DisplayNameContains)
-		}
-		for _, sp := range spList {
-			response.ApplicationIDs = append(response.ApplicationIDs, sp.ApplicationID)
-			response.ServicePrincipals = append(response.ServicePrincipals, servicePrincipalData{
-				ApplicationID:  sp.ApplicationID,
-				DisplayName:    sp.DisplayName,
-				Active:         sp.Active,
-				ID:             sp.ID,
-				SpID:           sp.ID,
-				ScimID:         sp.ID,
-				ExternalID:     sp.ExternalID,
-				AclPrincipalID: fmt.Sprintf("servicePrincipals/%s", sp.ApplicationID),
-				Home:           fmt.Sprintf("/Users/%s", sp.ApplicationID),
-				Repos:          fmt.Sprintf("/Repos/%s", sp.ApplicationID),
-			})
-		}
-		sort.Strings(response.ApplicationIDs)
-		sort.Slice(response.ServicePrincipals, func(i, j int) bool {
-			return response.ServicePrincipals[i].ApplicationID < response.ServicePrincipals[j].ApplicationID
-		})
-		return nil
+	s := common.StructToSchema(spnsData{}, func(m map[string]*schema.Schema) map[string]*schema.Schema {
+		common.AddApiField(m)
+		return m
 	})
+	common.AddNamespaceInSchema(s)
+	common.NamespaceCustomizeSchemaMap(s)
+
+	return common.Resource{
+		IsDual: true,
+		Schema: s,
+		Read: func(ctx context.Context, d *schema.ResourceData, m *common.DatabricksClient) error {
+			if err := common.ValidateApiLevelForUnifiedHostFromData(d, m); err != nil {
+				return err
+			}
+			newClient, err := m.DatabricksClientForDualResource(ctx, d)
+			if err != nil {
+				return err
+			}
+			var response spnsData
+			common.DataToStructPointer(d, s, &response)
+			spnAPI := NewServicePrincipalsAPI(ctx, newClient, common.GetApiLevel(d))
+
+			var filter string
+			if response.DisplayNameContains != "" {
+				filter = fmt.Sprintf(`displayName co "%s"`, response.DisplayNameContains)
+			}
+			spList, err := spnAPI.Filter(filter, true)
+			if err != nil {
+				return err
+			}
+			if len(spList) == 0 {
+				log.Printf("[INFO] cannot find SPs with display name containing %s", response.DisplayNameContains)
+			}
+			for _, sp := range spList {
+				response.ApplicationIDs = append(response.ApplicationIDs, sp.ApplicationID)
+				response.ServicePrincipals = append(response.ServicePrincipals, servicePrincipalData{
+					ApplicationID:  sp.ApplicationID,
+					DisplayName:    sp.DisplayName,
+					Active:         sp.Active,
+					ID:             sp.ID,
+					SpID:           sp.ID,
+					ScimID:         sp.ID,
+					ExternalID:     sp.ExternalID,
+					AclPrincipalID: fmt.Sprintf("servicePrincipals/%s", sp.ApplicationID),
+					Home:           fmt.Sprintf("/Users/%s", sp.ApplicationID),
+					Repos:          fmt.Sprintf("/Repos/%s", sp.ApplicationID),
+				})
+			}
+			sort.Strings(response.ApplicationIDs)
+			sort.Slice(response.ServicePrincipals, func(i, j int) bool {
+				return response.ServicePrincipals[i].ApplicationID < response.ServicePrincipals[j].ApplicationID
+			})
+			if err := common.StructToData(&response, s, d); err != nil {
+				return err
+			}
+			d.SetId("_")
+			return nil
+		},
+	}
 }

--- a/scim/data_service_principals_acc_test.go
+++ b/scim/data_service_principals_acc_test.go
@@ -48,3 +48,41 @@ func TestAccDataSourceSPNsOnAzure(t *testing.T) {
 		Template: azureSpns,
 	})
 }
+
+// Regression coverage for the same class of issue as #5664: the data source
+// is non-dual yet has provider_config in its schema, and at account level the
+// post-Read hook tries to resolve a workspace_id that doesn't exist.
+const accountSpnsByDisplayName = `
+resource "databricks_service_principal" "this" {
+	display_name = "SPN {var.RANDOM}"
+	api          = "account"
+}
+
+data "databricks_service_principals" "this" {
+	display_name_contains = databricks_service_principal.this.display_name
+	api                   = "account"
+	depends_on            = [databricks_service_principal.this]
+}`
+
+func TestMwsAccDataSourceSPNsByDisplayNameOnAccount(t *testing.T) {
+	acceptance.AccountLevel(t, acceptance.Step{
+		Template: accountSpnsByDisplayName,
+	})
+}
+
+const accountSpnsByDisplayNameNoApi = `
+resource "databricks_service_principal" "this" {
+	display_name = "SPN {var.RANDOM}"
+	api          = "account"
+}
+
+data "databricks_service_principals" "this" {
+	display_name_contains = databricks_service_principal.this.display_name
+	depends_on            = [databricks_service_principal.this]
+}`
+
+func TestMwsAccDataSourceSPNsByDisplayNameOnAccountNoApi(t *testing.T) {
+	acceptance.AccountLevel(t, acceptance.Step{
+		Template: accountSpnsByDisplayNameNoApi,
+	})
+}


### PR DESCRIPTION
## Summary

Fixes the v1.114.0 regression reported in #5664 on the **`databricks_service_principal`** and **`databricks_service_principals`** data sources when used with an account-level provider. Both fail with:

> Error: cannot populate provider_config for service principal{s}: failed to resolve workspace_id: failed to get the workspace_id: strconv.ParseInt: parsing "": invalid syntax

### Root cause

PR #5492 (released in v1.114.0) added a post-Read hook in `common.Resource.ToResource()` that resolves and writes the effective `workspace_id` into `provider_config` for any resource with `provider_config` in its schema. The hook is skipped for *dual* resources at account level (`isDual && IsAccountLevel`), but neither SP data source was marked dual:

- `databricks_service_principal` had `provider_config` in its schema via `AddNamespaceInSchema` without `IsDual`
- `databricks_service_principals` used the legacy `common.DataResource` helper, which adds `provider_config` unconditionally and never sets `IsDual`

So at account level the post-Read hook ran, tried to resolve a workspace_id from a workspace client built on account-level config, and hit `strconv.ParseInt("", …)` because the SDK's workspace `/Me` call against an account host returns no `X-Databricks-Org-Id`.

SCIM is the rare API mounted on both workspace and account hosts, so the data source's Read itself succeeded against the account host — only then did the post-Read hook fail. That's why this regression manifested specifically on these two SCIM data sources and not on, say, `data_current_user` (which fails earlier when constructing a workspace client).

### Fix

Make both data sources properly dual — same pattern already used by `databricks_user`, `databricks_group`, and `databricks_current_config`:

- `common.AddApiField(s)` — adds the `api` field
- `IsDual: true` — `ToResource()` now skips the post-Read `provider_config` hook at account level
- `common.ValidateApiLevelForUnifiedHostFromData(d, m)` — fails the plan on a UnifiedHost when `api` is unset
- `DatabricksClientForDualResource(ctx, d)` — returns the original client at account level, no workspace routing
- `NewServicePrincipalsAPI(..., common.GetApiLevel(d))` — propagates the chosen api level so SCIM hits the right endpoint

For `data_service_principals` (plural) this also required converting from the legacy `common.DataResource` helper to a hand-written `common.Resource` so we can set `IsDual` and add the `api` field; the Read function now explicitly calls `DataToStructPointer` / `StructToData` / `SetId("_")` to match the previous `DataResource` semantics.

## Test plan

End-to-end verification on `azure-prod-acct` via deco — same cloud and provider type as the original report:

- [x] **Reproduced byte-for-byte** on unfixed code (`strconv.ParseInt: parsing "": invalid syntax` — exact match with issue):
  - `TestMwsAccDataSourceSPNByDisplayNameOnAccountNoApi` (singular) → FAIL
  - `TestMwsAccDataSourceSPNsByDisplayNameOnAccountNoApi` (plural) → FAIL
- [x] **All four new acceptance tests PASS on `azure-prod-acct`** with the fix:
  - `TestMwsAccDataSourceSPNByDisplayNameOnAccount` (singular, explicit `api = "account"`)
  - `TestMwsAccDataSourceSPNByDisplayNameOnAccountNoApi` (singular, host-based inference — exact configuration from the bug report)
  - `TestMwsAccDataSourceSPNsByDisplayNameOnAccount` (plural, explicit `api`)
  - `TestMwsAccDataSourceSPNsByDisplayNameOnAccountNoApi` (plural, host-based inference)
- [x] Also verified on `aws-prod-acct` for the singular variant (different inner failure — `Unable to load OAuth Config` — same wrapper, same fix)
- [x] Existing `TestDataServicePrincipal*` and `TestDataServicePrincipals*` unit tests still pass (workspace-level callers unaffected)
- [x] `NEXT_CHANGELOG.md` updated under Bug Fixes for both data sources