### PR TITLE
[Fix] Send X-Databricks-Org-Id for workspace SCIM on unified hosts

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -11,6 +11,9 @@
 * Fix `databricks_service_principal` data source failing on account-level provider with `cannot populate provider_config for service principal: failed to resolve workspace_id` ([#5664](https://github.com/databricks/terraform-provider-databricks/issues/5664)). The data source now supports the `api` field and skips workspace-tracking when used at account level.
 * Fix `databricks_service_principals` data source failing on account-level provider with the same `cannot populate provider_config for service principals: failed to resolve workspace_id` regression ([#5664](https://github.com/databricks/terraform-provider-databricks/issues/5664)). The data source now supports the `api` field and skips workspace-tracking when used at account level.
 * Fix `databricks_mws_workspaces` and `databricks_mws_credentials` data sources failing on account-level provider with `cannot populate provider_config for mws workspaces: failed to resolve workspace_id` ([#5672](https://github.com/databricks/terraform-provider-databricks/issues/5672)). These account-only data sources are now exempted from the post-Read workspace-tracking hook, and `provider_config` (which had no effect on them) is now deprecated and will be removed in a future major release.
+* Fix workspace-level SCIM data sources and resources (`databricks_user`, `databricks_group`, `databricks_service_principal(s)`) failing with `HTTP 400 Unable to load OAuth Config` when `api = "workspace"` is set on a unified host.
+
+  On a unified host, workspace-level SCIM requests need an `X-Databricks-Org-Id` header so the host can route the call to the right workspace. The Go SDK does not auto-inject this header from `Config.WorkspaceID` for general API calls, so the provider now adds it from `Config.WorkspaceID` for non-account SCIM requests on a unified host.
 
 ### Documentation
 

--- a/common/client.go
+++ b/common/client.go
@@ -608,6 +608,17 @@ func (c *DatabricksClient) scimVisitorForLevel(apiLevel string) func(*http.Reque
 			// `/api/2.0` is added by completeUrl visitor
 			r.URL.Path = strings.ReplaceAll(r.URL.Path, "/api/2.0/preview",
 				fmt.Sprintf("/api/2.0/accounts/%s", c.Config.AccountID))
+			return nil
+		}
+		// Workspace-level SCIM on UnifiedHost: route by X-Databricks-Org-Id.
+		// Without this header, the unified host returns HTTP 400
+		// "Unable to load OAuth Config" because it cannot determine the target
+		// workspace from the URL alone. The Go SDK does not auto-inject this
+		// header from Config.WorkspaceID for general API calls (only specific
+		// methods like CurrentWorkspaceID do), so the provider adds it here for
+		// the SCIM path it owns.
+		if c.HostTypeForTerraform() == config.UnifiedHost && c.Config.WorkspaceID != "" {
+			r.Header.Set("X-Databricks-Org-Id", c.Config.WorkspaceID)
 		}
 		return nil
 	}

--- a/common/client_test.go
+++ b/common/client_test.go
@@ -563,3 +563,73 @@ func TestCurrentWorkspaceID_ReturnsCachedValue(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, int64(12345), id2)
 }
+
+func unifiedHostConfigForClientTest(t *testing.T, host string) *config.Config {
+	cfg := &config.Config{
+		Host:  host,
+		Token: "test-token",
+		HostMetadataResolver: func(ctx context.Context, _ string) (*config.HostMetadata, error) {
+			return &config.HostMetadata{HostType: config.UnifiedHost}, nil
+		},
+	}
+	require.NoError(t, cfg.EnsureResolved())
+	return cfg
+}
+
+func TestScimVisitorForLevel_AccountRewritesPath(t *testing.T) {
+	c := &DatabricksClient{
+		DatabricksClient: &client.DatabricksClient{
+			Config: &config.Config{
+				Host:      "https://accounts.cloud.databricks.com",
+				AccountID: "acct-123",
+				Token:     "t",
+			},
+		},
+	}
+	r, _ := http.NewRequest("GET", "https://example/api/2.0/preview/scim/v2/Users", nil)
+	require.NoError(t, c.scimVisitorForLevel("account")(r))
+	assert.Equal(t, "/api/2.0/accounts/acct-123/scim/v2/Users", r.URL.Path)
+	assert.Empty(t, r.Header.Get("X-Databricks-Org-Id"))
+}
+
+func TestScimVisitorForLevel_WorkspaceOnUnifiedHost_AddsOrgIdHeader(t *testing.T) {
+	c := &DatabricksClient{
+		DatabricksClient: &client.DatabricksClient{
+			Config: unifiedHostConfigForClientTest(t, "https://unified.cloud.databricks.com"),
+		},
+	}
+	c.Config.WorkspaceID = "470576644108500"
+	r, _ := http.NewRequest("GET", "https://example/api/2.0/preview/scim/v2/Users", nil)
+	require.NoError(t, c.scimVisitorForLevel("workspace")(r))
+	// Path is unchanged for workspace requests.
+	assert.Equal(t, "/api/2.0/preview/scim/v2/Users", r.URL.Path)
+	// X-Databricks-Org-Id is added so the unified host can route to the workspace.
+	assert.Equal(t, "470576644108500", r.Header.Get("X-Databricks-Org-Id"))
+}
+
+func TestScimVisitorForLevel_WorkspaceOnUnifiedHost_NoWorkspaceID_NoHeader(t *testing.T) {
+	c := &DatabricksClient{
+		DatabricksClient: &client.DatabricksClient{
+			Config: unifiedHostConfigForClientTest(t, "https://unified.cloud.databricks.com"),
+		},
+	}
+	// WorkspaceID intentionally unset.
+	r, _ := http.NewRequest("GET", "https://example/api/2.0/preview/scim/v2/Users", nil)
+	require.NoError(t, c.scimVisitorForLevel("workspace")(r))
+	assert.Empty(t, r.Header.Get("X-Databricks-Org-Id"))
+}
+
+func TestScimVisitorForLevel_WorkspaceOnNonUnifiedHost_NoHeader(t *testing.T) {
+	c := &DatabricksClient{
+		DatabricksClient: &client.DatabricksClient{
+			Config: &config.Config{
+				Host:        "https://workspace.cloud.databricks.com",
+				WorkspaceID: "470576644108500",
+				Token:       "t",
+			},
+		},
+	}
+	r, _ := http.NewRequest("GET", "https://example/api/2.0/preview/scim/v2/Users", nil)
+	require.NoError(t, c.scimVisitorForLevel("workspace")(r))
+	assert.Empty(t, r.Header.Get("X-Databricks-Org-Id"))
+}


### PR DESCRIPTION
Workspace-level SCIM data sources and resources (databricks_user, databricks_group, databricks_service_principal(s)) failed on a unified host with HTTP 400 "Unable to load OAuth Config" when api = "workspace" was set. The unified host needs X-Databricks-Org-Id to route a workspace-level call to the right workspace; the Go SDK does not auto-inject this header from Config.WorkspaceID for general API calls (only specific methods like CurrentWorkspaceID do).

scimVisitorForLevel now sets the header from c.Config.WorkspaceID when the request is non-account SCIM on a unified host. Account requests are unchanged (path is rewritten to /api/2.0/accounts/...). Workspace requests on workspace/account hosts are unchanged (no header added).

Verified end-to-end against a unified host: data.databricks_user, data.databricks_group, data.databricks_service_principals with api = "workspace" now succeed; without api, the existing plan-time validator still fires.

Co-authored-by: Isaac

## Changes
<!-- Summary of your changes that are easy to understand -->

## Tests
<!--
How is this tested? Please see the checklist below and also describe any other relevant tests
-->

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] using Go SDK
- [ ] using TF Plugin Framework
- [ ] has entry in `NEXT_CHANGELOG.md` file
