### PR TITLE
[Internal] Skip workspace-settings acceptance tests on GCP due to API eventual consistency

### DIFF
--- a/internal/acceptance/aibi_embedding_settings_test.go
+++ b/internal/acceptance/aibi_embedding_settings_test.go
@@ -5,8 +5,9 @@ import (
 )
 
 func TestAccAiBiEmbeddings(t *testing.T) {
+	// TODO: Enable once API is fixed.
 	if IsGcp(t) {
-		t.Skip("Skipping on GCP")
+		t.Skip("Skipping on GCP. The API is eventually consistent so Get after Update may return stale values.")
 	}
 	WorkspaceLevel(t, Step{
 		Template: `

--- a/internal/acceptance/aibi_embedding_settings_test.go
+++ b/internal/acceptance/aibi_embedding_settings_test.go
@@ -6,10 +6,7 @@ import (
 
 func TestAccAiBiEmbeddings(t *testing.T) {
 	if IsGcp(t) {
-		t.Skip("Skipping on GCP: workspace-settings estore ramp-up introduces " +
-			"~2min eventual-consistency staleness, so GET-after-PATCH returns the " +
-			"stale prior value and the post-apply refresh plan is non-empty. " +
-			"Re-enable once estore staleness is reduced.")
+		t.Skip("Skipping on GCP")
 	}
 	WorkspaceLevel(t, Step{
 		Template: `

--- a/internal/acceptance/aibi_embedding_settings_test.go
+++ b/internal/acceptance/aibi_embedding_settings_test.go
@@ -5,6 +5,12 @@ import (
 )
 
 func TestAccAiBiEmbeddings(t *testing.T) {
+	if IsGcp(t) {
+		t.Skip("Skipping on GCP: workspace-settings estore ramp-up introduces " +
+			"~2min eventual-consistency staleness, so GET-after-PATCH returns the " +
+			"stale prior value and the post-apply refresh plan is non-empty. " +
+			"Re-enable once estore staleness is reduced.")
+	}
 	WorkspaceLevel(t, Step{
 		Template: `
 resource "databricks_aibi_dashboard_embedding_access_policy_setting" "this" {

--- a/settings/disable_legacy_access_setting_test.go
+++ b/settings/disable_legacy_access_setting_test.go
@@ -13,6 +13,10 @@ import (
 )
 
 func TestAccDisableLegacyAccessSetting(t *testing.T) {
+	// TODO: Enable once API is fixed.
+	if acceptance.IsGcp(t) {
+		t.Skip("Skipping on GCP. The API is eventually consistent so Get after Update may return stale values.")
+	}
 	template := `
  	resource "databricks_disable_legacy_access_setting" "this" {
  		disable_legacy_access {
@@ -34,9 +38,7 @@ func TestAccDisableLegacyAccessSetting(t *testing.T) {
 				})
 				require.NoError(t, err)
 				// Check that the resource has been created and that it has the correct value.
-				if !acceptance.IsGcp(t) {
-					assert.True(t, res.DisableLegacyAccess.Value)
-				}
+				assert.True(t, res.DisableLegacyAccess.Value)
 				return nil
 			}),
 	},
@@ -65,9 +67,7 @@ func TestAccDisableLegacyAccessSetting(t *testing.T) {
 				// we should not be getting any error
 				assert.NoError(t, err)
 				// setting should go back to default
-				if !acceptance.IsGcp(t) {
-					assert.False(t, res.DisableLegacyAccess.Value)
-				}
+				assert.False(t, res.DisableLegacyAccess.Value)
 				return nil
 			}),
 		},

--- a/settings/disable_legacy_access_setting_test.go
+++ b/settings/disable_legacy_access_setting_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/databricks/terraform-provider-databricks/internal/acceptance"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -24,17 +23,10 @@ func TestAccDisableLegacyAccessSetting(t *testing.T) {
 		Template: template,
 		Check: acceptance.ResourceCheckWithState("databricks_disable_legacy_access_setting.this",
 			func(ctx context.Context, client *common.DatabricksClient, state *terraform.InstanceState) error {
-				ctx = context.WithValue(ctx, common.Api, common.API_2_1)
-				w, err := client.WorkspaceClient()
-				require.NoError(t, err)
 				etag := state.Attributes["etag"]
 				require.NotEmpty(t, etag)
-				res, err := w.Settings.DisableLegacyAccess().Get(ctx, settings.GetDisableLegacyAccessRequest{
-					Etag: etag,
-				})
-				require.NoError(t, err)
-				// Check that the resource has been created and that it has the correct value.
-				assert.True(t, res.DisableLegacyAccess.Value)
+				// TODO: re-enable value assertion once workspace-settings estore staleness
+				// (up to ~2min) is reduced. GET after PATCH may return stale value.
 				return nil
 			}),
 	},
@@ -45,9 +37,8 @@ func TestAccDisableLegacyAccessSetting(t *testing.T) {
 				ctx = context.WithValue(ctx, common.Api, common.API_2_1)
 				w, err := client.WorkspaceClient()
 				require.NoError(t, err)
-				// Terraform Check returns the latest resource status before it is destroyed, which has an outdated eTag.
-				// We are making an update call to get the current eTag in the response.
-				updateResp, err := w.Settings.DisableLegacyAccess().Update(ctx, settings.UpdateDisableLegacyAccessRequest{
+				// Reset the setting to its default so the workspace is left clean for the next run.
+				_, err = w.Settings.DisableLegacyAccess().Update(ctx, settings.UpdateDisableLegacyAccessRequest{
 					AllowMissing: true,
 					Setting: settings.DisableLegacyAccess{
 						DisableLegacyAccess: settings.BooleanMessage{
@@ -57,13 +48,8 @@ func TestAccDisableLegacyAccessSetting(t *testing.T) {
 					FieldMask: "disable_legacy_access.value",
 				})
 				require.NoError(t, err)
-				res, err := w.Settings.DisableLegacyAccess().Get(ctx, settings.GetDisableLegacyAccessRequest{
-					Etag: updateResp.Etag,
-				})
-				// we should not be getting any error
-				assert.NoError(t, err)
-				// setting should go back to default
-				assert.False(t, res.DisableLegacyAccess.Value)
+				// TODO: re-enable post-reset value assertion once workspace-settings
+				// estore staleness (up to ~2min) is reduced.
 				return nil
 			}),
 		},

--- a/settings/disable_legacy_access_setting_test.go
+++ b/settings/disable_legacy_access_setting_test.go
@@ -34,8 +34,6 @@ func TestAccDisableLegacyAccessSetting(t *testing.T) {
 				})
 				require.NoError(t, err)
 				// Check that the resource has been created and that it has the correct value.
-				// TODO: re-enable on GCP once workspace-settings estore staleness (~2min)
-				// is reduced — GET-after-PATCH may return the stale prior value there.
 				if !acceptance.IsGcp(t) {
 					assert.True(t, res.DisableLegacyAccess.Value)
 				}
@@ -67,7 +65,6 @@ func TestAccDisableLegacyAccessSetting(t *testing.T) {
 				// we should not be getting any error
 				assert.NoError(t, err)
 				// setting should go back to default
-				// TODO: re-enable on GCP once workspace-settings estore staleness (~2min) is reduced.
 				if !acceptance.IsGcp(t) {
 					assert.False(t, res.DisableLegacyAccess.Value)
 				}

--- a/settings/disable_legacy_access_setting_test.go
+++ b/settings/disable_legacy_access_setting_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/databricks/terraform-provider-databricks/internal/acceptance"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -23,10 +24,21 @@ func TestAccDisableLegacyAccessSetting(t *testing.T) {
 		Template: template,
 		Check: acceptance.ResourceCheckWithState("databricks_disable_legacy_access_setting.this",
 			func(ctx context.Context, client *common.DatabricksClient, state *terraform.InstanceState) error {
+				ctx = context.WithValue(ctx, common.Api, common.API_2_1)
+				w, err := client.WorkspaceClient()
+				require.NoError(t, err)
 				etag := state.Attributes["etag"]
 				require.NotEmpty(t, etag)
-				// TODO: re-enable value assertion once workspace-settings estore staleness
-				// (up to ~2min) is reduced. GET after PATCH may return stale value.
+				res, err := w.Settings.DisableLegacyAccess().Get(ctx, settings.GetDisableLegacyAccessRequest{
+					Etag: etag,
+				})
+				require.NoError(t, err)
+				// Check that the resource has been created and that it has the correct value.
+				// TODO: re-enable on GCP once workspace-settings estore staleness (~2min)
+				// is reduced — GET-after-PATCH may return the stale prior value there.
+				if !acceptance.IsGcp(t) {
+					assert.True(t, res.DisableLegacyAccess.Value)
+				}
 				return nil
 			}),
 	},
@@ -37,8 +49,9 @@ func TestAccDisableLegacyAccessSetting(t *testing.T) {
 				ctx = context.WithValue(ctx, common.Api, common.API_2_1)
 				w, err := client.WorkspaceClient()
 				require.NoError(t, err)
-				// Reset the setting to its default so the workspace is left clean for the next run.
-				_, err = w.Settings.DisableLegacyAccess().Update(ctx, settings.UpdateDisableLegacyAccessRequest{
+				// Terraform Check returns the latest resource status before it is destroyed, which has an outdated eTag.
+				// We are making an update call to get the current eTag in the response.
+				updateResp, err := w.Settings.DisableLegacyAccess().Update(ctx, settings.UpdateDisableLegacyAccessRequest{
 					AllowMissing: true,
 					Setting: settings.DisableLegacyAccess{
 						DisableLegacyAccess: settings.BooleanMessage{
@@ -48,8 +61,16 @@ func TestAccDisableLegacyAccessSetting(t *testing.T) {
 					FieldMask: "disable_legacy_access.value",
 				})
 				require.NoError(t, err)
-				// TODO: re-enable post-reset value assertion once workspace-settings
-				// estore staleness (up to ~2min) is reduced.
+				res, err := w.Settings.DisableLegacyAccess().Get(ctx, settings.GetDisableLegacyAccessRequest{
+					Etag: updateResp.Etag,
+				})
+				// we should not be getting any error
+				assert.NoError(t, err)
+				// setting should go back to default
+				// TODO: re-enable on GCP once workspace-settings estore staleness (~2min) is reduced.
+				if !acceptance.IsGcp(t) {
+					assert.False(t, res.DisableLegacyAccess.Value)
+				}
 				return nil
 			}),
 		},

--- a/settings/disable_legacy_dbfs_setting_test.go
+++ b/settings/disable_legacy_dbfs_setting_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/databricks/terraform-provider-databricks/internal/acceptance"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -24,17 +23,10 @@ func TestAccDisableLegacyDbfsSetting(t *testing.T) {
 		Template: template,
 		Check: acceptance.ResourceCheckWithState("databricks_disable_legacy_dbfs_setting.this",
 			func(ctx context.Context, client *common.DatabricksClient, state *terraform.InstanceState) error {
-				ctx = context.WithValue(ctx, common.Api, common.API_2_1)
-				w, err := client.WorkspaceClient()
-				require.NoError(t, err)
 				etag := state.Attributes["etag"]
 				require.NotEmpty(t, etag)
-				res, err := w.Settings.DisableLegacyDbfs().Get(ctx, settings.GetDisableLegacyDbfsRequest{
-					Etag: etag,
-				})
-				require.NoError(t, err)
-				// Check that the resource has been created and that it has the correct value.
-				assert.Equal(t, res.DisableLegacyDbfs.Value, true)
+				// TODO: re-enable value assertion once workspace-settings estore staleness
+				// (up to ~2min) is reduced. GET after PATCH may return stale value.
 				return nil
 			}),
 	},
@@ -45,9 +37,8 @@ func TestAccDisableLegacyDbfsSetting(t *testing.T) {
 				ctx = context.WithValue(ctx, common.Api, common.API_2_1)
 				w, err := client.WorkspaceClient()
 				require.NoError(t, err)
-				// Terraform Check returns the latest resource status before it is destroyed, which has an outdated eTag.
-				// We are making an update call to get the current eTag in the response.
-				updateResp, err := w.Settings.DisableLegacyDbfs().Update(ctx, settings.UpdateDisableLegacyDbfsRequest{
+				// Reset the setting to its default so the workspace is left clean for the next run.
+				_, err = w.Settings.DisableLegacyDbfs().Update(ctx, settings.UpdateDisableLegacyDbfsRequest{
 					AllowMissing: true,
 					Setting: settings.DisableLegacyDbfs{
 						DisableLegacyDbfs: settings.BooleanMessage{
@@ -57,13 +48,8 @@ func TestAccDisableLegacyDbfsSetting(t *testing.T) {
 					FieldMask: "disable_legacy_dbfs.value",
 				})
 				require.NoError(t, err)
-				res, err := w.Settings.DisableLegacyDbfs().Get(ctx, settings.GetDisableLegacyDbfsRequest{
-					Etag: updateResp.Etag,
-				})
-				// we should not be getting any error
-				assert.NoError(t, err)
-				// setting should go back to default
-				assert.Equal(t, res.DisableLegacyDbfs.Value, false)
+				// TODO: re-enable post-reset value assertion once workspace-settings
+				// estore staleness (up to ~2min) is reduced.
 				return nil
 			}),
 		},

--- a/settings/disable_legacy_dbfs_setting_test.go
+++ b/settings/disable_legacy_dbfs_setting_test.go
@@ -13,6 +13,10 @@ import (
 )
 
 func TestAccDisableLegacyDbfsSetting(t *testing.T) {
+	// TODO: Enable once API is fixed.
+	if acceptance.IsGcp(t) {
+		t.Skip("Skipping on GCP. The API is eventually consistent so Get after Update may return stale values.")
+	}
 	template := `
  	resource "databricks_disable_legacy_dbfs_setting" "this" {
  		disable_legacy_dbfs {
@@ -34,9 +38,7 @@ func TestAccDisableLegacyDbfsSetting(t *testing.T) {
 				})
 				require.NoError(t, err)
 				// Check that the resource has been created and that it has the correct value.
-				if !acceptance.IsGcp(t) {
-					assert.Equal(t, res.DisableLegacyDbfs.Value, true)
-				}
+				assert.Equal(t, res.DisableLegacyDbfs.Value, true)
 				return nil
 			}),
 	},
@@ -65,9 +67,7 @@ func TestAccDisableLegacyDbfsSetting(t *testing.T) {
 				// we should not be getting any error
 				assert.NoError(t, err)
 				// setting should go back to default
-				if !acceptance.IsGcp(t) {
-					assert.Equal(t, res.DisableLegacyDbfs.Value, false)
-				}
+				assert.Equal(t, res.DisableLegacyDbfs.Value, false)
 				return nil
 			}),
 		},

--- a/settings/disable_legacy_dbfs_setting_test.go
+++ b/settings/disable_legacy_dbfs_setting_test.go
@@ -34,8 +34,6 @@ func TestAccDisableLegacyDbfsSetting(t *testing.T) {
 				})
 				require.NoError(t, err)
 				// Check that the resource has been created and that it has the correct value.
-				// TODO: re-enable on GCP once workspace-settings estore staleness (~2min)
-				// is reduced — GET-after-PATCH may return the stale prior value there.
 				if !acceptance.IsGcp(t) {
 					assert.Equal(t, res.DisableLegacyDbfs.Value, true)
 				}
@@ -67,7 +65,6 @@ func TestAccDisableLegacyDbfsSetting(t *testing.T) {
 				// we should not be getting any error
 				assert.NoError(t, err)
 				// setting should go back to default
-				// TODO: re-enable on GCP once workspace-settings estore staleness (~2min) is reduced.
 				if !acceptance.IsGcp(t) {
 					assert.Equal(t, res.DisableLegacyDbfs.Value, false)
 				}

--- a/settings/disable_legacy_dbfs_setting_test.go
+++ b/settings/disable_legacy_dbfs_setting_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/databricks/terraform-provider-databricks/internal/acceptance"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -23,10 +24,21 @@ func TestAccDisableLegacyDbfsSetting(t *testing.T) {
 		Template: template,
 		Check: acceptance.ResourceCheckWithState("databricks_disable_legacy_dbfs_setting.this",
 			func(ctx context.Context, client *common.DatabricksClient, state *terraform.InstanceState) error {
+				ctx = context.WithValue(ctx, common.Api, common.API_2_1)
+				w, err := client.WorkspaceClient()
+				require.NoError(t, err)
 				etag := state.Attributes["etag"]
 				require.NotEmpty(t, etag)
-				// TODO: re-enable value assertion once workspace-settings estore staleness
-				// (up to ~2min) is reduced. GET after PATCH may return stale value.
+				res, err := w.Settings.DisableLegacyDbfs().Get(ctx, settings.GetDisableLegacyDbfsRequest{
+					Etag: etag,
+				})
+				require.NoError(t, err)
+				// Check that the resource has been created and that it has the correct value.
+				// TODO: re-enable on GCP once workspace-settings estore staleness (~2min)
+				// is reduced — GET-after-PATCH may return the stale prior value there.
+				if !acceptance.IsGcp(t) {
+					assert.Equal(t, res.DisableLegacyDbfs.Value, true)
+				}
 				return nil
 			}),
 	},
@@ -37,8 +49,9 @@ func TestAccDisableLegacyDbfsSetting(t *testing.T) {
 				ctx = context.WithValue(ctx, common.Api, common.API_2_1)
 				w, err := client.WorkspaceClient()
 				require.NoError(t, err)
-				// Reset the setting to its default so the workspace is left clean for the next run.
-				_, err = w.Settings.DisableLegacyDbfs().Update(ctx, settings.UpdateDisableLegacyDbfsRequest{
+				// Terraform Check returns the latest resource status before it is destroyed, which has an outdated eTag.
+				// We are making an update call to get the current eTag in the response.
+				updateResp, err := w.Settings.DisableLegacyDbfs().Update(ctx, settings.UpdateDisableLegacyDbfsRequest{
 					AllowMissing: true,
 					Setting: settings.DisableLegacyDbfs{
 						DisableLegacyDbfs: settings.BooleanMessage{
@@ -48,8 +61,16 @@ func TestAccDisableLegacyDbfsSetting(t *testing.T) {
 					FieldMask: "disable_legacy_dbfs.value",
 				})
 				require.NoError(t, err)
-				// TODO: re-enable post-reset value assertion once workspace-settings
-				// estore staleness (up to ~2min) is reduced.
+				res, err := w.Settings.DisableLegacyDbfs().Get(ctx, settings.GetDisableLegacyDbfsRequest{
+					Etag: updateResp.Etag,
+				})
+				// we should not be getting any error
+				assert.NoError(t, err)
+				// setting should go back to default
+				// TODO: re-enable on GCP once workspace-settings estore staleness (~2min) is reduced.
+				if !acceptance.IsGcp(t) {
+					assert.Equal(t, res.DisableLegacyDbfs.Value, false)
+				}
 				return nil
 			}),
 		},


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
The workspace-settings APIs on GCP are eventually consistent — a get issued shortly after an update may return the stale prior value. This causes three acceptance tests to fail intermittently on GCP. AWS and Azure are unaffected.

  Skip the affected tests on GCP with a top-level `t.Skip`, keeping the full original assertions on AWS/Azure:
  - `TestAccDisableLegacyDbfsSetting`
  - `TestAccDisableLegacyAccessSetting`
  - `TestAccAiBiEmbeddings`

  Each carries a `// TODO: Enable once API is fixed.` comment.

## Tests
<!--
How is this tested? Please see the checklist below and also describe any other relevant tests
-->
Tests passes

NO_CHANGELOG=true