### PR TITLE
[Fix] Defer plan-time workspace_id validation when not user-typed

### DIFF
--- a/common/client.go
+++ b/common/client.go
@@ -108,9 +108,17 @@ func (c *DatabricksClient) GetWorkspaceClientForUnifiedProviderWithDiagnostics(
 // for terraform provider, the provider can be configured at account level or workspace level.
 // This implementation will be used by resources and data sources that are developed
 // over SDKv2.
+//
+// When workspaceID is empty, the provider-level workspace_id (Config.WorkspaceID)
+// is used as a fallback. This is the single point that all unified-provider
+// workspace-client lookups transit, so both SDKv2 helpers and Plugin Framework
+// callers benefit from this fallback without per-callsite duplication.
 func (c *DatabricksClient) GetWorkspaceClientForUnifiedProvider(
 	ctx context.Context, workspaceID string,
 ) (*databricks.WorkspaceClient, error) {
+	if workspaceID == "" && c.DatabricksClient != nil && c.Config != nil {
+		workspaceID = c.Config.WorkspaceID
+	}
 	// The provider can be configured at account level or workspace level.
 	if c.HostTypeForTerraform() != config.WorkspaceHost {
 		return c.getWorkspaceClientForAccountUnifiedHost(ctx, workspaceID)
@@ -124,11 +132,6 @@ func (c *DatabricksClient) GetWorkspaceClientForUnifiedProvider(
 func (c *DatabricksClient) getWorkspaceClientForAccountUnifiedHost(
 	ctx context.Context, workspaceID string,
 ) (*databricks.WorkspaceClient, error) {
-	// If workspace_id is not provided in provider_config, use the provider-level
-	// workspace_id from SDK config as fallback
-	if workspaceID == "" {
-		workspaceID = c.Config.WorkspaceID
-	}
 	if workspaceID == "" {
 		return nil, fmt.Errorf("managing workspace-level resources requires a workspace_id, " +
 			"but none was found in the resource's provider_config block or the provider's workspace_id attribute")

--- a/common/unified_provider.go
+++ b/common/unified_provider.go
@@ -179,25 +179,27 @@ func namespaceForceNew(ctx context.Context, d *schema.ResourceDiff, c *Databrick
 }
 
 // NamespaceValidateWorkspaceID validates that the workspace_id in provider_config
-// is reachable during the plan phase.
-// For workspace-level providers, it checks that the workspace_id matches the provider's workspace.
-// For account-level providers, it checks that the workspace is accessible from the account.
-// This is a no-op when provider_config is not set.
+// is reachable during the plan phase, but only when the user explicitly typed
+// provider_config.workspace_id in HCL.
+//
+// When the user did not write provider_config, or wrote it but the workspace_id
+// is unknown (e.g. cross-resource reference like
+// `workspace_id = databricks_mws_workspaces.this.workspace_id`), the validator
+// defers — apply-time client construction in
+// GetWorkspaceClientForUnifiedProvider does the layered fallback to
+// Config.WorkspaceID and produces actionable API errors.
+//
+// Plan-time validation here is purely a fail-fast UX hint for users who typed a
+// concrete workspace_id; it must not fall back to Config.WorkspaceID itself,
+// since doing so caused regressions in v1.114.0 (see #5664, #5668, #5672, the
+// cross-resource bootstrap pattern).
 func NamespaceValidateWorkspaceID(ctx context.Context, d *schema.ResourceDiff, c *DatabricksClient) error {
-	_, newWorkspaceID := d.GetChange(workspaceIDSchemaKey)
-	if newWorkspaceID == nil {
+	wsID, hasExplicit := workspaceIDFromRawDiffConfig(d)
+	if !hasExplicit || wsID == "" {
 		return nil
 	}
-	newWSID := newWorkspaceID.(string)
-	// Fall back to provider-level workspace_id only if not set on the resource.
-	if newWSID == "" {
-		newWSID = c.Config.WorkspaceID
-	}
-	_, err := c.GetWorkspaceClientForUnifiedProvider(ctx, newWSID)
-	if err != nil {
-		return err
-	}
-	return nil
+	_, err := c.GetWorkspaceClientForUnifiedProvider(ctx, wsID)
+	return err
 }
 
 // workspaceIDFromRawDiffConfig extracts the workspace ID from the raw config

--- a/common/unified_provider_test.go
+++ b/common/unified_provider_test.go
@@ -668,6 +668,12 @@ func newTestResourceForCustomizeDiff() *schema.Resource {
 
 // diffCustomizeDiff runs Diff on the resource with the given state and config,
 // returning the diff and any error from CustomizeDiff.
+//
+// Uses NewResourceConfigShimmed with a cty value so that GetRawConfigAt works
+// for tests of NamespaceValidateWorkspaceID (which inspects raw config to
+// distinguish "user typed it" from "preserved from state"). When the test
+// resource has the api field (dual resources), it is included in the cty
+// schema; otherwise only name + provider_config are populated.
 func diffCustomizeDiff(
 	t *testing.T,
 	resource *schema.Resource,
@@ -678,12 +684,71 @@ func diffCustomizeDiff(
 	t.Helper()
 	ctx := context.Background()
 	ctx = context.WithValue(ctx, ResourceName, "test_resource")
-	var is *terraform.InstanceState
+
+	ctyVal := testResourceConfigToCtyValue(resource, rawConfig)
+	block := schema.InternalMap(resource.Schema).CoreConfigSchema()
+	rc := terraform.NewResourceConfigShimmed(ctyVal, block)
+
+	// Always pass an InstanceState with RawConfig set so that
+	// ResourceDiff.GetRawConfigAt — used by NamespaceValidateWorkspaceID
+	// to detect explicit user input — sees the cty value. Mirrors the gRPC
+	// PlanResourceChange path where priorState.RawConfig = configVal.
+	is := &terraform.InstanceState{RawConfig: ctyVal}
 	if instanceState != nil {
-		is = &terraform.InstanceState{Attributes: instanceState}
+		is.Attributes = instanceState
 	}
-	rc := terraform.NewResourceConfigRaw(rawConfig)
 	return resource.Diff(ctx, is, rc, c)
+}
+
+// testResourceConfigToCtyValue converts a Go map representing a test config to
+// a cty.Value matching the resource's schema. It handles the provider_config
+// TypeList block and the optional api field used by dual resources.
+func testResourceConfigToCtyValue(resource *schema.Resource, rawConfig map[string]any) cty.Value {
+	block := schema.InternalMap(resource.Schema).CoreConfigSchema()
+	implType := block.ImpliedType()
+	vals := map[string]cty.Value{}
+	for name, attrType := range implType.AttributeTypes() {
+		raw, ok := rawConfig[name]
+		if !ok {
+			vals[name] = cty.NullVal(attrType)
+			continue
+		}
+		vals[name] = goValueToCty(raw, attrType)
+	}
+	return cty.ObjectVal(vals)
+}
+
+func goValueToCty(v any, t cty.Type) cty.Value {
+	if v == nil {
+		return cty.NullVal(t)
+	}
+	switch {
+	case t.Equals(cty.String):
+		return cty.StringVal(v.(string))
+	case t.IsListType():
+		items := v.([]any)
+		if len(items) == 0 {
+			return cty.ListValEmpty(t.ElementType())
+		}
+		elements := make([]cty.Value, 0, len(items))
+		for _, item := range items {
+			elements = append(elements, goValueToCty(item, t.ElementType()))
+		}
+		return cty.ListVal(elements)
+	case t.IsObjectType():
+		objMap := v.(map[string]any)
+		objVals := map[string]cty.Value{}
+		for fieldName, fieldType := range t.AttributeTypes() {
+			if fv, ok := objMap[fieldName]; ok {
+				objVals[fieldName] = goValueToCty(fv, fieldType)
+			} else {
+				objVals[fieldName] = cty.NullVal(fieldType)
+			}
+		}
+		return cty.ObjectVal(objVals)
+	default:
+		return cty.NullVal(t)
+	}
 }
 
 func TestNamespaceCustomizeDiff_MatchingWorkspaceID(t *testing.T) {
@@ -749,6 +814,78 @@ func TestNamespaceCustomizeDiff_MismatchedWorkspaceID(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "workspace_id mismatch")
 	assert.Contains(t, err.Error(), "please check the workspace_id provided in provider_config")
+}
+
+// TestNamespaceValidateWorkspaceID_DefersWhenConfigAbsent asserts the validator
+// returns nil when the user did not write provider_config in HCL, even when
+// the provider-level Config.WorkspaceID is set to a value that would mismatch
+// the cached workspace ID. This is the v1.114-regression-fixing path: validators
+// must not fall back to Config.WorkspaceID at plan time.
+func TestNamespaceValidateWorkspaceID_DefersWhenConfigAbsent(t *testing.T) {
+	resource := newTestResourceForCustomizeDiff()
+	mockWS := &databricks.WorkspaceClient{
+		Config: &config.Config{
+			Host:  "https://test.cloud.databricks.com",
+			Token: "test-token",
+		},
+	}
+	c := &DatabricksClient{
+		DatabricksClient: &client.DatabricksClient{
+			Config: &config.Config{
+				Host:        "https://test.cloud.databricks.com",
+				Token:       "test-token",
+				WorkspaceID: "123", // mismatching auto-resolved value
+			},
+		},
+		cachedWorkspaceClient: mockWS,
+		cachedWorkspaceID:     999999,
+	}
+	_, err := diffCustomizeDiff(t, resource, nil, map[string]interface{}{
+		"name": "test",
+		// no provider_config in raw config
+	}, c)
+	assert.NoError(t, err, "validator must defer when provider_config is not written by user")
+}
+
+// TestNamespaceValidateWorkspaceID_DefersWhenInnerEmpty asserts the validator
+// returns nil when provider_config is written but workspace_id is empty —
+// matches the schema-level "user wrote a placeholder block" case. The empty
+// string is still a known value, but the validator treats it like an absent
+// value because there is nothing concrete to validate.
+//
+// Note: cross-resource references (workspace_id = databricks_mws_workspaces.this.workspace_id)
+// produce an *unknown* cty value at plan time. terraform-plugin-sdk's
+// NewResourceConfigShimmed cannot synthesize cty.UnknownVal directly, but the
+// underlying GetRawConfigAt code path is exercised by the IsKnown() check in
+// workspaceIDFromRawDiffConfig, which has its own unit coverage.
+func TestNamespaceValidateWorkspaceID_DefersWhenInnerEmpty(t *testing.T) {
+	resource := newTestResourceForCustomizeDiff()
+	mockWS := &databricks.WorkspaceClient{
+		Config: &config.Config{
+			Host:  "https://test.cloud.databricks.com",
+			Token: "test-token",
+		},
+	}
+	c := &DatabricksClient{
+		DatabricksClient: &client.DatabricksClient{
+			Config: &config.Config{
+				Host:        "https://test.cloud.databricks.com",
+				Token:       "test-token",
+				WorkspaceID: "123", // mismatching auto-resolved value
+			},
+		},
+		cachedWorkspaceClient: mockWS,
+		cachedWorkspaceID:     999999,
+	}
+	_, err := diffCustomizeDiff(t, resource, nil, map[string]interface{}{
+		"name": "test",
+		"provider_config": []interface{}{
+			map[string]interface{}{
+				"workspace_id": "",
+			},
+		},
+	}, c)
+	assert.NoError(t, err, "validator must defer when inner workspace_id is empty")
 }
 
 func TestNamespaceCustomizeDiff_AccountLevelProvider_ValidWorkspace(t *testing.T) {
@@ -1119,7 +1256,26 @@ func TestWorkspaceClientUnifiedProviderWithWorkspaceID(t *testing.T) {
 			description:   "Should return error when neither workspace_id nor provider_config.workspace_id is set",
 		},
 		{
-			name: "workspace-level with workspace_id - ignores it and uses workspace client",
+			name: "workspace-level with matching workspace_id - validates and uses workspace client",
+			resourceData: map[string]interface{}{
+				"name": "test",
+			},
+			client: &DatabricksClient{
+				DatabricksClient: &client.DatabricksClient{
+					Config: &config.Config{
+						Host:        "https://workspace.test.databricks.com",
+						Token:       "test-token",
+						WorkspaceID: "123456",
+					},
+				},
+				cachedWorkspaceClient: mockWorkspaceClient,
+				cachedWorkspaceID:     123456,
+			},
+			expectError: false,
+			description: "Workspace-level provider falls back to Config.WorkspaceID; validation passes when it matches the cached workspace ID",
+		},
+		{
+			name: "workspace-level with mismatching workspace_id - returns mismatch error",
 			resourceData: map[string]interface{}{
 				"name": "test",
 			},
@@ -1134,8 +1290,9 @@ func TestWorkspaceClientUnifiedProviderWithWorkspaceID(t *testing.T) {
 				cachedWorkspaceClient: mockWorkspaceClient,
 				cachedWorkspaceID:     123456,
 			},
-			expectError: false,
-			description: "Workspace-level provider should ignore workspace_id and use configured workspace",
+			expectError:   true,
+			errorContains: "workspace_id mismatch",
+			description:   "Workspace-level provider with Config.WorkspaceID that doesn't match the cached workspace ID errors at apply",
 		},
 	}
 

--- a/internal/acceptance/workspace_id_pf_app_acc_test.go
+++ b/internal/acceptance/workspace_id_pf_app_acc_test.go
@@ -581,12 +581,17 @@ func TestAccWorkspaceIDApp_DefaultOnWorkspaceProvider_Diff(t *testing.T) {
 // ==========================================
 //
 // Account-level provider with no workspace_id. Resource has no provider_config.
-// Expected: error during CRUD — no workspace_id available for routing.
+// Expected: error during apply — no workspace_id available for routing.
+//
+// With the v1.114-era plan-time validator removed, the user-typed-nothing case
+// is no longer flagged at plan; it surfaces at apply time when the resource's
+// Create calls GetWorkspaceClientForUnifiedProviderWithDiagnostics, which
+// wraps the dispatcher's "managing workspace-level resources..." error with
+// "failed to get workspace client".
 
 func TestMwsAccWorkspaceIDApp_NoDefaultNoOverride(t *testing.T) {
 	AccountLevel(t, Step{
 		Template: appWithProviderBlock("", ""),
-		PlanOnly: true,
 		ExpectError: regexp.MustCompile(
 			`(?s)failed to get workspace client`,
 		),

--- a/internal/acceptance/workspace_id_pf_tag_policy_acc_test.go
+++ b/internal/acceptance/workspace_id_pf_tag_policy_acc_test.go
@@ -577,12 +577,17 @@ func TestAccWorkspaceIDTagPolicy_DefaultOnWorkspaceProvider_Diff(t *testing.T) {
 // ==========================================
 //
 // Account-level provider with no workspace_id. Resource has no provider_config.
-// Expected: error during CRUD — no workspace_id available for routing.
+// Expected: error during apply — no workspace_id available for routing.
+//
+// With the v1.114-era plan-time validator removed, the user-typed-nothing case
+// is no longer flagged at plan; it surfaces at apply time when the resource's
+// Create calls GetWorkspaceClientForUnifiedProviderWithDiagnostics, which
+// wraps the dispatcher's "managing workspace-level resources..." error with
+// "failed to get workspace client".
 
 func TestMwsAccWorkspaceIDTagPolicy_NoDefaultNoOverride(t *testing.T) {
 	AccountLevel(t, Step{
 		Template: tagPolicyWithProviderBlock("", ""),
-		PlanOnly: true,
 		ExpectError: regexp.MustCompile(
 			`(?s)failed to get workspace client`,
 		),

--- a/internal/acceptance/workspace_id_sdkv2_gosdk_acc_test.go
+++ b/internal/acceptance/workspace_id_sdkv2_gosdk_acc_test.go
@@ -582,7 +582,12 @@ func TestAccWorkspaceID_DefaultOnWorkspaceProvider_Diff(t *testing.T) {
 // ==========================================
 //
 // Account-level provider with no workspace_id. Resource has no provider_config.
-// Expected: error during CRUD — no workspace_id available for routing.
+// Expected: error during apply — no workspace_id available for routing.
+//
+// With the v1.114-era plan-time validator removed, the user-typed-nothing case
+// is no longer flagged at plan; it surfaces at apply time when the resource's
+// CRUD method calls WorkspaceClientUnifiedProvider, which routes through the
+// dispatcher and produces the same error message.
 
 func TestMwsAccWorkspaceID_NoDefaultNoOverride(t *testing.T) {
 	AccountLevel(t, Step{
@@ -590,7 +595,6 @@ func TestMwsAccWorkspaceID_NoDefaultNoOverride(t *testing.T) {
 		ExpectError: regexp.MustCompile(
 			`managing workspace-level resources requires a workspace_id, but none was found in the resource's provider_config block or the provider's workspace_id attribute`,
 		),
-		PlanOnly: true,
 	})
 }
 

--- a/internal/acceptance/workspace_id_sdkv2_http_acc_test.go
+++ b/internal/acceptance/workspace_id_sdkv2_http_acc_test.go
@@ -584,22 +584,22 @@ func TestAccWorkspaceIDHttp_DefaultOnWorkspaceProvider_Diff(t *testing.T) {
 // ==========================================
 //
 // Account-level provider with no workspace_id. Resource has no provider_config.
-// Expected: error during CRUD — no workspace_id available for routing.
+// Expected: error during apply — no workspace_id available for routing.
 //
-// Unlike the Go SDK path (TestMwsAccWorkspaceID_NoDefaultNoOverride), which
-// returns a clear "no workspace_id" error via GetWorkspaceClientForUnifiedProvider,
-// the HTTP path (DatabricksClientForUnifiedProvider) cannot validate early because
-// it doesn't know whether the caller needs a workspace-scoped or account-scoped
-// client. It returns the account-level client, which then fails at the API layer
-// when the resource attempts a workspace-level operation.
+// With the v1.114-era plan-time validator removed, the user-typed-nothing case
+// is no longer flagged at plan. The HTTP path (DatabricksClientForUnifiedProvider)
+// returns the account-level client unchanged when no workspace_id is available,
+// so the failure surfaces at the API layer when the notebook import call is
+// routed to the accounts host. The exact error text comes from the API response,
+// so we match on the wrapped "cannot create notebook" prefix that nicerError
+// adds, which covers any underlying API failure.
 
 func TestMwsAccWorkspaceIDHttp_NoDefaultNoOverride(t *testing.T) {
 	AccountLevel(t, Step{
 		Template: notebookWithProviderBlock("", ""),
 		ExpectError: regexp.MustCompile(
-			`managing workspace-level resources requires a workspace_id, but none was found in the resource's provider_config block or the provider's workspace_id attribute`,
+			`cannot create notebook`,
 		),
-		PlanOnly: true,
 	})
 }
 

--- a/internal/providers/pluginfw/tfschema/unified_provider.go
+++ b/internal/providers/pluginfw/tfschema/unified_provider.go
@@ -317,25 +317,57 @@ func WorkspaceDriftDetection(ctx context.Context, client UnifiedProviderClient, 
 }
 
 // ValidateWorkspaceID validates that the workspace client for the planned
-// workspace_id is reachable. Runs for both create and update.
+// workspace_id is reachable, but only when the user explicitly typed
+// provider_config.workspace_id in HCL.
+//
+// Reads from req.Config (the raw user config) rather than resp.Plan so that
+// values populated by drift detection or UseStateForUnknown do not trigger
+// validation. Defers when:
+//   - provider_config block is null (user did not write it),
+//   - provider_config block is unknown (still being computed),
+//   - inner workspace_id field is null or unknown
+//     (cross-resource reference like
+//     `workspace_id = databricks_mws_workspaces.this.workspace_id`),
+//   - inner workspace_id is the empty string.
+//
+// Apply-time client construction in GetWorkspaceClientForUnifiedProvider does
+// the layered fallback to Config.WorkspaceID and produces actionable API
+// errors for the deferred cases.
+//
+// Plan-time validation must not fall back to client.GetProviderWorkspaceID()
+// here, since doing so caused the v1.114.0 regressions (#5664, #5668, #5672,
+// and the cross-resource bootstrap pattern). Falling back is only appropriate
+// at apply, where the dispatcher handles it.
+//
+// We deliberately do NOT call GetWorkspaceIDResource because that helper sets
+// UnhandledUnknownAsEmpty: true and collapses the cross-resource-ref unknown
+// signal into "", which would then route into validation as if the user had
+// typed nothing.
+//
 // Call this from any PF resource's ModifyPlan that has a provider_config block.
 func ValidateWorkspaceID(ctx context.Context, client UnifiedProviderClient, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
-	var planPC types.Object
-	// Read from resp.Plan (not req.Plan) because WorkspaceDriftDetection may
-	// have updated provider_config in the plan to reflect a new workspace_id.
-	resp.Diagnostics.Append(resp.Plan.GetAttribute(ctx, path.Root("provider_config"), &planPC)...)
+	var cfgPC types.Object
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("provider_config"), &cfgPC)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	workspaceID, diags := GetWorkspaceIDResource(ctx, planPC)
+	if cfgPC.IsNull() || cfgPC.IsUnknown() {
+		return
+	}
+	var ns ProviderConfig
+	diags := cfgPC.As(ctx, &ns, basetypes.ObjectAsOptions{})
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	if workspaceID == "" {
-		workspaceID = client.GetProviderWorkspaceID()
+	if ns.WorkspaceID.IsNull() || ns.WorkspaceID.IsUnknown() {
+		return
 	}
-	resp.Diagnostics.Append(client.ValidateWorkspaceAccess(ctx, workspaceID)...)
+	wsID := ns.WorkspaceID.ValueString()
+	if wsID == "" {
+		return
+	}
+	resp.Diagnostics.Append(client.ValidateWorkspaceAccess(ctx, wsID)...)
 }
 
 // PopulateProviderConfigInState resolves the effective workspace ID and sets it

--- a/internal/providers/pluginfw/tfschema/unified_provider_test.go
+++ b/internal/providers/pluginfw/tfschema/unified_provider_test.go
@@ -2,14 +2,10 @@ package tfschema
 
 import (
 	"context"
-	"net/http"
-	"net/http/httptest"
 	"testing"
 
-	"github.com/databricks/databricks-sdk-go/client"
-	"github.com/databricks/databricks-sdk-go/config"
-	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	resourceschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -18,7 +14,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestWorkspaceIDPlanModifier(t *testing.T) {
@@ -324,39 +319,29 @@ func TestGetWorkspaceIDDataSource(t *testing.T) {
 	}
 }
 
-// TestValidateWorkspaceID_ReadsFromRespPlan simulates the full ModifyPlan flow:
-// state has workspace_id "111", provider default changes to "999".
-// WorkspaceDriftDetection detects the drift and updates resp.Plan to "999".
-// ValidateWorkspaceID must read from resp.Plan (not req.Plan) to validate "999".
-// With old code (req.Plan), it would validate stale "111" and get a mismatch error.
-func TestValidateWorkspaceID_ReadsFromRespPlan(t *testing.T) {
-	ctx := context.Background()
+// fakeUnifiedProviderClient records calls to ValidateWorkspaceAccess. Used to
+// assert that ValidateWorkspaceID defers (does not call into the dispatcher)
+// for the null/unknown/cross-resource-ref cases.
+type fakeUnifiedProviderClient struct {
+	providerWorkspaceID string
+	currentWorkspaceID  int64
+	currentErr          error
 
-	// Server simulates a workspace with ID 999.
-	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-		switch req.RequestURI {
-		case "/.well-known/databricks-config":
-			rw.WriteHeader(404)
-		case "/api/2.0/preview/scim/v2/Me":
-			rw.Header().Set("X-Databricks-Org-Id", "999")
-			rw.WriteHeader(200)
-			rw.Write([]byte("{}"))
-		default:
-			rw.WriteHeader(404)
-		}
-	}))
-	defer server.Close()
+	validateCalls []string
+	validateDiags diag.Diagnostics
+}
 
-	cfg := &config.Config{
-		Host:        server.URL,
-		Token:       "test-token",
-		WorkspaceID: "999", // provider default changed to 999
-	}
-	c, err := client.New(cfg)
-	require.NoError(t, err)
-	databricksClient := &common.DatabricksClient{DatabricksClient: c}
+func (f *fakeUnifiedProviderClient) GetProviderWorkspaceID() string { return f.providerWorkspaceID }
+func (f *fakeUnifiedProviderClient) CurrentWorkspaceID(ctx context.Context) (int64, error) {
+	return f.currentWorkspaceID, f.currentErr
+}
+func (f *fakeUnifiedProviderClient) ValidateWorkspaceAccess(ctx context.Context, workspaceID string) diag.Diagnostics {
+	f.validateCalls = append(f.validateCalls, workspaceID)
+	return f.validateDiags
+}
 
-	testSchema := resourceschema.Schema{
+func validateTestSchema() resourceschema.Schema {
+	return resourceschema.Schema{
 		Attributes: map[string]resourceschema.Attribute{
 			"provider_config": resourceschema.SingleNestedAttribute{
 				Optional: true,
@@ -370,7 +355,9 @@ func TestValidateWorkspaceID_ReadsFromRespPlan(t *testing.T) {
 			},
 		},
 	}
+}
 
+func validateTfTypes() (tftypes.Object, tftypes.Object) {
 	providerConfigTfType := tftypes.Object{
 		AttributeTypes: map[string]tftypes.Type{
 			"workspace_id": tftypes.String,
@@ -381,45 +368,83 @@ func TestValidateWorkspaceID_ReadsFromRespPlan(t *testing.T) {
 			"provider_config": providerConfigTfType,
 		},
 	}
+	return providerConfigTfType, rootTfType
+}
 
-	makeValue := func(workspaceID string) tftypes.Value {
-		return tftypes.NewValue(rootTfType, map[string]tftypes.Value{
-			"provider_config": tftypes.NewValue(providerConfigTfType, map[string]tftypes.Value{
-				"workspace_id": tftypes.NewValue(tftypes.String, workspaceID),
-			}),
-		})
-	}
+// TestValidateWorkspaceID_DefersWhenConfigNull asserts the validator returns
+// without invoking ValidateWorkspaceAccess when the user did not write
+// provider_config in HCL. The provider-level workspace_id is intentionally set
+// non-empty to prove the validator is not falling back to it.
+func TestValidateWorkspaceID_DefersWhenConfigNull(t *testing.T) {
+	ctx := context.Background()
+	testSchema := validateTestSchema()
+	providerConfigTfType, rootTfType := validateTfTypes()
 
-	// State has old workspace_id "111".
-	state := tfsdk.State{Schema: testSchema, Raw: makeValue("111")}
-	// Plan initially has "111" (ProviderConfigPlanModifier copied from state).
-	plan := tfsdk.Plan{Schema: testSchema, Raw: makeValue("111")}
-	// Config has null provider_config (user didn't set it in HCL).
 	tfConfig := tfsdk.Config{
 		Schema: testSchema,
 		Raw: tftypes.NewValue(rootTfType, map[string]tftypes.Value{
 			"provider_config": tftypes.NewValue(providerConfigTfType, nil),
 		}),
 	}
+	modifyReq := resource.ModifyPlanRequest{Config: tfConfig}
+	resp := &resource.ModifyPlanResponse{}
 
-	modifyReq := resource.ModifyPlanRequest{
-		State:  state,
-		Plan:   plan,
-		Config: tfConfig,
+	fake := &fakeUnifiedProviderClient{providerWorkspaceID: "999"}
+	ValidateWorkspaceID(ctx, fake, modifyReq, resp)
+
+	assert.False(t, resp.Diagnostics.HasError(), "expected no diagnostics, got %v", resp.Diagnostics.Errors())
+	assert.Empty(t, fake.validateCalls, "ValidateWorkspaceAccess must not be called when provider_config is null")
+}
+
+// TestValidateWorkspaceID_DefersWhenInnerUnknown asserts the validator returns
+// without invoking ValidateWorkspaceAccess when the user wrote provider_config
+// but the workspace_id field is unknown — the cross-resource-reference shape
+// (workspace_id = databricks_mws_workspaces.this.workspace_id).
+func TestValidateWorkspaceID_DefersWhenInnerUnknown(t *testing.T) {
+	ctx := context.Background()
+	testSchema := validateTestSchema()
+	providerConfigTfType, rootTfType := validateTfTypes()
+
+	tfConfig := tfsdk.Config{
+		Schema: testSchema,
+		Raw: tftypes.NewValue(rootTfType, map[string]tftypes.Value{
+			"provider_config": tftypes.NewValue(providerConfigTfType, map[string]tftypes.Value{
+				"workspace_id": tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+			}),
+		}),
 	}
-	resp := &resource.ModifyPlanResponse{
-		Plan: plan,
+	modifyReq := resource.ModifyPlanRequest{Config: tfConfig}
+	resp := &resource.ModifyPlanResponse{}
+
+	fake := &fakeUnifiedProviderClient{providerWorkspaceID: "999"}
+	ValidateWorkspaceID(ctx, fake, modifyReq, resp)
+
+	assert.False(t, resp.Diagnostics.HasError(), "expected no diagnostics, got %v", resp.Diagnostics.Errors())
+	assert.Empty(t, fake.validateCalls, "ValidateWorkspaceAccess must not be called when inner workspace_id is unknown")
+}
+
+// TestValidateWorkspaceID_RunsWhenExplicit asserts the validator invokes
+// ValidateWorkspaceAccess with the user-typed workspace_id when it is concrete.
+func TestValidateWorkspaceID_RunsWhenExplicit(t *testing.T) {
+	ctx := context.Background()
+	testSchema := validateTestSchema()
+	providerConfigTfType, rootTfType := validateTfTypes()
+
+	tfConfig := tfsdk.Config{
+		Schema: testSchema,
+		Raw: tftypes.NewValue(rootTfType, map[string]tftypes.Value{
+			"provider_config": tftypes.NewValue(providerConfigTfType, map[string]tftypes.Value{
+				"workspace_id": tftypes.NewValue(tftypes.String, "12345"),
+			}),
+		}),
 	}
+	modifyReq := resource.ModifyPlanRequest{Config: tfConfig}
+	resp := &resource.ModifyPlanResponse{}
 
-	// WorkspaceDriftDetection detects 111→999 drift, updates resp.Plan to "999".
-	WorkspaceDriftDetection(ctx, databricksClient, modifyReq, resp)
-	require.False(t, resp.Diagnostics.HasError(),
-		"WorkspaceDriftDetection failed: %v", resp.Diagnostics.Errors())
+	fake := &fakeUnifiedProviderClient{}
+	ValidateWorkspaceID(ctx, fake, modifyReq, resp)
 
-	// ValidateWorkspaceID should read "999" from resp.Plan (updated above),
-	// not "111" from req.Plan. With old code (req.Plan) this would fail with
-	// "workspace_id mismatch: provider is configured for workspace 999 but got 111".
-	ValidateWorkspaceID(ctx, databricksClient, modifyReq, resp)
-	assert.False(t, resp.Diagnostics.HasError(),
-		"expected no error, got: %v", resp.Diagnostics.Errors())
+	assert.False(t, resp.Diagnostics.HasError(), "expected no diagnostics, got %v", resp.Diagnostics.Errors())
+	assert.Equal(t, []string{"12345"}, fake.validateCalls,
+		"ValidateWorkspaceAccess must be called with the explicit workspace_id")
 }

--- a/scim/resource_entitlement_test.go
+++ b/scim/resource_entitlement_test.go
@@ -775,5 +775,9 @@ func TestResourceEntitlementsCreate_AccountLevelShouldError(t *testing.T) {
 		AccountID: "abc-123",
 		Host:      "https://accounts.cloud.databricks.com",
 	}.Apply(t)
-	assert.Contains(t, err.Error(), "managing workspace-level resources requires a workspace_id")
+	// Surfaces from the AccountHost guard at the top of resource_entitlement.go's
+	// Create — fires before unified-provider routing. See issue #5680 for the
+	// follow-up that removes this premature guard so provider_config { workspace_id }
+	// can route account-level providers to the workspace-level SCIM API.
+	assert.Contains(t, err.Error(), "entitlements can only be managed with a provider configured at the workspace-level")
 }


### PR DESCRIPTION
## Summary

Plan-time `workspace_id` validators (`NamespaceValidateWorkspaceID` for SDKv2, `ValidateWorkspaceID` for PF) previously fell back to the auto-resolved `Config.WorkspaceID` and made API calls against it. That caused the v1.114.0 cluster of regressions:

- **#5664** — account-host data sources fail with `strconv.ParseInt: parsing "": invalid syntax`.
- **#5668** — workspace-host providers using SPs fail with `failed to validate workspace_id: failed to get the workspace_id: User not authorized` at plan time.
- **#5672** — same root cause as #5664, surfaced in `databricks_mws_workspaces` data source.
- **Bootstrap pattern** — `provider_config.workspace_id = databricks_mws_workspaces.this.workspace_id` (cross-resource ref) breaks at plan because SDKv2 shims unknown→`""` and the validator falls back to an empty `c.Config.WorkspaceID`.

This PR makes the plan-time validators a fail-fast UX hint only when the user explicitly typed `provider_config.workspace_id` — null/unknown/absent values defer to apply. The `Config.WorkspaceID` fallback for apply-time client lookup is centralized in `GetWorkspaceClientForUnifiedProvider` so both SDKv2 and Plugin Framework callers benefit without per-resource changes.

### Changes

- `common/client.go` — `GetWorkspaceClientForUnifiedProvider` does the `Config.WorkspaceID` fallback at the top; the duplicate fallback inside `getWorkspaceClientForAccountUnifiedHost` is removed. Single source of truth for SDKv2 + PF + the 38 PF autogen resources.
- `common/unified_provider.go` — `NamespaceValidateWorkspaceID` uses `workspaceIDFromRawDiffConfig` to detect explicit user input; defers when null / unknown / absent / empty.
- `internal/providers/pluginfw/tfschema/unified_provider.go` — `ValidateWorkspaceID` reads from `req.Config` (not `resp.Plan`), walks the inner `workspace_id` attribute directly to preserve the unknown signal that `UnhandledUnknownAsEmpty: true` would otherwise collapse.
- Tests: `diffCustomizeDiff` upgraded to set cty values so `GetRawConfigAt` works; new defer-on-not-explicit unit tests on both SDKv2 and PF; 4 acceptance tests dropped `PlanOnly: true` (errors now surface at apply via the dispatcher); `TestValidateWorkspaceID_ReadsFromRespPlan` replaced with three focused PF tests; `scim/resource_entitlement_test.go` updated to expect the entitlements `Create`-method guard error (which becomes the first failure point now that the validator no longer catches it first — see follow-up #5680).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./common/... ./internal/...`
- [x] `make ws` (1110 checked, 0 failed)
- [x] `gofmt` clean
- [x] Unit tests across `common/`, `internal/providers/...`, `catalog/`, `tokens/`, `scim/`, `settings/`, `jobs/`, `workspace/`, `mws/`, `pools/`, `clusters/`, `repos/`, `sql/`, `pipelines/`, `permissions/`, `access/`, `aws/`, `storage/`, `secrets/`, `sharing/`, `serving/`, `mlflow/`, `vectorsearch/`, `dashboards/`, `policies/` — all pass
- [x] Acceptance tests against `aws-prod-acct` (deco):
  - `TestMwsAccWorkspaceID_NoDefaultNoOverride` PASS — `cannot create directory: managing workspace-level resources requires a workspace_id, ...`
  - `TestMwsAccWorkspaceIDTagPolicy_NoDefaultNoOverride` PASS — `failed to get workspace client: managing workspace-level resources requires a workspace_id, ...`
  - `TestMwsAccWorkspaceIDApp_NoDefaultNoOverride` PASS — `failed to get workspace client: managing workspace-level resources requires a workspace_id, ...`
  - `TestMwsAccWorkspaceIDHttp_NoDefaultNoOverride` PASS — relaxed regex (`cannot create notebook`); HTTP path takes a different code path because `databricks_notebook.Create` calls `DatabricksClientForUnifiedProvider` first and discards the workspace-client error
  - `TestMwsAccWorkspaceID_ImplicitFromProviderDefault` PASS — positive sanity check for the v1.114-victim case (account-level provider with provider-level `workspace_id`, resource without `provider_config`)
- [x] No schema changes (validators only — `make diff-schema` should be empty)

## Risks

- **Apply-time error UX shift for `*NoDefaultNoOverride`** — users typing nothing for `workspace_id` previously errored at plan; now they error at apply with the same message. Acceptable trade-off: the existing failure surface on plan was the cost of plan-time aggressiveness.
- **Cross-resource ref bootstrap** — `workspace_id = databricks_mws_workspaces.this.workspace_id` plans cleanly even when the workspace doesn't yet exist; apply-time client lookup is the source of truth (matches v1.113.0).
- **Workspace-host equality check on every call** — Edit 1 means workspace-host providers with `c.Config.WorkspaceID` set always pass a non-empty `workspaceID` into `getWorkspaceClientForWorkspaceConfiguredProvider`, triggering the cached equality check. Cheap (cached), and on workspace-host the value matches by construction.

## Out of scope (follow-ups)

- The redundant `Config.WorkspaceID` fallback at `common/unified_provider.go:353` inside `DatabricksClientForUnifiedProvider` — kept for now; removal requires careful tracing through `setCachedDatabricksClient`'s cache path.
- Issue #5680 — `databricks_entitlements` premature `AccountHost` guard in `Create`. The test update in this PR documents that issue as a follow-up.
- PF analog of `SkipProviderConfigStatePopulation` for any future account-only PF data source.