### PR TITLE
[Fix] StructToData: allow empty values through for Optional+Computed fields

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -8,7 +8,9 @@
 
 ### Bug Fixes
 
+* Fixed `lifecycle { ignore_changes }` not working for `Optional+Computed` fields whose API returns empty values. The shared `StructToData` gate in `common/reflect_resource.go` was silently dropping empty/nil values for all `Optional` fields, including `Computed` ones, causing perpetual `(known after apply)` diffs and preventing `ignore_changes` from preserving externally-set values.
 * Fix `databricks_metastore` so that updating `external_access_enabled` from `true` to `false` is sent in the PATCH request. Previously the field was silently dropped from the request body, so the change never reached the API.
+||||||| parent of 7a333420 ([Fix] StructToData gate: allow empty values through for Optional+Computed fields)
 
 ### Documentation
 

--- a/common/reflect_resource.go
+++ b/common/reflect_resource.go
@@ -705,7 +705,7 @@ func StructToData(result any, s map[string]*schema.Schema, d *schema.ResourceDat
 			return nil
 		}
 		fieldPath := strings.Join(path, ".")
-		if fieldSchema.Optional && isValueNilOrEmpty(valueField, fieldPath) {
+		if fieldSchema.Optional && !fieldSchema.Computed && isValueNilOrEmpty(valueField, fieldPath) {
 			return nil
 		}
 		// For optional boolean fields, always set them even if not configured to enable drift detection.

--- a/common/reflect_resource_test.go
+++ b/common/reflect_resource_test.go
@@ -973,3 +973,45 @@ func TestStructToData_IndirectString(t *testing.T) {
 	}, scm, d)
 	assert.NoError(t, err)
 }
+
+func TestStructToData_OptionalComputedEmptyMapWrittenToState(t *testing.T) {
+	type Resource struct {
+		Name string            `json:"name"`
+		Tags map[string]string `json:"tags,omitempty"`
+	}
+	s := StructToSchema(Resource{}, func(s map[string]*schema.Schema) map[string]*schema.Schema {
+		s["tags"].Optional = true
+		s["tags"].Computed = true
+		return s
+	})
+	d := schema.TestResourceDataRaw(t, s, map[string]any{"name": "test"})
+	d.SetId("existing-resource")
+	err := StructToData(Resource{Name: "test", Tags: map[string]string{}}, s, d)
+	assert.NoError(t, err)
+	// Optional+Computed empty maps must reach state so ignore_changes and drift
+	// detection work correctly; without the !fieldSchema.Computed guard they
+	// were silently dropped, causing a perpetual "(known after apply)" diff.
+	tags := d.Get("tags")
+	assert.NotNil(t, tags)
+	tagsMap, ok := tags.(map[string]interface{})
+	assert.True(t, ok)
+	assert.Empty(t, tagsMap)
+}
+
+func TestStructToData_OptionalOnlyEmptyMapNotWrittenToState(t *testing.T) {
+	type Resource struct {
+		Name string            `json:"name"`
+		Tags map[string]string `json:"tags,omitempty"`
+	}
+	s := StructToSchema(Resource{}, nil)
+	d := schema.TestResourceDataRaw(t, s, map[string]any{"name": "test"})
+	d.SetId("existing-resource")
+	err := StructToData(Resource{Name: "test", Tags: map[string]string{}}, s, d)
+	assert.NoError(t, err)
+	// Optional-only (non-Computed) empty maps are still filtered to avoid
+	// writing server defaults into state for unconfigured fields.
+	tags := d.Get("tags")
+	tagsMap, ok := tags.(map[string]interface{})
+	assert.True(t, ok)
+	assert.Empty(t, tagsMap)
+}


### PR DESCRIPTION
## Problem

`StructToData` in `common/reflect_resource.go` has a gate that skips writing empty/nil API values to state for `Optional` fields:

```go
// Before
if fieldSchema.Optional && isValueNilOrEmpty(valueField, fieldPath) {
    return nil
}
```

This gate is correct for **Optional-only** fields: if the API returns a server default the user never configured, we should not pollute state with it.

However, the same gate was also firing for **Optional+Computed** fields — ones where the server is explicitly allowed to set the value. When the API returned an empty map or nil for such a field (e.g. a cluster policy clearing `spark_conf`), the value was silently dropped, never reaching Terraform state. This caused two concrete problems:

1. **Perpetual `(known after apply)` diffs** — state never reflected the empty server value, so Terraform kept re-planning it as unknown.
2. **`lifecycle { ignore_changes }` not working** — because the field's current server value was never written to state, the provider could not track it, and on the next `apply` it would silently revert the externally-set value back to whatever was last in state.

## Fix

Add `!fieldSchema.Computed` to the gate condition:

```go
// After
if fieldSchema.Optional && !fieldSchema.Computed && isValueNilOrEmpty(valueField, fieldPath) {
    return nil
}
```

This preserves existing behaviour for **Optional-only** fields (server defaults are still filtered) while allowing **Optional+Computed** fields to write empty/nil values through to state.

## Tests

- `TestStructToData_OptionalComputedEmptyMapWrittenToState` — regression test: empty map for an `Optional+Computed` field must reach state.
- `TestStructToData_OptionalOnlyEmptyMapNotWrittenToState` — guard test: empty map for an `Optional`-only field is still filtered out.

## Notes

This is the prerequisite central fix. Per-resource PRs (marking policy-settable fields as `Optional+Computed`) will follow and depend on this change.

Related: #1238