### PR TITLE
[Internal] Add internal/retrier package

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -16,6 +16,10 @@
 
 ### Internal Changes
 
+* Add `internal/retrier` package for unified retry and backoff handling ([#XXXX](https://github.com/databricks/terraform-provider-databricks/pull/XXXX)).
+
+  Introduces a value-aware retry loop (`Run`, `RunErr`) and deterministic exponential `BackoffPolicy` that consolidate the multiple retry implementations currently scattered across the provider (`terraform-plugin-sdk/helper/retry`, `databricks-sdk-go/retries`, hand-rolled loops). Each `Run` invocation gets its own retrier instance via a factory, making the loop safe to use from multiple goroutines without locking. Defaults: `Initial=10s`, `Maximum=5m`, `Factor=2`, no jitter. State-driven polling (the dominant pattern across waiters in this provider) is supported natively because the retrier predicate sees both the polled value and any error. This is a no-op for users; callers will be migrated in follow-up changes.
+
 * Pass `excludedAttributes=entitlements` on SCIM `/Me` requests ([#5725](https://github.com/databricks/terraform-provider-databricks/pull/5725)).
 
   The provider only needs identity fields (`userName`, `id`, `externalId`) from `/Me`, never entitlements. Skipping the entitlement computation avoids an expensive `getEffectivePermissions` traversal on the SCIM backend, which has caused incidents on workspaces with large grant counts.

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -16,10 +16,5 @@
 
 ### Internal Changes
 
-* Add `internal/retrier` package for unified retry and backoff handling ([#XXXX](https://github.com/databricks/terraform-provider-databricks/pull/XXXX)).
-
-  Introduces a value-aware retry loop (`Run`, `RunErr`) and deterministic exponential `BackoffPolicy` that consolidate the multiple retry implementations currently scattered across the provider (`terraform-plugin-sdk/helper/retry`, `databricks-sdk-go/retries`, hand-rolled loops). Each `Run` invocation gets its own retrier instance via a factory, making the loop safe to use from multiple goroutines without locking. Defaults: `Initial=10s`, `Maximum=5m`, `Factor=2`, no jitter. State-driven polling (the dominant pattern across waiters in this provider) is supported natively because the retrier predicate sees both the polled value and any error. This is a no-op for users; callers will be migrated in follow-up changes.
-
+* Add `internal/retrier` package for unified retry and backoff handling ([#5746](https://github.com/databricks/terraform-provider-databricks/pull/5746)).
 * Pass `excludedAttributes=entitlements` on SCIM `/Me` requests ([#5725](https://github.com/databricks/terraform-provider-databricks/pull/5725)).
-
-  The provider only needs identity fields (`userName`, `id`, `externalId`) from `/Me`, never entitlements. Skipping the entitlement computation avoids an expensive `getEffectivePermissions` traversal on the SCIM backend, which has caused incidents on workspaces with large grant counts.

--- a/common/retry.go
+++ b/common/retry.go
@@ -4,40 +4,58 @@ import (
 	"context"
 	"errors"
 	"regexp"
+	"time"
 
 	"github.com/databricks/databricks-sdk-go/apierr"
 	"github.com/databricks/databricks-sdk-go/logger"
-	"github.com/databricks/databricks-sdk-go/retries"
+	"github.com/databricks/terraform-provider-databricks/internal/retrier"
 )
 
 var timeoutRegex = regexp.MustCompile(`request timed out after .* of inactivity`)
 
-func RetryOnTimeout[T any](ctx context.Context, f func(context.Context) (*T, error)) (*T, error) {
-	r := retries.New[T](retries.WithRetryFunc(func(err error) bool {
-		msg := err.Error()
-		isTimeout := timeoutRegex.MatchString(msg)
-		if isTimeout {
-			logger.Debugf(ctx, "Retrying due to timeout: %s", msg)
-		}
-		return isTimeout
-	}))
-	return r.Run(ctx, func(ctx context.Context) (*T, error) {
-		return f(ctx)
-	})
+// transientErrorBackoff is the backoff used by both helpers below. Transient
+// errors typically resolve in a few seconds, so we start fast and cap quickly
+// rather than using the retrier package defaults of 10s/5m.
+var transientErrorBackoff = retrier.BackoffPolicy{
+	Initial: 1 * time.Second,
+	Maximum: 30 * time.Second,
+	Factor:  2,
 }
 
-// RetryOn504 returns a [retries.Retrier] that calls the given method
-// until it either succeeds or returns an error that is different from
-// [apierr.ErrDeadlineExceeded].
+// RetryOnTimeout retries f while it returns an error whose message matches
+// the SDK's "request timed out after ... of inactivity" pattern. Any other
+// error, or a successful call, halts.
+func RetryOnTimeout[T any](ctx context.Context, f func(context.Context) (*T, error)) (*T, error) {
+	return retrier.Run(ctx,
+		retrier.RetryIf(transientErrorBackoff, func(_ *T, err error) bool {
+			if err == nil {
+				return false
+			}
+			isTimeout := timeoutRegex.MatchString(err.Error())
+			if isTimeout {
+				logger.Debugf(ctx, "Retrying due to timeout: %s", err.Error())
+			}
+			return isTimeout
+		}),
+		f,
+	)
+}
+
+// RetryOn504 retries f while it returns an error wrapping
+// [apierr.ErrDeadlineExceeded] (HTTP 504). Any other error, or a successful
+// call, halts.
 func RetryOn504[T any](ctx context.Context, f func(context.Context) (*T, error)) (*T, error) {
-	r := retries.New[T](retries.WithTimeout(-1), retries.WithRetryFunc(func(err error) bool {
-		if !errors.Is(err, apierr.ErrDeadlineExceeded) {
-			return false
-		}
-		logger.Debugf(ctx, "Retrying on error 504")
-		return true
-	}))
-	return r.Run(ctx, func(ctx context.Context) (*T, error) {
-		return f(ctx)
-	})
+	return retrier.Run(ctx,
+		retrier.RetryIf(transientErrorBackoff, func(_ *T, err error) bool {
+			if err == nil {
+				return false
+			}
+			if !errors.Is(err, apierr.ErrDeadlineExceeded) {
+				return false
+			}
+			logger.Debugf(ctx, "Retrying on error 504")
+			return true
+		}),
+		f,
+	)
 }

--- a/common/retry.go
+++ b/common/retry.go
@@ -7,11 +7,30 @@ import (
 	"time"
 
 	"github.com/databricks/databricks-sdk-go/apierr"
-	"github.com/databricks/databricks-sdk-go/logger"
 	"github.com/databricks/terraform-provider-databricks/internal/retrier"
 )
 
-var timeoutRegex = regexp.MustCompile(`request timed out after .* of inactivity`)
+// RetryOnTimeout retries f while it returns an SDK inactivity-timeout error.
+//
+// TODO: Deprecate this function in favor of retrier.Run.
+func RetryOnTimeout[T any](ctx context.Context, f func(context.Context) (*T, error)) (*T, error) {
+	return retrier.Run(ctx, retryOnErr[*T](isTimeoutError), f)
+}
+
+// RetryOn504 retries f while it returns an error wrapping [apierr.ErrDeadlineExceeded].
+//
+// TODO: Deprecate this function in favor of retrier.Run.
+func RetryOn504[T any](ctx context.Context, f func(context.Context) (*T, error)) (*T, error) {
+	return retrier.Run(ctx, retryOnErr[*T](is504Error), f)
+}
+
+// retryOnErr adapts an error-only predicate to a value-aware retrier factory
+// using the transient backoff policy.
+func retryOnErr[V any](isRetriable func(error) bool) func() retrier.Retrier[V] {
+	return retrier.RetryIf(transientBackoff(), func(_ V, err error) bool {
+		return isRetriable(err)
+	})
+}
 
 // transientBackoff returns a fresh backoff tuned for transient errors:
 // start fast, cap quickly.
@@ -19,30 +38,13 @@ func transientBackoff() retrier.BackoffPolicy {
 	return retrier.BackoffPolicy{Initial: time.Second, Maximum: 30 * time.Second}
 }
 
-// RetryOnTimeout retries f while it returns an SDK inactivity-timeout error.
-func RetryOnTimeout[T any](ctx context.Context, f func(context.Context) (*T, error)) (*T, error) {
-	return retrier.Run(ctx,
-		retrier.RetryIf(transientBackoff(), func(_ *T, err error) bool {
-			if err == nil || !timeoutRegex.MatchString(err.Error()) {
-				return false
-			}
-			logger.Debugf(ctx, "Retrying due to timeout: %s", err.Error())
-			return true
-		}),
-		f,
-	)
+// TODO: Replace the regex check with type-aware error inspection.
+var timeoutRegex = regexp.MustCompile(`request timed out after .* of inactivity`)
+
+func isTimeoutError(err error) bool {
+	return err != nil && timeoutRegex.MatchString(err.Error())
 }
 
-// RetryOn504 retries f while it returns an error wrapping [apierr.ErrDeadlineExceeded].
-func RetryOn504[T any](ctx context.Context, f func(context.Context) (*T, error)) (*T, error) {
-	return retrier.Run(ctx,
-		retrier.RetryIf(transientBackoff(), func(_ *T, err error) bool {
-			if !errors.Is(err, apierr.ErrDeadlineExceeded) {
-				return false
-			}
-			logger.Debugf(ctx, "Retrying on error 504")
-			return true
-		}),
-		f,
-	)
+func is504Error(err error) bool {
+	return errors.Is(err, apierr.ErrDeadlineExceeded)
 }

--- a/common/retry.go
+++ b/common/retry.go
@@ -13,43 +13,30 @@ import (
 
 var timeoutRegex = regexp.MustCompile(`request timed out after .* of inactivity`)
 
-// transientErrorBackoff is the backoff used by both helpers below. Transient
-// errors typically resolve in a few seconds, so we start fast and cap quickly
-// rather than using the retrier package defaults of 10s/5m.
-var transientErrorBackoff = retrier.BackoffPolicy{
-	Initial: 1 * time.Second,
-	Maximum: 30 * time.Second,
-	Factor:  2,
+// transientBackoff returns a fresh backoff tuned for transient errors:
+// start fast, cap quickly.
+func transientBackoff() retrier.BackoffPolicy {
+	return retrier.BackoffPolicy{Initial: time.Second, Maximum: 30 * time.Second}
 }
 
-// RetryOnTimeout retries f while it returns an error whose message matches
-// the SDK's "request timed out after ... of inactivity" pattern. Any other
-// error, or a successful call, halts.
+// RetryOnTimeout retries f while it returns an SDK inactivity-timeout error.
 func RetryOnTimeout[T any](ctx context.Context, f func(context.Context) (*T, error)) (*T, error) {
 	return retrier.Run(ctx,
-		retrier.RetryIf(transientErrorBackoff, func(_ *T, err error) bool {
-			if err == nil {
+		retrier.RetryIf(transientBackoff(), func(_ *T, err error) bool {
+			if err == nil || !timeoutRegex.MatchString(err.Error()) {
 				return false
 			}
-			isTimeout := timeoutRegex.MatchString(err.Error())
-			if isTimeout {
-				logger.Debugf(ctx, "Retrying due to timeout: %s", err.Error())
-			}
-			return isTimeout
+			logger.Debugf(ctx, "Retrying due to timeout: %s", err.Error())
+			return true
 		}),
 		f,
 	)
 }
 
-// RetryOn504 retries f while it returns an error wrapping
-// [apierr.ErrDeadlineExceeded] (HTTP 504). Any other error, or a successful
-// call, halts.
+// RetryOn504 retries f while it returns an error wrapping [apierr.ErrDeadlineExceeded].
 func RetryOn504[T any](ctx context.Context, f func(context.Context) (*T, error)) (*T, error) {
 	return retrier.Run(ctx,
-		retrier.RetryIf(transientErrorBackoff, func(_ *T, err error) bool {
-			if err == nil {
-				return false
-			}
+		retrier.RetryIf(transientBackoff(), func(_ *T, err error) bool {
 			if !errors.Is(err, apierr.ErrDeadlineExceeded) {
 				return false
 			}

--- a/common/retry_test.go
+++ b/common/retry_test.go
@@ -19,10 +19,28 @@ func TestRetryOnTimeout(t *testing.T) {
 		wantErr   error
 		wantCalls int
 	}{
-		{name: "success on first call", callErrs: []error{nil}, wantCalls: 1},
-		{name: "timeout then succeed", callErrs: []error{timeoutErr, nil}, wantCalls: 2},
-		{name: "non-timeout halts", callErrs: []error{otherErr}, wantErr: otherErr, wantCalls: 1},
-		{name: "timeout then non-timeout halts", callErrs: []error{timeoutErr, otherErr}, wantErr: otherErr, wantCalls: 2},
+		{
+			name:      "success on first call",
+			callErrs:  []error{nil},
+			wantCalls: 1,
+		},
+		{
+			name:      "timeout then succeed",
+			callErrs:  []error{timeoutErr, nil},
+			wantCalls: 2,
+		},
+		{
+			name:      "non-timeout halts",
+			callErrs:  []error{otherErr},
+			wantErr:   otherErr,
+			wantCalls: 1,
+		},
+		{
+			name:      "timeout then non-timeout halts",
+			callErrs:  []error{timeoutErr, otherErr},
+			wantErr:   otherErr,
+			wantCalls: 2,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -52,11 +70,33 @@ func TestRetryOn504(t *testing.T) {
 		wantErr   error
 		wantCalls int
 	}{
-		{name: "success on first call", callErrs: []error{nil}, wantCalls: 1},
-		{name: "504 then succeed", callErrs: []error{apierr.ErrDeadlineExceeded, nil}, wantCalls: 2},
-		{name: "wrapped 504 then succeed", callErrs: []error{fmt.Errorf("got 504: %w", apierr.ErrDeadlineExceeded), nil}, wantCalls: 2},
-		{name: "non-504 halts", callErrs: []error{otherErr}, wantErr: otherErr, wantCalls: 1},
-		{name: "504 then non-504 halts", callErrs: []error{apierr.ErrDeadlineExceeded, otherErr}, wantErr: otherErr, wantCalls: 2},
+		{
+			name:      "success on first call",
+			callErrs:  []error{nil},
+			wantCalls: 1,
+		},
+		{
+			name:      "504 then succeed",
+			callErrs:  []error{apierr.ErrDeadlineExceeded, nil},
+			wantCalls: 2,
+		},
+		{
+			name:      "wrapped 504 then succeed",
+			callErrs:  []error{fmt.Errorf("got 504: %w", apierr.ErrDeadlineExceeded), nil},
+			wantCalls: 2,
+		},
+		{
+			name:      "non-504 halts",
+			callErrs:  []error{otherErr},
+			wantErr:   otherErr,
+			wantCalls: 1,
+		},
+		{
+			name:      "504 then non-504 halts",
+			callErrs:  []error{apierr.ErrDeadlineExceeded, otherErr},
+			wantErr:   otherErr,
+			wantCalls: 2,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/common/retry_test.go
+++ b/common/retry_test.go
@@ -6,129 +6,71 @@ import (
 	"testing"
 
 	"github.com/databricks/databricks-sdk-go/apierr"
-	"github.com/databricks/databricks-sdk-go/experimental/mocks"
-	"github.com/databricks/databricks-sdk-go/service/workspace"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 )
 
-func TestRetryOnTimeout_NoError(t *testing.T) {
-	w := mocks.NewMockWorkspaceClient(t)
-	expected := &workspace.ObjectInfo{}
-	api := w.GetMockWorkspaceAPI().EXPECT()
-	api.GetStatusByPath(mock.Anything, mock.Anything).Return(expected, nil)
-	res, err := RetryOnTimeout(context.Background(), func(ctx context.Context) (*workspace.ObjectInfo, error) {
-		return w.WorkspaceClient.Workspace.GetStatusByPath(ctx, "path")
-	})
-	assert.NoError(t, err)
-	assert.Equal(t, expected, res)
+func TestRetryOnTimeout(t *testing.T) {
+	timeoutErr := errors.New("request failed: request timed out after 1m0s of inactivity")
+	otherErr := errors.New("non-retriable")
+
+	testCases := []struct {
+		name      string
+		callErrs  []error
+		wantErr   error
+		wantCalls int
+	}{
+		{name: "success on first call", callErrs: []error{nil}, wantCalls: 1},
+		{name: "timeout then succeed", callErrs: []error{timeoutErr, nil}, wantCalls: 2},
+		{name: "non-timeout halts", callErrs: []error{otherErr}, wantErr: otherErr, wantCalls: 1},
+		{name: "timeout then non-timeout halts", callErrs: []error{timeoutErr, otherErr}, wantErr: otherErr, wantCalls: 2},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			calls := 0
+			_, err := RetryOnTimeout(context.Background(), func(ctx context.Context) (*struct{}, error) {
+				e := tc.callErrs[calls]
+				calls++
+				return nil, e
+			})
+			if calls != tc.wantCalls {
+				t.Errorf("call count = %d, want %d", calls, tc.wantCalls)
+			}
+			if !errors.Is(err, tc.wantErr) {
+				t.Errorf("err = %v, want %v", err, tc.wantErr)
+			}
+		})
+	}
 }
 
-func TestRetryOnTimeout_OneError(t *testing.T) {
-	w := mocks.NewMockWorkspaceClient(t)
-	expected := &workspace.ObjectInfo{}
-	api := w.GetMockWorkspaceAPI().EXPECT()
-	call1 := api.GetStatusByPath(mock.Anything, mock.Anything).Return(nil, errors.New("request failed: request timed out after 1m0s of inactivity"))
-	call1.Repeatability = 1
-	api.GetStatusByPath(mock.Anything, mock.Anything).Return(expected, nil)
-	res, err := RetryOnTimeout(context.Background(), func(ctx context.Context) (*workspace.ObjectInfo, error) {
-		return w.WorkspaceClient.Workspace.GetStatusByPath(ctx, "path")
-	})
-	assert.NoError(t, err)
-	assert.Equal(t, expected, res)
-}
+func TestRetryOn504(t *testing.T) {
+	otherErr := errors.New("not 504")
 
-func TestRetryOnTimeout_NonRetriableError(t *testing.T) {
-	w := mocks.NewMockWorkspaceClient(t)
-	expected := errors.New("request failed: non-retriable error")
-	api := w.GetMockWorkspaceAPI().EXPECT()
-	api.GetStatusByPath(mock.Anything, mock.Anything).Return(nil, expected)
-	_, err := RetryOnTimeout(context.Background(), func(ctx context.Context) (*workspace.ObjectInfo, error) {
-		return w.WorkspaceClient.Workspace.GetStatusByPath(ctx, "path")
-	})
-	assert.ErrorIs(t, err, expected)
-}
+	testCases := []struct {
+		name      string
+		callErrs  []error
+		wantErr   error
+		wantCalls int
+	}{
+		{name: "success on first call", callErrs: []error{nil}, wantCalls: 1},
+		{name: "504 then succeed", callErrs: []error{apierr.ErrDeadlineExceeded, nil}, wantCalls: 2},
+		{name: "non-504 halts", callErrs: []error{otherErr}, wantErr: otherErr, wantCalls: 1},
+		{name: "504 then non-504 halts", callErrs: []error{apierr.ErrDeadlineExceeded, otherErr}, wantErr: otherErr, wantCalls: 2},
+	}
 
-func TestRetryOn504_noError(t *testing.T) {
-	wantErr := error(nil)
-	wantRes := (*workspace.ObjectInfo)(nil)
-	wantCalls := 1
-
-	w := mocks.NewMockWorkspaceClient(t)
-	api := w.GetMockWorkspaceAPI().EXPECT()
-	api.GetStatusByPath(mock.Anything, mock.Anything).Return(wantRes, wantErr)
-
-	gotCalls := 0
-	gotRes, gotErr := RetryOn504(context.Background(), func(ctx context.Context) (*workspace.ObjectInfo, error) {
-		gotCalls += 1
-		return w.WorkspaceClient.Workspace.GetStatusByPath(ctx, "path")
-	})
-
-	assert.ErrorIs(t, gotErr, wantErr)
-	assert.Equal(t, gotRes, wantRes)
-	assert.Equal(t, gotCalls, wantCalls)
-}
-
-func TestRetryOn504_errorNot504(t *testing.T) {
-	wantErr := errors.New("test error")
-	wantRes := (*workspace.ObjectInfo)(nil)
-	wantCalls := 1
-
-	w := mocks.NewMockWorkspaceClient(t)
-	api := w.GetMockWorkspaceAPI().EXPECT()
-	api.GetStatusByPath(mock.Anything, mock.Anything).Return(wantRes, wantErr)
-
-	gotCalls := 0
-	gotRes, gotErr := RetryOn504(context.Background(), func(ctx context.Context) (*workspace.ObjectInfo, error) {
-		gotCalls += 1
-		return w.WorkspaceClient.Workspace.GetStatusByPath(ctx, "path")
-	})
-
-	assert.ErrorIs(t, gotErr, wantErr)
-	assert.Equal(t, gotRes, wantRes)
-	assert.Equal(t, gotCalls, wantCalls)
-}
-
-func TestRetryOn504_error504ThenFail(t *testing.T) {
-	wantErr := errors.New("test error")
-	wantRes := (*workspace.ObjectInfo)(nil)
-	wantCalls := 2
-
-	w := mocks.NewMockWorkspaceClient(t)
-	api := w.GetMockWorkspaceAPI().EXPECT()
-	call := api.GetStatusByPath(mock.Anything, mock.Anything).Return(nil, apierr.ErrDeadlineExceeded)
-	call.Repeatability = 1
-	api.GetStatusByPath(mock.Anything, mock.Anything).Return(wantRes, wantErr)
-
-	gotCalls := 0
-	gotRes, gotErr := RetryOn504(context.Background(), func(ctx context.Context) (*workspace.ObjectInfo, error) {
-		gotCalls++
-		return w.WorkspaceClient.Workspace.GetStatusByPath(ctx, "path")
-	})
-
-	assert.ErrorIs(t, gotErr, wantErr)
-	assert.Equal(t, gotRes, wantRes)
-	assert.Equal(t, gotCalls, wantCalls)
-}
-
-func TestRetryOn504_error504ThenSuccess(t *testing.T) {
-	wantErr := error(nil)
-	wantRes := &workspace.ObjectInfo{}
-	wantCalls := 2
-
-	w := mocks.NewMockWorkspaceClient(t)
-	api := w.GetMockWorkspaceAPI().EXPECT()
-	call := api.GetStatusByPath(mock.Anything, mock.Anything).Return(nil, apierr.ErrDeadlineExceeded)
-	call.Repeatability = 1
-	api.GetStatusByPath(mock.Anything, mock.Anything).Return(wantRes, wantErr)
-
-	gotCalls := 0
-	gotRes, gotErr := RetryOn504(context.Background(), func(ctx context.Context) (*workspace.ObjectInfo, error) {
-		gotCalls++
-		return w.WorkspaceClient.Workspace.GetStatusByPath(ctx, "path")
-	})
-
-	assert.ErrorIs(t, gotErr, wantErr)
-	assert.Equal(t, gotRes, wantRes)
-	assert.Equal(t, gotCalls, wantCalls)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			calls := 0
+			_, err := RetryOn504(context.Background(), func(ctx context.Context) (*struct{}, error) {
+				e := tc.callErrs[calls]
+				calls++
+				return nil, e
+			})
+			if calls != tc.wantCalls {
+				t.Errorf("call count = %d, want %d", calls, tc.wantCalls)
+			}
+			if !errors.Is(err, tc.wantErr) {
+				t.Errorf("err = %v, want %v", err, tc.wantErr)
+			}
+		})
+	}
 }

--- a/common/retry_test.go
+++ b/common/retry_test.go
@@ -3,6 +3,7 @@ package common
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/databricks/databricks-sdk-go/apierr"
@@ -53,6 +54,7 @@ func TestRetryOn504(t *testing.T) {
 	}{
 		{name: "success on first call", callErrs: []error{nil}, wantCalls: 1},
 		{name: "504 then succeed", callErrs: []error{apierr.ErrDeadlineExceeded, nil}, wantCalls: 2},
+		{name: "wrapped 504 then succeed", callErrs: []error{fmt.Errorf("got 504: %w", apierr.ErrDeadlineExceeded), nil}, wantCalls: 2},
 		{name: "non-504 halts", callErrs: []error{otherErr}, wantErr: otherErr, wantCalls: 1},
 		{name: "504 then non-504 halts", callErrs: []error{apierr.ErrDeadlineExceeded, otherErr}, wantErr: otherErr, wantCalls: 2},
 	}

--- a/internal/retrier/retrier.go
+++ b/internal/retrier/retrier.go
@@ -1,0 +1,192 @@
+// Package retrier provides a small, value-aware retry loop for waiting on
+// asynchronous state transitions (e.g. cluster startup, workspace creation)
+// and for retrying transient errors that the Databricks SDK does not absorb
+// itself. Retriers are constructed fresh per Run so independent invocations
+// have independent backoff state and can run concurrently.
+package retrier
+
+import (
+	"context"
+	"time"
+)
+
+// Retrier decides whether to retry an operation based on the outcome of
+// the last attempt. IsRetriable is called after every attempt with the
+// value and error produced by that attempt. It returns the delay to wait
+// before the next attempt and whether to retry at all.
+//
+// Passing both value and error lets callers express either of the two
+// dominant retry policies in this codebase:
+//
+//   - error-driven: retry transient errors (e.g. 504, timeout); halt on
+//     terminal errors; halt on success.
+//   - state-driven: retry while the value is in a non-terminal state
+//     (e.g. a cluster in PENDING); halt when the value reaches a
+//     terminal state; halt on any error.
+//
+// State-driven polling is the majority of retry sites in this provider,
+// so the value is always passed in. Error-driven retriers ignore it.
+type Retrier[V any] interface {
+	IsRetriable(V, error) (time.Duration, bool)
+}
+
+// RetrierErr is the error-only specialisation of Retrier, for retry policies
+// that do not inspect the operation's result value (e.g. retrying on transient
+// errors, polling until a resource is deleted).
+type RetrierErr = Retrier[struct{}]
+
+// RetryIf returns a retrier factory suitable for passing to Run. The
+// constructed retrier calls isRetriable after every attempt and, when it
+// returns true, sleeps for the duration produced by a fresh copy of bp before
+// the next attempt. bp is captured by value, so independent Run invocations
+// get independent backoff state and can run concurrently.
+func RetryIf[V any](bp BackoffPolicy, isRetriable func(V, error) bool) func() Retrier[V] {
+	return func() Retrier[V] {
+		return &retrier[V]{
+			backoffPolicy: bp,
+			isRetriable:   isRetriable,
+		}
+	}
+}
+
+// RetryIfErr is the error-only analog of RetryIf, suitable for passing to
+// RunErr. The isRetriable predicate sees only the error.
+func RetryIfErr(bp BackoffPolicy, isRetriable func(error) bool) func() RetrierErr {
+	return RetryIf(bp, func(_ struct{}, err error) bool {
+		return isRetriable(err)
+	})
+}
+
+type retrier[V any] struct {
+	backoffPolicy BackoffPolicy
+	isRetriable   func(V, error) bool
+}
+
+func (r *retrier[V]) IsRetriable(val V, err error) (time.Duration, bool) {
+	if !r.isRetriable(val, err) {
+		return 0, false
+	}
+	return r.backoffPolicy.Next(), true
+}
+
+// Run executes fn, retrying according to the retrier constructed by
+// newR. newR is invoked once per Run call so each invocation has its
+// own independent retrier state; this makes Run safe to use from
+// multiple goroutines with the same newR. If newR is nil, or if it
+// returns nil, Run performs exactly one attempt with no retry logic.
+// It returns the value and error of the final attempt.
+//
+// Run honours context cancellation between attempts and during sleeps;
+// if ctx completes, Run returns the last attempt's value and ctx.Err().
+func Run[V any](ctx context.Context, newR func() Retrier[V], fn func(context.Context) (V, error)) (V, error) {
+	return run(ctx, newR, fn, sleep)
+}
+
+// RunErr is the error-only analog of Run. It applies the same lifecycle
+// and concurrency contract as Run; see Run's documentation for the
+// details on newR, single-shot semantics, and ctx cancellation.
+func RunErr(ctx context.Context, newR func() RetrierErr, fn func(context.Context) error) error {
+	_, err := Run(ctx, newR, func(ctx context.Context) (struct{}, error) {
+		return struct{}{}, fn(ctx)
+	})
+	return err
+}
+
+// sleep sleeps for d, returning early with ctx.Err() if the context
+// completes first.
+func sleep(ctx context.Context, d time.Duration) error {
+	t := time.NewTimer(d)
+	select {
+	case <-ctx.Done():
+		t.Stop()
+		return ctx.Err()
+	case <-t.C:
+		return nil
+	}
+}
+
+// sleeper is the dependency injected into run so tests can substitute
+// a deterministic sleep.
+type sleeper func(ctx context.Context, d time.Duration) error
+
+// run is the implementation of Run. It takes the sleeper as an argument
+// so tests can substitute a deterministic sleep.
+func run[V any](ctx context.Context, newR func() Retrier[V], fn func(context.Context) (V, error), sleep sleeper) (V, error) {
+	// r is constructed lazily so single-shot Runs skip allocation and any
+	// operation-start state in the retrier anchors at first need.
+	var r Retrier[V]
+
+	for {
+		val, err := fn(ctx)
+
+		if r == nil {
+			if newR != nil {
+				r = newR()
+			}
+			if r == nil {
+				return val, err
+			}
+		}
+
+		delay, retry := r.IsRetriable(val, err)
+		if !retry {
+			return val, err
+		}
+
+		if sleepErr := sleep(ctx, delay); sleepErr != nil {
+			return val, sleepErr
+		}
+	}
+}
+
+// BackoffPolicy implements a deterministic exponential backoff. The retry
+// delay starts at Initial and grows by Factor at every step, capped at
+// Maximum. There is no jitter: the Databricks SDK already retries transient
+// errors on its own, and state-polling waiters in this package do not need
+// cross-client decorrelation.
+//
+// BackoffPolicies are stateful and cannot be reset. Construct a new one per
+// Run invocation rather than reusing.
+type BackoffPolicy struct {
+	// Initial delay before the first retry; defaults to 10 seconds.
+	Initial time.Duration
+
+	// Maximum delay between retries; defaults to 5 minutes.
+	Maximum time.Duration
+
+	// Factor by which the delay grows after each retry. Must be >= 1;
+	// defaults to 2 if zero or negative.
+	Factor float64
+
+	// current is the delay that will be returned by the next call to Next.
+	current time.Duration
+
+	// initialized tracks whether setDefaults has run.
+	initialized bool
+}
+
+func (bp *BackoffPolicy) Next() time.Duration {
+	if !bp.initialized {
+		bp.setDefaults()
+	}
+	d := bp.current
+	bp.current = min(time.Duration(float64(bp.current)*bp.Factor), bp.Maximum)
+	return d
+}
+
+func (bp *BackoffPolicy) setDefaults() {
+	if bp.Initial == 0 {
+		bp.Initial = 10 * time.Second
+	}
+	if bp.Maximum == 0 {
+		bp.Maximum = 5 * time.Minute
+	}
+	if bp.Initial > bp.Maximum {
+		bp.Initial = bp.Maximum // Initial cannot be greater than Maximum
+	}
+	if bp.Factor < 1 {
+		bp.Factor = 2
+	}
+	bp.current = bp.Initial
+	bp.initialized = true
+}

--- a/internal/retrier/retrier_test.go
+++ b/internal/retrier/retrier_test.go
@@ -1,0 +1,488 @@
+package retrier
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+)
+
+func TestBackoffPolicy_Next_initialization(t *testing.T) {
+	testCases := []struct {
+		name   string
+		bp     BackoffPolicy
+		wantBP BackoffPolicy
+	}{
+		{
+			name: "default",
+			bp:   BackoffPolicy{},
+			wantBP: BackoffPolicy{
+				Initial: 10 * time.Second,
+				Maximum: 5 * time.Minute,
+				Factor:  2,
+			},
+		},
+		{
+			name: "custom initial smaller than maximum",
+			bp: BackoffPolicy{
+				Initial: 100 * time.Millisecond,
+			},
+			wantBP: BackoffPolicy{
+				Initial: 100 * time.Millisecond,
+				Maximum: 5 * time.Minute,
+				Factor:  2,
+			},
+		},
+		{
+			name: "custom initial greater than maximum",
+			bp: BackoffPolicy{
+				Initial: 10 * time.Second,
+				Maximum: 1 * time.Second,
+			},
+			wantBP: BackoffPolicy{
+				Initial: 1 * time.Second,
+				Maximum: 1 * time.Second,
+				Factor:  2,
+			},
+		},
+		{
+			name: "custom factor less than 1",
+			bp: BackoffPolicy{
+				Factor: 0.5,
+			},
+			wantBP: BackoffPolicy{
+				Initial: 10 * time.Second,
+				Maximum: 5 * time.Minute,
+				Factor:  2,
+			},
+		},
+		{
+			name: "custom factor greater than 1",
+			bp: BackoffPolicy{
+				Factor: 1.5,
+			},
+			wantBP: BackoffPolicy{
+				Initial: 10 * time.Second,
+				Maximum: 5 * time.Minute,
+				Factor:  1.5,
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.bp.Next() // initializes defaults
+
+			if diff := cmp.Diff(tc.bp, tc.wantBP, cmpopts.IgnoreUnexported(BackoffPolicy{})); diff != "" {
+				t.Errorf("unexpected BackoffPolicy (-got +want):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestBackoffPolicy_Next_exponential(t *testing.T) {
+	bp := BackoffPolicy{
+		Initial: 100 * time.Millisecond,
+		Maximum: 10 * time.Second,
+		Factor:  2.0,
+	}
+
+	wantDelays := []time.Duration{
+		100 * time.Millisecond,
+		200 * time.Millisecond,
+		400 * time.Millisecond,
+		800 * time.Millisecond,
+		1600 * time.Millisecond,
+		3200 * time.Millisecond,
+		6400 * time.Millisecond,
+		10000 * time.Millisecond, // capped by Maximum
+		10000 * time.Millisecond, // stays capped
+	}
+
+	for i, want := range wantDelays {
+		if got := bp.Next(); got != want {
+			t.Errorf("Next() call %d = %v, want %v", i+1, got, want)
+		}
+	}
+}
+
+// mockRetrier implements Retrier[V] for use in tests.
+type mockRetrier[V any] struct {
+	fn func(V, error) (time.Duration, bool)
+}
+
+func (m *mockRetrier[V]) IsRetriable(val V, err error) (time.Duration, bool) {
+	return m.fn(val, err)
+}
+
+// noSleep is a sleeper that returns immediately so retry tests do not wait.
+func noSleep(ctx context.Context, _ time.Duration) error {
+	return nil
+}
+
+func TestRun_retries(t *testing.T) {
+	retriableErr := errors.New("retriable")
+	nonRetriableErr := errors.New("non-retriable")
+
+	// Factory that retries only on retriableErr; backoff delay is irrelevant
+	// because tests inject a noSleep sleeper.
+	retryOnRetriable := func() Retrier[int] {
+		return &mockRetrier[int]{
+			fn: func(_ int, err error) (time.Duration, bool) {
+				return 0, errors.Is(err, retriableErr)
+			},
+		}
+	}
+
+	testCases := []struct {
+		name      string
+		callErrs  []error
+		newR      func() Retrier[int]
+		wantErr   error
+		wantCalls int
+	}{
+		{
+			name:      "nil factory - fail immediately",
+			callErrs:  []error{retriableErr},
+			newR:      nil,
+			wantErr:   retriableErr,
+			wantCalls: 1,
+		},
+		{
+			name:      "factory returns nil - fail immediately",
+			callErrs:  []error{retriableErr},
+			newR:      func() Retrier[int] { return nil },
+			wantErr:   retriableErr,
+			wantCalls: 1,
+		},
+		{
+			name:      "non-retriable error - fail immediately",
+			callErrs:  []error{nonRetriableErr},
+			newR:      retryOnRetriable,
+			wantErr:   nonRetriableErr,
+			wantCalls: 1,
+		},
+		{
+			name:      "retriable error - retry once then succeed",
+			callErrs:  []error{retriableErr, nil},
+			newR:      retryOnRetriable,
+			wantCalls: 2,
+		},
+		{
+			name:      "retriable error - retry multiple times then succeed",
+			callErrs:  []error{retriableErr, retriableErr, retriableErr, nil},
+			newR:      retryOnRetriable,
+			wantCalls: 4,
+		},
+		{
+			name:      "retriable then fail with non-retriable",
+			callErrs:  []error{retriableErr, nonRetriableErr},
+			newR:      retryOnRetriable,
+			wantErr:   nonRetriableErr,
+			wantCalls: 2,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotCalls := 0
+			fn := func(ctx context.Context) (int, error) {
+				err := tc.callErrs[gotCalls]
+				gotCalls++
+				return gotCalls, err
+			}
+
+			_, gotErr := run(context.Background(), tc.newR, fn, noSleep)
+
+			if gotCalls != tc.wantCalls {
+				t.Errorf("call count = %d, want %d", gotCalls, tc.wantCalls)
+			}
+			if !errors.Is(gotErr, tc.wantErr) {
+				t.Errorf("err = %v, want %v", gotErr, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestRun_valueAware(t *testing.T) {
+	// State-driven: retry while the value is < 3. Verifies that the retrier
+	// sees the value (not just the error) and that Run returns the final
+	// terminal value.
+	newR := func() Retrier[int] {
+		return &mockRetrier[int]{
+			fn: func(val int, _ error) (time.Duration, bool) {
+				return 0, val < 3
+			},
+		}
+	}
+
+	calls := 0
+	fn := func(ctx context.Context) (int, error) {
+		calls++
+		return calls, nil
+	}
+
+	gotVal, gotErr := run(context.Background(), newR, fn, noSleep)
+
+	if gotErr != nil {
+		t.Errorf("unexpected error: %v", gotErr)
+	}
+	if gotVal != 3 {
+		t.Errorf("got val %d, want 3", gotVal)
+	}
+	if calls != 3 {
+		t.Errorf("call count = %d, want 3", calls)
+	}
+}
+
+func TestRun_contextCancellation(t *testing.T) {
+	// When the sleeper reports a cancelled context, Run surfaces that error
+	// and returns the most recent attempt's value. The kind of cancellation
+	// (cancel vs deadline) is passed through unchanged.
+	callErr := errors.New("call error")
+
+	newR := func() Retrier[int] {
+		return &mockRetrier[int]{
+			fn: func(_ int, _ error) (time.Duration, bool) {
+				return 5 * time.Millisecond, true // always retry
+			},
+		}
+	}
+
+	testCases := []struct {
+		name    string
+		sleeper sleeper
+		wantErr error
+	}{
+		{
+			name:    "context canceled during sleep",
+			sleeper: func(_ context.Context, _ time.Duration) error { return context.Canceled },
+			wantErr: context.Canceled,
+		},
+		{
+			name:    "deadline exceeded during sleep",
+			sleeper: func(_ context.Context, _ time.Duration) error { return context.DeadlineExceeded },
+			wantErr: context.DeadlineExceeded,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			calls := 0
+			fn := func(ctx context.Context) (int, error) {
+				calls++
+				return calls, callErr
+			}
+
+			gotVal, gotErr := run(context.Background(), newR, fn, tc.sleeper)
+
+			if !errors.Is(gotErr, tc.wantErr) {
+				t.Errorf("err = %v, want %v", gotErr, tc.wantErr)
+			}
+			if gotVal != 1 {
+				t.Errorf("val = %d, want 1 (last fn return before cancellation)", gotVal)
+			}
+			if calls != 1 {
+				t.Errorf("call count = %d, want 1", calls)
+			}
+		})
+	}
+}
+
+func TestRunErr_retries(t *testing.T) {
+	// RunErr is a thin adapter over Run; these cases confirm the adapter
+	// wires the error-only predicate through correctly and returns only
+	// the error.
+	retriableErr := errors.New("retriable")
+	nonRetriableErr := errors.New("non-retriable")
+
+	newR := RetryIfErr(
+		BackoffPolicy{Initial: time.Millisecond, Maximum: time.Millisecond, Factor: 1},
+		func(err error) bool { return errors.Is(err, retriableErr) },
+	)
+
+	testCases := []struct {
+		name      string
+		callErrs  []error
+		wantErr   error
+		wantCalls int
+	}{
+		{
+			name:      "success on first call",
+			callErrs:  []error{nil},
+			wantCalls: 1,
+		},
+		{
+			name:      "retry then succeed",
+			callErrs:  []error{retriableErr, retriableErr, nil},
+			wantCalls: 3,
+		},
+		{
+			name:      "non-retriable halts",
+			callErrs:  []error{nonRetriableErr},
+			wantErr:   nonRetriableErr,
+			wantCalls: 1,
+		},
+		{
+			name:      "retriable then non-retriable halts",
+			callErrs:  []error{retriableErr, nonRetriableErr},
+			wantErr:   nonRetriableErr,
+			wantCalls: 2,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			calls := 0
+			fn := func(ctx context.Context) error {
+				err := tc.callErrs[calls]
+				calls++
+				return err
+			}
+
+			gotErr := RunErr(context.Background(), newR, fn)
+
+			if !errors.Is(gotErr, tc.wantErr) {
+				t.Errorf("err = %v, want %v", gotErr, tc.wantErr)
+			}
+			if calls != tc.wantCalls {
+				t.Errorf("call count = %d, want %d", calls, tc.wantCalls)
+			}
+		})
+	}
+}
+
+func TestRetryIf_constructedRetrierUsesBackoff(t *testing.T) {
+	// RetryIf must wire both the predicate and the backoff into the returned
+	// retrier. With Factor 1, the delay stays at Initial on every call.
+	newR := RetryIf(
+		BackoffPolicy{Initial: 7 * time.Millisecond, Maximum: 7 * time.Millisecond, Factor: 1},
+		func(_ int, err error) bool { return err != nil },
+	)
+
+	r := newR()
+	for i := range 3 {
+		attempt := i + 1
+		delay, retry := r.IsRetriable(0, errors.New("boom"))
+		if !retry {
+			t.Fatalf("attempt %d: retry = false, want true", attempt)
+		}
+		if delay != 7*time.Millisecond {
+			t.Errorf("attempt %d: delay = %v, want 7ms", attempt, delay)
+		}
+	}
+
+	if _, retry := r.IsRetriable(0, nil); retry {
+		t.Errorf("on nil err: retry = true, want false")
+	}
+}
+
+func TestRetryIf_factoryProducesIndependentInstances(t *testing.T) {
+	// Each invocation of the factory must produce a retrier with its own
+	// backoff state; advancing one must not advance another.
+	newR := RetryIf(
+		BackoffPolicy{Initial: time.Millisecond, Maximum: time.Second, Factor: 2},
+		func(_ int, _ error) bool { return true },
+	)
+
+	boom := errors.New("boom")
+
+	r1 := newR()
+	r1.IsRetriable(0, boom)
+	r1.IsRetriable(0, boom)
+	d1, _ := r1.IsRetriable(0, boom) // r1 is now at attempt 4
+
+	r2 := newR()
+	d2, _ := r2.IsRetriable(0, boom) // r2's first attempt
+
+	if d1 <= d2 {
+		t.Errorf("expected r1's delay (%v) to exceed r2's first delay (%v); shared state suspected", d1, d2)
+	}
+}
+
+func TestRetryIfErr_wraps(t *testing.T) {
+	// RetryIfErr produces a Retrier[struct{}] that forwards to the
+	// error-only predicate, ignoring the value argument.
+	newR := RetryIfErr(
+		BackoffPolicy{Initial: time.Millisecond, Maximum: time.Millisecond, Factor: 1},
+		func(err error) bool { return errors.Is(err, context.Canceled) },
+	)
+
+	testCases := []struct {
+		name      string
+		err       error
+		wantRetry bool
+	}{
+		{name: "matching error retries", err: context.Canceled, wantRetry: true},
+		{name: "non-matching error halts", err: errors.New("other"), wantRetry: false},
+		{name: "nil error halts", err: nil, wantRetry: false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := newR()
+			_, retry := r.IsRetriable(struct{}{}, tc.err)
+			if retry != tc.wantRetry {
+				t.Errorf("retry = %v, want %v", retry, tc.wantRetry)
+			}
+		})
+	}
+}
+
+func TestSleep(t *testing.T) {
+	// sleep should return ctx.Err() promptly when the context is done and
+	// nil when the duration elapses normally.
+	testCases := []struct {
+		name     string
+		ctxSetup func() (context.Context, context.CancelFunc)
+		duration time.Duration
+		wantErr  error
+	}{
+		{
+			name: "pre-cancelled context returns immediately",
+			ctxSetup: func() (context.Context, context.CancelFunc) {
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+				return ctx, func() {}
+			},
+			duration: time.Hour,
+			wantErr:  context.Canceled,
+		},
+		{
+			name: "deadline exceeded returns immediately",
+			ctxSetup: func() (context.Context, context.CancelFunc) {
+				return context.WithTimeout(context.Background(), 5*time.Millisecond)
+			},
+			duration: time.Hour,
+			wantErr:  context.DeadlineExceeded,
+		},
+		{
+			name: "duration elapses normally",
+			ctxSetup: func() (context.Context, context.CancelFunc) {
+				return context.Background(), func() {}
+			},
+			duration: 5 * time.Millisecond,
+			wantErr:  nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := tc.ctxSetup()
+			defer cancel()
+
+			start := time.Now()
+			err := sleep(ctx, tc.duration)
+			elapsed := time.Since(start)
+
+			if !errors.Is(err, tc.wantErr) {
+				t.Errorf("err = %v, want %v", err, tc.wantErr)
+			}
+			if elapsed > 100*time.Millisecond {
+				t.Errorf("sleep took %v; expected < 100ms", elapsed)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

The repository has several ways to implement simple retry loops. This PR adds a new `internal/retrier` package that captures the common denominator across all of them. 

This PR already opportunistically migrates `common/retry.go` to use this new package internally. Subsequent PRs will migrate existing call sites to it, removing unnecessary middleware.

Design choices:

- **Value-aware predicate.** `Retrier[V].IsRetriable(V, error)` sees both the polled value and any error, so state-driven polling (the dominant pattern across the provider's waiters) is supported natively without sentinel-error wrapping.
- **Factory-per-Run.** `Run` takes a `func() Retrier[V]` and invokes it once per call. Each invocation gets its own retrier instance with independent backoff state, making `Run` safe to use from multiple goroutines with the same factory without locking.
- **Deterministic exponential backoff, no jitter.** The Databricks SDK already absorbs transient errors, and state-polling waiters here do not need cross-client decorrelation. The package is intended to sit on top of the SDK for longer polls (e.g. resource state transitions); jitter adds complexity without a corresponding benefit in that scenario. This is not a one-way door; it can be revisited if a use case calls for it.

## Test plan

- [x] `go test ./internal/retrier/...` passes (12 cases across BackoffPolicy initialization and exponential growth, `Run` retry/value-aware/ctx-cancellation paths, `RunErr`, `RetryIf` wiring and factory independence, `RetryIfErr` forwarding, `sleep` cancellation).
- [x] `go tool staticcheck ./internal/retrier/...` clean.
- [x] `make fmt lint ws` clean.
- [x] CI green.