### PR TITLE
[Feature] Add support for managing permissions of Agent Bricks resources

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### New Features and Improvements
 
+* Add support for managing permissions of Agent Bricks resources ([#5708](https://github.com/databricks/terraform-provider-databricks/issues/5669)). Reverts [#5582](https://github.com/databricks/terraform-provider-databricks/pull/5708).
+
 ### Bug Fixes
 
 * Fix `databricks_metastore` so that updating `external_access_enabled` from `true` to `false` is sent in the PATCH request. Previously the field was silently dropped from the request body, so the change never reached the API.

--- a/docs/resources/permissions.md
+++ b/docs/resources/permissions.md
@@ -989,6 +989,54 @@ resource "databricks_permissions" "db_project_usage" {
 }
 ```
 
+## Knowledge Assistant usage
+
+[Knowledge Assistants](knowledge_assistant.md) have two possible permissions: `CAN_QUERY` and `CAN_MANAGE`:
+
+```hcl
+resource "databricks_group" "eng" {
+  display_name = "Engineering"
+}
+
+resource "databricks_permissions" "knowledge_assistant_usage" {
+  knowledge_assistant_id = databricks_knowledge_assistant.this.id
+
+  access_control {
+    group_name       = "users"
+    permission_level = "CAN_QUERY"
+  }
+
+  access_control {
+    group_name       = databricks_group.eng.display_name
+    permission_level = "CAN_MANAGE"
+  }
+}
+```
+
+## Supervisor Agent usage
+
+[Supervisor Agents](supervisor_agent.md) have two possible permissions: `CAN_QUERY` and `CAN_MANAGE`:
+
+```hcl
+resource "databricks_group" "eng" {
+  display_name = "Engineering"
+}
+
+resource "databricks_permissions" "supervisor_agent_usage" {
+  supervisor_agent_id = databricks_supervisor_agent.this.supervisor_agent_id
+
+  access_control {
+    group_name       = "users"
+    permission_level = "CAN_QUERY"
+  }
+
+  access_control {
+    group_name       = databricks_group.eng.display_name
+    permission_level = "CAN_MANAGE"
+  }
+}
+```
+
 ## Instance Profiles
 
 [Instance Profiles](instance_profile.md) are not managed by General Permissions API and therefore [databricks_group_instance_profile](group_instance_profile.md) and [databricks_user_instance_profile](user_instance_profile.md) should be used to allow usage of specific AWS EC2 IAM roles to users or groups.
@@ -1031,6 +1079,8 @@ Exactly one of the following arguments is required:
 - `vector_search_endpoint_id` - [Vector Search](vector_search_endpoint.md) endpoint id.
 - `database_instance_name` - [Lakebase database instance](https://docs.databricks.com/aws/en/oltp/) name
 - `database_project_name` - [Lakebase database project](https://docs.databricks.com/aws/en/oltp/) name
+- `knowledge_assistant_id` - [Knowledge Assistant](knowledge_assistant.md) id
+- `supervisor_agent_id` - [Supervisor Agent](supervisor_agent.md) id
 - `authorization` - either [`tokens`](https://docs.databricks.com/administration-guide/access-control/tokens.html) or [`passwords`](https://docs.databricks.com/administration-guide/users-groups/single-sign-on/index.html#configure-password-permission).
 - `sql_endpoint_id` - [SQL warehouse](sql_endpoint.md) id
 - `sql_dashboard_id` - [SQL dashboard](sql_dashboard.md) id

--- a/permissions/permission_definitions.go
+++ b/permissions/permission_definitions.go
@@ -793,5 +793,27 @@ func allResourcePermissions() []resourcePermissions {
 			updateAclCustomizers: []update.ACLCustomizer{update.AddCurrentUserAsManage},
 			deleteAclCustomizers: []update.ACLCustomizer{update.AddCurrentUserAsManage},
 		},
+		{
+			field:             "knowledge_assistant_id",
+			objectType:        "knowledge-assistants",
+			requestObjectType: "knowledge-assistants",
+			allowedPermissionLevels: map[string]permissionLevelOptions{
+				"CAN_QUERY":  {isManagementPermission: false},
+				"CAN_MANAGE": {isManagementPermission: true},
+			},
+			updateAclCustomizers: []update.ACLCustomizer{update.AddCurrentUserAsManage},
+			deleteAclCustomizers: []update.ACLCustomizer{update.AddCurrentUserAsManage},
+		},
+		{
+			field:             "supervisor_agent_id",
+			objectType:        "supervisor-agents",
+			requestObjectType: "supervisor-agents",
+			allowedPermissionLevels: map[string]permissionLevelOptions{
+				"CAN_QUERY":  {isManagementPermission: false},
+				"CAN_MANAGE": {isManagementPermission: true},
+			},
+			updateAclCustomizers: []update.ACLCustomizer{update.AddCurrentUserAsManage},
+			deleteAclCustomizers: []update.ACLCustomizer{update.AddCurrentUserAsManage},
+		},
 	}
 }

--- a/permissions/resource_permissions_test.go
+++ b/permissions/resource_permissions_test.go
@@ -1922,7 +1922,7 @@ func TestAccessControlHashFunction(t *testing.T) {
 func TestResourcePermissionsCreate_KnowledgeAssistant(t *testing.T) {
 	d, err := qa.ResourceFixture{
 		MockWorkspaceClientFunc: func(mwc *mocks.MockWorkspaceClient) {
-			mwc.GetMockCurrentUserAPI().EXPECT().Me(mock.Anything).Return(&iam.User{UserName: TestingAdminUser}, nil)
+			mwc.GetMockCurrentUserAPI().EXPECT().Me(mock.Anything, mock.Anything).Return(&iam.User{UserName: TestingAdminUser}, nil)
 			e := mwc.GetMockPermissionsAPI().EXPECT()
 			e.Set(mock.Anything, iam.SetObjectPermissions{
 				RequestObjectId:   "ka-abc",
@@ -1994,7 +1994,7 @@ func TestResourcePermissionsCreate_KnowledgeAssistant_InvalidLevel(t *testing.T)
 func TestResourcePermissionsCreate_SupervisorAgent(t *testing.T) {
 	d, err := qa.ResourceFixture{
 		MockWorkspaceClientFunc: func(mwc *mocks.MockWorkspaceClient) {
-			mwc.GetMockCurrentUserAPI().EXPECT().Me(mock.Anything).Return(&iam.User{UserName: TestingAdminUser}, nil)
+			mwc.GetMockCurrentUserAPI().EXPECT().Me(mock.Anything, mock.Anything).Return(&iam.User{UserName: TestingAdminUser}, nil)
 			e := mwc.GetMockPermissionsAPI().EXPECT()
 			e.Set(mock.Anything, iam.SetObjectPermissions{
 				RequestObjectId:   "sa-abc",

--- a/permissions/resource_permissions_test.go
+++ b/permissions/resource_permissions_test.go
@@ -622,7 +622,7 @@ func TestResourcePermissionsCreate_invalid(t *testing.T) {
 	qa.ResourceFixture{
 		Resource: ResourcePermissions(),
 		Create:   true,
-	}.ExpectError(t, "at least one type of resource identifier must be set; allowed fields: alert_v2_id, app_name, authorization, cluster_id, cluster_policy_id, dashboard_id, database_instance_name, database_project_name, directory_id, directory_path, experiment_id, instance_pool_id, job_id, notebook_id, notebook_path, pipeline_id, registered_model_id, repo_id, repo_path, serving_endpoint_id, sql_alert_id, sql_dashboard_id, sql_endpoint_id, sql_query_id, vector_search_endpoint_id, workspace_file_id, workspace_file_path")
+	}.ExpectError(t, "at least one type of resource identifier must be set; allowed fields: alert_v2_id, app_name, authorization, cluster_id, cluster_policy_id, dashboard_id, database_instance_name, database_project_name, directory_id, directory_path, experiment_id, instance_pool_id, job_id, knowledge_assistant_id, notebook_id, notebook_path, pipeline_id, registered_model_id, repo_id, repo_path, serving_endpoint_id, sql_alert_id, sql_dashboard_id, sql_endpoint_id, sql_query_id, supervisor_agent_id, vector_search_endpoint_id, workspace_file_id, workspace_file_path")
 }
 
 func TestResourcePermissionsCreate_no_access_control(t *testing.T) {
@@ -1917,4 +1917,148 @@ func TestAccessControlHashFunction(t *testing.T) {
 	hash4 := acSchema.Set(elem4)
 	hash5 := acSchema.Set(elem5)
 	assert.Equal(t, hash4, hash5, "Service principal elements with and without empty fields should have the same hash")
+}
+
+func TestResourcePermissionsCreate_KnowledgeAssistant(t *testing.T) {
+	d, err := qa.ResourceFixture{
+		MockWorkspaceClientFunc: func(mwc *mocks.MockWorkspaceClient) {
+			mwc.GetMockCurrentUserAPI().EXPECT().Me(mock.Anything).Return(&iam.User{UserName: TestingAdminUser}, nil)
+			e := mwc.GetMockPermissionsAPI().EXPECT()
+			e.Set(mock.Anything, iam.SetObjectPermissions{
+				RequestObjectId:   "ka-abc",
+				RequestObjectType: "knowledge-assistants",
+				AccessControlList: []iam.AccessControlRequest{
+					{
+						UserName:        TestingUser,
+						PermissionLevel: "CAN_QUERY",
+					},
+					{
+						UserName:        TestingAdminUser,
+						PermissionLevel: "CAN_MANAGE",
+					},
+				},
+			}).Return(nil, nil)
+			e.Get(mock.Anything, iam.GetPermissionRequest{
+				RequestObjectId:   "ka-abc",
+				RequestObjectType: "knowledge-assistants",
+			}).Return(&iam.ObjectPermissions{
+				ObjectId:   "/knowledge-assistants/ka-abc",
+				ObjectType: "knowledge-assistants",
+				AccessControlList: []iam.AccessControlResponse{
+					{
+						UserName: TestingUser,
+						AllPermissions: []iam.Permission{
+							{
+								PermissionLevel: "CAN_QUERY",
+								Inherited:       false,
+							},
+						},
+					},
+				},
+			}, nil)
+		},
+		Resource: ResourcePermissions(),
+		State: map[string]any{
+			"knowledge_assistant_id": "ka-abc",
+			"access_control": []any{
+				map[string]any{
+					"user_name":        TestingUser,
+					"permission_level": "CAN_QUERY",
+				},
+			},
+		},
+		Create: true,
+	}.Apply(t)
+	assert.NoError(t, err)
+	ac := d.Get("access_control").(*schema.Set)
+	require.Equal(t, 1, len(ac.List()))
+	firstElem := ac.List()[0].(map[string]any)
+	assert.Equal(t, TestingUser, firstElem["user_name"])
+	assert.Equal(t, "CAN_QUERY", firstElem["permission_level"])
+}
+
+func TestResourcePermissionsCreate_KnowledgeAssistant_InvalidLevel(t *testing.T) {
+	qa.ResourceFixture{
+		Resource: ResourcePermissions(),
+		Create:   true,
+		HCL: `
+		knowledge_assistant_id = "ka-abc"
+		access_control {
+			user_name        = "ben"
+			permission_level = "CAN_VIEW"
+		}
+		`,
+	}.ExpectError(t, "permission_level CAN_VIEW is not supported with knowledge_assistant_id objects; allowed levels: CAN_MANAGE, CAN_QUERY")
+}
+
+func TestResourcePermissionsCreate_SupervisorAgent(t *testing.T) {
+	d, err := qa.ResourceFixture{
+		MockWorkspaceClientFunc: func(mwc *mocks.MockWorkspaceClient) {
+			mwc.GetMockCurrentUserAPI().EXPECT().Me(mock.Anything).Return(&iam.User{UserName: TestingAdminUser}, nil)
+			e := mwc.GetMockPermissionsAPI().EXPECT()
+			e.Set(mock.Anything, iam.SetObjectPermissions{
+				RequestObjectId:   "sa-abc",
+				RequestObjectType: "supervisor-agents",
+				AccessControlList: []iam.AccessControlRequest{
+					{
+						UserName:        TestingUser,
+						PermissionLevel: "CAN_QUERY",
+					},
+					{
+						UserName:        TestingAdminUser,
+						PermissionLevel: "CAN_MANAGE",
+					},
+				},
+			}).Return(nil, nil)
+			e.Get(mock.Anything, iam.GetPermissionRequest{
+				RequestObjectId:   "sa-abc",
+				RequestObjectType: "supervisor-agents",
+			}).Return(&iam.ObjectPermissions{
+				ObjectId:   "/supervisor-agents/sa-abc",
+				ObjectType: "supervisor-agents",
+				AccessControlList: []iam.AccessControlResponse{
+					{
+						UserName: TestingUser,
+						AllPermissions: []iam.Permission{
+							{
+								PermissionLevel: "CAN_QUERY",
+								Inherited:       false,
+							},
+						},
+					},
+				},
+			}, nil)
+		},
+		Resource: ResourcePermissions(),
+		State: map[string]any{
+			"supervisor_agent_id": "sa-abc",
+			"access_control": []any{
+				map[string]any{
+					"user_name":        TestingUser,
+					"permission_level": "CAN_QUERY",
+				},
+			},
+		},
+		Create: true,
+	}.Apply(t)
+	assert.NoError(t, err)
+	ac := d.Get("access_control").(*schema.Set)
+	require.Equal(t, 1, len(ac.List()))
+	firstElem := ac.List()[0].(map[string]any)
+	assert.Equal(t, TestingUser, firstElem["user_name"])
+	assert.Equal(t, "CAN_QUERY", firstElem["permission_level"])
+}
+
+func TestResourcePermissionsCreate_SupervisorAgent_InvalidLevel(t *testing.T) {
+	qa.ResourceFixture{
+		Resource: ResourcePermissions(),
+		Create:   true,
+		HCL: `
+		supervisor_agent_id = "sa-abc"
+		access_control {
+			user_name        = "ben"
+			permission_level = "CAN_VIEW"
+		}
+		`,
+	}.ExpectError(t, "permission_level CAN_VIEW is not supported with supervisor_agent_id objects; allowed levels: CAN_MANAGE, CAN_QUERY")
 }


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

Add support for managing permissions of
[databricks_knowledge_assistant](docs/resources/knowledge_assistant.md) and [databricks_supervisor_agent](docs/resources/supervisor_agent.md). Both support `CAN_QUERY` and `CAN_MANAGE` permission levels.

## Tests
<!--
How is this tested? Please see the checklist below and also describe any other relevant tests
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] using Go SDK
- [ ] using TF Plugin Framework
- [x] has entry in `NEXT_CHANGELOG.md` file
