### PR TITLE
[Internal] Skip flaky workspace-settings acceptance tests (until 2026-06-03)

### DIFF
--- a/internal/acceptance/aibi_embedding_settings_test.go
+++ b/internal/acceptance/aibi_embedding_settings_test.go
@@ -6,9 +6,8 @@ import (
 )
 
 func TestAccAiBiEmbeddings(t *testing.T) {
-	// Please see ES-1928456 for details.
 	if time.Now().Before(time.Date(2026, 6, 3, 0, 0, 0, 0, time.UTC)) {
-		t.Skip("temporarily skipped until 2026-06-03: workspace-settings API is eventually consistent so Get after Update may return stale values.")
+		t.Skip("temporarily skipped until 2026-06-03: workspace-settings API is eventually consistent so Get after Update may return stale values.") // Please see ES-1928456 for details.
 	}
 	WorkspaceLevel(t, Step{
 		Template: `

--- a/internal/acceptance/aibi_embedding_settings_test.go
+++ b/internal/acceptance/aibi_embedding_settings_test.go
@@ -6,8 +6,8 @@ import (
 
 func TestAccAiBiEmbeddings(t *testing.T) {
 	// TODO: Enable once API is fixed.
-	if IsGcp(t) {
-		t.Skip("Skipping on GCP. The API is eventually consistent so Get after Update may return stale values.")
+	if IsGcp(t) || IsAzure(t) {
+		t.Skip("Skipping on GCP/Azure. The API is eventually consistent so Get after Update may return stale values.")
 	}
 	WorkspaceLevel(t, Step{
 		Template: `

--- a/internal/acceptance/aibi_embedding_settings_test.go
+++ b/internal/acceptance/aibi_embedding_settings_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestAccAiBiEmbeddings(t *testing.T) {
 	if time.Now().Before(time.Date(2026, 6, 3, 0, 0, 0, 0, time.UTC)) {
-		t.Skip("temporarily skipped until 2026-06-03: workspace-settings API is eventually consistent so Get after Update may return stale values.") // Please see ES-1928456 for details.
+		t.Skip("temporarily skipped until 2026-06-03: workspace-settings API is eventually consistent so Get after Update may return stale values. Please see ES-1928456 for details.")
 	}
 	WorkspaceLevel(t, Step{
 		Template: `

--- a/internal/acceptance/aibi_embedding_settings_test.go
+++ b/internal/acceptance/aibi_embedding_settings_test.go
@@ -6,6 +6,7 @@ import (
 )
 
 func TestAccAiBiEmbeddings(t *testing.T) {
+	// Please see ES-1928456 for details.
 	if time.Now().Before(time.Date(2026, 6, 3, 0, 0, 0, 0, time.UTC)) {
 		t.Skip("temporarily skipped until 2026-06-03: workspace-settings API is eventually consistent so Get after Update may return stale values.")
 	}

--- a/internal/acceptance/aibi_embedding_settings_test.go
+++ b/internal/acceptance/aibi_embedding_settings_test.go
@@ -2,12 +2,13 @@ package acceptance
 
 import (
 	"testing"
+	"time"
 )
 
 func TestAccAiBiEmbeddings(t *testing.T) {
 	// TODO: Enable once API is fixed.
-	if IsGcp(t) || IsAzure(t) {
-		t.Skip("Skipping on GCP/Azure. The API is eventually consistent so Get after Update may return stale values.")
+	if time.Now().Before(time.Date(2026, 6, 3, 0, 0, 0, 0, time.UTC)) {
+		t.Skip("temporarily skipped until 2026-06-03: workspace-settings API is eventually consistent so Get after Update may return stale values.")
 	}
 	WorkspaceLevel(t, Step{
 		Template: `

--- a/internal/acceptance/aibi_embedding_settings_test.go
+++ b/internal/acceptance/aibi_embedding_settings_test.go
@@ -6,7 +6,6 @@ import (
 )
 
 func TestAccAiBiEmbeddings(t *testing.T) {
-	// TODO: Enable once API is fixed.
 	if time.Now().Before(time.Date(2026, 6, 3, 0, 0, 0, 0, time.UTC)) {
 		t.Skip("temporarily skipped until 2026-06-03: workspace-settings API is eventually consistent so Get after Update may return stale values.")
 	}

--- a/settings/disable_legacy_access_setting_test.go
+++ b/settings/disable_legacy_access_setting_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestAccDisableLegacyAccessSetting(t *testing.T) {
 	if time.Now().Before(time.Date(2026, 6, 3, 0, 0, 0, 0, time.UTC)) {
-		t.Skip("temporarily skipped until 2026-06-03: workspace-settings API is eventually consistent so Get after Update may return stale values.") // Please see ES-1928456 for details.
+		t.Skip("temporarily skipped until 2026-06-03: workspace-settings API is eventually consistent so Get after Update may return stale values. Please see ES-1928456 for details.")
 	}
 	template := `
  	resource "databricks_disable_legacy_access_setting" "this" {

--- a/settings/disable_legacy_access_setting_test.go
+++ b/settings/disable_legacy_access_setting_test.go
@@ -14,9 +14,8 @@ import (
 )
 
 func TestAccDisableLegacyAccessSetting(t *testing.T) {
-	// Please see ES-1928456 for details.
 	if time.Now().Before(time.Date(2026, 6, 3, 0, 0, 0, 0, time.UTC)) {
-		t.Skip("temporarily skipped until 2026-06-03: workspace-settings API is eventually consistent so Get after Update may return stale values.")
+		t.Skip("temporarily skipped until 2026-06-03: workspace-settings API is eventually consistent so Get after Update may return stale values.") // Please see ES-1928456 for details.
 	}
 	template := `
  	resource "databricks_disable_legacy_access_setting" "this" {

--- a/settings/disable_legacy_access_setting_test.go
+++ b/settings/disable_legacy_access_setting_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestAccDisableLegacyAccessSetting(t *testing.T) {
+	// Please see ES-1928456 for details.
 	if time.Now().Before(time.Date(2026, 6, 3, 0, 0, 0, 0, time.UTC)) {
 		t.Skip("temporarily skipped until 2026-06-03: workspace-settings API is eventually consistent so Get after Update may return stale values.")
 	}

--- a/settings/disable_legacy_access_setting_test.go
+++ b/settings/disable_legacy_access_setting_test.go
@@ -3,6 +3,7 @@ package settings_test
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/databricks/databricks-sdk-go/service/settings"
 	"github.com/databricks/terraform-provider-databricks/common"
@@ -14,8 +15,8 @@ import (
 
 func TestAccDisableLegacyAccessSetting(t *testing.T) {
 	// TODO: Enable once API is fixed.
-	if acceptance.IsGcp(t) || acceptance.IsAzure(t) {
-		t.Skip("Skipping on GCP/Azure. The API is eventually consistent so Get after Update may return stale values.")
+	if time.Now().Before(time.Date(2026, 6, 3, 0, 0, 0, 0, time.UTC)) {
+		t.Skip("temporarily skipped until 2026-06-03: workspace-settings API is eventually consistent so Get after Update may return stale values.")
 	}
 	template := `
  	resource "databricks_disable_legacy_access_setting" "this" {

--- a/settings/disable_legacy_access_setting_test.go
+++ b/settings/disable_legacy_access_setting_test.go
@@ -14,7 +14,6 @@ import (
 )
 
 func TestAccDisableLegacyAccessSetting(t *testing.T) {
-	// TODO: Enable once API is fixed.
 	if time.Now().Before(time.Date(2026, 6, 3, 0, 0, 0, 0, time.UTC)) {
 		t.Skip("temporarily skipped until 2026-06-03: workspace-settings API is eventually consistent so Get after Update may return stale values.")
 	}

--- a/settings/disable_legacy_access_setting_test.go
+++ b/settings/disable_legacy_access_setting_test.go
@@ -14,8 +14,8 @@ import (
 
 func TestAccDisableLegacyAccessSetting(t *testing.T) {
 	// TODO: Enable once API is fixed.
-	if acceptance.IsGcp(t) {
-		t.Skip("Skipping on GCP. The API is eventually consistent so Get after Update may return stale values.")
+	if acceptance.IsGcp(t) || acceptance.IsAzure(t) {
+		t.Skip("Skipping on GCP/Azure. The API is eventually consistent so Get after Update may return stale values.")
 	}
 	template := `
  	resource "databricks_disable_legacy_access_setting" "this" {

--- a/settings/disable_legacy_dbfs_setting_test.go
+++ b/settings/disable_legacy_dbfs_setting_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestAccDisableLegacyDbfsSetting(t *testing.T) {
+	// Please see ES-1928456 for details.
 	if time.Now().Before(time.Date(2026, 6, 3, 0, 0, 0, 0, time.UTC)) {
 		t.Skip("temporarily skipped until 2026-06-03: workspace-settings API is eventually consistent so Get after Update may return stale values.")
 	}

--- a/settings/disable_legacy_dbfs_setting_test.go
+++ b/settings/disable_legacy_dbfs_setting_test.go
@@ -14,9 +14,8 @@ import (
 )
 
 func TestAccDisableLegacyDbfsSetting(t *testing.T) {
-	// Please see ES-1928456 for details.
 	if time.Now().Before(time.Date(2026, 6, 3, 0, 0, 0, 0, time.UTC)) {
-		t.Skip("temporarily skipped until 2026-06-03: workspace-settings API is eventually consistent so Get after Update may return stale values.")
+		t.Skip("temporarily skipped until 2026-06-03: workspace-settings API is eventually consistent so Get after Update may return stale values.") // Please see ES-1928456 for details.
 	}
 	template := `
  	resource "databricks_disable_legacy_dbfs_setting" "this" {

--- a/settings/disable_legacy_dbfs_setting_test.go
+++ b/settings/disable_legacy_dbfs_setting_test.go
@@ -14,8 +14,8 @@ import (
 
 func TestAccDisableLegacyDbfsSetting(t *testing.T) {
 	// TODO: Enable once API is fixed.
-	if acceptance.IsGcp(t) {
-		t.Skip("Skipping on GCP. The API is eventually consistent so Get after Update may return stale values.")
+	if acceptance.IsGcp(t) || acceptance.IsAzure(t) {
+		t.Skip("Skipping on GCP/Azure. The API is eventually consistent so Get after Update may return stale values.")
 	}
 	template := `
  	resource "databricks_disable_legacy_dbfs_setting" "this" {

--- a/settings/disable_legacy_dbfs_setting_test.go
+++ b/settings/disable_legacy_dbfs_setting_test.go
@@ -14,7 +14,6 @@ import (
 )
 
 func TestAccDisableLegacyDbfsSetting(t *testing.T) {
-	// TODO: Enable once API is fixed.
 	if time.Now().Before(time.Date(2026, 6, 3, 0, 0, 0, 0, time.UTC)) {
 		t.Skip("temporarily skipped until 2026-06-03: workspace-settings API is eventually consistent so Get after Update may return stale values.")
 	}

--- a/settings/disable_legacy_dbfs_setting_test.go
+++ b/settings/disable_legacy_dbfs_setting_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestAccDisableLegacyDbfsSetting(t *testing.T) {
 	if time.Now().Before(time.Date(2026, 6, 3, 0, 0, 0, 0, time.UTC)) {
-		t.Skip("temporarily skipped until 2026-06-03: workspace-settings API is eventually consistent so Get after Update may return stale values.") // Please see ES-1928456 for details.
+		t.Skip("temporarily skipped until 2026-06-03: workspace-settings API is eventually consistent so Get after Update may return stale values. Please see ES-1928456 for details.")
 	}
 	template := `
  	resource "databricks_disable_legacy_dbfs_setting" "this" {

--- a/settings/disable_legacy_dbfs_setting_test.go
+++ b/settings/disable_legacy_dbfs_setting_test.go
@@ -3,6 +3,7 @@ package settings_test
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/databricks/databricks-sdk-go/service/settings"
 	"github.com/databricks/terraform-provider-databricks/common"
@@ -14,8 +15,8 @@ import (
 
 func TestAccDisableLegacyDbfsSetting(t *testing.T) {
 	// TODO: Enable once API is fixed.
-	if acceptance.IsGcp(t) || acceptance.IsAzure(t) {
-		t.Skip("Skipping on GCP/Azure. The API is eventually consistent so Get after Update may return stale values.")
+	if time.Now().Before(time.Date(2026, 6, 3, 0, 0, 0, 0, time.UTC)) {
+		t.Skip("temporarily skipped until 2026-06-03: workspace-settings API is eventually consistent so Get after Update may return stale values.")
 	}
 	template := `
  	resource "databricks_disable_legacy_dbfs_setting" "this" {


### PR DESCRIPTION
## Changes

Follow-up to #5721. The same eventual-consistency behavior in the workspace-settings APIs (a `Get` issued shortly after an `Update` may return the stale prior value) has been observed across all three clouds, not just GCP.

Drop the cloud-based skip and switch to a date-gated unconditional skip until 2026-06-03, mirroring the pattern used by `TestAccProviderPlanShouldSucceedWithIncompleteConfiguration`. After that date the skip auto-expires so we can re-verify the API behavior.

Applies to:
- `TestAccDisableLegacyDbfsSetting`
- `TestAccDisableLegacyAccessSetting`
- `TestAccAiBiEmbeddings`

## Tests

Tests are skipped.

NO_CHANGELOG=true