### PR TITLE
[DRAFT] Fix provider_config force new on upgrade for immutable SDKv2 resources

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -1,5 +1,11 @@
 # NEXT CHANGELOG
 
+## Release v1.114.3
+
+### Bug Fixes
+
+* Fix `provider_config` block triggering destroy-and-recreate on upgrade from v1.114.0 / v1.114.2 for SDKv2 resources without an `Update` method (`databricks_token`, `databricks_secret`, `databricks_secret_scope`, `databricks_secret_acl`, `databricks_mount`, `databricks_dbfs_file`, `databricks_obo_token`, `databricks_service_principal_secret`, `databricks_user_role`, `databricks_group_role`, `databricks_user_instance_profile`, `databricks_group_instance_profile`, `databricks_service_principal_role`, `databricks_group_member`, `databricks_metastore_data_access`, `databricks_online_table`, `databricks_workspace_binding`, `databricks_catalog_workspace_binding`, `databricks_vector_search_index`). The auto-ForceNew sweep in `common.Resource.ToResource` now skips `provider_config` and supplies a no-op `Update` wrapper, so an in-place change to `provider_config` is honored without recreating the resource.
+
 ## Release v1.114.2
 
 ### Breaking Changes

--- a/common/resource.go
+++ b/common/resource.go
@@ -105,15 +105,30 @@ func (r Resource) ToResource() *schema.Resource {
 			return nil
 		}
 	} else {
-		// set ForceNew to all attributes with CRD
+		// patch-1.114.3 (variant C): for resources without an Update
+		// that ALSO have the framework-injected `provider_config` block,
+		// stamp ForceNew on every non-Computed field EXCEPT
+		// provider_config, and supply a no-op Update wrapper. Result:
+		// InternalValidate passes via the has-Update branch (Optional
+		// provider_config counts as the one updateable attribute), and
+		// an in-place change to provider_config does not trigger
+		// destroy-and-recreate.
+		//
+		// Resources without provider_config (legacy mounts, mws_*) keep
+		// the historical behavior: every non-Computed field gets
+		// ForceNew, no synthesized Update.
+		_, hasProviderConfig := r.Schema["provider_config"]
 		queue := []*schema.Resource{
 			{Schema: r.Schema},
 		}
 		for {
 			head := queue[0]
 			queue = queue[1:]
-			for _, v := range head.Schema {
+			for k, v := range head.Schema {
 				if v.Computed {
+					continue
+				}
+				if hasProviderConfig && k == "provider_config" {
 					continue
 				}
 				if nested, ok := v.Elem.(*schema.Resource); ok {
@@ -123,6 +138,19 @@ func (r Resource) ToResource() *schema.Resource {
 			}
 			if len(queue) == 0 {
 				break
+			}
+		}
+		// Only synthesize the no-op Update for writable resources that
+		// have provider_config. Data sources flow through here and must
+		// not have Update; resources without provider_config would fail
+		// InternalValidate's "Update is superfluous" check.
+		if hasProviderConfig && (r.Create != nil || r.Delete != nil) {
+			update = func(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
+				c := m.(*DatabricksClient)
+				if err := recoverable(r.Read)(ctx, d, c); err != nil {
+					return diag.FromErr(nicerError(ctx, err, "read"))
+				}
+				return nil
 			}
 		}
 	}


### PR DESCRIPTION
The auto-ForceNew sweep in common.Resource.ToResource stamps ForceNew=true on every non-Computed top-level field of resources without an Update method, to satisfy the upstream SDK's InternalValidate invariant. With v1.114.0 adding the framework-injected provider_config block to those resources' schemas, upgrades from v1.114.0/v1.114.2 turn a state-vs-config diff for provider_config into destroy-and-recreate.

Skip provider_config in the sweep and synthesize a no-op Update (calling Read so state stays in sync) for resources that have provider_config and at least Create or Delete. InternalValidate now passes via the has-Update branch -- Optional provider_config counts as the one updateable attribute -- and provider_config changes are honored as in-place updates.

Affected resources (19): databricks_token, databricks_secret, databricks_secret_scope, databricks_secret_acl, databricks_mount, databricks_dbfs_file, databricks_obo_token, databricks_service_principal_secret, databricks_user_role, databricks_group_role, databricks_user_instance_profile, databricks_group_instance_profile, databricks_service_principal_role, databricks_group_member, databricks_metastore_data_access, databricks_online_table, databricks_workspace_binding, databricks_catalog_workspace_binding, databricks_vector_search_index.

## Changes
<!-- Summary of your changes that are easy to understand -->

## Tests
<!--
How is this tested? Please see the checklist below and also describe any other relevant tests
-->

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] using Go SDK
- [ ] using TF Plugin Framework
- [ ] has entry in `NEXT_CHANGELOG.md` file
