### PR TITLE
[Internal] Use slices.Sorted(maps.Keys) for sorted map iteration

### DIFF
--- a/workspace/resource_workspace_conf.go
+++ b/workspace/resource_workspace_conf.go
@@ -9,8 +9,8 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"maps"
 	"slices"
-	"sort"
 	"strconv"
 	"strings"
 
@@ -103,12 +103,7 @@ func deleteWorkspaceConf(ctx context.Context, d *schema.ResourceData, c *common.
 	config := d.Get("custom_config").(map[string]any)
 	// Delete keys one at a time to reset as many configuration values as possible to their original state.
 	// Delete in alphabetical order by key to ensure deterministic behavior.
-	keys := make([]string, 0, len(config))
-	for k := range config {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-	for _, k := range keys {
+	for _, k := range slices.Sorted(maps.Keys(config)) {
 		v := config[k]
 		patch := settings.WorkspaceConf{}
 		// The default value for all configurations is assumed to be "false" for boolean


### PR DESCRIPTION
## Summary

Follow-up to #5700. Replaces the manual collect-keys-and-sort sequence in `deleteWorkspaceConf` (`workspace/resource_workspace_conf.go`) with the Go 1.23+ iterator-based equivalent:

```go
// before
keys := make([]string, 0, len(config))
for k := range config {
    keys = append(keys, k)
}
sort.Strings(keys)
for _, k := range keys { ... }

// after
for _, k := range slices.Sorted(maps.Keys(config)) { ... }
```

Behavior is unchanged: keys are still iterated in alphabetical order.

NO_CHANGELOG=true

## Test plan

- [ ] CI green