### PR TITLE
[Doc] Update `databricks_app` documentation to cover Postgres and other resource types.

### DIFF
--- a/docs/data-sources/app.md
+++ b/docs/data-sources/app.md
@@ -28,6 +28,7 @@ The following arguments are required:
 In addition to all arguments above, the following attributes are exported:
 
 * `app` attribute
+  * `id` - The unique identifier of the app.
   * `name` - The name of the app.
   * `description` - The description of the app.
   * `resources` - A list of resources that the app have access to.
@@ -37,7 +38,7 @@ In addition to all arguments above, the following attributes are exported:
   * `app_status` attribute
     * `state` - State of the application.
     * `message` - Application status message
-  * `compute_size` - (Optional) A string specifying compute size for the App.
+  * `compute_size` - A string specifying compute size for the App.
   * `url` - The URL of the app once it is deployed.
   * `create_time` - The creation time of the app.
   * `creator` - The email of the user that created the app.
@@ -49,7 +50,35 @@ In addition to all arguments above, the following attributes are exported:
   * `default_source_code_path` - The default workspace file system path of the source code from which app deployment are created. This field tracks the workspace source code path of the last active deployment.
   * `budget_policy_id` - The Budget Policy ID set for this resource.
   * `effective_budget_policy_id` - The effective budget policy ID.
+  * `usage_policy_id` - The Usage Policy ID set for this resource.
+  * `effective_usage_policy_id` - The effective usage policy ID.
+  * `user_api_scopes` - A list of api scopes granted to the user access token.
   * `effective_user_api_scopes` - A list of effective api scopes granted to the user access token.
+  * `oauth2_app_client_id` - The OAuth2 client ID of the app's integration, set when the app uses user authorization.
+  * `oauth2_app_integration_id` - The unique ID of the OAuth2 integration associated with the app.
+  * `thumbnail_url` - The URL of the thumbnail image for the app.
+  * `space` - Name of the [app space](app_space.md) this app belongs to.
+  * `git_repository` attribute - Git repository configuration for app deployments.
+    * `url` - URL of the Git repository.
+    * `provider` - Git provider (case insensitive). Supported values: `gitHub`, `gitHubEnterprise`, `bitbucketCloud`, `bitbucketServer`, `azureDevOpsServices`, `gitLab`, `gitLabEnterpriseEdition`, `awsCodeCommit`.
+  * `telemetry_export_destinations` - A list of telemetry export destinations.
+    * `unity_catalog` attribute
+      * `logs_table` - Full name of the Unity Catalog table for OpenTelemetry logs.
+      * `metrics_table` - Full name of the Unity Catalog table for OpenTelemetry metrics.
+      * `traces_table` - Full name of the Unity Catalog table for OpenTelemetry traces (spans).
+  * `active_deployment` attribute - the active deployment of the app.
+    * `deployment_id` - The unique ID of the deployment.
+    * `source_code_path` - The workspace file system path of the source code used to create the deployment.
+    * `mode` - The deployment mode (`AUTO_SYNC` or `SNAPSHOT`).
+    * `create_time` - The creation time of the deployment.
+    * `creator` - The email of the user that created the deployment.
+    * `update_time` - The update time of the deployment.
+    * `status` attribute
+      * `state` - The state of the deployment.
+      * `message` - The status message of the deployment.
+    * `deployment_artifacts` attribute
+      * `source_code_path` - The snapshotted workspace file system path of the source code loaded by the deployed app.
+  * `pending_deployment` attribute - the pending deployment of the app. Schema is identical to `active_deployment`.
 
 ### resources Attribute
 
@@ -73,18 +102,28 @@ Exactly one of the following attributes will be provided:
 * `job` attribute
   * `id` - Id of the job to grant permission on.
   * `permission` - Permissions to grant on the Job. Supported permissions are: `CAN_MANAGE`, `IS_OWNER`, `CAN_MANAGE_RUN`, `CAN_VIEW`.
