### PR TITLE
[Doc] Fix `azure_private_endpoint_info` syntax in `databricks_endpoint` example

### DIFF
--- a/docs/resources/endpoint.md
+++ b/docs/resources/endpoint.md
@@ -20,7 +20,7 @@ resource "databricks_endpoint" "this" {
   parent       = "accounts/123e4567-e89b-12d3-a456-426614174000"
   display_name = "my-private-endpoint"
   region       = "westus"
-  azure_private_endpoint_info {
+  azure_private_endpoint_info = {
     private_endpoint_name          = "my-pe"
     private_endpoint_resource_guid = "12345678-1234-1234-1234-123456789abc"
   }


### PR DESCRIPTION
## Changes

The HCL example for `databricks_endpoint` used block syntax for `azure_private_endpoint_info`:

```hcl
azure_private_endpoint_info {
  ...
}
```

`azure_private_endpoint_info` is declared as a `SingleNestedAttribute` in the Plugin Framework schema (`internal/service/networking_tf/model.go`), so the correct HCL is the attribute-assignment form:

```hcl
azure_private_endpoint_info = {
  ...
}
```

Reported by a customer.

## Tests

- [ ] Doc-only change; no code paths affected.