### PR TITLE
[Fix] Defer ForceNew and drift detection when workspace_id is an unknown ref

### DIFF
--- a/common/unified_provider.go
+++ b/common/unified_provider.go
@@ -128,11 +128,23 @@ func namespaceForceNew(ctx context.Context, d *schema.ResourceDiff, c *Databrick
 	// Determine the new effective workspace ID by inspecting the raw config.
 	// With Optional+Computed, d.GetChange may return the preserved state value
 	// rather than reflecting the actual config, so we check the raw config directly.
-	configWsID, configHasProviderConfig := workspaceIDFromRawDiffConfig(d)
+	configWsID, configHasProviderConfig, configIsKnown := workspaceIDFromRawDiffConfig(d)
+
+	// Explicit-but-unknown: user wrote provider_config.workspace_id as a
+	// reference that isn't resolved yet (e.g. `workspace_id =
+	// databricks_mws_workspaces.foo.workspace_id` for a workspace being created
+	// in the same plan). Defer all force-new and drift decisions; falling back
+	// to c.Config.WorkspaceID here would silently substitute a different value
+	// than the user wrote, causing speculative ForceNew or spurious
+	// "managing workspace-level resources requires a workspace_id" errors on
+	// account-host providers. Apply will see the resolved value and act on it.
+	if configHasProviderConfig && !configIsKnown {
+		return nil
+	}
 
 	var newEffective string
 	if configHasProviderConfig {
-		// Config explicitly sets provider_config.workspace_id
+		// Config explicitly sets provider_config.workspace_id to a known value.
 		newEffective = configWsID
 	} else {
 		// Config does not have provider_config; use workspace_id
@@ -194,8 +206,8 @@ func namespaceForceNew(ctx context.Context, d *schema.ResourceDiff, c *Databrick
 // since doing so caused regressions in v1.114.0 (see #5664, #5668, #5672, the
 // cross-resource bootstrap pattern).
 func NamespaceValidateWorkspaceID(ctx context.Context, d *schema.ResourceDiff, c *DatabricksClient) error {
-	wsID, hasExplicit := workspaceIDFromRawDiffConfig(d)
-	if !hasExplicit || wsID == "" {
+	wsID, explicit, known := workspaceIDFromRawDiffConfig(d)
+	if !explicit || !known || wsID == "" {
 		return nil
 	}
 	_, err := c.GetWorkspaceClientForUnifiedProvider(ctx, wsID)
@@ -203,22 +215,45 @@ func NamespaceValidateWorkspaceID(ctx context.Context, d *schema.ResourceDiff, c
 }
 
 // workspaceIDFromRawDiffConfig extracts the workspace ID from the raw config
-// of a ResourceDiff. Returns the workspace ID string and whether provider_config
-// is present in the config.
-func workspaceIDFromRawDiffConfig(d *schema.ResourceDiff) (string, bool) {
+// of a ResourceDiff. Three distinct states are surfaced separately so callers
+// can disambiguate "user did not write provider_config" from "user wrote
+// provider_config.workspace_id as an unknown reference (not yet resolved)":
+//
+//   - explicit=false                 → user did not write provider_config
+//     (cty.Null). Returned value is "". Callers should fall back to whatever
+//     other source of workspace_id they have (e.g. c.Config.WorkspaceID).
+//   - explicit=true,  known=false    → user wrote provider_config.workspace_id
+//     but the value is unknown at plan time (e.g.
+//     `workspace_id = databricks_mws_workspaces.foo.workspace_id` for a
+//     workspace being created in the same plan). Returned value is "".
+//     Callers should DEFER any decision that depends on the value —
+//     Terraform Core will show "(known after apply)" in the diff, and apply
+//     will see the resolved value.
+//   - explicit=true,  known=true     → user wrote a literal string. Returned
+//     value is the literal. Callers can use it directly.
+//
+// Distinguishing the unknown case prevents speculative ForceNew (silently
+// substituting c.Config.WorkspaceID for an unknown ref and comparing against
+// state) and avoids spurious "managing workspace-level resources requires a
+// workspace_id" errors on account-host providers where the lazy-resolution
+// fallback can't run.
+func workspaceIDFromRawDiffConfig(d *schema.ResourceDiff) (value string, explicit, known bool) {
 	path := cty.Path{
 		cty.GetAttrStep{Name: "provider_config"},
 		cty.IndexStep{Key: cty.NumberIntVal(0)},
 		cty.GetAttrStep{Name: "workspace_id"},
 	}
 	rawValue, diags := d.GetRawConfigAt(path)
-	if diags.HasError() || rawValue.IsNull() || !rawValue.IsKnown() {
-		return "", false
+	if diags.HasError() || rawValue.IsNull() {
+		return "", false, true
+	}
+	if !rawValue.IsKnown() {
+		return "", true, false
 	}
 	if rawValue.Type() == cty.String {
-		return rawValue.AsString(), true
+		return rawValue.AsString(), true, true
 	}
-	return "", false
+	return "", false, true
 }
 
 // ValidateApiLevelForUnifiedHost fails the plan when the provider is configured

--- a/common/unified_provider_test.go
+++ b/common/unified_provider_test.go
@@ -888,6 +888,91 @@ func TestNamespaceValidateWorkspaceID_DefersWhenInnerEmpty(t *testing.T) {
 	assert.NoError(t, err, "validator must defer when inner workspace_id is empty")
 }
 
+// TestNamespaceCustomizeDiff_DefersWhenInnerUnknown is the load-bearing test for
+// the explicit-but-unknown case: user wrote
+//
+//	provider_config { workspace_id = databricks_mws_workspaces.foo.workspace_id }
+//
+// where the referenced workspace_id is computed and not yet resolved at plan
+// time. Both halves of NamespaceCustomizeDiff must defer:
+//
+//   - NamespaceValidateWorkspaceID must not call into the dispatcher (would
+//     have produced a confused "managing workspace-level resources" error on
+//     an account host).
+//   - namespaceForceNew must not silently substitute c.Config.WorkspaceID for
+//     the user's unknown ref (would have triggered speculative ForceNew or a
+//     spurious "resource has provider_config.workspace_id = … in state"
+//     error).
+//
+// The test deliberately constructs a setup where deferral matters:
+//   - Account host with empty c.Config.WorkspaceID (the lazy-resolution branch
+//     in namespaceForceNew would fail if reached).
+//   - State already has provider_config.0.workspace_id = "12345" so the old
+//     side of the comparison is non-empty.
+func TestNamespaceCustomizeDiff_DefersWhenInnerUnknown(t *testing.T) {
+	testSchema := map[string]*schema.Schema{
+		"name": {Type: schema.TypeString, Required: true},
+	}
+	AddNamespaceInSchema(testSchema)
+
+	r := &schema.Resource{
+		Schema: testSchema,
+		CustomizeDiff: func(ctx context.Context, d *schema.ResourceDiff, m interface{}) error {
+			dc, ok := m.(*DatabricksClient)
+			if !ok {
+				return fmt.Errorf("expected *DatabricksClient, got %T", m)
+			}
+			return NamespaceCustomizeDiff(ctx, d, dc)
+		},
+	}
+
+	// Build cty config with provider_config.0.workspace_id = UnknownVal.
+	ctyVal := cty.ObjectVal(map[string]cty.Value{
+		"name": cty.StringVal("test"),
+		"provider_config": cty.ListVal([]cty.Value{
+			cty.ObjectVal(map[string]cty.Value{
+				"workspace_id": cty.UnknownVal(cty.String),
+			}),
+		}),
+	})
+
+	block := schema.InternalMap(testSchema).CoreConfigSchema()
+	rc := terraform.NewResourceConfigShimmed(ctyVal, block)
+
+	// Prior state has a concrete workspace_id "12345" — the old side that
+	// namespaceForceNew compares against.
+	is := &terraform.InstanceState{
+		ID: "test-resource-id",
+		Attributes: map[string]string{
+			"name":                           "test",
+			"provider_config.#":              "1",
+			"provider_config.0.workspace_id": "12345",
+		},
+		RawConfig: ctyVal,
+	}
+
+	// Account-host provider with NO Config.WorkspaceID and NO cached workspace.
+	// If namespaceForceNew fails to defer, it will fall back to "" for the new
+	// effective and then attempt c.CurrentWorkspaceID, which would error on an
+	// account host. If the validator fails to defer, it would invoke the
+	// dispatcher with "" and produce the "managing workspace-level resources"
+	// error.
+	c := &DatabricksClient{
+		DatabricksClient: &client.DatabricksClient{
+			Config: unifiedHostConfig(t, "https://accounts.cloud.databricks.com"),
+		},
+	}
+
+	diff, err := r.Diff(context.Background(), is, rc, c)
+	assert.NoError(t, err, "namespaceForceNew and the validator must both defer when the user wrote provider_config.workspace_id as an unknown reference")
+
+	if diff != nil {
+		for k, v := range diff.Attributes {
+			assert.False(t, v.RequiresNew, "ForceNew must not fire for attribute %q while workspace_id is unknown", k)
+		}
+	}
+}
+
 func TestNamespaceCustomizeDiff_AccountLevelProvider_ValidWorkspace(t *testing.T) {
 	resource := newTestResourceForCustomizeDiff()
 	mockWS := &databricks.WorkspaceClient{

--- a/internal/acceptance/workspace_id_pf_app_acc_test.go
+++ b/internal/acceptance/workspace_id_pf_app_acc_test.go
@@ -604,6 +604,51 @@ func TestMwsAccWorkspaceIDApp_NoDefaultNoOverride(t *testing.T) {
 }
 
 // ==========================================
+// Unknown workspace_id reference — bootstrap pattern (end-to-end)
+// ==========================================
+//
+// The canonical bootstrap scenario: a brand-new serverless workspace is
+// created in the same plan as a PF resource that references the workspace's
+// computed workspace_id via provider_config. At plan time the ref is unknown;
+// PF WorkspaceDriftDetection and ValidateWorkspaceID must both defer.
+// Terraform Core renders the diff as "(known after apply)"; at apply the
+// workspace is provisioned first, then the app is created in the resolved
+// workspace via the PF client construction path.
+//
+// Without the fix, WorkspaceDriftDetection's outer-block / inner-attribute
+// unknown collapses into "" (via UnhandledUnknownAsEmpty), falls back to
+// client.GetProviderWorkspaceID() (empty on account host), then
+// client.CurrentWorkspaceID(ctx) (errors on account host) — surfacing as a
+// "Missing workspace_id" diagnostic.
+
+func TestMwsAccWorkspaceIDApp_UnknownWorkspaceIDRef(t *testing.T) {
+	AccountLevel(t, Step{
+		Template: `
+			resource "databricks_mws_workspaces" "src" {
+				account_id     = "{env.DATABRICKS_ACCOUNT_ID}"
+				workspace_name = "dwsid-{var.STICKY_RANDOM}"
+				aws_region     = "{env.AWS_REGION}"
+				compute_mode   = "SERVERLESS"
+			}
+			resource "databricks_app" "test" {
+				name        = "dwsid-app-{var.STICKY_RANDOM}"
+				description = "workspace_id acceptance test"
+				no_compute  = true
+				provider_config = {
+					workspace_id = databricks_mws_workspaces.src.workspace_id
+				}
+			}
+		`,
+		Check: resource.ComposeAggregateTestCheckFunc(
+			resource.TestCheckResourceAttrPair(
+				appResource, "provider_config.workspace_id",
+				"databricks_mws_workspaces.src", "workspace_id",
+			),
+		),
+	})
+}
+
+// ==========================================
 // Provider Upgrade (Existing Resources, No Config Changes)
 // ==========================================
 //

--- a/internal/acceptance/workspace_id_pf_tag_policy_acc_test.go
+++ b/internal/acceptance/workspace_id_pf_tag_policy_acc_test.go
@@ -600,6 +600,50 @@ func TestMwsAccWorkspaceIDTagPolicy_NoDefaultNoOverride(t *testing.T) {
 }
 
 // ==========================================
+// Unknown workspace_id reference — bootstrap pattern (end-to-end)
+// ==========================================
+//
+// The canonical bootstrap scenario: a brand-new serverless workspace is
+// created in the same plan as a PF resource that references the workspace's
+// computed workspace_id via provider_config. At plan time the ref is unknown;
+// PF WorkspaceDriftDetection and ValidateWorkspaceID must both defer.
+// Terraform Core renders the diff as "(known after apply)"; at apply the
+// workspace is provisioned first, then the tag_policy is created in the
+// resolved workspace via the PF client construction path.
+//
+// Without the fix, WorkspaceDriftDetection's outer-block / inner-attribute
+// unknown collapses into "" (via UnhandledUnknownAsEmpty), falls back to
+// client.GetProviderWorkspaceID() (empty on account host), then
+// client.CurrentWorkspaceID(ctx) (errors on account host) — surfacing as a
+// "Missing workspace_id" diagnostic.
+
+func TestMwsAccWorkspaceIDTagPolicy_UnknownWorkspaceIDRef(t *testing.T) {
+	AccountLevel(t, Step{
+		Template: `
+			resource "databricks_mws_workspaces" "src" {
+				account_id     = "{env.DATABRICKS_ACCOUNT_ID}"
+				workspace_name = "dwsid-{var.STICKY_RANDOM}"
+				aws_region     = "{env.AWS_REGION}"
+				compute_mode   = "SERVERLESS"
+			}
+			resource "databricks_tag_policy" "test" {
+				tag_key     = "dwsid-tp-{var.STICKY_RANDOM}"
+				description = "workspace_id acceptance test"
+				provider_config = {
+					workspace_id = databricks_mws_workspaces.src.workspace_id
+				}
+			}
+		`,
+		Check: resource.ComposeAggregateTestCheckFunc(
+			resource.TestCheckResourceAttrPair(
+				tagPolicyResource, "provider_config.workspace_id",
+				"databricks_mws_workspaces.src", "workspace_id",
+			),
+		),
+	})
+}
+
+// ==========================================
 // Provider Upgrade (Existing Resources, No Config Changes)
 // ==========================================
 //

--- a/internal/acceptance/workspace_id_sdkv2_gosdk_acc_test.go
+++ b/internal/acceptance/workspace_id_sdkv2_gosdk_acc_test.go
@@ -604,6 +604,54 @@ func TestMwsAccWorkspaceID_NoDefaultNoOverride(t *testing.T) {
 }
 
 // ==========================================
+// Unknown workspace_id reference — bootstrap pattern (end-to-end)
+// ==========================================
+//
+// The canonical bootstrap scenario: a brand-new serverless workspace is
+// created in the same plan as a workspace-level resource that references the
+// workspace's computed workspace_id via provider_config. At plan time the ref
+// is unknown; the validator and force-new detector must both defer.
+// Terraform Core renders the diff as "(known after apply)"; at apply the
+// workspace is provisioned first, then the directory is created in the
+// resolved workspace via the unified-provider dispatcher.
+//
+// Without the fix, namespaceForceNew folds "explicit-but-unknown" into
+// "absent", falls back to the empty c.Config.WorkspaceID on an account-host
+// provider, then takes the lazy-resolution branch which fails because account
+// hosts have no workspace context — surfacing as
+// `resource has provider_config.workspace_id = "..." in state, but managing
+// workspace-level resources requires a workspace_id`.
+//
+// The TestCheckResourceAttrPair on the state confirms that the directory's
+// recorded workspace_id is exactly the one the freshly-created workspace
+// reports — proving the apply-time routing went where the ref pointed.
+
+func TestMwsAccWorkspaceID_UnknownWorkspaceIDRef(t *testing.T) {
+	AccountLevel(t, Step{
+		Template: `
+			resource "databricks_mws_workspaces" "src" {
+				account_id     = "{env.DATABRICKS_ACCOUNT_ID}"
+				workspace_name = "dwsid-{var.STICKY_RANDOM}"
+				aws_region     = "{env.AWS_REGION}"
+				compute_mode   = "SERVERLESS"
+			}
+			resource "databricks_directory" "test" {
+				path = "/Shared/dwsid-test-{var.STICKY_RANDOM}"
+				provider_config {
+					workspace_id = databricks_mws_workspaces.src.workspace_id
+				}
+			}
+		`,
+		Check: resource.ComposeAggregateTestCheckFunc(
+			resource.TestCheckResourceAttrPair(
+				directoryResource, "provider_config.0.workspace_id",
+				"databricks_mws_workspaces.src", "workspace_id",
+			),
+		),
+	})
+}
+
+// ==========================================
 // Provider Upgrade (Existing Resources, No Config Changes)
 // ==========================================
 //

--- a/internal/acceptance/workspace_id_sdkv2_http_acc_test.go
+++ b/internal/acceptance/workspace_id_sdkv2_http_acc_test.go
@@ -609,6 +609,56 @@ func TestMwsAccWorkspaceIDHttp_NoDefaultNoOverride(t *testing.T) {
 }
 
 // ==========================================
+// Unknown workspace_id reference — bootstrap pattern (end-to-end)
+// ==========================================
+//
+// The canonical bootstrap scenario: a brand-new serverless workspace is
+// created in the same plan as a workspace-level resource that references the
+// workspace's computed workspace_id via provider_config. At plan time the ref
+// is unknown; the validator and force-new detector must both defer.
+// Terraform Core renders the diff as "(known after apply)"; at apply the
+// workspace is provisioned first, then the notebook is created in the
+// resolved workspace via the HTTP-path unified-provider dispatcher.
+//
+// Without the fix, namespaceForceNew folds "explicit-but-unknown" into
+// "absent", falls back to the empty c.Config.WorkspaceID on an account-host
+// provider, then takes the lazy-resolution branch which fails because account
+// hosts have no workspace context — surfacing as
+// `resource has provider_config.workspace_id = "..." in state, but managing
+// workspace-level resources requires a workspace_id`.
+//
+// The TestCheckResourceAttrPair on the state confirms that the notebook's
+// recorded workspace_id is exactly the one the freshly-created workspace
+// reports — proving the apply-time routing went where the ref pointed.
+
+func TestMwsAccWorkspaceIDHttp_UnknownWorkspaceIDRef(t *testing.T) {
+	AccountLevel(t, Step{
+		Template: fmt.Sprintf(`
+			resource "databricks_mws_workspaces" "src" {
+				account_id     = "{env.DATABRICKS_ACCOUNT_ID}"
+				workspace_name = "dwsid-{var.STICKY_RANDOM}"
+				aws_region     = "{env.AWS_REGION}"
+				compute_mode   = "SERVERLESS"
+			}
+			resource "databricks_notebook" "test" {
+				path           = "/Shared/dwsid-test-{var.STICKY_RANDOM}"
+				content_base64 = "%s"
+				language       = "PYTHON"
+				provider_config {
+					workspace_id = databricks_mws_workspaces.src.workspace_id
+				}
+			}
+		`, notebookContent),
+		Check: resource.ComposeAggregateTestCheckFunc(
+			resource.TestCheckResourceAttrPair(
+				notebookResource, "provider_config.0.workspace_id",
+				"databricks_mws_workspaces.src", "workspace_id",
+			),
+		),
+	})
+}
+
+// ==========================================
 // Provider Upgrade (Existing Resources, No Config Changes)
 // ==========================================
 //

--- a/internal/providers/pluginfw/tfschema/unified_provider.go
+++ b/internal/providers/pluginfw/tfschema/unified_provider.go
@@ -282,13 +282,32 @@ func WorkspaceDriftDetection(ctx context.Context, client UnifiedProviderClient, 
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	// Explicit-but-unknown: the user wrote provider_config (or its
+	// workspace_id field) as a reference that is not yet resolved at plan
+	// time. Defer drift detection — Terraform Core will show
+	// "(known after apply)" in the diff, and apply will see the resolved
+	// value. Falling back to GetProviderWorkspaceID / CurrentWorkspaceID
+	// here would silently substitute a different value for the user's ref,
+	// causing speculative RequiresReplace or a spurious "Missing workspace_id"
+	// error on account-host providers.
+	if !cfgPC.IsNull() && cfgPC.IsUnknown() {
+		return
+	}
 	var newWsID string
 	if !cfgPC.IsNull() && !cfgPC.IsUnknown() {
-		var wsIDDiags diag.Diagnostics
-		newWsID, wsIDDiags = GetWorkspaceIDResource(ctx, cfgPC)
-		resp.Diagnostics.Append(wsIDDiags...)
+		var ns ProviderConfig
+		nsDiags := cfgPC.As(ctx, &ns, basetypes.ObjectAsOptions{})
+		resp.Diagnostics.Append(nsDiags...)
 		if resp.Diagnostics.HasError() {
 			return
+		}
+		if ns.WorkspaceID.IsUnknown() {
+			// Inner workspace_id is the unknown leg of a cross-resource ref.
+			// Same reasoning as the outer-unknown guard above.
+			return
+		}
+		if !ns.WorkspaceID.IsNull() {
+			newWsID = ns.WorkspaceID.ValueString()
 		}
 	}
 	if newWsID == "" {

--- a/internal/providers/pluginfw/tfschema/unified_provider_test.go
+++ b/internal/providers/pluginfw/tfschema/unified_provider_test.go
@@ -2,6 +2,7 @@ package tfschema
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -447,4 +448,68 @@ func TestValidateWorkspaceID_RunsWhenExplicit(t *testing.T) {
 	assert.False(t, resp.Diagnostics.HasError(), "expected no diagnostics, got %v", resp.Diagnostics.Errors())
 	assert.Equal(t, []string{"12345"}, fake.validateCalls,
 		"ValidateWorkspaceAccess must be called with the explicit workspace_id")
+}
+
+// TestWorkspaceDriftDetection_DefersWhenInnerUnknown asserts that when the user
+// wrote `provider_config { workspace_id = some_resource.attr }` and the ref is
+// unknown at plan time, the drift detector defers — does not trigger
+// RequiresReplace, does not synthesize a new plan value for provider_config,
+// does not emit the "Missing workspace_id" error.
+//
+// Without this guard, the drift detector falls back to client.GetProviderWorkspaceID
+// (empty on an account host), then to CurrentWorkspaceID (errors on account
+// host), and either flags a phantom replacement or surfaces a misleading error.
+// Apply will see the resolved value and act on it.
+func TestWorkspaceDriftDetection_DefersWhenInnerUnknown(t *testing.T) {
+	ctx := context.Background()
+	testSchema := validateTestSchema()
+	providerConfigTfType, rootTfType := validateTfTypes()
+
+	// State has a concrete workspace_id "12345" — the old side that
+	// WorkspaceDriftDetection compares against.
+	state := tfsdk.State{
+		Schema: testSchema,
+		Raw: tftypes.NewValue(rootTfType, map[string]tftypes.Value{
+			"provider_config": tftypes.NewValue(providerConfigTfType, map[string]tftypes.Value{
+				"workspace_id": tftypes.NewValue(tftypes.String, "12345"),
+			}),
+		}),
+	}
+	// Config has provider_config.workspace_id = unknown (cross-resource ref
+	// not yet resolved).
+	tfConfig := tfsdk.Config{
+		Schema: testSchema,
+		Raw: tftypes.NewValue(rootTfType, map[string]tftypes.Value{
+			"provider_config": tftypes.NewValue(providerConfigTfType, map[string]tftypes.Value{
+				"workspace_id": tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+			}),
+		}),
+	}
+	// Plan starts as a copy of state (typical post-ProviderConfigPlanModifier shape).
+	plan := tfsdk.Plan{
+		Schema: testSchema,
+		Raw: tftypes.NewValue(rootTfType, map[string]tftypes.Value{
+			"provider_config": tftypes.NewValue(providerConfigTfType, map[string]tftypes.Value{
+				"workspace_id": tftypes.NewValue(tftypes.String, "12345"),
+			}),
+		}),
+	}
+	modifyReq := resource.ModifyPlanRequest{State: state, Config: tfConfig, Plan: plan}
+	resp := &resource.ModifyPlanResponse{Plan: plan}
+
+	// Fake account-host client: GetProviderWorkspaceID returns empty, and
+	// CurrentWorkspaceID errors (matches reality on an account host).
+	fake := &fakeUnifiedProviderClient{
+		currentErr: fmt.Errorf("account host has no workspace context"),
+	}
+
+	WorkspaceDriftDetection(ctx, fake, modifyReq, resp)
+
+	assert.False(t, resp.Diagnostics.HasError(),
+		"WorkspaceDriftDetection must defer when inner workspace_id is unknown; got %v",
+		resp.Diagnostics.Errors())
+	assert.Empty(t, resp.RequiresReplace,
+		"RequiresReplace must not be set for an unknown workspace_id ref")
+	assert.Empty(t, fake.validateCalls,
+		"ValidateWorkspaceAccess must not be called from drift detection")
 }


### PR DESCRIPTION
## Summary

Stacked on top of #5699. Fixes a latent defect in `workspaceIDFromRawDiffConfig` that conflates "user did not write `provider_config`" with "user wrote `provider_config.workspace_id` as an unknown reference (not yet resolved at plan time)."

The unknown case shows up in the canonical bootstrap pattern:

```hcl
resource "databricks_mws_workspaces" "foo" { ... }

resource "databricks_token" "x" {
  provider_config {
    workspace_id = databricks_mws_workspaces.foo.workspace_id   # unknown until apply
  }
  comment = "..."
}
```

Both halves of `NamespaceCustomizeDiff` (SDKv2) and `WorkspaceDriftDetection` (PF) misinterpreted unknown as "absent" and silently substituted `c.Config.WorkspaceID`:

- **Account host** with no provider-level `workspace_id`: the fallback yields `""`, lazy resolution via `CurrentWorkspaceID` fails (no workspace context on account host), and the plan errors with `resource has provider_config.workspace_id = "..." in state, but managing workspace-level resources requires a workspace_id` — even though the user wrote a valid HCL reference.
- **Workspace host** with provider-level `workspace_id` set: silently uses the provider's value as the new effective and may trigger speculative `ForceNew` (when the unknown ref will eventually resolve to a different value) or no diff (when it would resolve to the same value).

The validator (`NamespaceValidateWorkspaceID`) accidentally did the right thing — it conflated both deferral cases into one — but the drift/force-new path didn't.

## Changes

- `common/unified_provider.go::workspaceIDFromRawDiffConfig` — now returns `(value string, explicit, known bool)`. `explicit=false` = user didn't write `provider_config`; `explicit=true, known=false` = user wrote it but value is unknown (cross-resource ref); `explicit=true, known=true` = user wrote a literal.
- `common/unified_provider.go::namespaceForceNew` — defers (returns nil) when `explicit && !known`. Terraform Core will show `(known after apply)` for `provider_config.workspace_id` in the diff; apply-time client construction handles the resolved value.
- `common/unified_provider.go::NamespaceValidateWorkspaceID` — updated to the tri-state signature; semantics unchanged (both unknown and absent already defer here).
- `internal/providers/pluginfw/tfschema/unified_provider.go::WorkspaceDriftDetection` — adds two guards mirroring the SDKv2 fix: skip when the outer `provider_config` is unknown, and walk the inner `workspace_id` attribute (without `UnhandledUnknownAsEmpty`) so an inner unknown defers too.

## Test plan

- [x] `go build ./...`
- [x] `make test` — 3199 tests pass, 0 failures.
- [x] New unit test `TestNamespaceCustomizeDiff_DefersWhenInnerUnknown` in `common/unified_provider_test.go` reproduces failure mode A (account host + unknown ref + state with `"12345"`): asserts no error and no `RequiresNew`. Without the fix this test fails with `resource has provider_config.workspace_id = "12345" in state, but managing workspace-level resources requires a workspace_id`.
- [x] New unit test `TestWorkspaceDriftDetection_DefersWhenInnerUnknown` in `internal/providers/pluginfw/tfschema/unified_provider_test.go` exercises the PF path with a fake account-host client; asserts no diagnostics, no `RequiresReplace`, no `ValidateWorkspaceAccess` call.

## Risks

- **Plan-time drift detection is weakened for the unknown-ref case.** This is correct behavior: when a value is unknown at plan, the provider has no basis for deciding whether to ForceNew. Terraform Core's standard `(known after apply)` UX handles this; the resolved value gets validated and routed at apply.
- **No state-corruption risk.** Apply-time client construction in `GetWorkspaceClientForUnifiedProvider` still runs `validateWorkspaceIDFromProvider` on workspace-host providers and `parseWorkspaceID` on account-host providers. Any mismatch between the resolved unknown and the workspace the provider can reach is caught before `d.SetId` is called.

## Out of scope

- Validator-side semantics of explicit-unknown are unchanged — `NamespaceValidateWorkspaceID` and PF `ValidateWorkspaceID` already defer for both null and unknown. The tri-state helper makes the deferral explicit instead of accidental, but the user-visible behavior of the validator is the same as #5699.

NO_CHANGELOG=true