-* `uc_securable` attribute
-  * `securable_type` - the type of UC securable, i.e. `VOLUME`.
-  * `securable_full_name` - the full name of UC securable, i.e. `my-catalog.my-schema.my-volume`.
-  * `permission` - Permissions to grant on UC securable, i.e. `READ_VOLUME`, `WRITE_VOLUME`.
+* `uc_securable` attribute (see the [API docs](https://docs.databricks.com/api/workspace/apps/create#resources-uc_securable) for full list of supported UC objects)
+  * `securable_type` - The type of UC securable. Supported values are `CONNECTION`, `FUNCTION`, `TABLE`, `VOLUME`.
+  * `securable_full_name` - The full name of UC securable, i.e. `my-catalog.my-schema.my-volume`.
+  * `permission` - Permission to grant on UC securable. Supported values depend on `securable_type`: `READ_VOLUME` and `WRITE_VOLUME` for `VOLUME`, `SELECT` and `MODIFY` for `TABLE`, `EXECUTE` for `FUNCTION`, `USE_CONNECTION` for `CONNECTION`.
 * `database` attribute
   * `database_name` - The name of database.
   * `instance_name` - The name of database instance.
   * `permission` - Permission to grant on database. Supported permissions are: `CAN_CONNECT_AND_CREATE`.
+* `postgres` attribute
+  * `branch` - The resource path of the Lakebase Autoscaling branch (e.g. `projects/proj-abc123/branches/branch-xyz789`).
+  * `database` - The resource path of a specific database within the branch (e.g. `projects/proj-abc123/branches/branch-xyz789/databases/db-456`).
+  * `permission` - Permission to grant on the Lakebase Autoscaling branch or database. Supported permissions are: `CAN_CONNECT_AND_CREATE`.
 * `genie_space` attribute
   * `name` - The name of Genie Space.
-  * ``permission` - Permission to grant on Genie Space. Supported permissions are `CAN_MANAGE`, `CAN_EDIT`, `CAN_RUN`, `CAN_VIEW`.
+  * `permission` - Permission to grant on Genie Space. Supported permissions are `CAN_MANAGE`, `CAN_EDIT`, `CAN_RUN`, `CAN_VIEW`.
   * `space_id` - The unique ID of Genie Space.
+* `app` attribute - reference to another Databricks App.
+  * `name` - The name of the app to grant permission on.
+  * `permission` - Permission to grant on the app. Supported permissions are: `CAN_USE`.
+* `experiment` attribute
+  * `experiment_id` - The ID of the MLflow experiment to grant permission on.
+  * `permission` - Permission to grant on the experiment. Supported permissions are: `CAN_READ`, `CAN_EDIT`, `CAN_MANAGE`.
 
 ## Related Resources
 

--- a/docs/data-sources/apps.md
+++ b/docs/data-sources/apps.md
@@ -20,6 +20,7 @@ data "databricks_apps" "all_apps" {}
 The following attributes are exported:
 
 * `apps` - A list of [databricks_app](../resources/app.md) resources.
+  * `id` - The unique identifier of the app.
   * `name` - The name of the app.
   * `description` - The description of the app.
   * `resources` - A list of resources that the app have access to.
@@ -29,7 +30,7 @@ The following attributes are exported:
   * `app_status` attribute
     * `state` - State of the application.
     * `message` - Application status message
-  * `compute_size` - (Optional) A string specifying compute size for the App.
+  * `compute_size` - A string specifying compute size for the App.
   * `url` - The URL of the app once it is deployed.
   * `create_time` - The creation time of the app.
   * `creator` - The email of the user that created the app.
@@ -41,7 +42,35 @@ The following attributes are exported:
   * `default_source_code_path` - The default workspace file system path of the source code from which app deployment are created. This field tracks the workspace source code path of the last active deployment.
   * `budget_policy_id` - The Budget Policy ID set for this resource.
   * `effective_budget_policy_id` - The effective budget policy ID.
+  * `usage_policy_id` - The Usage Policy ID set for this resource.
+  * `effective_usage_policy_id` - The effective usage policy ID.
+  * `user_api_scopes` - A list of api scopes granted to the user access token.
   * `effective_user_api_scopes` - A list of effective api scopes granted to the user access token.
+  * `oauth2_app_client_id` - The OAuth2 client ID of the app's integration, set when the app uses user authorization.
+  * `oauth2_app_integration_id` - The unique ID of the OAuth2 integration associated with the app.
+  * `thumbnail_url` - The URL of the thumbnail image for the app.
+  * `space` - Name of the [app space](app_space.md) this app belongs to.
+  * `git_repository` attribute - Git repository configuration for app deployments.
+    * `url` - URL of the Git repository.
+    * `provider` - Git provider (case insensitive). Supported values: `gitHub`, `gitHubEnterprise`, `bitbucketCloud`, `bitbucketServer`, `azureDevOpsServices`, `gitLab`, `gitLabEnterpriseEdition`, `awsCodeCommit`.
+  * `telemetry_export_destinations` - A list of telemetry export destinations.
+    * `unity_catalog` attribute
+      * `logs_table` - Full name of the Unity Catalog table for OpenTelemetry logs.
+      * `metrics_table` - Full name of the Unity Catalog table for OpenTelemetry metrics.
+      * `traces_table` - Full name of the Unity Catalog table for OpenTelemetry traces (spans).
+  * `active_deployment` attribute - the active deployment of the app.
+    * `deployment_id` - The unique ID of the deployment.
+    * `source_code_path` - The workspace file system path of the source code used to create the deployment.
+    * `mode` - The deployment mode (`AUTO_SYNC` or `SNAPSHOT`).
+    * `create_time` - The creation time of the deployment.
+    * `creator` - The email of the user that created the deployment.
+    * `update_time` - The update time of the deployment.
+    * `status` attribute
+      * `state` - The state of the deployment.
+      * `message` - The status message of the deployment.
+    * `deployment_artifacts` attribute
+      * `source_code_path` - The snapshotted workspace file system path of the source code loaded by the deployed app.
+  * `pending_deployment` attribute - the pending deployment of the app. Schema is identical to `active_deployment`.
 
 ### resources Attribute
 
@@ -65,18 +94,28 @@ Exactly one of the following attributes will be provided:
 * `job` attribute
   * `id` - Id of the job to grant permission on.
   * `permission` - Permissions to grant on the Job. Supported permissions are: `CAN_MANAGE`, `IS_OWNER`, `CAN_MANAGE_RUN`, `CAN_VIEW`.
-* `uc_securable` attribute
-  * `securable_type` - the type of UC securable, i.e. `VOLUME`.
-  * `securable_full_name` - the full name of UC securable, i.e. `my-catalog.my-schema.my-volume`.
-  * `permission` - Permissions to grant on UC securable, i.e. `READ_VOLUME`, `WRITE_VOLUME`.
+* `uc_securable` attribute (see the [API docs](https://docs.databricks.com/api/workspace/apps/create#resources-uc_securable) for full list of supported UC objects)
+  * `securable_type` - The type of UC securable. Supported values are `CONNECTION`, `FUNCTION`, `TABLE`, `VOLUME`.
+  * `securable_full_name` - The full name of UC securable, i.e. `my-catalog.my-schema.my-volume`.
+  * `permission` - Permission to grant on UC securable. Supported values depend on `securable_type`: `READ_VOLUME` and `WRITE_VOLUME` for `VOLUME`, `SELECT` and `MODIFY` for `TABLE`, `EXECUTE` for `FUNCTION`, `USE_CONNECTION` for `CONNECTION`.
 * `database` attribute
   * `database_name` - The name of database.
   * `instance_name` - The name of database instance.
   * `permission` - Permission to grant on database. Supported permissions are: `CAN_CONNECT_AND_CREATE`.
+* `postgres` attribute
+  * `branch` - The resource path of the Lakebase Autoscaling branch (e.g. `projects/proj-abc123/branches/branch-xyz789`).
+  * `database` - The resource path of a specific database within the branch (e.g. `projects/proj-abc123/branches/branch-xyz789/databases/db-456`).
+  * `permission` - Permission to grant on the Lakebase Autoscaling branch or database. Supported permissions are: `CAN_CONNECT_AND_CREATE`.
 * `genie_space` attribute
   * `name` - The name of Genie Space.
-  * ``permission` - Permission to grant on Genie Space. Supported permissions are `CAN_MANAGE`, `CAN_EDIT`, `CAN_RUN`, `CAN_VIEW`.
+  * `permission` - Permission to grant on Genie Space. Supported permissions are `CAN_MANAGE`, `CAN_EDIT`, `CAN_RUN`, `CAN_VIEW`.
   * `space_id` - The unique ID of Genie Space.
+* `app` attribute - reference to another Databricks App.
+  * `name` - The name of the app to grant permission on.
+  * `permission` - Permission to grant on the app. Supported permissions are: `CAN_USE`.
+* `experiment` attribute
+  * `experiment_id` - The ID of the MLflow experiment to grant permission on.
+  * `permission` - Permission to grant on the experiment. Supported permissions are: `CAN_READ`, `CAN_EDIT`, `CAN_MANAGE`.
 
 ## Related Resources
 

--- a/docs/resources/app.md
+++ b/docs/resources/app.md
@@ -47,7 +47,7 @@ The following arguments are required:
 * `budget_policy_id` - (Optional) The Budget Policy ID set for this resource.
 * `usage_policy_id` - (Optional) The Usage Policy ID set for this resource.
 * `resources` - (Optional) A list of resources that the app have access to.
-* `user_api_scopes` - (Optional) A list of api scopes granted to the user access token.
+* `user_api_scopes` - (Optional) A list of api scopes granted to the user access token.  See [REST API docs](https://docs.databricks.com/api/workspace/api/scopes) for full list of supported scopes.
 * `compute_size` - (Optional) A string specifying compute size for the App. Possible values are `MEDIUM`, `LARGE`.
 * `git_repository` - (Optional) Git repository configuration for app deployments (see [below](#git_repository-configuration-attribute)). When specified, deployments can reference code from this repository by providing only the git reference (branch, tag, or commit).
 * `telemetry_export_destinations` - (Optional) A list of destinations to which the app's telemetry (logs, metrics, traces) is exported (see [below](#telemetry_export_destinations-configuration-attribute)).

--- a/docs/resources/app.md
+++ b/docs/resources/app.md
@@ -79,6 +79,10 @@ Exactly one of the following attributes must be provided:
   * `database_name` - The name of database.
   * `instance_name` - The name of database instance.
   * `permission` - Permission to grant on database. Supported permissions are: `CAN_CONNECT_AND_CREATE`.
+* `postgres` attribute
+  * `branch` - The resource path of the Lakebase Autoscaling branch to grant permission on (e.g. `projects/proj-abc123/branches/branch-xyz789`).
+  * `database` - (Optional) The resource path of a specific database within the branch to grant permission on (e.g. `projects/proj-abc123/branches/branch-xyz789/databases/db-456`). If omitted, permission applies to the branch.
+  * `permission` - Permission to grant on the Lakebase Autoscaling branch or database. Supported permissions are: `CAN_CONNECT_AND_CREATE`.
 * `genie_space` attribute
   * `name` - The name of Genie Space.
   * ``permission` - Permission to grant on Genie Space. Supported permissions are `CAN_MANAGE`, `CAN_EDIT`, `CAN_RUN`, `CAN_VIEW`.

--- a/docs/resources/app.md
+++ b/docs/resources/app.md
@@ -45,9 +45,12 @@ The following arguments are required:
 * `name` - (Required) The name of the app. The name must contain only lowercase alphanumeric characters and hyphens. It must be unique within the workspace.
 * `description` - (Optional) The description of the app.
 * `budget_policy_id` - (Optional) The Budget Policy ID set for this resource.
+* `usage_policy_id` - (Optional) The Usage Policy ID set for this resource.
 * `resources` - (Optional) A list of resources that the app have access to.
 * `user_api_scopes` - (Optional) A list of api scopes granted to the user access token.
 * `compute_size` - (Optional) A string specifying compute size for the App. Possible values are `MEDIUM`, `LARGE`.
+* `git_repository` - (Optional) Git repository configuration for app deployments (see [below](#git_repository-configuration-attribute)). When specified, deployments can reference code from this repository by providing only the git reference (branch, tag, or commit).
+* `telemetry_export_destinations` - (Optional) A list of destinations to which the app's telemetry (logs, metrics, traces) is exported (see [below](#telemetry_export_destinations-configuration-attribute)).
 
 ### resources Configuration Attribute
 
@@ -72,9 +75,9 @@ Exactly one of the following attributes must be provided:
   * `id` - Id of the job to grant permission on.
   * `permission` - Permissions to grant on the Job. Supported permissions are: `CAN_MANAGE`, `IS_OWNER`, `CAN_MANAGE_RUN`, `CAN_VIEW`.
 * `uc_securable` attribute (see the [API docs](https://docs.databricks.com/api/workspace/apps/create#resources-uc_securable) for full list of supported UC objects)
-  * `securable_type` - the type of UC securable, i.e. `VOLUME`.
-  * `securable_full_name` - the full name of UC securable, i.e. `my-catalog.my-schema.my-volume`.
-  * `permission` - Permissions to grant on UC securable, i.e. `READ_VOLUME`, `WRITE_VOLUME`.
+  * `securable_type` - The type of UC securable. Supported values are `CONNECTION`, `FUNCTION`, `TABLE`, `VOLUME`.
+  * `securable_full_name` - The full name of UC securable, i.e. `my-catalog.my-schema.my-volume`.
+  * `permission` - Permission to grant on UC securable. Supported values depend on `securable_type`: `READ_VOLUME` and `WRITE_VOLUME` for `VOLUME`, `SELECT` and `MODIFY` for `TABLE`, `EXECUTE` for `FUNCTION`, `USE_CONNECTION` for `CONNECTION`.
 * `database` attribute
   * `database_name` - The name of database.
   * `instance_name` - The name of database instance.
@@ -85,13 +88,36 @@ Exactly one of the following attributes must be provided:
   * `permission` - Permission to grant on the Lakebase Autoscaling branch or database. Supported permissions are: `CAN_CONNECT_AND_CREATE`.
 * `genie_space` attribute
   * `name` - The name of Genie Space.
-  * ``permission` - Permission to grant on Genie Space. Supported permissions are `CAN_MANAGE`, `CAN_EDIT`, `CAN_RUN`, `CAN_VIEW`.
+  * `permission` - Permission to grant on Genie Space. Supported permissions are `CAN_MANAGE`, `CAN_EDIT`, `CAN_RUN`, `CAN_VIEW`.
   * `space_id` - The unique ID of Genie Space.
+* `app` attribute - reference to another Databricks App.
+  * `name` - The name of the app to grant permission on.
+  * `permission` - Permission to grant on the app. Supported permissions are: `CAN_USE`.
+* `experiment` attribute
+  * `experiment_id` - The ID of the MLflow experiment to grant permission on.
+  * `permission` - Permission to grant on the experiment. Supported permissions are: `CAN_READ`, `CAN_EDIT`, `CAN_MANAGE`.
+
+### git_repository Configuration Attribute
+
+This block configures a Git repository associated with the app, allowing deployments to reference code from this repository:
+
+* `url` - (Required) URL of the Git repository.
+* `provider` - (Required) Git provider. Case insensitive. Supported values: `gitHub`, `gitHubEnterprise`, `bitbucketCloud`, `bitbucketServer`, `azureDevOpsServices`, `gitLab`, `gitLabEnterpriseEdition`, `awsCodeCommit`.
+
+### telemetry_export_destinations Configuration Attribute
+
+Each item describes a single destination to which the app's telemetry (logs, metrics, traces) is exported. Exactly one of the following nested blocks must be provided per destination:
+
+* `unity_catalog` attribute - export telemetry to Unity Catalog tables (must already exist and be writable by the app's service principal).
+  * `logs_table` - (Required) Full name of the Unity Catalog table for OpenTelemetry logs.
+  * `metrics_table` - (Required) Full name of the Unity Catalog table for OpenTelemetry metrics.
+  * `traces_table` - (Required) Full name of the Unity Catalog table for OpenTelemetry traces (spans).
 
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
 
+* `id` - The unique identifier of the app.
 * `compute_status` attribute
   * `state` - State of the app compute.
   * `message` - Compute status message
@@ -108,7 +134,24 @@ In addition to all arguments above, the following attributes are exported:
 * `service_principal_name` - name of the app service principal
 * `default_source_code_path` - The default workspace file system path of the source code from which app deployment are created. This field tracks the workspace source code path of the last active deployment.
 * `effective_budget_policy_id` - The effective budget policy ID.
+* `effective_usage_policy_id` - The effective usage policy ID.
 * `effective_user_api_scopes` - A list of effective api scopes granted to the user access token.
+* `oauth2_app_client_id` - The OAuth2 client ID of the app's integration, set when the app uses user authorization.
+* `oauth2_app_integration_id` - The unique ID of the OAuth2 integration associated with the app.
+* `thumbnail_url` - The URL of the thumbnail image for the app.
+* `active_deployment` attribute - the active deployment of the app. A deployment is considered active when it has been deployed to the app compute.
+  * `deployment_id` - The unique ID of the deployment.
+  * `source_code_path` - The workspace file system path of the source code used to create the deployment.
+  * `mode` - The deployment mode (`AUTO_SYNC` or `SNAPSHOT`).
+  * `create_time` - The creation time of the deployment.
+  * `creator` - The email of the user that created the deployment.
+  * `update_time` - The update time of the deployment.
+  * `status` attribute
+    * `state` - The state of the deployment.
+    * `message` - The status message of the deployment.
+  * `deployment_artifacts` attribute
+    * `source_code_path` - The snapshotted workspace file system path of the source code loaded by the deployed app.
+* `pending_deployment` attribute - the pending deployment of the app. A deployment is considered pending when it is being prepared for deployment to the app compute. Schema is identical to `active_deployment`.
 
 ## Import
 


### PR DESCRIPTION
## Summary

As `databricks_app` was written manually, it documentation should be also updated manually when API adds new fields.

The `AppResourcePostgres` type has been GA in the Apps API since the proto was promoted, but the `postgres` block was missing from the `### resources Configuration Attribute` section of the `databricks_app` docs. Every other resource type (secret, sql_warehouse, serving_endpoint, job, uc_securable, database, genie_space) was listed — `postgres` was silently omitted.



The Go implementation (`internal/service/apps_tf/model.go`) already supports all three fields (`branch`, `database`, `permission`). This is a docs-only change.

## Changes

- `docs/resources/app.md`: adds the `postgres` attribute block documenting `branch`, `database`, and `permission` fields and the single supported permission value `CAN_CONNECT_AND_CREATE`.
- add documentation for `app` and `experiment` resources.
- add new fields for telemetry push and Git repository configuration

## Notes

Lakebase Autoscaling (postgres) resources can be referenced from a Databricks App today — customers just had no documentation to follow.

NO_CHANGELOG=true

This pull request was prepared by Anna Stepanyan (anna.stepanyan@databricks.com).