### PR TITLE
[Exporter] Add support for exporting Agent Bricks resources

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -18,6 +18,7 @@
 ### Exporter
 
 * Support `alert_task` when exporting `databricks_job` ([#5629](https://github.com/databricks/terraform-provider-databricks/pull/5629)).
+* Add support for exporting Agent Bricks resources ([#5704](https://github.com/databricks/terraform-provider-databricks/issues/5704)).
 
 ### Internal Changes
 

--- a/docs/guides/experimental-exporter.md
+++ b/docs/guides/experimental-exporter.md
@@ -222,6 +222,7 @@ Services could be specified in combination with predefined aliases (`all` - for 
 -> Please note that for services not marked with **listing**, we'll export resources only if they are referenced from other resources.
 
 * `access` -  **listing** [databricks_permissions](../resources/permissions.md), [databricks_instance_profile](../resources/instance_profile.md), [databricks_ip_access_list](../resources/ip_access_list.md), and [databricks_access_control_rule_set](../resources/access_control_rule_set.md).   *Please note that for `databricks_permissions` we list only `authorization = "tokens"`, the permissions for other objects (notebooks, ...) will be emitted when corresponding objects are processed!*
+* `agentbricks` - **listing** [databricks_knowledge_assistant](../resources/knowledge_assistant.md) and [databricks_supervisor_agent](../resources/supervisor_agent.md) together with their child resources [databricks_knowledge_assistant_knowledge_source](../resources/knowledge_assistant_knowledge_source.md) and [databricks_supervisor_agent_tool](../resources/supervisor_agent_tool.md).
 * `alerts` - **listing** [databricks_alert](../resources/alert.md) and [databricks_alert_v2](../resources/alert_v2.md).
 * `apps` - **listing** [databricks_app](../resources/app.md) and [databricks_apps_settings_custom_template](../resources/apps_settings_custom_template.md).
 * `billing` - **listing** [databricks_budget](../resources/budget.md) and [databricks_budget_policy](../resources/budget_policy.md).
@@ -326,6 +327,8 @@ Exporter aims to generate HCL code for most of the resources within the Databric
 | [databricks_instance_profile](../resources/instance_profile.md) | Yes | No | Yes | No |
 | [databricks_ip_access_list](../resources/ip_access_list.md) | Yes | Yes | Yes\*\* | No |
 | [databricks_job](../resources/job.md) | Yes | No | Yes | No |
+| [databricks_knowledge_assistant](../resources/knowledge_assistant.md) | Yes | Yes | Yes | No |
+| [databricks_knowledge_assistant_knowledge_source](../resources/knowledge_assistant_knowledge_source.md) | Yes | No | Yes | No |
 | [databricks_library](../resources/library.md) | Yes\* | No | Yes | No |
 | [databricks_metastore](../resources/metastore.md) | Yes | Yes | No | Yes |
 | [databricks_metastore_assignment](../resources/metastore_assignment.md) | Yes | No | No | Yes |
@@ -376,6 +379,8 @@ Exporter aims to generate HCL code for most of the resources within the Databric
 | [databricks_sql_visualization](../resources/sql_visualization.md) | Yes | Yes | Yes | No |
 | [databricks_sql_widget](../resources/sql_widget.md) | Yes | Yes | Yes | No |
 | [databricks_storage_credential](../resources/storage_credential.md) | Yes | Yes | Yes | No |
+| [databricks_supervisor_agent](../resources/supervisor_agent.md) | Yes | Yes | Yes | No |
+| [databricks_supervisor_agent_tool](../resources/supervisor_agent_tool.md) | Yes | No | Yes | No |
 | [databricks_system_schema](../resources/system_schema.md) | Yes | No | Yes | No |
 | [databricks_tag_policy](../resources/tag_policy.md) | Yes | No | Yes | No |
 | [databricks_token](../resources/token.md) | Not Applicable | No | Yes | No |

--- a/exporter/codegen.go
+++ b/exporter/codegen.go
@@ -318,7 +318,7 @@ func (ic *importContext) unifiedDataToHcl(imp importable, path []string,
 
 		var genErr error
 		if wrapper.IsPluginFramework() {
-			genErr = ic.generatePluginFrameworkField(imp, path, field, res, body)
+			genErr = ic.generatePluginFrameworkField(imp, path, field, res, body, wrapper)
 		} else {
 			genErr = ic.generateSdkv2Field(imp, path, field, res, body, varCnt)
 		}
@@ -566,9 +566,9 @@ func (ic *importContext) generateSdkv2Field(imp importable, path []string,
 
 // generatePluginFrameworkField generates HCL for a single Plugin Framework field
 func (ic *importContext) generatePluginFrameworkField(imp importable, path []string,
-	field fieldGenerationInfo, res *resource, body *hclwrite.Body) error {
+	field fieldGenerationInfo, res *resource, body *hclwrite.Body, wrapper ResourceDataWrapper) error {
 
-	return ic.pluginFrameworkFieldToHcl(imp, path, field.Name, field.FieldSchema, field.RawValue, res, body)
+	return ic.pluginFrameworkFieldToHcl(imp, path, field.Name, field.FieldSchema, field.RawValue, res, body, wrapper)
 }
 
 func (ic *importContext) dataToHcl(imp importable, path []string,
@@ -737,7 +737,7 @@ func (ic *importContext) dataToHcl(imp importable, path []string,
 
 // pluginFrameworkFieldToHcl generates HCL for a single Plugin Framework field
 func (ic *importContext) pluginFrameworkFieldToHcl(imp importable, path []string, fieldName string,
-	fieldSchema FieldSchema, raw interface{}, res *resource, body *hclwrite.Body) error {
+	fieldSchema FieldSchema, raw interface{}, res *resource, body *hclwrite.Body, wrapper ResourceDataWrapper) error {
 
 	// Check for nested types first (before checking primitive types)
 	// This handles ListNestedAttribute, SetNestedAttribute, SingleNestedAttribute, etc.
@@ -772,7 +772,7 @@ func (ic *importContext) pluginFrameworkFieldToHcl(imp importable, path []string
 					if nestedData, ok := item.(map[string]interface{}); ok {
 						// Include the index in the path for proper reference resolution
 						nestedPath := append(path, fieldName, strconv.Itoa(i))
-						objTokens := ic.pluginFrameworkNestedObjectToTokens(imp, nestedPath, nestedSchema, nestedData, res)
+						objTokens := ic.pluginFrameworkNestedObjectToTokens(imp, nestedPath, nestedSchema, nestedData, res, wrapper)
 						listTokens = append(listTokens, objTokens...)
 					}
 				}
@@ -791,7 +791,7 @@ func (ic *importContext) pluginFrameworkFieldToHcl(imp importable, path []string
 			nestedSchema := fieldSchema.GetNestedSchema()
 			if nestedSchema != nil {
 				// Generate single nested object as attribute: field = { ... }
-				objTokens := ic.pluginFrameworkNestedObjectToTokens(imp, append(path, fieldName), nestedSchema, nestedData, res)
+				objTokens := ic.pluginFrameworkNestedObjectToTokens(imp, append(path, fieldName), nestedSchema, nestedData, res, wrapper)
 				body.SetAttributeRaw(fieldName, objTokens)
 				return nil
 			}
@@ -921,7 +921,7 @@ func (ic *importContext) pluginFrameworkFieldToHcl(imp importable, path []string
 
 // pluginFrameworkNestedObjectToTokens generates HCL tokens for a nested object
 func (ic *importContext) pluginFrameworkNestedObjectToTokens(imp importable, path []string,
-	nestedSchema SchemaWrapper, nestedData map[string]interface{}, res *resource) hclwrite.Tokens {
+	nestedSchema SchemaWrapper, nestedData map[string]interface{}, res *resource, wrapper ResourceDataWrapper) hclwrite.Tokens {
 
 	if nestedSchema == nil || nestedData == nil {
 		return hclwrite.Tokens{}
@@ -945,6 +945,14 @@ func (ic *importContext) pluginFrameworkNestedObjectToTokens(imp importable, pat
 		if fieldSchema == nil {
 			log.Printf("[DEBUG] No schema found for field %s in path %v", fieldName, path)
 			continue
+		}
+
+		pathString := strings.Join(append(path, fieldName), ".")
+		if imp.ShouldOmitFieldUnified != nil && wrapper != nil {
+			if imp.ShouldOmitFieldUnified(ic, pathString, fieldSchema, wrapper, res) {
+				log.Printf("[DEBUG] ShouldOmitFieldUnified omitting nested field %s", pathString)
+				continue
+			}
 		}
 
 		// Apply field omission logic - check computed-only fields
@@ -1006,7 +1014,6 @@ func (ic *importContext) pluginFrameworkNestedObjectToTokens(imp importable, pat
 		}
 
 		// Check if ShouldGenerateField forces generation
-		pathString := strings.Join(append(path, fieldName), ".")
 		if shouldSkip && (imp.ShouldGenerateField == nil || !imp.ShouldGenerateField(ic, pathString, nil, nil, res)) {
 			log.Printf("[DEBUG] Skipping field %s with zero value in path %v", fieldName, path)
 			continue
@@ -1015,7 +1022,7 @@ func (ic *importContext) pluginFrameworkNestedObjectToTokens(imp importable, pat
 		log.Printf("[DEBUG] Processing field %s in path %v, value type: %T", fieldName, path, raw)
 
 		// Generate HCL for this nested field
-		if err := ic.pluginFrameworkFieldToHcl(imp, path, fieldName, fieldSchema, raw, res, tempBody); err != nil {
+		if err := ic.pluginFrameworkFieldToHcl(imp, path, fieldName, fieldSchema, raw, res, tempBody, wrapper); err != nil {
 			log.Printf("[WARN] Error generating HCL for nested field %s: %v", fieldName, err)
 		}
 	}

--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/databricks/databricks-sdk-go/service/database"
 	"github.com/databricks/databricks-sdk-go/service/iam"
 	sdk_jobs "github.com/databricks/databricks-sdk-go/service/jobs"
+	"github.com/databricks/databricks-sdk-go/service/knowledgeassistants"
 	"github.com/databricks/databricks-sdk-go/service/ml"
 	"github.com/databricks/databricks-sdk-go/service/pipelines"
 	"github.com/databricks/databricks-sdk-go/service/qualitymonitorv2"
@@ -30,6 +31,7 @@ import (
 	"github.com/databricks/databricks-sdk-go/service/settingsv2"
 	"github.com/databricks/databricks-sdk-go/service/sharing"
 	sdk_sql "github.com/databricks/databricks-sdk-go/service/sql"
+	"github.com/databricks/databricks-sdk-go/service/supervisoragents"
 	"github.com/databricks/databricks-sdk-go/service/tags"
 	sdk_vs "github.com/databricks/databricks-sdk-go/service/vectorsearch"
 	sdk_workspace "github.com/databricks/databricks-sdk-go/service/workspace"
@@ -338,6 +340,20 @@ var emptyVectorSearch = qa.HTTPFixture{
 	Response:     sdk_vs.ListEndpointResponse{},
 }
 
+var emptyKnowledgeAssistants = qa.HTTPFixture{
+	Method:       "GET",
+	ReuseRequest: true,
+	Resource:     "/api/2.1/knowledge-assistants?",
+	Response:     knowledgeassistants.ListKnowledgeAssistantsResponse{},
+}
+
+var emptySupervisorAgents = qa.HTTPFixture{
+	Method:       "GET",
+	ReuseRequest: true,
+	Resource:     "/api/2.1/supervisor-agents?",
+	Response:     supervisoragents.ListSupervisorAgentsResponse{},
+}
+
 var emptyShares = qa.HTTPFixture{
 	Method:       "GET",
 	ReuseRequest: true,
@@ -633,6 +649,8 @@ func TestImportingUsersGroupsSecretScopes(t *testing.T) {
 			emptySqlAlerts,
 			emptyAlertsV2,
 			emptyVectorSearch,
+			emptyKnowledgeAssistants,
+			emptySupervisorAgents,
 			emptyPipelines,
 			emptyClusterPolicies,
 			emptyPolicyFamilies,
@@ -915,6 +933,8 @@ func TestImportingNoResourcesError(t *testing.T) {
 			emptyWorkspace,
 			emptySqlEndpoints,
 			emptyVectorSearch,
+			emptyKnowledgeAssistants,
+			emptySupervisorAgents,
 			emptySqlQueries,
 			emptySqlDashboards,
 			emptySqlAlerts,

--- a/exporter/impl_agentbricks.go
+++ b/exporter/impl_agentbricks.go
@@ -1,0 +1,183 @@
+package exporter
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/databricks/databricks-sdk-go/service/knowledgeassistants"
+	"github.com/databricks/databricks-sdk-go/service/supervisoragents"
+	knowledge_assistant_resource "github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/products/knowledge_assistant"
+	knowledge_source_resource "github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/products/knowledge_assistant_knowledge_source"
+	supervisor_agent_resource "github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/products/supervisor_agent"
+	supervisor_agent_tool_resource "github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/products/supervisor_agent_tool"
+)
+
+func listKnowledgeAssistants(ic *importContext) error {
+	assistants, err := ic.workspaceClient.KnowledgeAssistants.ListKnowledgeAssistantsAll(ic.Context,
+		knowledgeassistants.ListKnowledgeAssistantsRequest{})
+	if err != nil {
+		return err
+	}
+	i := 0
+	for _, assistant := range assistants {
+		if !ic.MatchesName(assistant.DisplayName) {
+			log.Printf("[INFO] Skipping knowledge assistant %s because it doesn't match %s",
+				assistant.DisplayName, ic.match)
+			continue
+		}
+		ic.EmitIfUpdatedAfterMillis(&resource{
+			Resource: "databricks_knowledge_assistant",
+			ID:       assistant.Name,
+		}, 0, fmt.Sprintf("knowledge assistant '%s'", assistant.DisplayName))
+		i++
+	}
+	if i > 0 {
+		log.Printf("[INFO] Scanned %d Knowledge Assistants", i)
+	}
+	return nil
+}
+
+func importKnowledgeAssistant(ic *importContext, r *resource) error {
+	var assistant knowledgeassistants.KnowledgeAssistant
+	if err := convertPluginFrameworkToGoSdk(ic, r.DataWrapper,
+		knowledge_assistant_resource.KnowledgeAssistant{}, &assistant); err != nil {
+		return err
+	}
+
+	sources, err := ic.workspaceClient.KnowledgeAssistants.ListKnowledgeSourcesAll(ic.Context,
+		knowledgeassistants.ListKnowledgeSourcesRequest{Parent: r.ID})
+	if err != nil {
+		log.Printf("[WARN] Failed to list knowledge sources for %s: %s", r.ID, err)
+		return nil
+	}
+	for _, source := range sources {
+		ic.Emit(&resource{
+			Resource: "databricks_knowledge_assistant_knowledge_source",
+			ID:       source.Name,
+		})
+	}
+	return nil
+}
+
+func importKnowledgeSource(ic *importContext, r *resource) error {
+	var source knowledgeassistants.KnowledgeSource
+	if err := convertPluginFrameworkToGoSdk(ic, r.DataWrapper,
+		knowledge_source_resource.KnowledgeSource{}, &source); err != nil {
+		return err
+	}
+
+	if source.FileTable != nil && source.FileTable.TableName != "" {
+		ic.Emit(&resource{
+			Resource: "databricks_sql_table",
+			ID:       source.FileTable.TableName,
+		})
+	}
+	if source.Index != nil && source.Index.IndexName != "" {
+		ic.Emit(&resource{
+			Resource: "databricks_vector_search_index",
+			ID:       source.Index.IndexName,
+		})
+	}
+	if source.Files != nil && source.Files.Path != "" {
+		// Path format: /Volumes/<catalog>/<schema>/<volume>/<optional subdirs/files>
+		parts := strings.Split(source.Files.Path, "/")
+		if len(parts) >= 5 && parts[1] == "Volumes" {
+			ic.Emit(&resource{
+				Resource: "databricks_volume",
+				ID:       strings.Join(parts[2:5], "."),
+			})
+		}
+	}
+	return nil
+}
+
+func listSupervisorAgents(ic *importContext) error {
+	agents, err := ic.workspaceClient.SupervisorAgents.ListSupervisorAgentsAll(ic.Context,
+		supervisoragents.ListSupervisorAgentsRequest{})
+	if err != nil {
+		return err
+	}
+	i := 0
+	for _, agent := range agents {
+		if !ic.MatchesName(agent.DisplayName) {
+			log.Printf("[INFO] Skipping supervisor agent %s because it doesn't match %s",
+				agent.DisplayName, ic.match)
+			continue
+		}
+		ic.EmitIfUpdatedAfterMillis(&resource{
+			Resource: "databricks_supervisor_agent",
+			ID:       agent.Name,
+		}, 0, fmt.Sprintf("supervisor agent '%s'", agent.DisplayName))
+		i++
+	}
+	if i > 0 {
+		log.Printf("[INFO] Scanned %d Supervisor Agents", i)
+	}
+	return nil
+}
+
+func importSupervisorAgent(ic *importContext, r *resource) error {
+	var agent supervisoragents.SupervisorAgent
+	if err := convertPluginFrameworkToGoSdk(ic, r.DataWrapper,
+		supervisor_agent_resource.SupervisorAgent{}, &agent); err != nil {
+		return err
+	}
+
+	tools, err := ic.workspaceClient.SupervisorAgents.ListToolsAll(ic.Context,
+		supervisoragents.ListToolsRequest{Parent: r.ID})
+	if err != nil {
+		log.Printf("[WARN] Failed to list tools for %s: %s", r.ID, err)
+		return nil
+	}
+	for _, tool := range tools {
+		log.Printf("[INFO] Tool: %s", tool.Name)
+		ic.Emit(&resource{
+			Resource: "databricks_supervisor_agent_tool",
+			ID:       tool.Name,
+		})
+	}
+	return nil
+}
+
+// shouldOmitSupervisorAgentToolField skips deprecated API-only fields that should not appear in exported HCL.
+func shouldOmitSupervisorAgentToolField(ic *importContext, pathString string, fieldSchema FieldSchema, wrapper ResourceDataWrapper, r *resource) bool {
+	if pathString == "knowledge_assistant.serving_endpoint_name" {
+		return true
+	}
+	return DefaultShouldOmitFieldFuncWithAbstraction(ic, pathString, fieldSchema, wrapper, r)
+}
+
+func importSupervisorAgentTool(ic *importContext, r *resource) error {
+	var tool supervisoragents.Tool
+	if err := convertPluginFrameworkToGoSdk(ic, r.DataWrapper,
+		supervisor_agent_tool_resource.Tool{}, &tool); err != nil {
+		return err
+	}
+
+	if tool.App != nil && tool.App.Name != "" {
+		ic.Emit(&resource{
+			Resource: "databricks_app",
+			ID:       tool.App.Name,
+		})
+	}
+	if tool.UcConnection != nil && tool.UcConnection.Name != "" {
+		ic.Emit(&resource{
+			Resource: "databricks_connection",
+			ID:       tool.UcConnection.Name,
+		})
+	}
+	if tool.Volume != nil && tool.Volume.Name != "" {
+		ic.Emit(&resource{
+			Resource: "databricks_volume",
+			ID:       tool.Volume.Name,
+		})
+	}
+	if tool.KnowledgeAssistant != nil && tool.KnowledgeAssistant.KnowledgeAssistantId != "" {
+		ic.Emit(&resource{
+			Resource: "databricks_knowledge_assistant",
+			ID:       "knowledge-assistants/" + tool.KnowledgeAssistant.KnowledgeAssistantId,
+		})
+	}
+	return nil
+}

--- a/exporter/impl_agentbricks_test.go
+++ b/exporter/impl_agentbricks_test.go
@@ -1,0 +1,151 @@
+package exporter
+
+import (
+	"context"
+	"testing"
+
+	"github.com/databricks/databricks-sdk-go/service/knowledgeassistants"
+	"github.com/databricks/databricks-sdk-go/service/supervisoragents"
+	"github.com/databricks/terraform-provider-databricks/common"
+	"github.com/databricks/terraform-provider-databricks/qa"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListKnowledgeAssistants(t *testing.T) {
+	qa.HTTPFixturesApply(t, []qa.HTTPFixture{
+		{
+			Method:       "GET",
+			Resource:     "/api/2.1/knowledge-assistants?",
+			ReuseRequest: true,
+			Response: knowledgeassistants.ListKnowledgeAssistantsResponse{
+				KnowledgeAssistants: []knowledgeassistants.KnowledgeAssistant{
+					{
+						Name:        "knowledge-assistants/abc-123",
+						DisplayName: "Sales Assistant",
+					},
+					{
+						Name:        "knowledge-assistants/def-456",
+						DisplayName: "Support Assistant",
+					},
+				},
+			},
+		},
+	}, func(ctx context.Context, client *common.DatabricksClient) {
+		ic := importContextForTestWithClient(ctx, client)
+		ic.enableServices("agentbricks")
+		err := resourcesMap["databricks_knowledge_assistant"].List(ic)
+		assert.NoError(t, err)
+		require.Equal(t, 2, len(ic.testEmits))
+		assert.True(t, ic.testEmits["databricks_knowledge_assistant[<unknown>] (id: knowledge-assistants/abc-123)"])
+		assert.True(t, ic.testEmits["databricks_knowledge_assistant[<unknown>] (id: knowledge-assistants/def-456)"])
+	})
+}
+
+func TestListKnowledgeAssistantsWithMatch(t *testing.T) {
+	qa.HTTPFixturesApply(t, []qa.HTTPFixture{
+		{
+			Method:   "GET",
+			Resource: "/api/2.1/knowledge-assistants?",
+			Response: knowledgeassistants.ListKnowledgeAssistantsResponse{
+				KnowledgeAssistants: []knowledgeassistants.KnowledgeAssistant{
+					{
+						Name:        "knowledge-assistants/abc-123",
+						DisplayName: "Sales Assistant",
+					},
+					{
+						Name:        "knowledge-assistants/def-456",
+						DisplayName: "Other",
+					},
+				},
+			},
+		},
+	}, func(ctx context.Context, client *common.DatabricksClient) {
+		ic := importContextForTestWithClient(ctx, client)
+		ic.enableServices("agentbricks")
+		ic.match = "Sales"
+		err := resourcesMap["databricks_knowledge_assistant"].List(ic)
+		assert.NoError(t, err)
+		require.Equal(t, 1, len(ic.testEmits))
+		assert.True(t, ic.testEmits["databricks_knowledge_assistant[<unknown>] (id: knowledge-assistants/abc-123)"])
+	})
+}
+
+func TestListSupervisorAgents(t *testing.T) {
+	qa.HTTPFixturesApply(t, []qa.HTTPFixture{
+		{
+			Method:       "GET",
+			Resource:     "/api/2.1/supervisor-agents?",
+			ReuseRequest: true,
+			Response: supervisoragents.ListSupervisorAgentsResponse{
+				SupervisorAgents: []supervisoragents.SupervisorAgent{
+					{
+						Name:        "supervisor-agents/agent-1",
+						DisplayName: "Primary Agent",
+					},
+					{
+						Name:        "supervisor-agents/agent-2",
+						DisplayName: "Secondary Agent",
+					},
+				},
+			},
+		},
+	}, func(ctx context.Context, client *common.DatabricksClient) {
+		ic := importContextForTestWithClient(ctx, client)
+		ic.enableServices("agentbricks")
+		err := resourcesMap["databricks_supervisor_agent"].List(ic)
+		assert.NoError(t, err)
+		require.Equal(t, 2, len(ic.testEmits))
+		assert.True(t, ic.testEmits["databricks_supervisor_agent[<unknown>] (id: supervisor-agents/agent-1)"])
+		assert.True(t, ic.testEmits["databricks_supervisor_agent[<unknown>] (id: supervisor-agents/agent-2)"])
+	})
+}
+
+func TestListSupervisorAgentsWithMatch(t *testing.T) {
+	qa.HTTPFixturesApply(t, []qa.HTTPFixture{
+		{
+			Method:   "GET",
+			Resource: "/api/2.1/supervisor-agents?",
+			Response: supervisoragents.ListSupervisorAgentsResponse{
+				SupervisorAgents: []supervisoragents.SupervisorAgent{
+					{
+						Name:        "supervisor-agents/agent-1",
+						DisplayName: "Primary Agent",
+					},
+					{
+						Name:        "supervisor-agents/agent-2",
+						DisplayName: "Other",
+					},
+				},
+			},
+		},
+	}, func(ctx context.Context, client *common.DatabricksClient) {
+		ic := importContextForTestWithClient(ctx, client)
+		ic.enableServices("agentbricks")
+		ic.match = "Primary"
+		err := resourcesMap["databricks_supervisor_agent"].List(ic)
+		assert.NoError(t, err)
+		require.Equal(t, 1, len(ic.testEmits))
+		assert.True(t, ic.testEmits["databricks_supervisor_agent[<unknown>] (id: supervisor-agents/agent-1)"])
+	})
+}
+
+func TestSupervisorAgentToolNameUnified(t *testing.T) {
+	ic := importContextForTest()
+	ir := resourcesMap["databricks_supervisor_agent_tool"]
+
+	wrapperWithToolId := &mockResourceDataWrapper{
+		data: map[string]any{
+			"id":      "supervisor-agents/abc/tools/xyz",
+			"tool_id": "my_tool",
+		},
+	}
+	assert.Equal(t, "my_tool_supervisor-agents/abc/tools/xyz", ir.NameUnified(ic, wrapperWithToolId))
+
+	wrapperWithoutToolId := &mockResourceDataWrapper{
+		data: map[string]any{
+			"id": "supervisor-agents/abc/tools/xyz",
+		},
+	}
+	assert.Equal(t, "supervisor-agents/abc/tools/xyz", ir.NameUnified(ic, wrapperWithoutToolId))
+}

--- a/exporter/importables.go
+++ b/exporter/importables.go
@@ -2226,6 +2226,57 @@ var resourcesMap map[string]importable = map[string]importable{
 			{Path: "direct_access_index_spec.embedding_source_columns.model_endpoint_name_for_query", Resource: "databricks_model_serving"},
 		},
 	},
+	"databricks_knowledge_assistant": {
+		WorkspaceLevel:  true,
+		PluginFramework: true,
+		Service:         "agentbricks",
+		NameUnified:     makeNamePlusIdFuncUnified("display_name"),
+		List:            listKnowledgeAssistants,
+		Import:          importKnowledgeAssistant,
+		Ignore:          generateIgnoreObjectWithEmptyAttributeValue("databricks_knowledge_assistant", "display_name"),
+	},
+	"databricks_knowledge_assistant_knowledge_source": {
+		WorkspaceLevel:  true,
+		PluginFramework: true,
+		Service:         "agentbricks",
+		NameUnified:     makeNamePlusIdFuncUnified("display_name"),
+		Import:          importKnowledgeSource,
+		Depends: []reference{
+			{Path: "parent", Resource: "databricks_knowledge_assistant", Match: "name"},
+			{Path: "file_table.table_name", Resource: "databricks_sql_table"},
+			{Path: "index.index_name", Resource: "databricks_vector_search_index"},
+			{Path: "files.path", Resource: "databricks_volume", Match: "volume_path", MatchType: MatchLongestPrefix},
+		},
+	},
+	"databricks_supervisor_agent": {
+		WorkspaceLevel:  true,
+		PluginFramework: true,
+		Service:         "agentbricks",
+		NameUnified:     makeNamePlusIdFuncUnified("display_name"),
+		List:            listSupervisorAgents,
+		Import:          importSupervisorAgent,
+		Ignore:          generateIgnoreObjectWithEmptyAttributeValue("databricks_supervisor_agent", "display_name"),
+	},
+	"databricks_supervisor_agent_tool": {
+		WorkspaceLevel:  true,
+		PluginFramework: true,
+		Service:         "agentbricks",
+		NameUnified: func(ic *importContext, wrapper ResourceDataWrapper) string {
+			if toolId, ok := wrapper.GetOk("tool_id"); ok && toolId != "" {
+				return toolId.(string) + "_" + wrapper.Id()
+			}
+			return wrapper.Id()
+		},
+		Import:                 importSupervisorAgentTool,
+		ShouldOmitFieldUnified: shouldOmitSupervisorAgentToolField,
+		Depends: []reference{
+			{Path: "parent", Resource: "databricks_supervisor_agent", Match: "name"},
+			{Path: "app.name", Resource: "databricks_app", Match: "name"},
+			{Path: "uc_connection.name", Resource: "databricks_connection", Match: "name"},
+			{Path: "volume.name", Resource: "databricks_volume", Match: "name"},
+			{Path: "knowledge_assistant.knowledge_assistant_id", Resource: "databricks_knowledge_assistant"},
+		},
+	},
 	"databricks_mws_network_connectivity_config": {
 		AccountLevel: true,
 		Service:      "nccs",


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

Add support for exporting `databricks_knowledge_assistant`, `databricks_knowledge_assistant_knowledge_source`, `databricks_supervisor_agent`, and `databricks_supervisor_agent_tool` resources under the new `agentbricks` service.

## Tests
<!--
How is this tested? Please see the checklist below and also describe any other relevant tests
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [x] using Go SDK
- [x] using TF Plugin Framework
- [x] has entry in `NEXT_CHANGELOG.md` file
