### PR TITLE
Fix `databricks_mws_ncc_private_endpoint_rule` Create polling

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -8,6 +8,10 @@
 
 ### Bug Fixes
 
+* Fix `databricks_mws_ncc_private_endpoint_rule` so that Create waits for the private endpoint to be provisioned on the cloud side before returning ([#XXXX](https://github.com/databricks/terraform-provider-databricks/pull/XXXX)).
+
+  The NCC `CreatePrivateEndpointRule` API can return immediately with `connection_state=CREATING` and an empty `vpc_endpoint_id` / `endpoint_name`, breaking downstream resources that reference those fields. Create now polls `GetPrivateEndpointRule` until `connection_state` reaches `PENDING` or `ESTABLISHED`, surfaces `error_message` on `CREATE_FAILED`, and honours a configurable Create timeout (default 30 minutes; override with a `timeouts { create = "..." }` block).
+
 ### Documentation
 
 ### Exporter

--- a/mws/resource_mws_ncc_private_endpoint_rule.go
+++ b/mws/resource_mws_ncc_private_endpoint_rule.go
@@ -2,13 +2,65 @@ package mws
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"log"
 	"strings"
+	"time"
 
+	"github.com/databricks/databricks-sdk-go"
 	"github.com/databricks/databricks-sdk-go/service/settings"
 	"github.com/databricks/terraform-provider-databricks/common"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
+
+// defaultPrivateEndpointRuleCreateTimeout is the default Create timeout for
+// polling a newly-submitted private endpoint rule to a cloud-provisioned
+// state. The NCC CreatePrivateEndpointRule API can return immediately with
+// connection_state=CREATING while the underlying cloud endpoint is still
+// being provisioned; the provider polls GetPrivateEndpointRule until the
+// rule reaches PENDING or ESTABLISHED (success) or CREATE_FAILED (failure).
+// Users can override via a `timeouts { create = "..." }` block on the
+// resource.
+const defaultPrivateEndpointRuleCreateTimeout = 30 * time.Minute
+
+// waitForPrivateEndpointRuleCreate polls Get until the rule leaves the
+// CREATING state. PENDING and ESTABLISHED are success terminal states; at
+// that point vpc_endpoint_id (AWS) / endpoint_name (Azure) / gcp_endpoint
+// (GCP) are populated. CREATE_FAILED is terminal failure and surfaces
+// ErrorMessage. REJECTED / DISCONNECTED / EXPIRED are not expected on a
+// fresh Create but are treated as terminal failures defensively.
+func waitForPrivateEndpointRuleCreate(ctx context.Context, acc *databricks.AccountClient, nccId, ruleId string, timeout time.Duration) (*settings.NccPrivateEndpointRule, error) {
+	var result *settings.NccPrivateEndpointRule
+	err := retry.RetryContext(ctx, timeout, func() *retry.RetryError {
+		rule, err := acc.NetworkConnectivity.GetPrivateEndpointRuleByNetworkConnectivityConfigIdAndPrivateEndpointRuleId(ctx, nccId, ruleId)
+		if err != nil {
+			return retry.NonRetryableError(err)
+		}
+		switch rule.ConnectionState {
+		case settings.NccPrivateEndpointRulePrivateLinkConnectionStatePending,
+			settings.NccPrivateEndpointRulePrivateLinkConnectionStateEstablished:
+			result = rule
+			return nil
+		case settings.NccPrivateEndpointRulePrivateLinkConnectionStateCreateFailed:
+			return retry.NonRetryableError(fmt.Errorf("private endpoint rule %s creation failed: %s", ruleId, rule.ErrorMessage))
+		case settings.NccPrivateEndpointRulePrivateLinkConnectionStateRejected,
+			settings.NccPrivateEndpointRulePrivateLinkConnectionStateDisconnected,
+			settings.NccPrivateEndpointRulePrivateLinkConnectionStateExpired:
+			return retry.NonRetryableError(fmt.Errorf("private endpoint rule %s reached unexpected terminal state %s during creation", ruleId, rule.ConnectionState))
+		default:
+			msg := fmt.Sprintf("private endpoint rule %s is in state %s, waiting for cloud-side provisioning", ruleId, rule.ConnectionState)
+			log.Printf("[DEBUG] %s", msg)
+			return retry.RetryableError(errors.New(msg))
+		}
+	})
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
 
 func ResourceMwsNccPrivateEndpointRule() common.Resource {
 	s := common.StructToSchema(settings.NccPrivateEndpointRule{}, func(m map[string]*schema.Schema) map[string]*schema.Schema {
@@ -43,6 +95,9 @@ func ResourceMwsNccPrivateEndpointRule() common.Resource {
 	p := common.NewPairSeparatedID("network_connectivity_config_id", "rule_id", "/")
 	return common.Resource{
 		Schema: s,
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(defaultPrivateEndpointRuleCreateTimeout),
+		},
 		Create: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
 			var create settings.CreatePrivateEndpointRuleRequest
 			common.DataToStructPointer(d, s, &create.PrivateEndpointRule)
@@ -55,9 +110,21 @@ func ResourceMwsNccPrivateEndpointRule() common.Resource {
 			if err != nil {
 				return err
 			}
+			// Pack the ID before polling so a polling failure or context cancellation
+			// still leaves a Read-able resource in state for `terraform destroy` to
+			// clean up the partially-created rule on the server.
 			common.StructToData(rule, s, d)
 			p.Pack(d)
-			return nil
+			// The NCC API can return immediately with connection_state=CREATING and an
+			// empty vpc_endpoint_id / endpoint_name while PLLM provisions the cloud
+			// endpoint. Poll until a terminal cloud-provisioned state (PENDING /
+			// ESTABLISHED) is reached. When the server returns a terminal state
+			// directly, the first Get exits the loop immediately.
+			final, err := waitForPrivateEndpointRuleCreate(ctx, acc, create.NetworkConnectivityConfigId, rule.RuleId, d.Timeout(schema.TimeoutCreate))
+			if err != nil {
+				return err
+			}
+			return common.StructToData(final, s, d)
 		},
 		Read: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
 			nccId, ruleId, err := p.Unpack(d)
@@ -87,6 +154,8 @@ func ResourceMwsNccPrivateEndpointRule() common.Resource {
 			// only enabled, domain names & resource names are updatable
 			// they do require update_mask to be set
 			// resource_names are not applicable to Azure, so we exclude them from the update
+			// Update does not poll: the server's update handler does not touch
+			// connection_state, so the rule never re-enters CREATING.
 			updateMask := []string{}
 			updatePrivateEndpointRule := settings.UpdatePrivateEndpointRule{}
 

--- a/mws/resource_mws_ncc_private_endpoint_rule_test.go
+++ b/mws/resource_mws_ncc_private_endpoint_rule_test.go
@@ -74,6 +74,149 @@ func TestResourceNccPrivateEndpointRulePrivateEndpointRuleCreate_Error(t *testin
 	assert.Equal(t, "", d.Id())
 }
 
+// TestResourceNccPrivateEndpointRuleCreate_AsyncPolling exercises the
+// happy-path of the async API rollout: Create returns CREATING, the first
+// poll Get returns CREATING, and the second Get returns PENDING with
+// vpc_endpoint_id populated.
+func TestResourceNccPrivateEndpointRuleCreate_AsyncPolling(t *testing.T) {
+	creating := &settings.NccPrivateEndpointRule{
+		RuleId:                      "rule_id",
+		NetworkConnectivityConfigId: "ncc_id",
+		ResourceId:                  "resource_id",
+		GroupId:                     "blob",
+		ConnectionState:             "CREATING",
+	}
+	pending := &settings.NccPrivateEndpointRule{
+		RuleId:                      "rule_id",
+		NetworkConnectivityConfigId: "ncc_id",
+		ResourceId:                  "resource_id",
+		GroupId:                     "blob",
+		ConnectionState:             "PENDING",
+		VpcEndpointId:               "vpce-abc",
+		EndpointName:                "endpoint_name",
+	}
+	qa.ResourceFixture{
+		MockAccountClientFunc: func(a *mocks.MockAccountClient) {
+			e := a.GetMockNetworkConnectivityAPI().EXPECT()
+			e.CreatePrivateEndpointRule(mock.Anything, settings.CreatePrivateEndpointRuleRequest{
+				NetworkConnectivityConfigId: "ncc_id",
+				PrivateEndpointRule: settings.CreatePrivateEndpointRule{
+					ResourceId: "resource_id",
+					GroupId:    "blob",
+				},
+			}).Return(creating, nil)
+			// Two sequential Gets while polling, then a third for the auto-Read
+			// pass that common.Resource fires after Create.
+			e.GetPrivateEndpointRuleByNetworkConnectivityConfigIdAndPrivateEndpointRuleId(mock.Anything, "ncc_id", "rule_id").Return(creating, nil).Once()
+			e.GetPrivateEndpointRuleByNetworkConnectivityConfigIdAndPrivateEndpointRuleId(mock.Anything, "ncc_id", "rule_id").Return(pending, nil).Once()
+			e.GetPrivateEndpointRuleByNetworkConnectivityConfigIdAndPrivateEndpointRuleId(mock.Anything, "ncc_id", "rule_id").Return(pending, nil)
+		},
+		Resource:  ResourceMwsNccPrivateEndpointRule(),
+		AccountID: "abc",
+		Host:      "https://accounts.cloud.databricks.com",
+		HCL: `
+		network_connectivity_config_id = "ncc_id"
+		resource_id = "resource_id"
+		group_id = "blob"
+		`,
+		Create: true,
+	}.ApplyAndExpectData(t, map[string]any{
+		"id":               "ncc_id/rule_id",
+		"connection_state": "PENDING",
+		"vpc_endpoint_id":  "vpce-abc",
+		"endpoint_name":    "endpoint_name",
+	})
+}
+
+// TestResourceNccPrivateEndpointRuleCreate_AsyncCreateFailed verifies that
+// the poller surfaces error_message on CREATE_FAILED. The resource ID is
+// still packed before polling so the user can `terraform destroy` the
+// orphaned rule.
+func TestResourceNccPrivateEndpointRuleCreate_AsyncCreateFailed(t *testing.T) {
+	creating := &settings.NccPrivateEndpointRule{
+		RuleId:                      "rule_id",
+		NetworkConnectivityConfigId: "ncc_id",
+		ResourceId:                  "resource_id",
+		GroupId:                     "blob",
+		ConnectionState:             "CREATING",
+	}
+	failed := &settings.NccPrivateEndpointRule{
+		RuleId:                      "rule_id",
+		NetworkConnectivityConfigId: "ncc_id",
+		ResourceId:                  "resource_id",
+		GroupId:                     "blob",
+		ConnectionState:             "CREATE_FAILED",
+		ErrorMessage:                "quota exceeded",
+	}
+	d, err := qa.ResourceFixture{
+		MockAccountClientFunc: func(a *mocks.MockAccountClient) {
+			e := a.GetMockNetworkConnectivityAPI().EXPECT()
+			e.CreatePrivateEndpointRule(mock.Anything, settings.CreatePrivateEndpointRuleRequest{
+				NetworkConnectivityConfigId: "ncc_id",
+				PrivateEndpointRule: settings.CreatePrivateEndpointRule{
+					ResourceId: "resource_id",
+					GroupId:    "blob",
+				},
+			}).Return(creating, nil)
+			e.GetPrivateEndpointRuleByNetworkConnectivityConfigIdAndPrivateEndpointRuleId(mock.Anything, "ncc_id", "rule_id").Return(failed, nil)
+		},
+		Resource:  ResourceMwsNccPrivateEndpointRule(),
+		AccountID: "abc",
+		Host:      "https://accounts.cloud.databricks.com",
+		HCL: `
+		network_connectivity_config_id = "ncc_id"
+		resource_id = "resource_id"
+		group_id = "blob"
+		`,
+		Create: true,
+	}.Apply(t)
+	assert.ErrorContains(t, err, "quota exceeded")
+	assert.Equal(t, "ncc_id/rule_id", d.Id())
+}
+
+// TestResourceNccPrivateEndpointRuleCreate_AsyncRejected is defense-in-depth:
+// REJECTED is not expected on a fresh Create, but the poller should fail
+// fast rather than retry forever if the server reports it.
+func TestResourceNccPrivateEndpointRuleCreate_AsyncRejected(t *testing.T) {
+	creating := &settings.NccPrivateEndpointRule{
+		RuleId:                      "rule_id",
+		NetworkConnectivityConfigId: "ncc_id",
+		ResourceId:                  "resource_id",
+		GroupId:                     "blob",
+		ConnectionState:             "CREATING",
+	}
+	rejected := &settings.NccPrivateEndpointRule{
+		RuleId:                      "rule_id",
+		NetworkConnectivityConfigId: "ncc_id",
+		ResourceId:                  "resource_id",
+		GroupId:                     "blob",
+		ConnectionState:             "REJECTED",
+	}
+	_, err := qa.ResourceFixture{
+		MockAccountClientFunc: func(a *mocks.MockAccountClient) {
+			e := a.GetMockNetworkConnectivityAPI().EXPECT()
+			e.CreatePrivateEndpointRule(mock.Anything, settings.CreatePrivateEndpointRuleRequest{
+				NetworkConnectivityConfigId: "ncc_id",
+				PrivateEndpointRule: settings.CreatePrivateEndpointRule{
+					ResourceId: "resource_id",
+					GroupId:    "blob",
+				},
+			}).Return(creating, nil)
+			e.GetPrivateEndpointRuleByNetworkConnectivityConfigIdAndPrivateEndpointRuleId(mock.Anything, "ncc_id", "rule_id").Return(rejected, nil)
+		},
+		Resource:  ResourceMwsNccPrivateEndpointRule(),
+		AccountID: "abc",
+		Host:      "https://accounts.cloud.databricks.com",
+		HCL: `
+		network_connectivity_config_id = "ncc_id"
+		resource_id = "resource_id"
+		group_id = "blob"
+		`,
+		Create: true,
+	}.Apply(t)
+	assert.ErrorContains(t, err, "REJECTED")
+}
+
 func TestResourceNccPrivateEndpointRuleRead(t *testing.T) {
 	qa.ResourceFixture{
 		MockAccountClientFunc: func(a *mocks.MockAccountClient) {


### PR DESCRIPTION
## Summary

- `databricks_mws_ncc_private_endpoint_rule.Create` now polls `GetPrivateEndpointRule` until the rule leaves the `CREATING` state, instead of storing whatever the server returns immediately. The NCC API can return with `connection_state=CREATING` and empty `vpc_endpoint_id` / `endpoint_name` while the cloud-side endpoint is still being provisioned, which previously broke downstream resources that referenced those fields.
- `PENDING` and `ESTABLISHED` are terminal success states (at `PENDING` the endpoint exists on the cloud and the identifier fields are populated; the docs note `ESTABLISHED` requires out-of-band customer approval that can take up to 14 days, so we cannot wait for it during an apply). `CREATE_FAILED` is terminal failure and surfaces `error_message`; `REJECTED` / `DISCONNECTED` / `EXPIRED` are treated as terminal failure defensively. Unknown states fall through to retry.
- Added a `Timeouts { Create = 30m }` block; users can override with `timeouts { create = "..." }`.
- Resource ID is packed before polling, so a polling failure or context cancellation leaves a Read-able resource in state for `terraform destroy` to clean up the orphaned rule on the server.
- Update does not poll: the server's update handler does not touch `connection_state`, so the rule never re-enters `CREATING`.

## Test plan

- [x] `make fmt lint ws` passes.
- [x] `go test -v -run TestResourceNccPrivateEndpointRule ./mws` passes (12 tests, including 3 new tests for the async-polling path).
  - `TestResourceNccPrivateEndpointRuleCreate_AsyncPolling` - Create returns CREATING, first Get returns CREATING, second Get returns PENDING with `vpc_endpoint_id` populated.
  - `TestResourceNccPrivateEndpointRuleCreate_AsyncCreateFailed` - surfaces `error_message`; ID is packed so destroy works.
  - `TestResourceNccPrivateEndpointRuleCreate_AsyncRejected` - defense-in-depth for unexpected terminal states.
- [x] Sync-mode backwards compatibility: existing `TestResourceNccPrivateEndpointRulePrivateEndpointRuleCreate` still passes - when the server returns `PENDING` directly, the wait helper's first Get short-circuits.
- [ ] Manual acceptance pass against an NCC-enabled account once the async behavior is enabled server-side.