### PR TITLE
Revert "[Fix] Migrate account data sources from DataResource to AccountData"

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -10,7 +10,6 @@
 
 * Fix `databricks_service_principal` data source failing on account-level provider with `cannot populate provider_config for service principal: failed to resolve workspace_id` ([#5664](https://github.com/databricks/terraform-provider-databricks/issues/5664)). The data source now supports the `api` field and skips workspace-tracking when used at account level.
 * Fix `databricks_service_principals` data source failing on account-level provider with the same `cannot populate provider_config for service principals: failed to resolve workspace_id` regression ([#5664](https://github.com/databricks/terraform-provider-databricks/issues/5664)). The data source now supports the `api` field and skips workspace-tracking when used at account level.
-* Remove invalid `provider_config` attribute from account-only data sources `databricks_mws_workspaces` and `databricks_mws_credentials` ([#5664](https://github.com/databricks/terraform-provider-databricks/issues/5664)).
 
 ### Documentation
 

--- a/docs/data-sources/mws_credentials.md
+++ b/docs/data-sources/mws_credentials.md
@@ -24,6 +24,11 @@ output "all_mws_credentials" {
 }
 ```
 
+## Argument Reference
+
+* `provider_config` - (Optional) Configure the provider for management through account provider. This block consists of the following fields:
+  * `workspace_id` - (Required) Workspace ID which the resource belongs to. This workspace must be part of the account which the provider is configured with.
+
 ## Attribute Reference
 
 -> This resource has an evolving interface, which may change in future versions of the provider.

--- a/docs/data-sources/mws_workspaces.md
+++ b/docs/data-sources/mws_workspaces.md
@@ -24,6 +24,11 @@ output "all_mws_workspaces" {
 }
 ```
 
+## Argument Reference
+
+* `provider_config` - (Optional) Configure the provider for management through account provider. This block consists of the following fields:
+  * `workspace_id` - (Required) Workspace ID which the resource belongs to. This workspace must be part of the account which the provider is configured with.
+
 ## Attribute Reference
 
 -> This resource has an evolving interface, which may change in future versions of the provider.

--- a/mws/data_mws_credentials.go
+++ b/mws/data_mws_credentials.go
@@ -3,7 +3,6 @@ package mws
 import (
 	"context"
 
-	"github.com/databricks/databricks-sdk-go"
 	"github.com/databricks/terraform-provider-databricks/common"
 )
 
@@ -11,14 +10,15 @@ func DataSourceMwsCredentials() common.Resource {
 	type mwsCredentialsData struct {
 		Ids map[string]string `json:"ids,omitempty" tf:"computed"`
 	}
-	return common.AccountData(func(ctx context.Context, data *mwsCredentialsData, acc *databricks.AccountClient) error {
-		credentials, err := acc.Credentials.List(ctx)
+	return common.DataResource(mwsCredentialsData{}, func(ctx context.Context, e any, c *common.DatabricksClient) error {
+		data := e.(*mwsCredentialsData)
+		credentials, err := NewCredentialsAPI(ctx, c).List(c.Config.AccountID)
 		if err != nil {
 			return err
 		}
 		data.Ids = make(map[string]string)
 		for _, v := range credentials {
-			data.Ids[v.CredentialsName] = v.CredentialsId
+			data.Ids[v.CredentialsName] = v.CredentialsID
 		}
 		return nil
 	})

--- a/mws/data_mws_credentials_acc_test.go
+++ b/mws/data_mws_credentials_acc_test.go
@@ -2,7 +2,6 @@ package mws_test
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/databricks/terraform-provider-databricks/internal/acceptance"
@@ -22,17 +21,6 @@ func TestAccDataSourceMwsCredentials(t *testing.T) {
 			ids := r.Primary.Attributes["ids.%"]
 			if ids == "" {
 				return fmt.Errorf("ids is empty: %v", r.Primary.Attributes)
-			}
-			// Regression check for https://github.com/databricks/terraform-provider-databricks/issues/5664.
-			// databricks_mws_credentials is account-only and must not carry a
-			// provider_config block in state — the post-Read hook that populates
-			// it is keyed off schema presence, so the absence of any
-			// provider_config.* attribute confirms the schema is clean and the
-			// hook never ran.
-			for k := range r.Primary.Attributes {
-				if strings.HasPrefix(k, "provider_config") {
-					return fmt.Errorf("unexpected provider_config in state: %s=%q", k, r.Primary.Attributes[k])
-				}
 			}
 			return nil
 		},

--- a/mws/data_mws_credentials_test.go
+++ b/mws/data_mws_credentials_test.go
@@ -38,13 +38,6 @@ func TestDataSourceMwsCredentials(t *testing.T) {
 	})
 }
 
-func TestDataSourceMwsCredentials_NoProviderConfigInSchema(t *testing.T) {
-	s := DataSourceMwsCredentials().Schema
-	if _, ok := s["provider_config"]; ok {
-		t.Fatalf("databricks_mws_credentials is account-only and must not expose provider_config")
-	}
-}
-
 func TestDataSourceMwsCredentials_Error(t *testing.T) {
 	qa.ResourceFixture{
 		Fixtures:    qa.HTTPFailures,

--- a/mws/data_mws_workspaces.go
+++ b/mws/data_mws_workspaces.go
@@ -3,7 +3,6 @@ package mws
 import (
 	"context"
 
-	"github.com/databricks/databricks-sdk-go"
 	"github.com/databricks/terraform-provider-databricks/common"
 )
 
@@ -11,14 +10,15 @@ func DataSourceMwsWorkspaces() common.Resource {
 	type mwsWorkspacesData struct {
 		Ids map[string]int64 `json:"ids" tf:"computed"`
 	}
-	return common.AccountData(func(ctx context.Context, data *mwsWorkspacesData, acc *databricks.AccountClient) error {
-		workspaces, err := acc.Workspaces.List(ctx)
+	return common.DataResource(mwsWorkspacesData{}, func(ctx context.Context, e any, c *common.DatabricksClient) error {
+		data := e.(*mwsWorkspacesData)
+		workspaces, err := NewWorkspacesAPI(ctx, c).List(c.Config.AccountID)
 		if err != nil {
 			return err
 		}
 		data.Ids = map[string]int64{}
 		for _, v := range workspaces {
-			data.Ids[v.WorkspaceName] = v.WorkspaceId
+			data.Ids[v.WorkspaceName] = v.WorkspaceID
 		}
 		return nil
 	})

--- a/mws/data_mws_workspaces_acc_test.go
+++ b/mws/data_mws_workspaces_acc_test.go
@@ -2,11 +2,11 @@ package mws_test
 
 import (
 	"fmt"
-	"strings"
-	"testing"
 
 	"github.com/databricks/terraform-provider-databricks/internal/acceptance"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+
+	"testing"
 )
 
 func TestAccDataSourceMwsWorkspaces(t *testing.T) {
@@ -22,17 +22,6 @@ func TestAccDataSourceMwsWorkspaces(t *testing.T) {
 			ids := r.Primary.Attributes["ids.%"]
 			if ids == "" {
 				return fmt.Errorf("ids is empty: %v", r.Primary.Attributes)
-			}
-			// Regression check for https://github.com/databricks/terraform-provider-databricks/issues/5664.
-			// databricks_mws_workspaces is account-only and must not carry a
-			// provider_config block in state — the post-Read hook that populates
-			// it is keyed off schema presence, so the absence of any
-			// provider_config.* attribute confirms the schema is clean and the
-			// hook never ran.
-			for k := range r.Primary.Attributes {
-				if strings.HasPrefix(k, "provider_config") {
-					return fmt.Errorf("unexpected provider_config in state: %s=%q", k, r.Primary.Attributes[k])
-				}
 			}
 			return nil
 		},

--- a/mws/data_mws_workspaces_test.go
+++ b/mws/data_mws_workspaces_test.go
@@ -49,13 +49,6 @@ func TestCatalogsData_Error(t *testing.T) {
 	}.ExpectError(t, "i'm a teapot")
 }
 
-func TestDataSourceMwsWorkspaces_NoProviderConfigInSchema(t *testing.T) {
-	s := DataSourceMwsWorkspaces().Schema
-	if _, ok := s["provider_config"]; ok {
-		t.Fatalf("databricks_mws_workspaces is account-only and must not expose provider_config")
-	}
-}
-
 func TestDataSourceMwsWorkspaces_Empty(t *testing.T) {
 	qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
Reverts: https://github.com/databricks/terraform-provider-databricks/pull/5667
- data_mws_credentials
- data_mws_workspaces

This would be followed by support to not trigger default workspace id support based on provider_config schema. Earlier there were some discussions about annotating all resources and using that information to make decisions but we have decided to move forward with fix forward.  https://github.com/databricks/terraform-provider-databricks/pull/5689


## Tests
<!--
How is this tested? Please see the checklist below and also describe any other relevant tests
-->
All existing tests pass