### PR TITLE
[Internal] Group SDKv2 resources and data sources by API level

### DIFF
--- a/internal/providers/sdkv2/resources.go
+++ b/internal/providers/sdkv2/resources.go
@@ -1,0 +1,227 @@
+package sdkv2
+
+import (
+	"maps"
+
+	"github.com/databricks/terraform-provider-databricks/access"
+	"github.com/databricks/terraform-provider-databricks/apps"
+	"github.com/databricks/terraform-provider-databricks/aws"
+	"github.com/databricks/terraform-provider-databricks/catalog"
+	"github.com/databricks/terraform-provider-databricks/clusters"
+	"github.com/databricks/terraform-provider-databricks/dashboards"
+	"github.com/databricks/terraform-provider-databricks/finops"
+	"github.com/databricks/terraform-provider-databricks/jobs"
+	"github.com/databricks/terraform-provider-databricks/mlflow"
+	"github.com/databricks/terraform-provider-databricks/mws"
+	"github.com/databricks/terraform-provider-databricks/permissions"
+	"github.com/databricks/terraform-provider-databricks/pipelines"
+	"github.com/databricks/terraform-provider-databricks/policies"
+	"github.com/databricks/terraform-provider-databricks/pools"
+	"github.com/databricks/terraform-provider-databricks/repos"
+	"github.com/databricks/terraform-provider-databricks/scim"
+	"github.com/databricks/terraform-provider-databricks/secrets"
+	"github.com/databricks/terraform-provider-databricks/serving"
+	"github.com/databricks/terraform-provider-databricks/settings"
+	"github.com/databricks/terraform-provider-databricks/sharing"
+	"github.com/databricks/terraform-provider-databricks/sql"
+	"github.com/databricks/terraform-provider-databricks/storage"
+	"github.com/databricks/terraform-provider-databricks/tokens"
+	"github.com/databricks/terraform-provider-databricks/vectorsearch"
+	"github.com/databricks/terraform-provider-databricks/workspace"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// DataSources returns a new map of all data sources in the provider.
+func DataSources() map[string]*schema.Resource {
+	return merge(WorkspaceDataSources, AccountDataSources, DualDataSources)
+}
+
+// Resources returns a new map of all resources in the provider.
+func Resources() map[string]*schema.Resource {
+	return merge(WorkspaceResources, AccountResources, DualResources)
+}
+
+// WorkspaceDataSources is a map of all workspace data sources in the provider.
+var WorkspaceDataSources = map[string]*schema.Resource{
+	"databricks_aws_crossaccount_policy":              aws.DataAwsCrossaccountPolicy().ToResource(),
+	"databricks_aws_assume_role_policy":               aws.DataAwsAssumeRolePolicy().ToResource(),
+	"databricks_aws_bucket_policy":                    aws.DataAwsBucketPolicy().ToResource(),
+	"databricks_aws_unity_catalog_assume_role_policy": aws.DataAwsUnityCatalogAssumeRolePolicy().ToResource(),
+	"databricks_aws_unity_catalog_policy":             aws.DataAwsUnityCatalogPolicy().ToResource(),
+	"databricks_cluster":                              clusters.DataSourceCluster().ToResource(),
+	"databricks_clusters":                             clusters.DataSourceClusters().ToResource(),
+	"databricks_cluster_policy":                       policies.DataSourceClusterPolicy().ToResource(),
+	"databricks_catalog":                              catalog.DataSourceCatalog().ToResource(),
+	"databricks_catalogs":                             catalog.DataSourceCatalogs().ToResource(),
+	"databricks_current_metastore":                    catalog.DataSourceCurrentMetastore().ToResource(),
+	"databricks_current_user":                         scim.DataSourceCurrentUser().ToResource(),
+	"databricks_dbfs_file":                            storage.DataSourceDbfsFile().ToResource(),
+	"databricks_dbfs_file_paths":                      storage.DataSourceDbfsFilePaths().ToResource(),
+	"databricks_directory":                            workspace.DataSourceDirectory().ToResource(),
+	"databricks_external_location":                    catalog.DataSourceExternalLocation().ToResource(),
+	"databricks_external_locations":                   catalog.DataSourceExternalLocations().ToResource(),
+	"databricks_instance_pool":                        pools.DataSourceInstancePool().ToResource(),
+	"databricks_instance_profiles":                    aws.DataSourceInstanceProfiles().ToResource(),
+	"databricks_jobs":                                 jobs.DataSourceJobs().ToResource(),
+	"databricks_job":                                  jobs.DataSourceJob().ToResource(),
+	"databricks_metastores":                           catalog.DataSourceMetastores().ToResource(),
+	"databricks_mlflow_experiment":                    mlflow.DataSourceExperiment().ToResource(),
+	"databricks_mlflow_model":                         mlflow.DataSourceModel().ToResource(),
+	"databricks_mlflow_models":                        mlflow.DataSourceModels().ToResource(),
+	"databricks_node_type":                            clusters.DataSourceNodeType().ToResource(),
+	"databricks_notebook":                             workspace.DataSourceNotebook().ToResource(),
+	"databricks_notebook_paths":                       workspace.DataSourceNotebookPaths().ToResource(),
+	"databricks_pipelines":                            pipelines.DataSourcePipelines().ToResource(),
+	"databricks_schema":                               catalog.DataSourceSchema().ToResource(),
+	"databricks_schemas":                              catalog.DataSourceSchemas().ToResource(),
+	"databricks_share":                                sharing.DataSourceShare().ToResource(),
+	"databricks_shares":                               sharing.DataSourceShares().ToResource(),
+	"databricks_spark_version":                        clusters.DataSourceSparkVersion().ToResource(),
+	"databricks_sql_warehouse":                        sql.DataSourceWarehouse().ToResource(),
+	"databricks_sql_warehouses":                       sql.DataSourceWarehouses().ToResource(),
+	"databricks_storage_credential":                   catalog.DataSourceStorageCredential().ToResource(),
+	"databricks_storage_credentials":                  catalog.DataSourceStorageCredentials().ToResource(),
+	"databricks_table":                                catalog.DataSourceTable().ToResource(),
+	"databricks_tables":                               catalog.DataSourceTables().ToResource(),
+	"databricks_views":                                catalog.DataSourceViews().ToResource(),
+	"databricks_volume":                               catalog.DataSourceVolume().ToResource(),
+	"databricks_volumes":                              catalog.DataSourceVolumes().ToResource(),
+	"databricks_zones":                                clusters.DataSourceClusterZones().ToResource(),
+}
+
+// AccountDataSources is a map of all account data sources in the provider.
+var AccountDataSources = map[string]*schema.Resource{
+	"databricks_metastore":                        catalog.DataSourceMetastore().ToResource(),
+	"databricks_mws_credentials":                  mws.DataSourceMwsCredentials().ToResource(),
+	"databricks_mws_network_connectivity_config":  mws.DataSourceMwsNetworkConnectivityConfig().ToResource(),
+	"databricks_mws_network_connectivity_configs": mws.DataSourceMwsNetworkConnectivityConfigs().ToResource(),
+	"databricks_mws_workspaces":                   mws.DataSourceMwsWorkspaces().ToResource(),
+}
+
+// DualDataSources is a map of all dual data sources in the provider.
+var DualDataSources = map[string]*schema.Resource{
+	"databricks_current_config":     mws.DataSourceCurrentConfiguration().ToResource(),
+	"databricks_group":              scim.DataSourceGroup().ToResource(),
+	"databricks_service_principal":  scim.DataSourceServicePrincipal().ToResource(),
+	"databricks_service_principals": scim.DataSourceServicePrincipals().ToResource(),
+	"databricks_user":               scim.DataSourceUser().ToResource(),
+}
+
+// WorkspaceResources is a map of all workspace resources in the provider.
+var WorkspaceResources = map[string]*schema.Resource{
+	"databricks_alert":                                sql.ResourceAlert().ToResource(),
+	"databricks_artifact_allowlist":                   catalog.ResourceArtifactAllowlist().ToResource(),
+	"databricks_aws_s3_mount":                         storage.ResourceAWSS3Mount().ToResource(),
+	"databricks_azure_adls_gen1_mount":                storage.ResourceAzureAdlsGen1Mount().ToResource(),
+	"databricks_azure_adls_gen2_mount":                storage.ResourceAzureAdlsGen2Mount().ToResource(),
+	"databricks_azure_blob_mount":                     storage.ResourceAzureBlobMount().ToResource(),
+	"databricks_catalog":                              catalog.ResourceCatalog().ToResource(),
+	"databricks_catalog_workspace_binding":            catalog.ResourceCatalogWorkspaceBinding().ToResource(),
+	"databricks_credential":                           catalog.ResourceCredential().ToResource(),
+	"databricks_connection":                           catalog.ResourceConnection().ToResource(),
+	"databricks_cluster":                              clusters.ResourceCluster().ToResource(),
+	"databricks_cluster_policy":                       policies.ResourceClusterPolicy().ToResource(),
+	"databricks_dashboard":                            dashboards.ResourceDashboard().ToResource(),
+	"databricks_dbfs_file":                            storage.ResourceDbfsFile().ToResource(),
+	"databricks_directory":                            workspace.ResourceDirectory().ToResource(),
+	"databricks_entitlements":                         scim.ResourceEntitlements().ToResource(),
+	"databricks_external_location":                    catalog.ResourceExternalLocation().ToResource(),
+	"databricks_file":                                 storage.ResourceFile().ToResource(),
+	"databricks_git_credential":                       repos.ResourceGitCredential().ToResource(),
+	"databricks_global_init_script":                   workspace.ResourceGlobalInitScript().ToResource(),
+	"databricks_grant":                                catalog.ResourceGrant().ToResource(),
+	"databricks_grants":                               catalog.ResourceGrants().ToResource(),
+	"databricks_instance_pool":                        pools.ResourceInstancePool().ToResource(),
+	"databricks_instance_profile":                     aws.ResourceInstanceProfile().ToResource(),
+	"databricks_ip_access_list":                       access.ResourceIPAccessList().ToResource(),
+	"databricks_job":                                  jobs.ResourceJob().ToResource(),
+	"databricks_lakehouse_monitor":                    catalog.ResourceLakehouseMonitor().ToResource(),
+	"databricks_library":                              clusters.ResourceLibrary().ToResource(),
+	"databricks_mlflow_experiment":                    mlflow.ResourceMlflowExperiment().ToResource(),
+	"databricks_mlflow_model":                         mlflow.ResourceMlflowModel().ToResource(),
+	"databricks_mlflow_webhook":                       mlflow.ResourceMlflowWebhook().ToResource(),
+	"databricks_model_serving":                        serving.ResourceModelServing().ToResource(),
+	"databricks_model_serving_provisioned_throughput": serving.ResourceModelServingProvisionedThroughput().ToResource(),
+	"databricks_mount":                                storage.ResourceMount().ToResource(),
+	"databricks_notebook":                             workspace.ResourceNotebook().ToResource(),
+	"databricks_notification_destination":             settings.ResourceNotificationDestination().ToResource(),
+	"databricks_obo_token":                            tokens.ResourceOboToken().ToResource(),
+	"databricks_online_table":                         catalog.ResourceOnlineTable().ToResource(),
+	"databricks_permission_assignment":                access.ResourcePermissionAssignment().ToResource(),
+	"databricks_permissions":                          permissions.ResourcePermissions().ToResource(),
+	"databricks_pipeline":                             pipelines.ResourcePipeline().ToResource(),
+	"databricks_provider":                             sharing.ResourceProvider().ToResource(),
+	"databricks_quality_monitor":                      catalog.ResourceQualityMonitor().ToResource(),
+	"databricks_query":                                sql.ResourceQuery().ToResource(),
+	"databricks_recipient":                            sharing.ResourceRecipient().ToResource(),
+	"databricks_registered_model":                     catalog.ResourceRegisteredModel().ToResource(),
+	"databricks_repo":                                 repos.ResourceRepo().ToResource(),
+	"databricks_schema":                               catalog.ResourceSchema().ToResource(),
+	"databricks_secret":                               secrets.ResourceSecret().ToResource(),
+	"databricks_secret_scope":                         secrets.ResourceSecretScope().ToResource(),
+	"databricks_secret_acl":                           secrets.ResourceSecretACL().ToResource(),
+	"databricks_share":                                sharing.ResourceShare().ToResource(),
+	"databricks_sql_dashboard":                        sql.ResourceSqlDashboard().ToResource(),
+	"databricks_sql_endpoint":                         sql.ResourceSqlEndpoint().ToResource(),
+	"databricks_sql_global_config":                    sql.ResourceSqlGlobalConfig().ToResource(),
+	"databricks_sql_permissions":                      access.ResourceSqlPermissions().ToResource(),
+	"databricks_sql_query":                            sql.ResourceSqlQuery().ToResource(),
+	"databricks_sql_alert":                            sql.ResourceSqlAlert().ToResource(),
+	"databricks_sql_table":                            catalog.ResourceSqlTable().ToResource(),
+	"databricks_sql_visualization":                    sql.ResourceSqlVisualization().ToResource(),
+	"databricks_sql_widget":                           sql.ResourceSqlWidget().ToResource(),
+	"databricks_system_schema":                        catalog.ResourceSystemSchema().ToResource(),
+	"databricks_table":                                catalog.ResourceTable().ToResource(),
+	"databricks_token":                                tokens.ResourceToken().ToResource(),
+	"databricks_vector_search_endpoint":               vectorsearch.ResourceVectorSearchEndpoint().ToResource(),
+	"databricks_vector_search_index":                  vectorsearch.ResourceVectorSearchIndex().ToResource(),
+	"databricks_volume":                               catalog.ResourceVolume().ToResource(),
+	"databricks_workspace_binding":                    catalog.ResourceWorkspaceBinding().ToResource(),
+	"databricks_workspace_conf":                       workspace.ResourceWorkspaceConf().ToResource(),
+	"databricks_workspace_file":                       workspace.ResourceWorkspaceFile().ToResource(),
+}
+
+// AccountResources is a map of all account resources in the provider.
+var AccountResources = map[string]*schema.Resource{
+	"databricks_budget":                          finops.ResourceBudget().ToResource(),
+	"databricks_custom_app_integration":          apps.ResourceCustomAppIntegration().ToResource(),
+	"databricks_mws_credentials":                 mws.ResourceMwsCredentials().ToResource(),
+	"databricks_mws_customer_managed_keys":       mws.ResourceMwsCustomerManagedKeys().ToResource(),
+	"databricks_mws_log_delivery":                mws.ResourceMwsLogDelivery().ToResource(),
+	"databricks_mws_ncc_binding":                 mws.ResourceMwsNccBinding().ToResource(),
+	"databricks_mws_ncc_private_endpoint_rule":   mws.ResourceMwsNccPrivateEndpointRule().ToResource(),
+	"databricks_mws_network_connectivity_config": mws.ResourceMwsNetworkConnectivityConfig().ToResource(),
+	"databricks_mws_networks":                    mws.ResourceMwsNetworks().ToResource(),
+	"databricks_mws_permission_assignment":       mws.ResourceMwsPermissionAssignment().ToResource(),
+	"databricks_mws_private_access_settings":     mws.ResourceMwsPrivateAccessSettings().ToResource(),
+	"databricks_mws_storage_configurations":      mws.ResourceMwsStorageConfigurations().ToResource(),
+	"databricks_mws_vpc_endpoint":                mws.ResourceMwsVpcEndpoint().ToResource(),
+	"databricks_mws_workspaces":                  mws.ResourceMwsWorkspaces().ToResource(),
+}
+
+// DualResources is a map of all dual resources in the provider.
+var DualResources = map[string]*schema.Resource{
+	"databricks_access_control_rule_set":  permissions.ResourceAccessControlRuleSet().ToResource(),
+	"databricks_group":                    scim.ResourceGroup().ToResource(),
+	"databricks_group_instance_profile":   aws.ResourceGroupInstanceProfile().ToResource(),
+	"databricks_group_member":             scim.ResourceGroupMember().ToResource(),
+	"databricks_group_role":               scim.ResourceGroupRole().ToResource(),
+	"databricks_metastore":                catalog.ResourceMetastore().ToResource(),
+	"databricks_metastore_assignment":     catalog.ResourceMetastoreAssignment().ToResource(),
+	"databricks_metastore_data_access":    catalog.ResourceMetastoreDataAccess().ToResource(),
+	"databricks_service_principal":        scim.ResourceServicePrincipal().ToResource(),
+	"databricks_service_principal_role":   aws.ResourceServicePrincipalRole().ToResource(),
+	"databricks_service_principal_secret": tokens.ResourceServicePrincipalSecret().ToResource(),
+	"databricks_storage_credential":       catalog.ResourceStorageCredential().ToResource(),
+	"databricks_user":                     scim.ResourceUser().ToResource(),
+	"databricks_user_instance_profile":    aws.ResourceUserInstanceProfile().ToResource(),
+	"databricks_user_role":                aws.ResourceUserRole().ToResource(),
+}
+
+func merge(groups ...map[string]*schema.Resource) map[string]*schema.Resource {
+	result := make(map[string]*schema.Resource)
+	for _, g := range groups {
+		maps.Copy(result, g)
+	}
+	return result
+}

--- a/internal/providers/sdkv2/resources_test.go
+++ b/internal/providers/sdkv2/resources_test.go
@@ -1,0 +1,74 @@
+package sdkv2
+
+import (
+	"maps"
+	"slices"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func TestApiField_RegistrationConsistency(t *testing.T) {
+	cases := []struct {
+		name    string
+		entries map[string]*schema.Resource
+		wantApi bool
+	}{
+		{"DualResources", DualResources, true},
+		{"DualDataSources", DualDataSources, true},
+		{"WorkspaceResources", WorkspaceResources, false},
+		{"AccountResources", AccountResources, false},
+		{"WorkspaceDataSources", WorkspaceDataSources, false},
+		{"AccountDataSources", AccountDataSources, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, key := range slices.Sorted(maps.Keys(tc.entries)) {
+				hasApi := tc.entries[key].Schema["api"] != nil
+				switch {
+				case tc.wantApi && !hasApi:
+					t.Errorf("%s[%q] is missing the \"api\" field", tc.name, key)
+				case !tc.wantApi && hasApi:
+					t.Errorf("%s[%q] has an \"api\" field; move it to DualResources/DualDataSources", tc.name, key)
+				}
+			}
+		})
+	}
+}
+
+func TestNoOverlap(t *testing.T) {
+	type group struct {
+		name    string
+		entries map[string]*schema.Resource
+	}
+	cases := []struct {
+		kind   string
+		groups []group
+	}{
+		{"resources", []group{
+			{"WorkspaceResources", WorkspaceResources},
+			{"AccountResources", AccountResources},
+			{"DualResources", DualResources},
+		}},
+		{"dataSources", []group{
+			{"WorkspaceDataSources", WorkspaceDataSources},
+			{"AccountDataSources", AccountDataSources},
+			{"DualDataSources", DualDataSources},
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.kind, func(t *testing.T) {
+			owners := map[string][]string{}
+			for _, g := range tc.groups {
+				for _, key := range slices.Sorted(maps.Keys(g.entries)) {
+					owners[key] = append(owners[key], g.name)
+				}
+			}
+			for _, key := range slices.Sorted(maps.Keys(owners)) {
+				if len(owners[key]) > 1 {
+					t.Errorf("%q is registered in multiple maps: %v", key, owners[key])
+				}
+			}
+		})
+	}
+}

--- a/internal/providers/sdkv2/resources_test.go
+++ b/internal/providers/sdkv2/resources_test.go
@@ -36,39 +36,26 @@ func TestApiField_RegistrationConsistency(t *testing.T) {
 	}
 }
 
-func TestNoOverlap(t *testing.T) {
-	type group struct {
-		name    string
-		entries map[string]*schema.Resource
+func TestNoDuplicateKeys(t *testing.T) {
+	testNoDuplicateKeys(t, WorkspaceDataSources, AccountDataSources, DualDataSources)
+	testNoDuplicateKeys(t, WorkspaceResources, AccountResources, DualResources)
+}
+
+func testNoDuplicateKeys(t *testing.T, ms ...map[string]*schema.Resource) {
+	count := count(ms...)
+	for _, key := range slices.Sorted(maps.Keys(count)) {
+		if c := count[key]; c > 1 {
+			t.Errorf("%q is registered in multiple maps: %v", key, c)
+		}
 	}
-	cases := []struct {
-		kind   string
-		groups []group
-	}{
-		{"resources", []group{
-			{"WorkspaceResources", WorkspaceResources},
-			{"AccountResources", AccountResources},
-			{"DualResources", DualResources},
-		}},
-		{"dataSources", []group{
-			{"WorkspaceDataSources", WorkspaceDataSources},
-			{"AccountDataSources", AccountDataSources},
-			{"DualDataSources", DualDataSources},
-		}},
+}
+
+func count(ms ...map[string]*schema.Resource) map[string]int {
+	count := map[string]int{}
+	for _, m := range ms {
+		for key := range m {
+			count[key]++
+		}
 	}
-	for _, tc := range cases {
-		t.Run(tc.kind, func(t *testing.T) {
-			owners := map[string][]string{}
-			for _, g := range tc.groups {
-				for _, key := range slices.Sorted(maps.Keys(g.entries)) {
-					owners[key] = append(owners[key], g.name)
-				}
-			}
-			for _, key := range slices.Sorted(maps.Keys(owners)) {
-				if len(owners[key]) > 1 {
-					t.Errorf("%q is registered in multiple maps: %v", key, owners[key])
-				}
-			}
-		})
-	}
+	return count
 }

--- a/internal/providers/sdkv2/sdkv2.go
+++ b/internal/providers/sdkv2/sdkv2.go
@@ -21,36 +21,12 @@ import (
 	"github.com/databricks/databricks-sdk-go/config"
 	"github.com/databricks/databricks-sdk-go/useragent"
 
-	"github.com/databricks/terraform-provider-databricks/access"
-	"github.com/databricks/terraform-provider-databricks/apps"
-	"github.com/databricks/terraform-provider-databricks/aws"
-	"github.com/databricks/terraform-provider-databricks/catalog"
-	"github.com/databricks/terraform-provider-databricks/clusters"
 	"github.com/databricks/terraform-provider-databricks/common"
-	"github.com/databricks/terraform-provider-databricks/dashboards"
-	"github.com/databricks/terraform-provider-databricks/finops"
 	"github.com/databricks/terraform-provider-databricks/internal/providers/client"
 	providercommon "github.com/databricks/terraform-provider-databricks/internal/providers/common"
 	"github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw"
-	"github.com/databricks/terraform-provider-databricks/jobs"
 	"github.com/databricks/terraform-provider-databricks/logger"
-	"github.com/databricks/terraform-provider-databricks/mlflow"
-	"github.com/databricks/terraform-provider-databricks/mws"
-	"github.com/databricks/terraform-provider-databricks/permissions"
-	"github.com/databricks/terraform-provider-databricks/pipelines"
-	"github.com/databricks/terraform-provider-databricks/policies"
-	"github.com/databricks/terraform-provider-databricks/pools"
-	"github.com/databricks/terraform-provider-databricks/repos"
-	"github.com/databricks/terraform-provider-databricks/scim"
-	"github.com/databricks/terraform-provider-databricks/secrets"
-	"github.com/databricks/terraform-provider-databricks/serving"
 	"github.com/databricks/terraform-provider-databricks/settings"
-	"github.com/databricks/terraform-provider-databricks/sharing"
-	"github.com/databricks/terraform-provider-databricks/sql"
-	"github.com/databricks/terraform-provider-databricks/storage"
-	"github.com/databricks/terraform-provider-databricks/tokens"
-	"github.com/databricks/terraform-provider-databricks/vectorsearch"
-	"github.com/databricks/terraform-provider-databricks/workspace"
 )
 
 func init() {
@@ -111,164 +87,9 @@ func DatabricksProvider(opts ...SdkV2ProviderOption) *schema.Provider {
 		optFunc(providerOptions)
 	}
 
-	dataSourceMap := map[string]*schema.Resource{ // must be in alphabetical order
-		"databricks_aws_crossaccount_policy":              aws.DataAwsCrossaccountPolicy().ToResource(),
-		"databricks_aws_assume_role_policy":               aws.DataAwsAssumeRolePolicy().ToResource(),
-		"databricks_aws_bucket_policy":                    aws.DataAwsBucketPolicy().ToResource(),
-		"databricks_aws_unity_catalog_assume_role_policy": aws.DataAwsUnityCatalogAssumeRolePolicy().ToResource(),
-		"databricks_aws_unity_catalog_policy":             aws.DataAwsUnityCatalogPolicy().ToResource(),
-		"databricks_cluster":                              clusters.DataSourceCluster().ToResource(),
-		"databricks_clusters":                             clusters.DataSourceClusters().ToResource(),
-		"databricks_cluster_policy":                       policies.DataSourceClusterPolicy().ToResource(),
-		"databricks_catalog":                              catalog.DataSourceCatalog().ToResource(),
-		"databricks_catalogs":                             catalog.DataSourceCatalogs().ToResource(),
-		"databricks_current_config":                       mws.DataSourceCurrentConfiguration().ToResource(),
-		"databricks_current_metastore":                    catalog.DataSourceCurrentMetastore().ToResource(),
-		"databricks_current_user":                         scim.DataSourceCurrentUser().ToResource(),
-		"databricks_dbfs_file":                            storage.DataSourceDbfsFile().ToResource(),
-		"databricks_dbfs_file_paths":                      storage.DataSourceDbfsFilePaths().ToResource(),
-		"databricks_directory":                            workspace.DataSourceDirectory().ToResource(),
-		"databricks_external_location":                    catalog.DataSourceExternalLocation().ToResource(),
-		"databricks_external_locations":                   catalog.DataSourceExternalLocations().ToResource(),
-		"databricks_group":                                scim.DataSourceGroup().ToResource(),
-		"databricks_instance_pool":                        pools.DataSourceInstancePool().ToResource(),
-		"databricks_instance_profiles":                    aws.DataSourceInstanceProfiles().ToResource(),
-		"databricks_jobs":                                 jobs.DataSourceJobs().ToResource(),
-		"databricks_job":                                  jobs.DataSourceJob().ToResource(),
-		"databricks_metastore":                            catalog.DataSourceMetastore().ToResource(),
-		"databricks_metastores":                           catalog.DataSourceMetastores().ToResource(),
-		"databricks_mlflow_experiment":                    mlflow.DataSourceExperiment().ToResource(),
-		"databricks_mlflow_model":                         mlflow.DataSourceModel().ToResource(),
-		"databricks_mlflow_models":                        mlflow.DataSourceModels().ToResource(),
-		"databricks_mws_credentials":                      mws.DataSourceMwsCredentials().ToResource(),
-		"databricks_mws_network_connectivity_config":      mws.DataSourceMwsNetworkConnectivityConfig().ToResource(),
-		"databricks_mws_network_connectivity_configs":     mws.DataSourceMwsNetworkConnectivityConfigs().ToResource(),
-		"databricks_mws_workspaces":                       mws.DataSourceMwsWorkspaces().ToResource(),
-		"databricks_node_type":                            clusters.DataSourceNodeType().ToResource(),
-		"databricks_notebook":                             workspace.DataSourceNotebook().ToResource(),
-		"databricks_notebook_paths":                       workspace.DataSourceNotebookPaths().ToResource(),
-		"databricks_pipelines":                            pipelines.DataSourcePipelines().ToResource(),
-		"databricks_schema":                               catalog.DataSourceSchema().ToResource(),
-		"databricks_schemas":                              catalog.DataSourceSchemas().ToResource(),
-		"databricks_service_principal":                    scim.DataSourceServicePrincipal().ToResource(),
-		"databricks_service_principals":                   scim.DataSourceServicePrincipals().ToResource(),
-		"databricks_share":                                sharing.DataSourceShare().ToResource(),
-		"databricks_shares":                               sharing.DataSourceShares().ToResource(),
-		"databricks_spark_version":                        clusters.DataSourceSparkVersion().ToResource(),
-		"databricks_sql_warehouse":                        sql.DataSourceWarehouse().ToResource(),
-		"databricks_sql_warehouses":                       sql.DataSourceWarehouses().ToResource(),
-		"databricks_storage_credential":                   catalog.DataSourceStorageCredential().ToResource(),
-		"databricks_storage_credentials":                  catalog.DataSourceStorageCredentials().ToResource(),
-		"databricks_table":                                catalog.DataSourceTable().ToResource(),
-		"databricks_tables":                               catalog.DataSourceTables().ToResource(),
-		"databricks_views":                                catalog.DataSourceViews().ToResource(),
-		"databricks_volume":                               catalog.DataSourceVolume().ToResource(),
-		"databricks_volumes":                              catalog.DataSourceVolumes().ToResource(),
-		"databricks_user":                                 scim.DataSourceUser().ToResource(),
-		"databricks_zones":                                clusters.DataSourceClusterZones().ToResource(),
-	}
+	dataSourceMap := DataSources()
 
-	resourceMap := map[string]*schema.Resource{ // must be in alphabetical order
-		"databricks_access_control_rule_set":              permissions.ResourceAccessControlRuleSet().ToResource(),
-		"databricks_alert":                                sql.ResourceAlert().ToResource(),
-		"databricks_artifact_allowlist":                   catalog.ResourceArtifactAllowlist().ToResource(),
-		"databricks_aws_s3_mount":                         storage.ResourceAWSS3Mount().ToResource(),
-		"databricks_azure_adls_gen1_mount":                storage.ResourceAzureAdlsGen1Mount().ToResource(),
-		"databricks_azure_adls_gen2_mount":                storage.ResourceAzureAdlsGen2Mount().ToResource(),
-		"databricks_azure_blob_mount":                     storage.ResourceAzureBlobMount().ToResource(),
-		"databricks_budget":                               finops.ResourceBudget().ToResource(),
-		"databricks_catalog":                              catalog.ResourceCatalog().ToResource(),
-		"databricks_catalog_workspace_binding":            catalog.ResourceCatalogWorkspaceBinding().ToResource(),
-		"databricks_credential":                           catalog.ResourceCredential().ToResource(),
-		"databricks_custom_app_integration":               apps.ResourceCustomAppIntegration().ToResource(),
-		"databricks_connection":                           catalog.ResourceConnection().ToResource(),
-		"databricks_cluster":                              clusters.ResourceCluster().ToResource(),
-		"databricks_cluster_policy":                       policies.ResourceClusterPolicy().ToResource(),
-		"databricks_dashboard":                            dashboards.ResourceDashboard().ToResource(),
-		"databricks_dbfs_file":                            storage.ResourceDbfsFile().ToResource(),
-		"databricks_directory":                            workspace.ResourceDirectory().ToResource(),
-		"databricks_entitlements":                         scim.ResourceEntitlements().ToResource(),
-		"databricks_external_location":                    catalog.ResourceExternalLocation().ToResource(),
-		"databricks_file":                                 storage.ResourceFile().ToResource(),
-		"databricks_git_credential":                       repos.ResourceGitCredential().ToResource(),
-		"databricks_global_init_script":                   workspace.ResourceGlobalInitScript().ToResource(),
-		"databricks_grant":                                catalog.ResourceGrant().ToResource(),
-		"databricks_grants":                               catalog.ResourceGrants().ToResource(),
-		"databricks_group":                                scim.ResourceGroup().ToResource(),
-		"databricks_group_instance_profile":               aws.ResourceGroupInstanceProfile().ToResource(),
-		"databricks_group_member":                         scim.ResourceGroupMember().ToResource(),
-		"databricks_group_role":                           scim.ResourceGroupRole().ToResource(),
-		"databricks_instance_pool":                        pools.ResourceInstancePool().ToResource(),
-		"databricks_instance_profile":                     aws.ResourceInstanceProfile().ToResource(),
-		"databricks_ip_access_list":                       access.ResourceIPAccessList().ToResource(),
-		"databricks_job":                                  jobs.ResourceJob().ToResource(),
-		"databricks_lakehouse_monitor":                    catalog.ResourceLakehouseMonitor().ToResource(),
-		"databricks_library":                              clusters.ResourceLibrary().ToResource(),
-		"databricks_metastore":                            catalog.ResourceMetastore().ToResource(),
-		"databricks_metastore_assignment":                 catalog.ResourceMetastoreAssignment().ToResource(),
-		"databricks_metastore_data_access":                catalog.ResourceMetastoreDataAccess().ToResource(),
-		"databricks_mlflow_experiment":                    mlflow.ResourceMlflowExperiment().ToResource(),
-		"databricks_mlflow_model":                         mlflow.ResourceMlflowModel().ToResource(),
-		"databricks_mlflow_webhook":                       mlflow.ResourceMlflowWebhook().ToResource(),
-		"databricks_model_serving":                        serving.ResourceModelServing().ToResource(),
-		"databricks_model_serving_provisioned_throughput": serving.ResourceModelServingProvisionedThroughput().ToResource(),
-		"databricks_mount":                                storage.ResourceMount().ToResource(),
-		"databricks_mws_customer_managed_keys":            mws.ResourceMwsCustomerManagedKeys().ToResource(),
-		"databricks_mws_credentials":                      mws.ResourceMwsCredentials().ToResource(),
-		"databricks_mws_log_delivery":                     mws.ResourceMwsLogDelivery().ToResource(),
-		"databricks_mws_ncc_binding":                      mws.ResourceMwsNccBinding().ToResource(),
-		"databricks_mws_ncc_private_endpoint_rule":        mws.ResourceMwsNccPrivateEndpointRule().ToResource(),
-		"databricks_mws_networks":                         mws.ResourceMwsNetworks().ToResource(),
-		"databricks_mws_network_connectivity_config":      mws.ResourceMwsNetworkConnectivityConfig().ToResource(),
-		"databricks_mws_permission_assignment":            mws.ResourceMwsPermissionAssignment().ToResource(),
-		"databricks_mws_private_access_settings":          mws.ResourceMwsPrivateAccessSettings().ToResource(),
-		"databricks_mws_storage_configurations":           mws.ResourceMwsStorageConfigurations().ToResource(),
-		"databricks_mws_vpc_endpoint":                     mws.ResourceMwsVpcEndpoint().ToResource(),
-		"databricks_mws_workspaces":                       mws.ResourceMwsWorkspaces().ToResource(),
-		"databricks_notebook":                             workspace.ResourceNotebook().ToResource(),
-		"databricks_notification_destination":             settings.ResourceNotificationDestination().ToResource(),
-		"databricks_obo_token":                            tokens.ResourceOboToken().ToResource(),
-		"databricks_online_table":                         catalog.ResourceOnlineTable().ToResource(),
-		"databricks_permission_assignment":                access.ResourcePermissionAssignment().ToResource(),
-		"databricks_permissions":                          permissions.ResourcePermissions().ToResource(),
-		"databricks_pipeline":                             pipelines.ResourcePipeline().ToResource(),
-		"databricks_provider":                             sharing.ResourceProvider().ToResource(),
-		"databricks_quality_monitor":                      catalog.ResourceQualityMonitor().ToResource(),
-		"databricks_query":                                sql.ResourceQuery().ToResource(),
-		"databricks_recipient":                            sharing.ResourceRecipient().ToResource(),
-		"databricks_registered_model":                     catalog.ResourceRegisteredModel().ToResource(),
-		"databricks_repo":                                 repos.ResourceRepo().ToResource(),
-		"databricks_schema":                               catalog.ResourceSchema().ToResource(),
-		"databricks_secret":                               secrets.ResourceSecret().ToResource(),
-		"databricks_secret_scope":                         secrets.ResourceSecretScope().ToResource(),
-		"databricks_secret_acl":                           secrets.ResourceSecretACL().ToResource(),
-		"databricks_service_principal":                    scim.ResourceServicePrincipal().ToResource(),
-		"databricks_service_principal_role":               aws.ResourceServicePrincipalRole().ToResource(),
-		"databricks_service_principal_secret":             tokens.ResourceServicePrincipalSecret().ToResource(),
-		"databricks_share":                                sharing.ResourceShare().ToResource(),
-		"databricks_sql_dashboard":                        sql.ResourceSqlDashboard().ToResource(),
-		"databricks_sql_endpoint":                         sql.ResourceSqlEndpoint().ToResource(),
-		"databricks_sql_global_config":                    sql.ResourceSqlGlobalConfig().ToResource(),
-		"databricks_sql_permissions":                      access.ResourceSqlPermissions().ToResource(),
-		"databricks_sql_query":                            sql.ResourceSqlQuery().ToResource(),
-		"databricks_sql_alert":                            sql.ResourceSqlAlert().ToResource(),
-		"databricks_sql_table":                            catalog.ResourceSqlTable().ToResource(),
-		"databricks_sql_visualization":                    sql.ResourceSqlVisualization().ToResource(),
-		"databricks_sql_widget":                           sql.ResourceSqlWidget().ToResource(),
-		"databricks_storage_credential":                   catalog.ResourceStorageCredential().ToResource(),
-		"databricks_system_schema":                        catalog.ResourceSystemSchema().ToResource(),
-		"databricks_table":                                catalog.ResourceTable().ToResource(),
-		"databricks_token":                                tokens.ResourceToken().ToResource(),
-		"databricks_user":                                 scim.ResourceUser().ToResource(),
-		"databricks_user_instance_profile":                aws.ResourceUserInstanceProfile().ToResource(),
-		"databricks_user_role":                            aws.ResourceUserRole().ToResource(),
-		"databricks_vector_search_endpoint":               vectorsearch.ResourceVectorSearchEndpoint().ToResource(),
-		"databricks_vector_search_index":                  vectorsearch.ResourceVectorSearchIndex().ToResource(),
-		"databricks_volume":                               catalog.ResourceVolume().ToResource(),
-		"databricks_workspace_binding":                    catalog.ResourceWorkspaceBinding().ToResource(),
-		"databricks_workspace_conf":                       workspace.ResourceWorkspaceConf().ToResource(),
-		"databricks_workspace_file":                       workspace.ResourceWorkspaceFile().ToResource(),
-	}
+	resourceMap := Resources()
 
 	// Remove the resources and data sources that are being migrated to plugin framework
 	for _, dataSourceToRemove := range pluginfw.GetSdkV2DataSourcesToRemove(providerOptions.sdkV2DataSourceFallbacks) {


### PR DESCRIPTION
## Summary

Moves the SDKv2 resource and data source registration out of `sdkv2.go` into a new `resources.go`, split into `Workspace*`, `Account*`, and `Dual*` maps. `sdkv2.go` now calls `DataSources()` / `Resources()`, which flatten the three maps via `merge`.

Adds two registration-consistency tests in `resources_test.go`:

- `TestApiField_RegistrationConsistency` asserts the dual invariant from the schema; every entry in `Dual*` must have an `api` attribute, and every entry in `Workspace*` / `Account*` must not. The dual case is mechanically detectable because `common.AddApiField` is the single source of the `api` schema attribute.
- `TestNoOverlap` asserts that a Terraform name appears in at most one resource map and at most one data source map. Resource and data source namespaces are checked separately (a `databricks_table` resource and `databricks_table` data source legitimately coexist).

The workspace-vs-account split is an organizational distinction with no runtime effect today; the merged map is what the provider uses. The split makes intent visible at the registration site and gives a clear home for future account-level additions. There is no mechanical schema signal that distinguishes workspace from account; the TODO in `common/resource.go` lines 117-122 calls out the proper next step (a resource-level `Level` annotation), which is out of scope here.

## Test plan

- [x] `go build ./...` clean
- [x] `make fmt lint ws` clean
- [x] `go test ./internal/providers/sdkv2/...` passes, including the two new tests
- [ ] CI green