### PR TITLE
[Fix] Migrate account data sources from DataResource to AccountData

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bug Fixes
 
+* Remove invalid `provider_config` attribute from account-only data sources `databricks_mws_workspaces` and `databricks_mws_credentials` ([#5664](https://github.com/databricks/terraform-provider-databricks/issues/5664)).
+
 ### Documentation
 
 ### Exporter

--- a/docs/data-sources/mws_credentials.md
+++ b/docs/data-sources/mws_credentials.md
@@ -24,11 +24,6 @@ output "all_mws_credentials" {
 }
 ```
 
-## Argument Reference
-
-* `provider_config` - (Optional) Configure the provider for management through account provider. This block consists of the following fields:
-  * `workspace_id` - (Required) Workspace ID which the resource belongs to. This workspace must be part of the account which the provider is configured with.
-
 ## Attribute Reference
 
 -> This resource has an evolving interface, which may change in future versions of the provider.

--- a/docs/data-sources/mws_workspaces.md
+++ b/docs/data-sources/mws_workspaces.md
@@ -24,11 +24,6 @@ output "all_mws_workspaces" {
 }
 ```
 
-## Argument Reference
-
-* `provider_config` - (Optional) Configure the provider for management through account provider. This block consists of the following fields:
-  * `workspace_id` - (Required) Workspace ID which the resource belongs to. This workspace must be part of the account which the provider is configured with.
-
 ## Attribute Reference
 
 -> This resource has an evolving interface, which may change in future versions of the provider.

--- a/mws/data_mws_credentials.go
+++ b/mws/data_mws_credentials.go
@@ -3,6 +3,7 @@ package mws
 import (
 	"context"
 
+	"github.com/databricks/databricks-sdk-go"
 	"github.com/databricks/terraform-provider-databricks/common"
 )
 
@@ -10,15 +11,14 @@ func DataSourceMwsCredentials() common.Resource {
 	type mwsCredentialsData struct {
 		Ids map[string]string `json:"ids,omitempty" tf:"computed"`
 	}
-	return common.DataResource(mwsCredentialsData{}, func(ctx context.Context, e any, c *common.DatabricksClient) error {
-		data := e.(*mwsCredentialsData)
-		credentials, err := NewCredentialsAPI(ctx, c).List(c.Config.AccountID)
+	return common.AccountData(func(ctx context.Context, data *mwsCredentialsData, acc *databricks.AccountClient) error {
+		credentials, err := acc.Credentials.List(ctx)
 		if err != nil {
 			return err
 		}
 		data.Ids = make(map[string]string)
 		for _, v := range credentials {
-			data.Ids[v.CredentialsName] = v.CredentialsID
+			data.Ids[v.CredentialsName] = v.CredentialsId
 		}
 		return nil
 	})

--- a/mws/data_mws_credentials_acc_test.go
+++ b/mws/data_mws_credentials_acc_test.go
@@ -2,6 +2,7 @@ package mws_test
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/databricks/terraform-provider-databricks/internal/acceptance"
@@ -21,6 +22,17 @@ func TestAccDataSourceMwsCredentials(t *testing.T) {
 			ids := r.Primary.Attributes["ids.%"]
 			if ids == "" {
 				return fmt.Errorf("ids is empty: %v", r.Primary.Attributes)
+			}
+			// Regression check for https://github.com/databricks/terraform-provider-databricks/issues/5664.
+			// databricks_mws_credentials is account-only and must not carry a
+			// provider_config block in state — the post-Read hook that populates
+			// it is keyed off schema presence, so the absence of any
+			// provider_config.* attribute confirms the schema is clean and the
+			// hook never ran.
+			for k := range r.Primary.Attributes {
+				if strings.HasPrefix(k, "provider_config") {
+					return fmt.Errorf("unexpected provider_config in state: %s=%q", k, r.Primary.Attributes[k])
+				}
 			}
 			return nil
 		},

--- a/mws/data_mws_credentials_test.go
+++ b/mws/data_mws_credentials_test.go
@@ -38,6 +38,13 @@ func TestDataSourceMwsCredentials(t *testing.T) {
 	})
 }
 
+func TestDataSourceMwsCredentials_NoProviderConfigInSchema(t *testing.T) {
+	s := DataSourceMwsCredentials().Schema
+	if _, ok := s["provider_config"]; ok {
+		t.Fatalf("databricks_mws_credentials is account-only and must not expose provider_config")
+	}
+}
+
 func TestDataSourceMwsCredentials_Error(t *testing.T) {
 	qa.ResourceFixture{
 		Fixtures:    qa.HTTPFailures,

--- a/mws/data_mws_workspaces.go
+++ b/mws/data_mws_workspaces.go
@@ -3,6 +3,7 @@ package mws
 import (
 	"context"
 
+	"github.com/databricks/databricks-sdk-go"
 	"github.com/databricks/terraform-provider-databricks/common"
 )
 
@@ -10,15 +11,14 @@ func DataSourceMwsWorkspaces() common.Resource {
 	type mwsWorkspacesData struct {
 		Ids map[string]int64 `json:"ids" tf:"computed"`
 	}
-	return common.DataResource(mwsWorkspacesData{}, func(ctx context.Context, e any, c *common.DatabricksClient) error {
-		data := e.(*mwsWorkspacesData)
-		workspaces, err := NewWorkspacesAPI(ctx, c).List(c.Config.AccountID)
+	return common.AccountData(func(ctx context.Context, data *mwsWorkspacesData, acc *databricks.AccountClient) error {
+		workspaces, err := acc.Workspaces.List(ctx)
 		if err != nil {
 			return err
 		}
 		data.Ids = map[string]int64{}
 		for _, v := range workspaces {
-			data.Ids[v.WorkspaceName] = v.WorkspaceID
+			data.Ids[v.WorkspaceName] = v.WorkspaceId
 		}
 		return nil
 	})

--- a/mws/data_mws_workspaces_acc_test.go
+++ b/mws/data_mws_workspaces_acc_test.go
@@ -2,11 +2,11 @@ package mws_test
 
 import (
 	"fmt"
+	"strings"
+	"testing"
 
 	"github.com/databricks/terraform-provider-databricks/internal/acceptance"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-
-	"testing"
 )
 
 func TestAccDataSourceMwsWorkspaces(t *testing.T) {
@@ -22,6 +22,17 @@ func TestAccDataSourceMwsWorkspaces(t *testing.T) {
 			ids := r.Primary.Attributes["ids.%"]
 			if ids == "" {
 				return fmt.Errorf("ids is empty: %v", r.Primary.Attributes)
+			}
+			// Regression check for https://github.com/databricks/terraform-provider-databricks/issues/5664.
+			// databricks_mws_workspaces is account-only and must not carry a
+			// provider_config block in state — the post-Read hook that populates
+			// it is keyed off schema presence, so the absence of any
+			// provider_config.* attribute confirms the schema is clean and the
+			// hook never ran.
+			for k := range r.Primary.Attributes {
+				if strings.HasPrefix(k, "provider_config") {
+					return fmt.Errorf("unexpected provider_config in state: %s=%q", k, r.Primary.Attributes[k])
+				}
 			}
 			return nil
 		},

--- a/mws/data_mws_workspaces_test.go
+++ b/mws/data_mws_workspaces_test.go
@@ -49,6 +49,13 @@ func TestCatalogsData_Error(t *testing.T) {
 	}.ExpectError(t, "i'm a teapot")
 }
 
+func TestDataSourceMwsWorkspaces_NoProviderConfigInSchema(t *testing.T) {
+	s := DataSourceMwsWorkspaces().Schema
+	if _, ok := s["provider_config"]; ok {
+		t.Fatalf("databricks_mws_workspaces is account-only and must not expose provider_config")
+	}
+}
+
 func TestDataSourceMwsWorkspaces_Empty(t *testing.T) {
 	qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{


### PR DESCRIPTION
## Changes
`databricks_mws_workspaces` and `databricks_mws_credentials` are account-level data sources, but they were defined via the deprecated `common.DataResource` helper, which injects a workspace-only `provider_config { workspace_id }` block into the schema (issue #5664).

That schema field is the runtime signal for a post-Read hook: `Resource.ToResource()` sets `hasProviderConfig` from schema presence (`common/resource.go:169`), and when true the wrapper invokes `populateProviderConfigInState` after every Read (`common/resource.go:244`). That hook resolves a workspace ID (lazily via `CurrentWorkspaceID()` → `GET /api/2.0/preview/scim/v2/Me` if needed) and writes it into state — for a data source that has no workspace context.

Migrate both data sources from the deprecated `common.DataResource` to`common.AccountData`. `AccountData` doesn't inject `provider_config`, so `hasProviderConfig` is false and the hook never runs. The SDK calls (`acc.Workspaces.List(ctx)`, `acc.Credentials.List(ctx)`) hit the same `/api/2.0/accounts/{id}/{workspaces,credentials}` endpoints as the legacy `NewWorkspacesAPI/NewCredentialsAPI` helpers, so existing fixtures match unchanged.

Docs updated to drop the `provider_config` argument block. Added regression test `TestDataSourceMws{Workspaces,Credentials}_NoProviderConfigInSchema` that fail if `provider_config` reappears in the schema.

Fixes https://github.com/databricks/terraform-provider-databricks/issues/5664. Related: #5666.

## Tests
- Added unit tests
- Manually verified the regression is fixed over these changes locally (error repro on 1.114.0 and terraform apply passing over these changes)