### PR TITLE
Add databricks_connection data source

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### New Features and Improvements
 
+* Add `databricks_connection` data source to look up connections by name ([#5692](https://github.com/databricks/terraform-provider-databricks/pull/5692)).
+
 ### Bug Fixes
 
 * Fix `databricks_service_principal` data source failing on account-level provider with `cannot populate provider_config for service principal: failed to resolve workspace_id` ([#5664](https://github.com/databricks/terraform-provider-databricks/issues/5664)). The data source now supports the `api` field and skips workspace-tracking when used at account level.

--- a/catalog/data_connection.go
+++ b/catalog/data_connection.go
@@ -1,0 +1,27 @@
+package catalog
+
+import (
+	"context"
+
+	"github.com/databricks/databricks-sdk-go"
+	"github.com/databricks/databricks-sdk-go/service/catalog"
+	"github.com/databricks/terraform-provider-databricks/common"
+)
+
+func DataSourceConnection() common.Resource {
+	type ConnectionByName struct {
+		common.Namespace
+		Id         string                  `json:"id,omitempty" tf:"computed"`
+		Name       string                  `json:"name"`
+		Connection *catalog.ConnectionInfo `json:"connection_info,omitempty" tf:"computed"`
+	}
+	return common.WorkspaceData(func(ctx context.Context, data *ConnectionByName, w *databricks.WorkspaceClient) error {
+		conn, err := w.Connections.GetByName(ctx, data.Name)
+		if err != nil {
+			return err
+		}
+		data.Connection = conn
+		data.Id = conn.Name
+		return nil
+	})
+}

--- a/catalog/data_connection_test.go
+++ b/catalog/data_connection_test.go
@@ -1,0 +1,50 @@
+package catalog
+
+import (
+	"testing"
+
+	"github.com/databricks/databricks-sdk-go/experimental/mocks"
+	"github.com/databricks/databricks-sdk-go/service/catalog"
+	"github.com/databricks/terraform-provider-databricks/qa"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestConnectionDataVerify(t *testing.T) {
+	qa.ResourceFixture{
+		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
+			e := w.GetMockConnectionsAPI().EXPECT()
+			e.GetByName(mock.Anything, "test_conn").Return(
+				&catalog.ConnectionInfo{
+					Name:           "test_conn",
+					ConnectionType: "POSTGRESQL",
+					Owner:          "admin",
+					Comment:        "test connection",
+					FullName:       "test_conn",
+					MetastoreId:    "abc",
+				},
+				nil)
+		},
+		Resource:    DataSourceConnection(),
+		Read:        true,
+		NonWritable: true,
+		ID:          "_",
+		HCL: `
+		name = "test_conn"
+		`,
+	}.ApplyAndExpectData(t, map[string]any{
+		"id":                                "test_conn",
+		"connection_info.0.owner":           "admin",
+		"connection_info.0.connection_type": "POSTGRESQL",
+		"connection_info.0.comment":         "test connection",
+	})
+}
+
+func TestConnectionDataError(t *testing.T) {
+	qa.ResourceFixture{
+		Fixtures:    qa.HTTPFailures,
+		Resource:    DataSourceConnection(),
+		Read:        true,
+		NonWritable: true,
+		ID:          "_",
+	}.ExpectError(t, "i'm a teapot")
+}

--- a/docs/data-sources/connection.md
+++ b/docs/data-sources/connection.md
@@ -1,0 +1,45 @@
+---
+subcategory: "Unity Catalog"
+---
+
+# databricks_connection Data Source
+
+-> This resource can only be used with a workspace-level provider!
+
+Retrieves details of an existing [databricks_connection](../resources/connection.md) by name. This is useful for referencing connections managed outside of the current Terraform configuration, e.g. to validate that a connection exists before creating a foreign catalog.
+
+## Example Usage
+
+```hcl
+data "databricks_connection" "this" {
+  name = "my_postgresql_connection"
+}
+
+output "connection_type" {
+  value = data.databricks_connection.this.connection_info.0.connection_type
+}
+```
+
+## Argument Reference
+
+* `name` - (Required) The name of the connection.
+
+## Attribute Reference
+
+* `id` - The name of the connection.
+* `connection_info` - block with information about the connection. It has the following fields:
+  * `connection_type` - Connection type (e.g. `POSTGRESQL`, `MYSQL`, `SNOWFLAKE`, `REDSHIFT`).
+  * `owner` - Owner of the connection.
+  * `options` - Map of connection options (sensitive values are redacted).
+  * `comment` - Free-form comment on the connection.
+  * `read_only` - Whether the connection is read-only.
+  * `full_name` - Full name of the connection.
+  * `metastore_id` - Unique identifier of the parent metastore.
+  * `created_at` - Time at which the connection was created, in epoch milliseconds.
+  * `created_by` - Username of connection creator.
+  * `updated_at` - Time at which the connection was last modified, in epoch milliseconds.
+  * `updated_by` - Username of user who last modified the connection.
+
+## Related Resources
+
+* [databricks_connection](../resources/connection.md) resource to manage connections.

--- a/internal/providers/sdkv2/sdkv2.go
+++ b/internal/providers/sdkv2/sdkv2.go
@@ -122,6 +122,7 @@ func DatabricksProvider(opts ...SdkV2ProviderOption) *schema.Provider {
 		"databricks_cluster_policy":                       policies.DataSourceClusterPolicy().ToResource(),
 		"databricks_catalog":                              catalog.DataSourceCatalog().ToResource(),
 		"databricks_catalogs":                             catalog.DataSourceCatalogs().ToResource(),
+		"databricks_connection":                           catalog.DataSourceConnection().ToResource(),
 		"databricks_current_config":                       mws.DataSourceCurrentConfiguration().ToResource(),
 		"databricks_current_metastore":                    catalog.DataSourceCurrentMetastore().ToResource(),
 		"databricks_current_user":                         scim.DataSourceCurrentUser().ToResource(),


### PR DESCRIPTION
## Summary
- Add `databricks_connection` data source. Look up connection by name.
- Unit tests: happy path + error path.
- Docs: `docs/data-sources/connection.md`.
- Register in sdkv2 provider.

## Test plan
- [x] `go build ./...` — compiles
- [x] `go test ./catalog/ -run TestConnection` — passes
- [x] `make fmt lint ws` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)