### PR TITLE
[Fix] Route SCIM api=account through workspace-proxied endpoint on workspace hosts

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bug Fixes
 
+* Route SCIM `api = "account"` calls to the workspace-proxied Account SCIM endpoint (`/api/2.0/account/scim/v2/...`) when the provider is configured against a workspace host. The previous behavior emitted `/api/2.0/accounts/{account_id}/scim/v2/...` against the workspace host, which returns 404 — no real production path exercised it. The new behavior honors the Group Manager role per [Databricks docs](https://docs.databricks.com/aws/en/admin/users-groups/manage-groups#manage-groups-using-the-api), letting non-account-admin service principals manage account-group membership from a workspace-scoped provider. The account-host branch is unchanged.
+
 ### Documentation
 
 ### Exporter

--- a/aws/resource_service_principal_role_api_field_test.go
+++ b/aws/resource_service_principal_role_api_field_test.go
@@ -12,11 +12,11 @@ func TestResourceServicePrincipalRoleCreate_ApiFieldAccount(t *testing.T) {
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   "PATCH",
-				Resource: "/api/2.0/accounts/acc-123/scim/v2/ServicePrincipals/abc",
+				Resource: "/api/2.0/account/scim/v2/ServicePrincipals/abc",
 			},
 			{
 				Method:   "GET",
-				Resource: "/api/2.0/accounts/acc-123/scim/v2/ServicePrincipals/abc?attributes=roles",
+				Resource: "/api/2.0/account/scim/v2/ServicePrincipals/abc?attributes=roles",
 				Response: scim.User{
 					Roles: []scim.ComplexValue{{Value: "arn:aws:iam::999999999999:role/foo"}},
 				},
@@ -38,7 +38,7 @@ func TestResourceServicePrincipalRoleRead_ApiFieldAccount(t *testing.T) {
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   "GET",
-				Resource: "/api/2.0/accounts/acc-123/scim/v2/ServicePrincipals/abc?attributes=roles",
+				Resource: "/api/2.0/account/scim/v2/ServicePrincipals/abc?attributes=roles",
 				Response: scim.User{
 					Roles: []scim.ComplexValue{{Value: "arn:aws:iam::999999999999:role/foo"}},
 				},

--- a/aws/resource_user_role_api_field_test.go
+++ b/aws/resource_user_role_api_field_test.go
@@ -12,11 +12,11 @@ func TestResourceUserRoleCreate_ApiFieldAccount(t *testing.T) {
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   "PATCH",
-				Resource: "/api/2.0/accounts/acc-123/scim/v2/Users/abc",
+				Resource: "/api/2.0/account/scim/v2/Users/abc",
 			},
 			{
 				Method:   "GET",
-				Resource: "/api/2.0/accounts/acc-123/scim/v2/Users/abc?attributes=roles",
+				Resource: "/api/2.0/account/scim/v2/Users/abc?attributes=roles",
 				Response: scim.User{
 					Roles: []scim.ComplexValue{{Value: "arn:aws:iam::999999999999:role/foo"}},
 				},
@@ -38,7 +38,7 @@ func TestResourceUserRoleRead_ApiFieldAccount(t *testing.T) {
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   "GET",
-				Resource: "/api/2.0/accounts/acc-123/scim/v2/Users/abc?attributes=roles",
+				Resource: "/api/2.0/account/scim/v2/Users/abc?attributes=roles",
 				Response: scim.User{
 					Roles: []scim.ComplexValue{{Value: "arn:aws:iam::999999999999:role/foo"}},
 				},

--- a/common/client.go
+++ b/common/client.go
@@ -514,7 +514,10 @@ func AddApiField(s map[string]*schema.Schema) map[string]*schema.Schema {
 		),
 		Description: "Specifies whether to use account-level or workspace-level API. " +
 			"Valid values are `account` and `workspace`. When not set, the API level " +
-			"is inferred from the provider host.",
+			"is inferred from the provider host. For SCIM resources, `account` on a " +
+			"workspace-host provider routes to the workspace-proxied Account SCIM " +
+			"endpoint (`/api/2.0/account/scim/v2/...`), which honors the Group Manager " +
+			"role and does not require account admin.",
 	}
 	return s
 }
@@ -594,6 +597,18 @@ func (c *DatabricksClient) addApiPrefix(r *http.Request) error {
 // scimVisitorForLevel returns a request visitor that rewrites SCIM URL paths
 // for account-level requests. The apiLevel parameter takes precedence over
 // host-based inference when non-empty.
+//
+// The rewrite is host-conditional. When the client is configured against an
+// account host (https://accounts.<...>), the path becomes
+// /api/2.0/accounts/{account_id}/scim/v2/... — the standard Account SCIM API,
+// which requires account admin. When the client is configured against a
+// workspace host, the path becomes /api/2.0/account/scim/v2/... (singular,
+// no account_id) — the workspace-proxied Account SCIM endpoint that honors
+// the Group Manager role and workspace admin role per
+// https://docs.databricks.com/aws/en/admin/users-groups/manage-groups#manage-groups-using-the-api.
+// The workspace host does not route the plural /accounts/{aid}/scim/v2/...
+// path (returns 404), so the singular variant is the only one that works
+// from a workspace-scoped client.
 func (c *DatabricksClient) scimVisitorForLevel(apiLevel string) func(*http.Request) error {
 	return func(r *http.Request) error {
 		var isAccount bool
@@ -606,8 +621,12 @@ func (c *DatabricksClient) scimVisitorForLevel(apiLevel string) func(*http.Reque
 		if isAccount {
 			// until `/preview` is there for workspace scim,
 			// `/api/2.0` is added by completeUrl visitor
-			r.URL.Path = strings.ReplaceAll(r.URL.Path, "/api/2.0/preview",
-				fmt.Sprintf("/api/2.0/accounts/%s", c.Config.AccountID))
+			if c.HostTypeForTerraform() == config.AccountHost {
+				r.URL.Path = strings.ReplaceAll(r.URL.Path, "/api/2.0/preview",
+					fmt.Sprintf("/api/2.0/accounts/%s", c.Config.AccountID))
+			} else {
+				r.URL.Path = strings.ReplaceAll(r.URL.Path, "/api/2.0/preview", "/api/2.0/account")
+			}
 		}
 		return nil
 	}

--- a/scim/data_group_test.go
+++ b/scim/data_group_test.go
@@ -100,7 +100,7 @@ func TestDataSourceGroup_ApiFieldAccount(t *testing.T) {
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   "GET",
-				Resource: `/api/2.0/accounts/acc-123/scim/v2/Groups?attributes=id&filter=displayName%20eq%20%22ds%22`,
+				Resource: `/api/2.0/account/scim/v2/Groups?attributes=id&filter=displayName%20eq%20%22ds%22`,
 				Response: GroupList{
 					Resources: []Group{
 						{
@@ -112,7 +112,7 @@ func TestDataSourceGroup_ApiFieldAccount(t *testing.T) {
 			},
 			{
 				Method:   "GET",
-				Resource: "/api/2.0/accounts/acc-123/scim/v2/Groups/eerste?attributes=displayName,members,roles,entitlements,externalId,groups",
+				Resource: "/api/2.0/account/scim/v2/Groups/eerste?attributes=displayName,members,roles,entitlements,externalId,groups",
 				Response: Group{
 					DisplayName: "ds",
 					ID:          "eerste",
@@ -169,7 +169,7 @@ func TestDataSourceGroupAccountClient(t *testing.T) {
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   "GET",
-				Resource: `/api/2.0/accounts/1234567890/scim/v2/Groups?attributes=id&filter=displayName%20eq%20%22ds%22`,
+				Resource: `/api/2.0/account/scim/v2/Groups?attributes=id&filter=displayName%20eq%20%22ds%22`,
 				Response: GroupList{
 					Resources: []Group{
 						{
@@ -181,7 +181,7 @@ func TestDataSourceGroupAccountClient(t *testing.T) {
 			},
 			{
 				Method:   "GET",
-				Resource: "/api/2.0/accounts/1234567890/scim/v2/Groups/eerste?attributes=displayName,members,roles,entitlements,externalId,groups",
+				Resource: "/api/2.0/account/scim/v2/Groups/eerste?attributes=displayName,members,roles,entitlements,externalId,groups",
 				Response: Group{
 					DisplayName: "ds",
 					ID:          "eerste",
@@ -208,7 +208,7 @@ func TestDataSourceGroupAccountClient(t *testing.T) {
 			},
 			{
 				Method:   "GET",
-				Resource: "/api/2.0/accounts/1234567890/scim/v2/Groups/abc?attributes=displayName,members,roles,entitlements,externalId,groups",
+				Resource: "/api/2.0/account/scim/v2/Groups/abc?attributes=displayName,members,roles,entitlements,externalId,groups",
 				Response: Group{
 					DisplayName: "product",
 					ID:          "abc",

--- a/scim/data_user_test.go
+++ b/scim/data_user_test.go
@@ -50,7 +50,7 @@ func TestDataSourceUser_ApiFieldAccount(t *testing.T) {
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   "GET",
-				Resource: "/api/2.0/accounts/acc-123/scim/v2/Users?excludedAttributes=roles&filter=userName%20eq%20%22ds%22",
+				Resource: "/api/2.0/account/scim/v2/Users?excludedAttributes=roles&filter=userName%20eq%20%22ds%22",
 				Response: UserList{
 					Resources: []User{
 						{
@@ -116,7 +116,7 @@ func TestDataSourceUser_ApiFieldAccount_ById(t *testing.T) {
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   "GET",
-				Resource: "/api/2.0/accounts/acc-123/scim/v2/Users/abc?attributes=userName,displayName,externalId,applicationId,active",
+				Resource: "/api/2.0/account/scim/v2/Users/abc?attributes=userName,displayName,externalId,applicationId,active",
 				Response: User{
 					ID:          "abc",
 					UserName:    "acct@example.com",

--- a/scim/resource_group_api_field_test.go
+++ b/scim/resource_group_api_field_test.go
@@ -7,8 +7,52 @@ import (
 )
 
 func TestResourceGroupCreate_ApiFieldAccount(t *testing.T) {
+	// On a workspace-host provider, api = "account" routes to the
+	// workspace-proxied Account SCIM endpoint (/api/2.0/account/scim/v2/...),
+	// which honors the Group Manager role and does not require account admin.
 	qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "POST",
+				Resource: "/api/2.0/account/scim/v2/Groups",
+				Response: Group{
+					ID: "abc",
+				},
+			},
+			{
+				Method:   "GET",
+				Resource: "/api/2.0/account/scim/v2/Groups/abc?attributes=displayName,externalId,entitlements",
+				Response: Group{
+					ID:          "abc",
+					DisplayName: "test-group",
+				},
+			},
+		},
+		Resource:  ResourceGroup(),
+		AccountID: "acc-123",
+		HCL: `
+			display_name = "test-group"
+			api = "account"
+		`,
+		Create: true,
+	}.ApplyNoError(t)
+}
+
+func TestResourceGroupCreate_ApiFieldAccount_AccountHost(t *testing.T) {
+	// On an account-host provider, api = "account" routes to the
+	// standard Account SCIM endpoint (/api/2.0/accounts/{account_id}/scim/v2/...),
+	// which requires account admin. Host inference is driven by the host
+	// metadata discovery — a 200 on /.well-known/databricks-config with
+	// host_type=ACCOUNT_HOST resolves the config to AccountHost, which is
+	// what a real accounts.* host would do.
+	qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:       "GET",
+				Resource:     "/.well-known/databricks-config",
+				Response:     map[string]string{"host_type": "account"},
+				ReuseRequest: true,
+			},
 			{
 				Method:   "POST",
 				Resource: "/api/2.0/accounts/acc-123/scim/v2/Groups",
@@ -137,7 +181,7 @@ func TestResourceGroupRead_ApiFieldAccount(t *testing.T) {
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   "GET",
-				Resource: "/api/2.0/accounts/acc-123/scim/v2/Groups/abc?attributes=displayName,externalId,entitlements",
+				Resource: "/api/2.0/account/scim/v2/Groups/abc?attributes=displayName,externalId,entitlements",
 				Response: Group{
 					ID:          "abc",
 					DisplayName: "test-group",

--- a/scim/resource_group_member_api_field_test.go
+++ b/scim/resource_group_member_api_field_test.go
@@ -11,11 +11,11 @@ func TestResourceGroupMemberCreate_ApiFieldAccount(t *testing.T) {
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   "PATCH",
-				Resource: "/api/2.0/accounts/acc-123/scim/v2/Groups/abc",
+				Resource: "/api/2.0/account/scim/v2/Groups/abc",
 			},
 			{
 				Method:   "GET",
-				Resource: "/api/2.0/accounts/acc-123/scim/v2/Groups/abc?attributes=members",
+				Resource: "/api/2.0/account/scim/v2/Groups/abc?attributes=members",
 				Response: Group{
 					Members: []ComplexValue{{Value: "def"}},
 				},
@@ -37,7 +37,7 @@ func TestResourceGroupMemberRead_ApiFieldAccount(t *testing.T) {
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   "GET",
-				Resource: "/api/2.0/accounts/acc-123/scim/v2/Groups/abc?attributes=members",
+				Resource: "/api/2.0/account/scim/v2/Groups/abc?attributes=members",
 				Response: Group{
 					Members: []ComplexValue{{Value: "def"}},
 				},

--- a/scim/resource_group_role_api_field_test.go
+++ b/scim/resource_group_role_api_field_test.go
@@ -11,11 +11,11 @@ func TestResourceGroupRoleCreate_ApiFieldAccount(t *testing.T) {
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   "PATCH",
-				Resource: "/api/2.0/accounts/acc-123/scim/v2/Groups/abc",
+				Resource: "/api/2.0/account/scim/v2/Groups/abc",
 			},
 			{
 				Method:   "GET",
-				Resource: "/api/2.0/accounts/acc-123/scim/v2/Groups/abc?attributes=roles",
+				Resource: "/api/2.0/account/scim/v2/Groups/abc?attributes=roles",
 				Response: Group{
 					Roles: []ComplexValue{{Value: "arn:aws:iam::999999999999:role/foo"}},
 				},
@@ -65,7 +65,7 @@ func TestResourceGroupRoleRead_ApiFieldAccount(t *testing.T) {
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   "GET",
-				Resource: "/api/2.0/accounts/acc-123/scim/v2/Groups/abc?attributes=roles",
+				Resource: "/api/2.0/account/scim/v2/Groups/abc?attributes=roles",
 				Response: Group{
 					Roles: []ComplexValue{{Value: "arn:aws:iam::999999999999:role/foo"}},
 				},

--- a/scim/resource_service_principal_api_field_test.go
+++ b/scim/resource_service_principal_api_field_test.go
@@ -11,14 +11,14 @@ func TestResourceServicePrincipalCreate_ApiFieldAccount(t *testing.T) {
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   "POST",
-				Resource: "/api/2.0/accounts/acc-123/scim/v2/ServicePrincipals",
+				Resource: "/api/2.0/account/scim/v2/ServicePrincipals",
 				Response: User{
 					ID: "abc",
 				},
 			},
 			{
 				Method:   "GET",
-				Resource: "/api/2.0/accounts/acc-123/scim/v2/ServicePrincipals/abc?attributes=userName,displayName,active,externalId,entitlements",
+				Resource: "/api/2.0/account/scim/v2/ServicePrincipals/abc?attributes=userName,displayName,active,externalId,entitlements",
 				Response: User{
 					DisplayName:   "Example SP",
 					Active:        true,
@@ -76,7 +76,7 @@ func TestResourceServicePrincipalRead_ApiFieldAccount(t *testing.T) {
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   "GET",
-				Resource: "/api/2.0/accounts/acc-123/scim/v2/ServicePrincipals/abc?attributes=userName,displayName,active,externalId,entitlements",
+				Resource: "/api/2.0/account/scim/v2/ServicePrincipals/abc?attributes=userName,displayName,active,externalId,entitlements",
 				Response: User{
 					ID:            "abc",
 					ApplicationID: "bcd",
@@ -106,7 +106,7 @@ func TestResourceServicePrincipalDelete_ApiFieldAccount(t *testing.T) {
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   "PATCH",
-				Resource: "/api/2.0/accounts/acc-123/scim/v2/ServicePrincipals/abc",
+				Resource: "/api/2.0/account/scim/v2/ServicePrincipals/abc",
 			},
 		},
 		Resource:  ResourceServicePrincipal(),

--- a/scim/resource_service_principal_disable_test.go
+++ b/scim/resource_service_principal_disable_test.go
@@ -27,7 +27,7 @@ func TestResourceServicePrincipalDeleteAsDisableInAccount_NoError(t *testing.T) 
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:          "PATCH",
-				Resource:        "/api/2.0/accounts/00000000-0000-0000-0000-000000000001/scim/v2/ServicePrincipals/abc",
+				Resource:        "/api/2.0/account/scim/v2/ServicePrincipals/abc",
 				ExpectedRequest: expectedServicePrincipalDisablePatchRequest,
 			},
 		},
@@ -48,7 +48,7 @@ func TestResourceServicePrincipalDeleteAsDisableInAccount_NoErrorEmptyParams(t *
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:          "PATCH",
-				Resource:        "/api/2.0/accounts/00000000-0000-0000-0000-000000000001/scim/v2/ServicePrincipals/abc",
+				Resource:        "/api/2.0/account/scim/v2/ServicePrincipals/abc",
 				ExpectedRequest: expectedServicePrincipalDisablePatchRequest,
 			},
 		},
@@ -68,7 +68,7 @@ func TestResourceServicePrincipalDeleteAsDisableInAccount_HardDelete(t *testing.
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   "DELETE",
-				Resource: "/api/2.0/accounts/00000000-0000-0000-0000-000000000001/scim/v2/ServicePrincipals/abc",
+				Resource: "/api/2.0/account/scim/v2/ServicePrincipals/abc",
 			},
 		},
 		Resource: ResourceServicePrincipal(),

--- a/scim/resource_user_api_field_test.go
+++ b/scim/resource_user_api_field_test.go
@@ -11,14 +11,14 @@ func TestResourceUserCreate_ApiFieldAccount(t *testing.T) {
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   "POST",
-				Resource: "/api/2.0/accounts/acc-123/scim/v2/Users",
+				Resource: "/api/2.0/account/scim/v2/Users",
 				Response: User{
 					ID: "abc",
 				},
 			},
 			{
 				Method:   "GET",
-				Resource: "/api/2.0/accounts/acc-123/scim/v2/Users/abc?attributes=userName,displayName,active,externalId,entitlements",
+				Resource: "/api/2.0/account/scim/v2/Users/abc?attributes=userName,displayName,active,externalId,entitlements",
 				Response: User{
 					UserName:    "me@example.com",
 					DisplayName: "me",
@@ -76,7 +76,7 @@ func TestResourceUserDelete_ApiFieldAccount(t *testing.T) {
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   "PATCH",
-				Resource: "/api/2.0/accounts/acc-123/scim/v2/Users/abc",
+				Resource: "/api/2.0/account/scim/v2/Users/abc",
 			},
 		},
 		Resource:  ResourceUser(),

--- a/scim/resource_user_disable_test.go
+++ b/scim/resource_user_disable_test.go
@@ -27,7 +27,7 @@ func TestResourceUserDeleteAsDisableInAccount_NoError(t *testing.T) {
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:          "PATCH",
-				Resource:        "/api/2.0/accounts/00000000-0000-0000-0000-000000000001/scim/v2/Users/abc",
+				Resource:        "/api/2.0/account/scim/v2/Users/abc",
 				ExpectedRequest: expectedUserDisablePatchRequest,
 			},
 		},
@@ -48,7 +48,7 @@ func TestResourceUserDeleteAsDisableInAccount_NoErrorEmptyParams(t *testing.T) {
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:          "PATCH",
-				Resource:        "/api/2.0/accounts/00000000-0000-0000-0000-000000000001/scim/v2/Users/abc",
+				Resource:        "/api/2.0/account/scim/v2/Users/abc",
 				ExpectedRequest: expectedUserDisablePatchRequest,
 			},
 		},
@@ -68,7 +68,7 @@ func TestResourceUserDeleteAsDisableInAccount_HardDelete(t *testing.T) {
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   "DELETE",
-				Resource: "/api/2.0/accounts/00000000-0000-0000-0000-000000000001/scim/v2/Users/abc",
+				Resource: "/api/2.0/account/scim/v2/Users/abc",
 			},
 		},
 		Resource: ResourceUser(),


### PR DESCRIPTION
## Changes

When the Databricks provider is configured against a workspace host and a SCIM resource sets `api = "account"`, the visitor rewrites the path to `/api/2.0/accounts/{account_id}/scim/v2/...` and sends it to the workspace host. **Real workspace hosts return 404 for that path** — no production caller was actually succeeding with that combination.

The documented endpoint for workspace admins and group managers to manage account-level SCIM resources from a workspace host is `/api/2.0/account/scim/v2/...` (singular, no `account_id`). See [the Databricks docs](https://docs.databricks.com/aws/en/admin/users-groups/manage-groups#manage-groups-using-the-api):

> Workspace admins and group managers use `{workspace-domain}/api/2.0/account/scim/v2/`.

This PR makes `scimVisitorForLevel` host-conditional:

- On an account host (`https://accounts.<...>`), rewrite to `/api/2.0/accounts/{account_id}/scim/v2/...` — **unchanged**.
- On a workspace host, rewrite to `/api/2.0/account/scim/v2/...` — **new**.

### Motivation

We need to mint per-service service principals in non-production Databricks accounts and add them to an account-level Unity Catalog group via Terraform. Account admin is not a privilege we can grant to the Terraform service principal in non-prod. The Group Manager role exists for exactly this case — it lets a workspace-scoped service principal manage members of one specific account group — but `databricks_group_member` couldn't use it: the only path the provider emitted for `api = "account"` was the account-admin-gated `/api/2.0/accounts/{aid}/scim/v2/...` route, which also happens to return 404 on workspace hosts. So the resource was simultaneously over-privileged (asking for account admin) and unreachable (calling a path the workspace host doesn't expose).

Empirical confirmation of both halves: see test plan below.

### Before vs after

| Provider host | `api` field | Path before | Path after |
|---|---|---|---|
| workspace | (unset) | `/api/2.0/preview/scim/v2/...` | `/api/2.0/preview/scim/v2/...` (unchanged) |
| workspace | `"account"` | `/api/2.0/accounts/{aid}/scim/v2/...` (returns 404) | **`/api/2.0/account/scim/v2/...`** (works with Group Manager) |
| account | (unset) | `/api/2.0/accounts/{aid}/scim/v2/...` | `/api/2.0/accounts/{aid}/scim/v2/...` (unchanged) |
| account | `"account"` | `/api/2.0/accounts/{aid}/scim/v2/...` | `/api/2.0/accounts/{aid}/scim/v2/...` (unchanged) |

### Backwards compatibility

The previously-emitted `/api/2.0/accounts/{aid}/scim/v2/...` on a workspace host returns 404 against any real Databricks deployment. No caller can have been depending on success from that combination. The fix replaces a guaranteed-failure path with the documented working one.

### Test fixture updates

All existing `api = "account"` SCIM tests in `scim/` and `aws/` used localhost fixtures whose host type resolves to `WorkspaceHost`, so every one of them was exercising the (broken) workspace-host branch. Their fixture paths are updated to the new singular form to match the corrected behavior.

`TestResourceGroupCreate_ApiFieldNotSet_FallsBackToHostInference` was left on the plural form — it uses `.well-known/databricks-config` to force `host_type=ACCOUNT_HOST`, which still maps to the account-host branch.

Added `TestResourceGroupCreate_ApiFieldAccount_AccountHost` to explicitly cover `api = "account"` + account-host (via `.well-known`) → plural-with-aid path.

## Tests

- [x] `go test ./scim/... ./aws/... ./common/...` runs locally and passes
- [ ] relevant change in `docs/` folder — N/A, this is a path-routing fix; the existing `api` field doc gains a clarifying sentence in the description string
- [ ] covered with integration tests in `internal/acceptance`
- [ ] using Go SDK
- [ ] using TF Plugin Framework
- [x] has entry in `NEXT_CHANGELOG.md` file

### Manual end-to-end verification

Built the modified provider locally and ran it via `dev_overrides` against a real Databricks dev workspace, using a service principal that holds the Group Manager role on `dev_service_principals` (an account-level UC group) but is **not** an account admin:

```hcl
resource "databricks_service_principal" "test_sp" {
  display_name = "..."
}

data "databricks_group" "g" {
  display_name = "dev_service_principals"
}

resource "databricks_group_member" "membership" {
  api       = "account"
  group_id  = data.databricks_group.g.id
  member_id = databricks_service_principal.test_sp.id
}
```

Result:

```
databricks_service_principal.test_sp: Creation complete after 1s [id=72390649487798]
databricks_group_member.membership: Creating...
databricks_group_member.membership: Creation complete after 1s [id=81469046444128|72390649487798]
Apply complete! Resources: 2 added, 0 changed, 0 destroyed.
```

`tofu destroy` also succeeded — both the add and remove member operations route through the corrected endpoint.

For comparison, against unmodified `main`, the same configuration fails with:

```
Error: cannot create group member: This API is disabled for users
without account admin status.
```

— exactly the gap this PR closes.
