### PR TITLE
[Internal] [Fix] Defer workspace_id validation when value is unknown at plan time

### DIFF
--- a/common/unified_provider.go
+++ b/common/unified_provider.go
@@ -188,16 +188,50 @@ func NamespaceValidateWorkspaceID(ctx context.Context, d *schema.ResourceDiff, c
 	if newWorkspaceID == nil {
 		return nil
 	}
-	newWSID := newWorkspaceID.(string)
-	// Fall back to provider-level workspace_id only if not set on the resource.
+	newWSID, ok := newWorkspaceID.(string)
+	if !ok {
+		return nil
+	}
 	if newWSID == "" {
+		// When the user wrote provider_config.workspace_id but its value
+		// references another resource's computed attribute that hasn't been
+		// applied yet (e.g. databricks_mws_workspaces.this.workspace_id), the
+		// value is unknown at plan time. Defer validation to the next plan —
+		// falling back to the provider-level workspace_id here would attempt
+		// to validate against a different value than what the user wrote.
+		if isWorkspaceIDUnknownInRawConfig(d) {
+			return nil
+		}
+		// Fall back to provider-level workspace_id only if not set on the resource.
 		newWSID = c.Config.WorkspaceID
+	}
+	// "none" is a sentinel the Databricks CLI writes to ~/.databrickscfg when
+	// a profile has no workspace bound (e.g. account-level auth login). Treat
+	// it as "no workspace_id" and skip validation rather than failing parse.
+	if newWSID == "" || newWSID == "none" {
+		return nil
 	}
 	_, err := c.GetWorkspaceClientForUnifiedProvider(ctx, newWSID)
 	if err != nil {
 		return err
 	}
 	return nil
+}
+
+// isWorkspaceIDUnknownInRawConfig returns true when provider_config.workspace_id
+// is present in the user's raw config but its value is unknown at plan time
+// (e.g. a reference to a yet-to-be-created resource's computed attribute).
+func isWorkspaceIDUnknownInRawConfig(d *schema.ResourceDiff) bool {
+	path := cty.Path{
+		cty.GetAttrStep{Name: "provider_config"},
+		cty.IndexStep{Key: cty.NumberIntVal(0)},
+		cty.GetAttrStep{Name: "workspace_id"},
+	}
+	rawValue, diags := d.GetRawConfigAt(path)
+	if diags.HasError() {
+		return false
+	}
+	return !rawValue.IsNull() && !rawValue.IsKnown()
 }
 
 // workspaceIDFromRawDiffConfig extracts the workspace ID from the raw config

--- a/common/unified_provider_test.go
+++ b/common/unified_provider_test.go
@@ -845,6 +845,52 @@ func TestNamespaceCustomizeDiff_UnifiedHost_DirectFallback(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+// TestNamespaceCustomizeDiff_UnknownWorkspaceIDFromCrossResourceRef covers the
+// case where a resource declares
+//
+//	provider_config { workspace_id = databricks_mws_workspaces.this.workspace_id }
+//
+// and the referenced workspace doesn't exist yet. The workspace_id is unknown
+// at plan time, so validation must defer (return nil) instead of falling back
+// to the provider-level workspace_id and parsing a sentinel like "none" that
+// some Databricks CLI flows write to ~/.databrickscfg for account profiles.
+func TestNamespaceCustomizeDiff_UnknownWorkspaceIDFromCrossResourceRef(t *testing.T) {
+	resource := newTestResourceForCustomizeDiff()
+
+	c := &DatabricksClient{
+		DatabricksClient: &client.DatabricksClient{
+			Config: &config.Config{
+				Host:        "https://accounts.cloud.databricks.com",
+				AccountID:   "test-account-id",
+				Token:       "test-token",
+				WorkspaceID: "none", // sentinel written by `databricks auth login` for account profiles
+			},
+		},
+	}
+
+	rawConfig := cty.ObjectVal(map[string]cty.Value{
+		"name": cty.StringVal("test"),
+		"provider_config": cty.ListVal([]cty.Value{
+			cty.ObjectVal(map[string]cty.Value{
+				// Unknown simulates a reference like
+				// databricks_mws_workspaces.this.workspace_id where the
+				// referenced resource has not been applied yet.
+				"workspace_id": cty.UnknownVal(cty.String),
+			}),
+		}),
+	})
+
+	block := schema.InternalMap(resource.Schema).CoreConfigSchema()
+	rc := terraform.NewResourceConfigShimmed(rawConfig, block)
+	is := &terraform.InstanceState{
+		Attributes: map[string]string{"name": "test"},
+		RawConfig:  rawConfig,
+	}
+
+	_, err := resource.Diff(context.Background(), is, rc, c)
+	assert.NoError(t, err, "validation should defer when workspace_id is unknown at plan time")
+}
+
 // newDualResourceForCustomizeDiff builds a test resource with the `api` field
 // (mirroring dual resources that call AddApiField) wired to CustomizeDiffDualResources.
 func newDualResourceForCustomizeDiff() *schema.Resource {


### PR DESCRIPTION
## What changed?

  When `provider_config.workspace_id` references another resource's computed attribute (e.g. `databricks_mws_workspaces.this.workspace_id`) that hasn't been applied yet, the
  workspace_id is unknown at plan time. Plan-time validation now defers (returns nil) in that case instead of falling back to the provider-level `workspace_id`.

  ## Why?

  `terraform-plugin-sdk` v2 shims unknown values to empty strings in `d.GetChange()`. The previous code path treated this identically to "user didn't set workspace_id" and fell back to
   `c.Config.WorkspaceID`. When that value is the literal `"none"` (a sentinel some Databricks CLI auth flows write to `~/.databrickscfg` for account profiles),
  `parseWorkspaceID("none")` fails with:

  failed to parse workspace_id, please check if the workspace_id in provider_config is a valid integer: strconv.ParseInt: parsing "none": invalid syntax

  Repro:

  ```hcl
  provider "databricks" { profile = "accounts" }

  resource "databricks_mws_workspaces" "this" { ... }

  resource "databricks_job" "test" {
    provider_config {
      workspace_id = databricks_mws_workspaces.this.workspace_id
    }
    ...
  }

  terraform apply succeeds on v1.113.0 and fails on v1.114.0.

  How?

  Added isWorkspaceIDUnknownInRawConfig() which uses GetRawConfigAt to read the value as a cty.Value and check IsKnown(). When unknown, NamespaceValidateWorkspaceID returns early. The
  "none" sentinel guard is kept as defense-in-depth for cases without a cross-resource ref.

  Tests

  - TestNamespaceCustomizeDiff_UnknownWorkspaceIDFromCrossResourceRef — sets Config.WorkspaceID = "none" and provider_config.workspace_id = cty.UnknownVal(cty.String), asserts Diff
  returns no error.
  - Manually verified: terraform apply against an account profile with a job referencing a to-be-created workspace's id now succeeds.