### PR TITLE
[Internal] Inject workspace-id routing header per-resource for non-Go-SDK resources

### DIFF
--- a/access/resource_permission_assignment.go
+++ b/access/resource_permission_assignment.go
@@ -31,8 +31,10 @@ func (a PermissionAssignmentAPI) CreateOrUpdate(assignment permissionAssignmentE
 	if assignment.PrincipalId != 0 {
 		var resp permissionAssignmentResponseItem
 		path := fmt.Sprintf("/api/2.0/preview/permissionassignments/principals/%d", assignment.PrincipalId)
+		// Bypass the c.Put wrapper because path is already /api/2.0-prefixed,
+		// but still inject the workspace_id routing header for unified hosts.
 		err := a.client.Do(a.context, http.MethodPut, path, nil, nil,
-			Permissions{Permissions: assignment.Permissions}, &resp)
+			Permissions{Permissions: assignment.Permissions}, &resp, a.client.AddWorkspaceIdHeader)
 		if err == nil && resp.Error != "" {
 			err = errors.New(resp.Error)
 		}

--- a/access/resource_permission_assignment.go
+++ b/access/resource_permission_assignment.go
@@ -53,7 +53,7 @@ func (a PermissionAssignmentAPI) CreateOrUpdate(assignment permissionAssignmentE
 				},
 			},
 		}
-		err := a.client.Post(a.context, "/preview/permissionassignments", request, &principal)
+		err := a.client.Post(a.context, "/preview/permissionassignments", request, &principal, a.client.AddWorkspaceIdHeader)
 		if err != nil {
 			return principalInfo{}, err
 		}
@@ -69,7 +69,7 @@ func (a PermissionAssignmentAPI) CreateOrUpdate(assignment permissionAssignmentE
 
 func (a PermissionAssignmentAPI) Remove(principalId string) error {
 	path := fmt.Sprintf("/preview/permissionassignments/principals/%s", principalId)
-	return a.client.Delete(a.context, path, nil)
+	return a.client.Delete(a.context, path, nil, a.client.AddWorkspaceIdHeader)
 }
 
 type principalInfo struct {
@@ -121,7 +121,7 @@ func (l permissionAssignmentResponse) ForPrincipal(principalId int64) (res permi
 }
 
 func (a PermissionAssignmentAPI) List() (list permissionAssignmentResponse, err error) {
-	err = a.client.Get(a.context, "/preview/permissionassignments", nil, &list)
+	err = a.client.Get(a.context, "/preview/permissionassignments", nil, &list, a.client.AddWorkspaceIdHeader)
 	return
 }
 

--- a/aws/resource_instance_profile.go
+++ b/aws/resource_instance_profile.go
@@ -45,7 +45,7 @@ type InstanceProfilesAPI struct {
 
 // Create creates an instance profile record on Databricks
 func (a InstanceProfilesAPI) Create(ipi InstanceProfileInfo) error {
-	return a.client.Post(a.context, "/instance-profiles/add", ipi, nil)
+	return a.client.Post(a.context, "/instance-profiles/add", ipi, nil, a.client.AddWorkspaceIdHeader)
 }
 
 // Read returns the ARN back if it exists on the Databricks workspace
@@ -72,7 +72,7 @@ func (a InstanceProfilesAPI) Read(instanceProfileARN string) (result InstancePro
 // List lists all the instance profiles in the workspace
 func (a InstanceProfilesAPI) List() ([]InstanceProfileInfo, error) {
 	var instanceProfilesArnList InstanceProfileList
-	err := a.client.Get(a.context, "/instance-profiles/list", nil, &instanceProfilesArnList)
+	err := a.client.Get(a.context, "/instance-profiles/list", nil, &instanceProfilesArnList, a.client.AddWorkspaceIdHeader)
 	return instanceProfilesArnList.InstanceProfiles, err
 }
 
@@ -80,7 +80,7 @@ func (a InstanceProfilesAPI) List() ([]InstanceProfileInfo, error) {
 func (a InstanceProfilesAPI) Delete(instanceProfileARN string) error {
 	return a.client.Post(a.context, "/instance-profiles/remove", map[string]any{
 		"instance_profile_arn": instanceProfileARN,
-	}, nil)
+	}, nil, a.client.AddWorkspaceIdHeader)
 }
 
 // Update updates the IAM role ARN of an existing instance profile
@@ -92,7 +92,7 @@ func (a InstanceProfilesAPI) Update(ipi InstanceProfileInfo) error {
 	if ipi.IamRoleArn != "" {
 		data["iam_role_arn"] = ipi.IamRoleArn
 	}
-	return a.client.Post(a.context, "/instance-profiles/edit", data, nil)
+	return a.client.Post(a.context, "/instance-profiles/edit", data, nil, a.client.AddWorkspaceIdHeader)
 }
 
 // IsRegistered checks if instance profile exists

--- a/catalog/resource_sql_table.go
+++ b/catalog/resource_sql_table.go
@@ -108,7 +108,7 @@ func NewSqlTablesAPI(ctx context.Context, m any) SqlTablesAPI {
 }
 
 func (a SqlTablesAPI) getTable(name string) (ti SqlTableInfo, err error) {
-	err = a.client.Get(a.context, "/unity-catalog/tables/"+name, nil, &ti)
+	err = a.client.Get(a.context, "/unity-catalog/tables/"+name, nil, &ti, a.client.AddWorkspaceIdHeader)
 	// Copy returned properties & options to read-only attributes
 	ti.EffectiveProperties = ti.Properties
 	ti.Properties = nil

--- a/catalog/resource_table.go
+++ b/catalog/resource_table.go
@@ -52,16 +52,16 @@ func (ti TableInfo) FullName() string {
 }
 
 func (a TablesAPI) createTable(ti *TableInfo) error {
-	return a.client.Post(a.context, "/unity-catalog/tables", ti, ti)
+	return a.client.Post(a.context, "/unity-catalog/tables", ti, ti, a.client.AddWorkspaceIdHeader)
 }
 
 func (a TablesAPI) getTable(name string) (ti TableInfo, err error) {
-	err = a.client.Get(a.context, "/unity-catalog/tables/"+name, nil, &ti)
+	err = a.client.Get(a.context, "/unity-catalog/tables/"+name, nil, &ti, a.client.AddWorkspaceIdHeader)
 	return
 }
 
 func (a TablesAPI) deleteTable(name string) error {
-	return a.client.Delete(a.context, "/unity-catalog/tables/"+name, nil)
+	return a.client.Delete(a.context, "/unity-catalog/tables/"+name, nil, a.client.AddWorkspaceIdHeader)
 }
 
 type TableSchemaStruct struct {

--- a/catalog/update.go
+++ b/catalog/update.go
@@ -57,6 +57,6 @@ func updateFunctionFactory(pathPrefix string, updatable []string) func(context.C
 		if len(patch) == 0 {
 			return nil
 		}
-		return c.Patch(context.WithValue(ctx, common.Api, common.API_2_1), path.Join(pathPrefix, d.Id()), patch)
+		return c.Patch(context.WithValue(ctx, common.Api, common.API_2_1), path.Join(pathPrefix, d.Id()), patch, c.AddWorkspaceIdHeader)
 	}
 }

--- a/clusters/clusters_api.go
+++ b/clusters/clusters_api.go
@@ -575,7 +575,7 @@ func (a ClustersAPI) Context() context.Context {
 // Create creates a new Spark cluster and waits till it's running
 func (a ClustersAPI) Create(cluster Cluster) (info ClusterInfo, err error) {
 	var ci ClusterID
-	err = a.client.Post(a.context, "/clusters/create", cluster, &ci)
+	err = a.client.Post(a.context, "/clusters/create", cluster, &ci, a.client.AddWorkspaceIdHeader)
 	if err != nil {
 		return
 	}
@@ -602,7 +602,7 @@ func (a ClustersAPI) Resize(resizeRequest ResizeRequest) (info ClusterInfo, err 
 		return info, fmt.Errorf("resize: Cluster %v is in %v state. RUNNING state required to use resize API", info.ClusterID, info.State)
 	}
 
-	err = a.client.Post(a.context, "/clusters/resize", resizeRequest, &info)
+	err = a.client.Post(a.context, "/clusters/resize", resizeRequest, &info, a.client.AddWorkspaceIdHeader)
 	if err != nil {
 		return info, fmt.Errorf("resize: %w", err)
 	}
@@ -637,7 +637,7 @@ func (a ClustersAPI) Edit(cluster Cluster) (info ClusterInfo, err error) {
 		// we don't know what to do, so return error
 		return info, fmt.Errorf("unexpected state: %#v", info.StateMessage)
 	}
-	err = a.client.Post(a.context, "/clusters/edit", cluster, nil)
+	err = a.client.Post(a.context, "/clusters/edit", cluster, nil, a.client.AddWorkspaceIdHeader)
 	if err != nil {
 		return info, err
 	}
@@ -652,7 +652,7 @@ func (a ClustersAPI) Edit(cluster Cluster) (info ClusterInfo, err error) {
 // ListZones returns the zones info sent by the cloud service provider
 func (a ClustersAPI) ListZones() (ZonesInfo, error) {
 	var zonesInfo ZonesInfo
-	err := a.client.Get(a.context, "/clusters/list-zones", nil, &zonesInfo)
+	err := a.client.Get(a.context, "/clusters/list-zones", nil, &zonesInfo, a.client.AddWorkspaceIdHeader)
 	return zonesInfo, err
 }
 
@@ -686,7 +686,7 @@ func (a ClustersAPI) StartAndGetInfo(clusterID string) (ClusterInfo, error) {
 		// most likely we can start error'ed cluster again...
 		log.Printf("[ERROR] Cluster %s: %s", info.State, info.StateMessage)
 	}
-	err = a.client.Post(a.context, "/clusters/start", ClusterID{ClusterID: clusterID}, nil)
+	err = a.client.Post(a.context, "/clusters/start", ClusterID{ClusterID: clusterID}, nil, a.client.AddWorkspaceIdHeader)
 	if err != nil {
 		if !strings.Contains(err.Error(),
 			fmt.Sprintf("Cluster %s is in unexpected state Pending.", clusterID)) {
@@ -761,7 +761,7 @@ func (a ClustersAPI) waitForClusterStatus(clusterID string, desired ClusterState
 
 // Terminate terminates a Spark cluster given its ID
 func (a ClustersAPI) Terminate(clusterID string) error {
-	err := a.client.Post(a.context, "/clusters/delete", ClusterID{ClusterID: clusterID}, nil)
+	err := a.client.Post(a.context, "/clusters/delete", ClusterID{ClusterID: clusterID}, nil, a.client.AddWorkspaceIdHeader)
 	if err != nil {
 		return err
 	}
@@ -776,7 +776,7 @@ func (a ClustersAPI) PermanentDelete(clusterID string) error {
 		return err
 	}
 	r := ClusterID{ClusterID: clusterID}
-	err = a.client.Post(a.context, "/clusters/permanent-delete", r, nil)
+	err = a.client.Post(a.context, "/clusters/permanent-delete", r, nil, a.client.AddWorkspaceIdHeader)
 	if err == nil {
 		return nil
 	}
@@ -789,31 +789,31 @@ func (a ClustersAPI) PermanentDelete(clusterID string) error {
 		return err
 	}
 	// and try removing it again
-	return a.client.Post(a.context, "/clusters/permanent-delete", r, nil)
+	return a.client.Post(a.context, "/clusters/permanent-delete", r, nil, a.client.AddWorkspaceIdHeader)
 }
 
 // Get retrieves the information for a cluster given its identifier
 func (a ClustersAPI) Get(clusterID string) (ci ClusterInfo, err error) {
 	err = wrapMissingClusterError(a.client.Get(a.context, "/clusters/get",
-		ClusterID{ClusterID: clusterID}, &ci), clusterID)
+		ClusterID{ClusterID: clusterID}, &ci, a.client.AddWorkspaceIdHeader), clusterID)
 	return
 }
 
 // Pin ensure that an interactive cluster configuration is retained even after a cluster has been terminated for more than 30 days
 func (a ClustersAPI) Pin(clusterID string) error {
-	return a.client.Post(a.context, "/clusters/pin", ClusterID{ClusterID: clusterID}, nil)
+	return a.client.Post(a.context, "/clusters/pin", ClusterID{ClusterID: clusterID}, nil, a.client.AddWorkspaceIdHeader)
 }
 
 // Unpin allows the cluster to eventually be removed from the list returned by the List API
 func (a ClustersAPI) Unpin(clusterID string) error {
-	return a.client.Post(a.context, "/clusters/unpin", ClusterID{ClusterID: clusterID}, nil)
+	return a.client.Post(a.context, "/clusters/unpin", ClusterID{ClusterID: clusterID}, nil, a.client.AddWorkspaceIdHeader)
 }
 
 // Events - only using Cluster ID string to get all events
 // https://docs.databricks.com/dev-tools/api/latest/clusters.html#events
 func (a ClustersAPI) Events(eventsRequest EventsRequest) ([]ClusterEvent, error) {
 	var eventsResponse EventsResponse
-	err := a.client.Post(a.context, "/clusters/events", eventsRequest, &eventsResponse)
+	err := a.client.Post(a.context, "/clusters/events", eventsRequest, &eventsResponse, a.client.AddWorkspaceIdHeader)
 	if err != nil {
 		return nil, err
 	}
@@ -830,7 +830,7 @@ func (a ClustersAPI) Events(eventsRequest EventsRequest) ([]ClusterEvent, error)
 	curPos := len(eventsResponse.Events)
 	copy(events[startPos:curPos], eventsResponse.Events)
 	for curPos < totalCount && eventsResponse.NextPage != nil {
-		err := a.client.Post(a.context, "/clusters/events", eventsResponse.NextPage, &eventsResponse)
+		err := a.client.Post(a.context, "/clusters/events", eventsResponse.NextPage, &eventsResponse, a.client.AddWorkspaceIdHeader)
 		if err != nil {
 			return nil, err
 		}
@@ -852,7 +852,7 @@ func (a ClustersAPI) Events(eventsRequest EventsRequest) ([]ClusterEvent, error)
 // and up to 30 of the most recently terminated job clusters in the past 30 days
 func (a ClustersAPI) List() ([]ClusterInfo, error) {
 	var clusterList ClusterList
-	err := a.client.Get(a.context, "/clusters/list", nil, &clusterList)
+	err := a.client.Get(a.context, "/clusters/list", nil, &clusterList, a.client.AddWorkspaceIdHeader)
 	return clusterList.Clusters, err
 }
 

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -122,7 +122,7 @@ func (a CommandsAPI) createCommand(contextID, clusterID, language, commandStr st
 		ClusterID: clusterID,
 		ContextID: contextID,
 		Command:   commandStr,
-	}, &command)
+	}, &command, a.client.AddWorkspaceIdHeader)
 	return command.ID, err
 }
 
@@ -132,7 +132,7 @@ func (a CommandsAPI) getCommand(commandID, contextID, clusterID string) (Command
 		CommandID: commandID,
 		ContextID: contextID,
 		ClusterID: clusterID,
-	}, &commandResp)
+	}, &commandResp, a.client.AddWorkspaceIdHeader)
 	return commandResp, err
 }
 
@@ -140,7 +140,7 @@ func (a CommandsAPI) deleteContext(contextID, clusterID string) error {
 	return a.client.Post(a.context, "/contexts/destroy", genericCommandRequest{
 		ContextID: contextID,
 		ClusterID: clusterID,
-	}, nil)
+	}, nil, a.client.AddWorkspaceIdHeader)
 }
 
 func (a CommandsAPI) getContext(contextID, clusterID string) (string, error) {
@@ -148,7 +148,7 @@ func (a CommandsAPI) getContext(contextID, clusterID string) (string, error) {
 	err := a.client.Get(a.context, "/contexts/status", genericCommandRequest{
 		ContextID: contextID,
 		ClusterID: clusterID,
-	}, &contextStatus)
+	}, &contextStatus, a.client.AddWorkspaceIdHeader)
 	return contextStatus.Status, err
 }
 
@@ -157,7 +157,7 @@ func (a CommandsAPI) createContext(language, clusterID string) (string, error) {
 	err := a.client.Post(a.context, "/contexts/create", genericCommandRequest{
 		Language:  language,
 		ClusterID: clusterID,
-	}, &context)
+	}, &context, a.client.AddWorkspaceIdHeader)
 	return context.ID, err
 }
 

--- a/common/client.go
+++ b/common/client.go
@@ -508,39 +508,61 @@ func (c *DatabricksClient) AccountOrWorkspaceRequest(d *schema.ResourceData, acc
 	return wsCallback(ws)
 }
 
-// Get on path
-func (c *DatabricksClient) Get(ctx context.Context, path string, request any, response any) error {
-	return c.Do(ctx, http.MethodGet, path, nil, nil, request, response, c.addApiPrefix, c.AddWorkspaceIdHeader)
+// Get on path. Extra visitors are appended after addApiPrefix; workspace-level
+// resources should pass c.AddWorkspaceIdHeader to send the routing header.
+func (c *DatabricksClient) Get(ctx context.Context, path string, request any, response any, visitors ...func(*http.Request) error) error {
+	return c.Do(ctx, http.MethodGet, path, nil, nil, request, response, prependVisitor(c.addApiPrefix, visitors)...)
 }
 
-// Post on path
-func (c *DatabricksClient) Post(ctx context.Context, path string, request any, response any) error {
-	return c.Do(ctx, http.MethodPost, path, nil, nil, request, response, c.addApiPrefix, c.AddWorkspaceIdHeader)
+// Post on path. Extra visitors are appended after addApiPrefix; workspace-level
+// resources should pass c.AddWorkspaceIdHeader to send the routing header.
+func (c *DatabricksClient) Post(ctx context.Context, path string, request any, response any, visitors ...func(*http.Request) error) error {
+	return c.Do(ctx, http.MethodPost, path, nil, nil, request, response, prependVisitor(c.addApiPrefix, visitors)...)
 }
 
 // Delete on path. Ignores succesfull responses from the server.
-func (c *DatabricksClient) Delete(ctx context.Context, path string, request any) error {
-	return c.Do(ctx, http.MethodDelete, path, nil, nil, request, nil, c.addApiPrefix, c.AddWorkspaceIdHeader)
+// Extra visitors are appended after addApiPrefix; workspace-level resources
+// should pass c.AddWorkspaceIdHeader to send the routing header.
+func (c *DatabricksClient) Delete(ctx context.Context, path string, request any, visitors ...func(*http.Request) error) error {
+	return c.Do(ctx, http.MethodDelete, path, nil, nil, request, nil, prependVisitor(c.addApiPrefix, visitors)...)
 }
 
 // Delete on path. Deserializes the response into the response parameter.
-func (c *DatabricksClient) DeleteWithResponse(ctx context.Context, path string, request any, response any) error {
-	return c.Do(ctx, http.MethodDelete, path, nil, nil, request, response, c.addApiPrefix, c.AddWorkspaceIdHeader)
+// Extra visitors are appended after addApiPrefix; workspace-level resources
+// should pass c.AddWorkspaceIdHeader to send the routing header.
+func (c *DatabricksClient) DeleteWithResponse(ctx context.Context, path string, request any, response any, visitors ...func(*http.Request) error) error {
+	return c.Do(ctx, http.MethodDelete, path, nil, nil, request, response, prependVisitor(c.addApiPrefix, visitors)...)
 }
 
 // Patch on path. Ignores succesfull responses from the server.
-func (c *DatabricksClient) Patch(ctx context.Context, path string, request any) error {
-	return c.Do(ctx, http.MethodPatch, path, nil, nil, request, nil, c.addApiPrefix, c.AddWorkspaceIdHeader)
+// Extra visitors are appended after addApiPrefix; workspace-level resources
+// should pass c.AddWorkspaceIdHeader to send the routing header.
+func (c *DatabricksClient) Patch(ctx context.Context, path string, request any, visitors ...func(*http.Request) error) error {
+	return c.Do(ctx, http.MethodPatch, path, nil, nil, request, nil, prependVisitor(c.addApiPrefix, visitors)...)
 }
 
 // Patch on path. Deserializes the response into the response parameter.
-func (c *DatabricksClient) PatchWithResponse(ctx context.Context, path string, request any, response any) error {
-	return c.Do(ctx, http.MethodPatch, path, nil, nil, request, response, c.addApiPrefix, c.AddWorkspaceIdHeader)
+// Extra visitors are appended after addApiPrefix; workspace-level resources
+// should pass c.AddWorkspaceIdHeader to send the routing header.
+func (c *DatabricksClient) PatchWithResponse(ctx context.Context, path string, request any, response any, visitors ...func(*http.Request) error) error {
+	return c.Do(ctx, http.MethodPatch, path, nil, nil, request, response, prependVisitor(c.addApiPrefix, visitors)...)
 }
 
-// Put on path
-func (c *DatabricksClient) Put(ctx context.Context, path string, request any) error {
-	return c.Do(ctx, http.MethodPut, path, nil, nil, request, nil, c.addApiPrefix, c.AddWorkspaceIdHeader)
+// Put on path.
+// Extra visitors are appended after addApiPrefix; workspace-level resources
+// should pass c.AddWorkspaceIdHeader to send the routing header.
+func (c *DatabricksClient) Put(ctx context.Context, path string, request any, visitors ...func(*http.Request) error) error {
+	return c.Do(ctx, http.MethodPut, path, nil, nil, request, nil, prependVisitor(c.addApiPrefix, visitors)...)
+}
+
+// prependVisitor returns a visitor slice with head first, then the rest.
+// addApiPrefix must run first to translate the path; subsequent visitors see
+// the prefixed URL.
+func prependVisitor(head func(*http.Request) error, rest []func(*http.Request) error) []func(*http.Request) error {
+	out := make([]func(*http.Request) error, 0, 1+len(rest))
+	out = append(out, head)
+	out = append(out, rest...)
+	return out
 }
 
 const (
@@ -684,10 +706,20 @@ func (c *DatabricksClient) scimVisitorForLevel(apiLevel string) func(*http.Reque
 
 // Scim sets SCIM headers. The apiLevel parameter controls whether account-level
 // or workspace-level SCIM endpoints are used. Pass "" to infer from the provider host.
+//
+// SCIM is dual-mode: users/groups/service_principals can be addressed at either
+// the account or the workspace level. The X-Databricks-Workspace-Id routing
+// header is only meaningful for workspace-level calls — on account-level calls
+// the request targets /api/2.0/accounts/{account_id}/scim/v2/... and must not
+// be tagged with a workspace.
 func (c *DatabricksClient) Scim(ctx context.Context, method, path string, request any, response any, apiLevel string) error {
+	visitors := []func(*http.Request) error{c.addApiPrefix, c.scimVisitorForLevel(apiLevel)}
+	if !isAccountLevelFromApiLevel(apiLevel, c) {
+		visitors = append(visitors, c.AddWorkspaceIdHeader)
+	}
 	return c.Do(ctx, method, path, map[string]string{
 		"Content-Type": "application/scim+json; charset=utf-8",
-	}, nil, request, response, c.addApiPrefix, c.scimVisitorForLevel(apiLevel), c.AddWorkspaceIdHeader)
+	}, nil, request, response, visitors...)
 }
 
 // IsAzure returns true if client is configured for Azure Databricks - either by using AAD auth or with host+token combination

--- a/common/client.go
+++ b/common/client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -648,6 +649,10 @@ const (
 	API_2_1 ApiVersion = "2.1"
 )
 
+// accountPathRE matches account-scoped request paths after addApiPrefix has
+// run: /api/<version>/accounts/<account_id>/...
+var accountPathRE = regexp.MustCompile(`^/api/[^/]+/accounts/`)
+
 // AddWorkspaceIdHeader injects the X-Databricks-Workspace-Id routing header
 // from Config.WorkspaceID. This mirrors the per-method header injection in the
 // generated Go SDK service impls (see vendor/.../service/<svc>/impl.go) and is
@@ -661,8 +666,22 @@ const (
 // X-Databricks-Workspace-Id on requests during the migration window
 // (databricks/databricks-sdk-go#1688). The response echo header remains
 // X-Databricks-Org-Id for now.
+//
+// Defensive guard: this helper is the per-resource opt-in for workspace-scoped
+// calls. If it's invoked on an account-scoped path (/api/<ver>/accounts/...)
+// the header is suppressed and a warning is logged — this is a code bug, not
+// expected runtime behavior. Account-only resources (mws_*) and dual resources
+// at api=account must never pass AddWorkspaceIdHeader.
+//
+// TODO: replace this URL-path heuristic with an explicit resource-type check
+// (account / workspace / dual) once we have a typed annotation on each
+// resource — see follow-up around resource classification metadata.
 func (c *DatabricksClient) AddWorkspaceIdHeader(r *http.Request) error {
 	if c.Config == nil || c.Config.WorkspaceID == "" {
+		return nil
+	}
+	if r.URL != nil && accountPathRE.MatchString(r.URL.Path) {
+		log.Printf("[WARN] AddWorkspaceIdHeader invoked on account-scoped path %q; suppressing header. This is a code bug — see common/client.go.", r.URL.Path)
 		return nil
 	}
 	r.Header.Set("X-Databricks-Workspace-Id", c.Config.WorkspaceID)

--- a/common/client.go
+++ b/common/client.go
@@ -510,37 +510,37 @@ func (c *DatabricksClient) AccountOrWorkspaceRequest(d *schema.ResourceData, acc
 
 // Get on path
 func (c *DatabricksClient) Get(ctx context.Context, path string, request any, response any) error {
-	return c.Do(ctx, http.MethodGet, path, nil, nil, request, response, c.addApiPrefix)
+	return c.Do(ctx, http.MethodGet, path, nil, nil, request, response, c.addApiPrefix, c.AddWorkspaceIdHeader)
 }
 
 // Post on path
 func (c *DatabricksClient) Post(ctx context.Context, path string, request any, response any) error {
-	return c.Do(ctx, http.MethodPost, path, nil, nil, request, response, c.addApiPrefix)
+	return c.Do(ctx, http.MethodPost, path, nil, nil, request, response, c.addApiPrefix, c.AddWorkspaceIdHeader)
 }
 
 // Delete on path. Ignores succesfull responses from the server.
 func (c *DatabricksClient) Delete(ctx context.Context, path string, request any) error {
-	return c.Do(ctx, http.MethodDelete, path, nil, nil, request, nil, c.addApiPrefix)
+	return c.Do(ctx, http.MethodDelete, path, nil, nil, request, nil, c.addApiPrefix, c.AddWorkspaceIdHeader)
 }
 
 // Delete on path. Deserializes the response into the response parameter.
 func (c *DatabricksClient) DeleteWithResponse(ctx context.Context, path string, request any, response any) error {
-	return c.Do(ctx, http.MethodDelete, path, nil, nil, request, response, c.addApiPrefix)
+	return c.Do(ctx, http.MethodDelete, path, nil, nil, request, response, c.addApiPrefix, c.AddWorkspaceIdHeader)
 }
 
 // Patch on path. Ignores succesfull responses from the server.
 func (c *DatabricksClient) Patch(ctx context.Context, path string, request any) error {
-	return c.Do(ctx, http.MethodPatch, path, nil, nil, request, nil, c.addApiPrefix)
+	return c.Do(ctx, http.MethodPatch, path, nil, nil, request, nil, c.addApiPrefix, c.AddWorkspaceIdHeader)
 }
 
 // Patch on path. Deserializes the response into the response parameter.
 func (c *DatabricksClient) PatchWithResponse(ctx context.Context, path string, request any, response any) error {
-	return c.Do(ctx, http.MethodPatch, path, nil, nil, request, response, c.addApiPrefix)
+	return c.Do(ctx, http.MethodPatch, path, nil, nil, request, response, c.addApiPrefix, c.AddWorkspaceIdHeader)
 }
 
 // Put on path
 func (c *DatabricksClient) Put(ctx context.Context, path string, request any) error {
-	return c.Do(ctx, http.MethodPut, path, nil, nil, request, nil, c.addApiPrefix)
+	return c.Do(ctx, http.MethodPut, path, nil, nil, request, nil, c.addApiPrefix, c.AddWorkspaceIdHeader)
 }
 
 const (
@@ -626,6 +626,27 @@ const (
 	API_2_1 ApiVersion = "2.1"
 )
 
+// AddWorkspaceIdHeader injects the X-Databricks-Workspace-Id routing header
+// from Config.WorkspaceID. This mirrors the per-method header injection in the
+// generated Go SDK service impls (see vendor/.../service/<svc>/impl.go) and is
+// required on unified hosts, where the gateway uses the header to route the
+// request to the correct workspace. Without it, raw-HTTP resources (those
+// going through common.DatabricksClient.Get/Post/Patch/Delete/Put/Scim rather
+// than a generated w.<Service>.<Method> call) send no routing information and
+// the request fails or routes to the wrong workspace.
+//
+// The platform accepts both the legacy X-Databricks-Org-Id and the new
+// X-Databricks-Workspace-Id on requests during the migration window
+// (databricks/databricks-sdk-go#1688). The response echo header remains
+// X-Databricks-Org-Id for now.
+func (c *DatabricksClient) AddWorkspaceIdHeader(r *http.Request) error {
+	if c.Config == nil || c.Config.WorkspaceID == "" {
+		return nil
+	}
+	r.Header.Set("X-Databricks-Workspace-Id", c.Config.WorkspaceID)
+	return nil
+}
+
 func (c *DatabricksClient) addApiPrefix(r *http.Request) error {
 	if r.URL == nil {
 		return fmt.Errorf("no URL found in request")
@@ -666,7 +687,7 @@ func (c *DatabricksClient) scimVisitorForLevel(apiLevel string) func(*http.Reque
 func (c *DatabricksClient) Scim(ctx context.Context, method, path string, request any, response any, apiLevel string) error {
 	return c.Do(ctx, method, path, map[string]string{
 		"Content-Type": "application/scim+json; charset=utf-8",
-	}, nil, request, response, c.addApiPrefix, c.scimVisitorForLevel(apiLevel))
+	}, nil, request, response, c.addApiPrefix, c.scimVisitorForLevel(apiLevel), c.AddWorkspaceIdHeader)
 }
 
 // IsAzure returns true if client is configured for Azure Databricks - either by using AAD auth or with host+token combination

--- a/common/client_test.go
+++ b/common/client_test.go
@@ -727,6 +727,47 @@ func TestScim_AccountLevel_OmitsHeader(t *testing.T) {
 	assert.Contains(t, (*captured)[0].URL, "/accounts/test-account/scim/v2/Users")
 }
 
+// TestAddWorkspaceIdHeader_SuppressedOnAccountPath verifies the defensive
+// guard: if AddWorkspaceIdHeader is called on an /api/<ver>/accounts/... path
+// (defensive — this means a workspace-only visitor leaked onto an account
+// resource), the header is suppressed and a warning is logged.
+func TestAddWorkspaceIdHeader_SuppressedOnAccountPath(t *testing.T) {
+	dc, captured := newHeaderCaptureClient(t, "12345")
+	ctx := context.Background()
+
+	// Capture log output so we can verify the warning fired.
+	var logbuf strings.Builder
+	prev := log.Writer()
+	log.SetOutput(&logbuf)
+	t.Cleanup(func() { log.SetOutput(prev) })
+
+	// Simulate an account-scoped path being hit through Post + AddWorkspaceIdHeader.
+	// In production this would be a code bug; here we exercise it directly.
+	require.NoError(t, dc.Post(ctx, "/accounts/test-account/credentials", map[string]string{}, nil, dc.AddWorkspaceIdHeader))
+
+	require.Len(t, *captured, 1)
+	assert.Empty(t, (*captured)[0].Header.Get("X-Databricks-Workspace-Id"),
+		"header must not be set on /accounts/... paths even when the visitor is passed")
+	assert.Contains(t, logbuf.String(), "AddWorkspaceIdHeader invoked on account-scoped path",
+		"expected a warning when the visitor is mis-applied to an account path")
+}
+
+// TestAddWorkspaceIdHeader_FiresOnWorkspacePath confirms the guard is precise:
+// non-account paths still get the header.
+func TestAddWorkspaceIdHeader_FiresOnWorkspacePath(t *testing.T) {
+	dc, captured := newHeaderCaptureClient(t, "12345")
+	ctx := context.Background()
+
+	require.NoError(t, dc.Post(ctx, "/repos", map[string]string{}, nil, dc.AddWorkspaceIdHeader))
+	require.NoError(t, dc.Get(ctx, "/unity-catalog/tables", nil, nil, dc.AddWorkspaceIdHeader))
+
+	require.Len(t, *captured, 2)
+	for i, c := range *captured {
+		assert.Equal(t, "12345", c.Header.Get("X-Databricks-Workspace-Id"),
+			"request %d should carry the workspace-id header on a workspace path", i)
+	}
+}
+
 func TestCurrentWorkspaceID_ReturnsCachedValue(t *testing.T) {
 	c := &DatabricksClient{
 		DatabricksClient: &client.DatabricksClient{

--- a/common/client_test.go
+++ b/common/client_test.go
@@ -5,8 +5,10 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"net/http/httptest"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -599,6 +601,68 @@ func TestGetApiLevelFromDiff_ReturnsWorkspace(t *testing.T) {
 
 func TestGetApiLevelFromDiff_ReturnsEmptyWhenNotSet(t *testing.T) {
 	assert.Equal(t, "", testGetApiLevelFromDiff(t, ""))
+}
+
+// newHeaderCaptureClient spins up a test HTTP server that records the headers
+// of every incoming request, and returns a DatabricksClient pointed at it.
+// Use it to assert that raw-HTTP helpers (Get/Post/Patch/Delete/Put/Scim)
+// inject X-Databricks-Workspace-Id per AddWorkspaceIdHeader.
+func newHeaderCaptureClient(t *testing.T, workspaceID string) (*DatabricksClient, *[]http.Header) {
+	t.Helper()
+	var mu sync.Mutex
+	var captured []http.Header
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		mu.Lock()
+		captured = append(captured, req.Header.Clone())
+		mu.Unlock()
+		rw.WriteHeader(http.StatusOK)
+		_, _ = rw.Write([]byte(`{}`))
+	}))
+	t.Cleanup(server.Close)
+
+	cfg := &config.Config{
+		Host:        server.URL,
+		Token:       "dapi-test",
+		WorkspaceID: workspaceID,
+		HostMetadataResolver: func(ctx context.Context, host string) (*config.HostMetadata, error) {
+			return nil, nil
+		},
+	}
+	sdkClient, err := client.New(cfg)
+	require.NoError(t, err)
+	return &DatabricksClient{DatabricksClient: sdkClient}, &captured
+}
+
+func TestWorkspaceIdHeader_InjectedWhenWorkspaceIDSet(t *testing.T) {
+	dc, captured := newHeaderCaptureClient(t, "12345")
+	ctx := context.Background()
+
+	require.NoError(t, dc.Get(ctx, "/clusters/list", nil, nil))
+	require.NoError(t, dc.Post(ctx, "/instance-pools/create", map[string]string{}, nil))
+	require.NoError(t, dc.Patch(ctx, "/repos/1", map[string]string{}))
+	require.NoError(t, dc.Delete(ctx, "/token/delete", map[string]string{}))
+	require.NoError(t, dc.Put(ctx, "/sql/config/warehouses", map[string]string{}))
+	require.NoError(t, dc.Scim(ctx, http.MethodGet, "/preview/scim/v2/Me", nil, nil, ""))
+
+	require.Len(t, *captured, 6)
+	for i, h := range *captured {
+		assert.Equal(t, "12345", h.Get("X-Databricks-Workspace-Id"), "request %d missing workspace-id header", i)
+	}
+	// Sanity-check the SCIM content-type is still set alongside the new header.
+	assert.Equal(t, "application/scim+json; charset=utf-8", (*captured)[5].Get("Content-Type"))
+}
+
+func TestWorkspaceIdHeader_OmittedWhenWorkspaceIDEmpty(t *testing.T) {
+	dc, captured := newHeaderCaptureClient(t, "")
+	ctx := context.Background()
+
+	require.NoError(t, dc.Get(ctx, "/clusters/list", nil, nil))
+	require.NoError(t, dc.Scim(ctx, http.MethodGet, "/preview/scim/v2/Me", nil, nil, ""))
+
+	require.Len(t, *captured, 2)
+	for i, h := range *captured {
+		assert.Empty(t, h.Get("X-Databricks-Workspace-Id"), "request %d should not carry workspace-id header", i)
+	}
 }
 
 func TestCurrentWorkspaceID_ReturnsCachedValue(t *testing.T) {

--- a/common/client_test.go
+++ b/common/client_test.go
@@ -603,17 +603,27 @@ func TestGetApiLevelFromDiff_ReturnsEmptyWhenNotSet(t *testing.T) {
 	assert.Equal(t, "", testGetApiLevelFromDiff(t, ""))
 }
 
-// newHeaderCaptureClient spins up a test HTTP server that records the headers
-// of every incoming request, and returns a DatabricksClient pointed at it.
+// capturedRequest records an outbound HTTP request so tests can assert on its
+// headers and URL.
+type capturedRequest struct {
+	Header http.Header
+	URL    string
+}
+
+// newHeaderCaptureClient spins up a test HTTP server that records every
+// incoming request, and returns a DatabricksClient pointed at it.
 // Use it to assert that raw-HTTP helpers (Get/Post/Patch/Delete/Put/Scim)
 // inject X-Databricks-Workspace-Id per AddWorkspaceIdHeader.
-func newHeaderCaptureClient(t *testing.T, workspaceID string) (*DatabricksClient, *[]http.Header) {
+func newHeaderCaptureClient(t *testing.T, workspaceID string) (*DatabricksClient, *[]capturedRequest) {
 	t.Helper()
 	var mu sync.Mutex
-	var captured []http.Header
+	var captured []capturedRequest
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		mu.Lock()
-		captured = append(captured, req.Header.Clone())
+		captured = append(captured, capturedRequest{
+			Header: req.Header.Clone(),
+			URL:    req.URL.String(),
+		})
 		mu.Unlock()
 		rw.WriteHeader(http.StatusOK)
 		_, _ = rw.Write([]byte(`{}`))
@@ -633,7 +643,13 @@ func newHeaderCaptureClient(t *testing.T, workspaceID string) (*DatabricksClient
 	return &DatabricksClient{DatabricksClient: sdkClient}, &captured
 }
 
-func TestWorkspaceIdHeader_InjectedWhenWorkspaceIDSet(t *testing.T) {
+// TestWorkspaceIdHeader_OmittedByDefault confirms the helpers no longer inject
+// X-Databricks-Workspace-Id automatically. Header injection is now per-callsite —
+// callers must opt in by passing AddWorkspaceIdHeader as a trailing visitor.
+// This catches accidental regressions where someone re-wires the helpers to
+// always inject the header (which would silently send routing headers from
+// account-only resources too).
+func TestWorkspaceIdHeader_OmittedByDefault(t *testing.T) {
 	dc, captured := newHeaderCaptureClient(t, "12345")
 	ctx := context.Background()
 
@@ -642,27 +658,73 @@ func TestWorkspaceIdHeader_InjectedWhenWorkspaceIDSet(t *testing.T) {
 	require.NoError(t, dc.Patch(ctx, "/repos/1", map[string]string{}))
 	require.NoError(t, dc.Delete(ctx, "/token/delete", map[string]string{}))
 	require.NoError(t, dc.Put(ctx, "/sql/config/warehouses", map[string]string{}))
-	require.NoError(t, dc.Scim(ctx, http.MethodGet, "/preview/scim/v2/Me", nil, nil, ""))
 
-	require.Len(t, *captured, 6)
+	require.Len(t, *captured, 5)
 	for i, h := range *captured {
-		assert.Equal(t, "12345", h.Get("X-Databricks-Workspace-Id"), "request %d missing workspace-id header", i)
+		assert.Empty(t, h.Header.Get("X-Databricks-Workspace-Id"), "request %d unexpectedly carries workspace-id header by default", i)
 	}
-	// Sanity-check the SCIM content-type is still set alongside the new header.
-	assert.Equal(t, "application/scim+json; charset=utf-8", (*captured)[5].Get("Content-Type"))
 }
 
-func TestWorkspaceIdHeader_OmittedWhenWorkspaceIDEmpty(t *testing.T) {
+// TestWorkspaceIdHeader_InjectedWithVisitor confirms callers can opt in by
+// passing AddWorkspaceIdHeader. This is the contract every workspace-level
+// resource follows.
+func TestWorkspaceIdHeader_InjectedWithVisitor(t *testing.T) {
+	dc, captured := newHeaderCaptureClient(t, "12345")
+	ctx := context.Background()
+
+	require.NoError(t, dc.Get(ctx, "/clusters/list", nil, nil, dc.AddWorkspaceIdHeader))
+	require.NoError(t, dc.Post(ctx, "/instance-pools/create", map[string]string{}, nil, dc.AddWorkspaceIdHeader))
+	require.NoError(t, dc.Patch(ctx, "/repos/1", map[string]string{}, dc.AddWorkspaceIdHeader))
+	require.NoError(t, dc.Delete(ctx, "/token/delete", map[string]string{}, dc.AddWorkspaceIdHeader))
+	require.NoError(t, dc.Put(ctx, "/sql/config/warehouses", map[string]string{}, dc.AddWorkspaceIdHeader))
+
+	require.Len(t, *captured, 5)
+	for i, h := range *captured {
+		assert.Equal(t, "12345", h.Header.Get("X-Databricks-Workspace-Id"), "request %d missing workspace-id header", i)
+	}
+}
+
+// TestWorkspaceIdHeader_VisitorNoOpWhenWorkspaceIDEmpty confirms the visitor is
+// safe to pass even when Config.WorkspaceID is empty (no-op, no header).
+func TestWorkspaceIdHeader_VisitorNoOpWhenWorkspaceIDEmpty(t *testing.T) {
 	dc, captured := newHeaderCaptureClient(t, "")
 	ctx := context.Background()
 
-	require.NoError(t, dc.Get(ctx, "/clusters/list", nil, nil))
-	require.NoError(t, dc.Scim(ctx, http.MethodGet, "/preview/scim/v2/Me", nil, nil, ""))
+	require.NoError(t, dc.Get(ctx, "/clusters/list", nil, nil, dc.AddWorkspaceIdHeader))
 
-	require.Len(t, *captured, 2)
-	for i, h := range *captured {
-		assert.Empty(t, h.Get("X-Databricks-Workspace-Id"), "request %d should not carry workspace-id header", i)
-	}
+	require.Len(t, *captured, 1)
+	assert.Empty(t, (*captured)[0].Header.Get("X-Databricks-Workspace-Id"))
+}
+
+// TestScim_WorkspaceLevel_InjectsHeader verifies that the SCIM helper injects
+// the routing header for workspace-level SCIM calls (the dual-resource case
+// where users/groups/service_principals are addressed at the workspace).
+func TestScim_WorkspaceLevel_InjectsHeader(t *testing.T) {
+	dc, captured := newHeaderCaptureClient(t, "12345")
+	ctx := context.Background()
+
+	require.NoError(t, dc.Scim(ctx, http.MethodGet, "/preview/scim/v2/Users", nil, nil, ApiLevelWorkspace))
+
+	require.Len(t, *captured, 1)
+	assert.Equal(t, "12345", (*captured)[0].Header.Get("X-Databricks-Workspace-Id"))
+	assert.Equal(t, "application/scim+json; charset=utf-8", (*captured)[0].Header.Get("Content-Type"))
+}
+
+// TestScim_AccountLevel_OmitsHeader verifies the SCIM helper does NOT inject
+// the routing header for account-level SCIM calls — those target
+// /api/2.0/accounts/{aid}/scim/v2/... and must not be workspace-tagged.
+func TestScim_AccountLevel_OmitsHeader(t *testing.T) {
+	dc, captured := newHeaderCaptureClient(t, "12345")
+	dc.Config.AccountID = "test-account"
+	ctx := context.Background()
+
+	require.NoError(t, dc.Scim(ctx, http.MethodGet, "/preview/scim/v2/Users", nil, nil, ApiLevelAccount))
+
+	require.Len(t, *captured, 1)
+	assert.Empty(t, (*captured)[0].Header.Get("X-Databricks-Workspace-Id"))
+	// Confirm the SCIM account rewrite still applied — the path should be
+	// /api/2.0/accounts/{aid}/scim/v2/Users (the scimVisitorForLevel did its job).
+	assert.Contains(t, (*captured)[0].URL, "/accounts/test-account/scim/v2/Users")
 }
 
 func TestCurrentWorkspaceID_ReturnsCachedValue(t *testing.T) {

--- a/common/unified_provider_test.go
+++ b/common/unified_provider_test.go
@@ -816,7 +816,7 @@ func TestNamespaceCustomizeDiff_UnifiedHost_DirectFallback(t *testing.T) {
 	}
 	// No cached workspace client — WorkspaceClientForWorkspace falls back to
 	// tryWorkspaceClientDirect which succeeds for unified hosts (routes via
-	// X-Databricks-Org-Id header). Actual workspace validation happens at apply time.
+	// X-Databricks-Workspace-Id header). Actual workspace validation happens at apply time.
 	_, err := diffCustomizeDiff(t, resource, nil, map[string]interface{}{
 		"name": "test",
 		"provider_config": []interface{}{

--- a/exporter/util.go
+++ b/exporter/util.go
@@ -110,7 +110,7 @@ func dbsqlListObjects(ic *importContext, path string) (events []map[string]any, 
 	// TODO: create API method & use it also for data resource
 	var listResponse dbsqlListResponse
 	page_size := 100
-	err = ic.Client.Get(ic.Context, path, map[string]any{"page_size": page_size}, &listResponse)
+	err = ic.Client.Get(ic.Context, path, map[string]any{"page_size": page_size}, &listResponse, ic.Client.AddWorkspaceIdHeader)
 	if err != nil {
 		return nil, err
 	}
@@ -124,7 +124,7 @@ func dbsqlListObjects(ic *importContext, path string) (events []map[string]any, 
 		var listResponse dbsqlListResponse
 		err := ic.Client.Get(ic.Context, path,
 			map[string]any{"page_size": page_size, "page": page},
-			&listResponse)
+			&listResponse, ic.Client.AddWorkspaceIdHeader)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/acceptance/unified_host_acc_test.go
+++ b/internal/acceptance/unified_host_acc_test.go
@@ -143,7 +143,11 @@ func TestMwsAccAccountHostCreateJobs(t *testing.T) {
 // the contrast is direct: jobs (Go SDK) passes, repo (raw HTTP) is expected to
 // fail on the unified host.
 func createRepoWithProviderConfig(t *testing.T, workspaceID string, providerFactories map[string]func() (tfprotov6.ProviderServer, error)) {
-	repoPath := "/Repos/tf-acc-" + RandomName()
+	// Path validator on databricks_repo.path requires /Repos/<directory>/<repo>
+	// (3 components after the leading slash) — see repos/resource_repo.go's
+	// validatePath. Use a fixed middle segment so each run is unique only in
+	// the leaf to avoid collisions between concurrent matrix jobs.
+	repoPath := "/Repos/tf-acc/repo-" + RandomName()
 
 	step := Step{
 		Template: `

--- a/internal/acceptance/unified_host_acc_test.go
+++ b/internal/acceptance/unified_host_acc_test.go
@@ -10,6 +10,7 @@ import (
 	databricks "github.com/databricks/databricks-sdk-go"
 	"github.com/databricks/databricks-sdk-go/config"
 	"github.com/databricks/databricks-sdk-go/service/jobs"
+	"github.com/databricks/databricks-sdk-go/service/workspace"
 	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/databricks/terraform-provider-databricks/internal/providers"
 	"github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw"
@@ -128,4 +129,80 @@ func TestMwsAccAccountHostCreateJobs(t *testing.T) {
 	LoadAccountEnv(t)
 	workspaceID := GetEnvOrSkipTest(t, "TEST_WORKSPACE_ID")
 	createJobWithProviderConfig(t, workspaceID, nil)
+}
+
+// createRepoWithProviderConfig exercises a NewXYZAPI-style raw-HTTP resource
+// (databricks_repo → NewReposAPI → DatabricksClient.Post/Get/Delete) against a
+// unified host. The Go SDK only injects the X-Databricks-Workspace-Id routing header
+// from the generated per-service impl.go files (e.g. service/jobs/impl.go), so
+// resources that go through common.DatabricksClient's raw HTTP path send no
+// routing header at all. On a unified host that is fatal: the gateway has no
+// way to route the request to the right workspace.
+//
+// Mirror of createJobWithProviderConfig — same shape, different resource — so
+// the contrast is direct: jobs (Go SDK) passes, repo (raw HTTP) is expected to
+// fail on the unified host.
+func createRepoWithProviderConfig(t *testing.T, workspaceID string, providerFactories map[string]func() (tfprotov6.ProviderServer, error)) {
+	repoPath := "/Repos/tf-acc-" + RandomName()
+
+	step := Step{
+		Template: `
+		resource "databricks_repo" "r1" {
+			url  = "https://github.com/databricks/databricks-sdk-go"
+			path = "` + repoPath + `"
+			provider_config {
+				workspace_id = ` + workspaceID + `
+			}
+		}
+		`,
+		Check: ResourceCheck("databricks_repo.r1", func(ctx context.Context, client *common.DatabricksClient, id string) error {
+			w, err := client.GetWorkspaceClientForUnifiedProvider(ctx, workspaceID)
+			if err != nil {
+				return err
+			}
+			repoID, err := strconv.ParseInt(id, 10, 64)
+			if err != nil {
+				return err
+			}
+			res, err := w.Repos.Get(ctx, workspace.GetRepoRequest{RepoId: repoID})
+			if err != nil {
+				return err
+			}
+			if res.Path != repoPath {
+				return fmt.Errorf("expected repo path %q, got %q (repo may have been created in the wrong workspace)", repoPath, res.Path)
+			}
+			return nil
+		}),
+	}
+	if providerFactories != nil {
+		step.ProtoV6ProviderFactories = providerFactories
+	}
+	run(t, []Step{step})
+}
+
+func TestMwsAccUnifiedHostCreateRepo(t *testing.T) {
+	initUnifiedHostAccountEnv(t)
+	unifiedHost := os.Getenv("UNIFIED_HOST")
+	workspaceID := GetEnvOrSkipTest(t, "TEST_WORKSPACE_ID")
+	accountID := GetEnvOrSkipTest(t, "DATABRICKS_ACCOUNT_ID")
+	createRepoWithProviderConfig(t, workspaceID, unifiedHostProviderFactories(unifiedHost, accountID))
+}
+
+func TestAccUnifiedHostWorkspaceCreateRepo(t *testing.T) {
+	initUnifiedHostWorkspaceEnv(t)
+	unifiedHost := os.Getenv("UNIFIED_HOST")
+	accountID := GetEnvOrSkipTest(t, "TEST_ACCOUNT_ID")
+	ctx := context.Background()
+	w := databricks.Must(databricks.NewWorkspaceClient())
+	workspaceID, err := w.CurrentWorkspaceID(ctx)
+	if err != nil {
+		t.Fatalf("failed to get current workspace ID: %s", err)
+	}
+	createRepoWithProviderConfig(t, strconv.FormatInt(workspaceID, 10), unifiedHostProviderFactories(unifiedHost, accountID))
+}
+
+func TestMwsAccAccountHostCreateRepo(t *testing.T) {
+	LoadAccountEnv(t)
+	workspaceID := GetEnvOrSkipTest(t, "TEST_WORKSPACE_ID")
+	createRepoWithProviderConfig(t, workspaceID, nil)
 }

--- a/jobs/resource_job.go
+++ b/jobs/resource_job.go
@@ -691,7 +691,7 @@ func (a JobsAPI) ListByName(name string, expandTasks bool) ([]Job, error) {
 		if nextPageToken != "" {
 			params["page_token"] = nextPageToken
 		}
-		err := a.client.Get(ctx, "/jobs/list", params, &resp)
+		err := a.client.Get(ctx, "/jobs/list", params, &resp, a.client.AddWorkspaceIdHeader)
 		if err != nil {
 			return nil, err
 		}
@@ -711,7 +711,7 @@ func (a JobsAPI) List() (l []Job, err error) {
 
 // RunsList returns a job runs list
 func (a JobsAPI) RunsList(r JobRunsListRequest) (jrl JobRunsList, err error) {
-	err = a.client.Get(a.context, "/jobs/runs/list", r, &jrl)
+	err = a.client.Get(a.context, "/jobs/runs/list", r, &jrl, a.client.AddWorkspaceIdHeader)
 	return
 }
 
@@ -720,7 +720,7 @@ func (a JobsAPI) RunsCancel(runID int64, timeout time.Duration) error {
 	var response any
 	err := a.client.Post(a.context, "/jobs/runs/cancel", map[string]any{
 		"run_id": runID,
-	}, &response)
+	}, &response, a.client.AddWorkspaceIdHeader)
 	if err != nil {
 		return err
 	}
@@ -755,7 +755,7 @@ func (a JobsAPI) RunNow(jobID int64) (int64, error) {
 	var jr JobRun
 	err := a.client.Post(a.context, "/jobs/run-now", RunParameters{
 		JobID: jobID,
-	}, &jr)
+	}, &jr, a.client.AddWorkspaceIdHeader)
 	return jr.RunID, err
 }
 
@@ -764,7 +764,7 @@ func (a JobsAPI) RunsGet(runID int64) (JobRun, error) {
 	var jr JobRun
 	err := a.client.Get(a.context, "/jobs/runs/get", map[string]any{
 		"run_id": runID,
-	}, &jr)
+	}, &jr, a.client.AddWorkspaceIdHeader)
 	return jr, err
 }
 
@@ -810,7 +810,7 @@ func (a JobsAPI) Create(jobSettings JobSettings) (Job, error) {
 			return job, fmt.Errorf("git source is not empty but none of branch, commit and tag is specified")
 		}
 	}
-	err := a.client.Post(a.context, "/jobs/create", jobSettings, &job)
+	err := a.client.Post(a.context, "/jobs/create", jobSettings, &job, a.client.AddWorkspaceIdHeader)
 	return job, err
 }
 
@@ -823,7 +823,7 @@ func (a JobsAPI) Update(id string, jobSettings JobSettings) error {
 	return wrapMissingJobError(a.client.Post(a.context, "/jobs/reset", UpdateJobRequest{
 		JobID:       jobID,
 		NewSettings: &jobSettings,
-	}, nil), id)
+	}, nil, a.client.AddWorkspaceIdHeader), id)
 }
 
 // Read returns the job object with all the attributes
@@ -834,7 +834,7 @@ func (a JobsAPI) Read(id string) (job Job, err error) {
 	}
 	err = wrapMissingJobError(a.client.Get(a.context, "/jobs/get", map[string]int64{
 		"job_id": jobID,
-	}, &job), id)
+	}, &job, a.client.AddWorkspaceIdHeader), id)
 	if job.Settings != nil {
 		job.Settings.adjustTasks()
 		job.Settings.sortWebhooksByID()
@@ -866,7 +866,7 @@ func (a JobsAPI) Delete(id string) error {
 	}
 	return wrapMissingJobError(a.client.Post(a.context, "/jobs/delete", map[string]int64{
 		"job_id": jobID,
-	}, nil), id)
+	}, nil, a.client.AddWorkspaceIdHeader), id)
 }
 
 func wrapMissingJobError(err error, id string) error {

--- a/pools/resource_instance_pool.go
+++ b/pools/resource_instance_pool.go
@@ -146,26 +146,26 @@ type InstancePoolsAPI struct {
 // Create creates the instance pool to given the instance pool configuration
 func (a InstancePoolsAPI) Create(instancePool InstancePool) (InstancePoolAndStats, error) {
 	var instancePoolInfo InstancePoolAndStats
-	err := a.client.Post(a.context, "/instance-pools/create", instancePool, &instancePoolInfo)
+	err := a.client.Post(a.context, "/instance-pools/create", instancePool, &instancePoolInfo, a.client.AddWorkspaceIdHeader)
 	return instancePoolInfo, err
 }
 
 // Update edits the configuration of a instance pool to match the provided attributes and size
 func (a InstancePoolsAPI) Update(ip InstancePool) error {
-	return a.client.Post(a.context, "/instance-pools/edit", ip, nil)
+	return a.client.Post(a.context, "/instance-pools/edit", ip, nil, a.client.AddWorkspaceIdHeader)
 }
 
 // Read retrieves the information for a instance pool given its identifier
 func (a InstancePoolsAPI) Read(instancePoolID string) (ip InstancePool, err error) {
 	err = a.client.Get(a.context, "/instance-pools/get", map[string]string{
 		"instance_pool_id": instancePoolID,
-	}, &ip)
+	}, &ip, a.client.AddWorkspaceIdHeader)
 	return
 }
 
 // List retrieves the list of existing instance pools
 func (a InstancePoolsAPI) List() (ipl InstancePoolList, err error) {
-	err = a.client.Get(a.context, "/instance-pools/list", nil, &ipl)
+	err = a.client.Get(a.context, "/instance-pools/list", nil, &ipl, a.client.AddWorkspaceIdHeader)
 	return
 }
 
@@ -173,7 +173,7 @@ func (a InstancePoolsAPI) List() (ipl InstancePoolList, err error) {
 func (a InstancePoolsAPI) Delete(instancePoolID string) error {
 	return a.client.Post(a.context, "/instance-pools/delete", map[string]string{
 		"instance_pool_id": instancePoolID,
-	}, nil)
+	}, nil, a.client.AddWorkspaceIdHeader)
 }
 
 // ResourceInstancePool ...

--- a/repos/resource_repo.go
+++ b/repos/resource_repo.go
@@ -67,12 +67,12 @@ func (a ReposAPI) Create(r reposCreateRequest) (ReposInformation, error) {
 		}
 	}
 
-	err := a.client.Post(a.context, "/repos", r, &resp)
+	err := a.client.Post(a.context, "/repos", r, &resp, a.client.AddWorkspaceIdHeader)
 	return resp, err
 }
 
 func (a ReposAPI) Delete(id string) error {
-	return a.client.Delete(a.context, fmt.Sprintf("/repos/%s", id), nil)
+	return a.client.Delete(a.context, fmt.Sprintf("/repos/%s", id), nil, a.client.AddWorkspaceIdHeader)
 }
 
 func (a ReposAPI) Update(id string, r map[string]any) error {
@@ -82,18 +82,18 @@ func (a ReposAPI) Update(id string, r map[string]any) error {
 	// TODO: update may change ONE OF (url AND provider (optional)), (path), or (branch OR tag).
 	// for URL/provider force re-create as there are limits on what could be done for changing URL/provider
 	if path, ok := r["path"]; ok {
-		err := a.client.Patch(a.context, fmt.Sprintf("/repos/%s", id), map[string]any{"path": path})
+		err := a.client.Patch(a.context, fmt.Sprintf("/repos/%s", id), map[string]any{"path": path}, a.client.AddWorkspaceIdHeader)
 		if err != nil {
 			return err
 		}
 		delete(r, "path")
 	}
-	return a.client.Patch(a.context, fmt.Sprintf("/repos/%s", id), r)
+	return a.client.Patch(a.context, fmt.Sprintf("/repos/%s", id), r, a.client.AddWorkspaceIdHeader)
 }
 
 func (a ReposAPI) Read(id string) (ReposInformation, error) {
 	var resp ReposInformation
-	err := a.client.Get(a.context, fmt.Sprintf("/repos/%s", id), nil, &resp)
+	err := a.client.Get(a.context, fmt.Sprintf("/repos/%s", id), nil, &resp, a.client.AddWorkspaceIdHeader)
 	return resp, err
 }
 
@@ -110,7 +110,7 @@ func (a ReposAPI) List(prefix string) ([]ReposInformation, error) {
 	reposList := []ReposInformation{}
 	for {
 		var resp ReposListResponse
-		err := a.client.Get(a.context, "/repos", req, &resp)
+		err := a.client.Get(a.context, "/repos", req, &resp, a.client.AddWorkspaceIdHeader)
 		if err != nil {
 			return nil, err
 		}

--- a/sharing/resource_provider.go
+++ b/sharing/resource_provider.go
@@ -29,16 +29,16 @@ type Providers struct {
 }
 
 func (a ProvidersAPI) createProvider(ci *ProviderInfo) error {
-	return a.client.Post(a.context, "/unity-catalog/providers", ci, ci)
+	return a.client.Post(a.context, "/unity-catalog/providers", ci, ci, a.client.AddWorkspaceIdHeader)
 }
 
 func (a ProvidersAPI) getProvider(name string) (ci ProviderInfo, err error) {
-	err = a.client.Get(a.context, "/unity-catalog/providers/"+name, nil, &ci)
+	err = a.client.Get(a.context, "/unity-catalog/providers/"+name, nil, &ci, a.client.AddWorkspaceIdHeader)
 	return
 }
 
 func (a ProvidersAPI) deleteProvider(name string) error {
-	return a.client.Delete(a.context, "/unity-catalog/providers/"+name, nil)
+	return a.client.Delete(a.context, "/unity-catalog/providers/"+name, nil, a.client.AddWorkspaceIdHeader)
 }
 
 func (a ProvidersAPI) updateProvider(ci *ProviderInfo) error {
@@ -47,7 +47,7 @@ func (a ProvidersAPI) updateProvider(ci *ProviderInfo) error {
 	}{
 		Comment: ci.Comment,
 	}
-	return a.client.Patch(a.context, "/unity-catalog/providers/"+ci.Name, patch)
+	return a.client.Patch(a.context, "/unity-catalog/providers/"+ci.Name, patch, a.client.AddWorkspaceIdHeader)
 }
 
 func ResourceProvider() common.Resource {

--- a/sql/resource_sql_dashboard.go
+++ b/sql/resource_sql_dashboard.go
@@ -72,13 +72,13 @@ type DashboardAPI struct {
 
 // Create ...
 func (a DashboardAPI) Create(d *api.Dashboard) error {
-	return a.client.Post(a.context, "/preview/sql/dashboards", d, &d)
+	return a.client.Post(a.context, "/preview/sql/dashboards", d, &d, a.client.AddWorkspaceIdHeader)
 }
 
 // Read ...
 func (a DashboardAPI) Read(dashboardID string) (*api.Dashboard, error) {
 	var d api.Dashboard
-	err := a.client.Get(a.context, fmt.Sprintf("/preview/sql/dashboards/%s", dashboardID), nil, &d)
+	err := a.client.Get(a.context, fmt.Sprintf("/preview/sql/dashboards/%s", dashboardID), nil, &d, a.client.AddWorkspaceIdHeader)
 	if err != nil {
 		return nil, err
 	}
@@ -88,12 +88,12 @@ func (a DashboardAPI) Read(dashboardID string) (*api.Dashboard, error) {
 
 // Update ...
 func (a DashboardAPI) Update(dashboardID string, d *api.Dashboard) error {
-	return a.client.Post(a.context, fmt.Sprintf("/preview/sql/dashboards/%s", dashboardID), d, nil)
+	return a.client.Post(a.context, fmt.Sprintf("/preview/sql/dashboards/%s", dashboardID), d, nil, a.client.AddWorkspaceIdHeader)
 }
 
 // Delete ...
 func (a DashboardAPI) Delete(dashboardID string) error {
-	return a.client.Delete(a.context, fmt.Sprintf("/preview/sql/dashboards/%s", dashboardID), nil)
+	return a.client.Delete(a.context, fmt.Sprintf("/preview/sql/dashboards/%s", dashboardID), nil, a.client.AddWorkspaceIdHeader)
 }
 
 func ResourceSqlDashboard() common.Resource {

--- a/sql/resource_sql_global_config.go
+++ b/sql/resource_sql_global_config.go
@@ -92,13 +92,13 @@ func (a globalConfigAPI) Set(gc GlobalConfig, d *schema.ResourceData) error {
 	}
 	common.SetForceSendFields(&data, d, []string{"enable_serverless_compute"})
 
-	return a.client.Put(a.context, "/sql/config/warehouses", data)
+	return a.client.Put(a.context, "/sql/config/warehouses", data, a.client.AddWorkspaceIdHeader)
 }
 
 func (a globalConfigAPI) Get() (GlobalConfig, error) {
 	gc := GlobalConfig{}
 	gcr := GlobalConfigForRead{}
-	if err := a.client.Get(a.context, "/sql/config/warehouses", nil, &gcr); err != nil {
+	if err := a.client.Get(a.context, "/sql/config/warehouses", nil, &gcr, a.client.AddWorkspaceIdHeader); err != nil {
 		return gc, err
 	}
 	gc.InstanceProfileARN = gcr.InstanceProfileARN

--- a/sql/resource_sql_query.go
+++ b/sql/resource_sql_query.go
@@ -466,7 +466,7 @@ type QueryAPI struct {
 
 // Create ...
 func (a QueryAPI) Create(q *api.Query) error {
-	err := a.client.Post(a.context, "/preview/sql/queries", q, &q)
+	err := a.client.Post(a.context, "/preview/sql/queries", q, &q, a.client.AddWorkspaceIdHeader)
 	if err != nil {
 		return err
 	}
@@ -492,7 +492,7 @@ func (a QueryAPI) Create(q *api.Query) error {
 // Read ...
 func (a QueryAPI) Read(queryID string) (*api.Query, error) {
 	var q api.Query
-	err := a.client.Get(a.context, fmt.Sprintf("/preview/sql/queries/%s", queryID), nil, &q)
+	err := a.client.Get(a.context, fmt.Sprintf("/preview/sql/queries/%s", queryID), nil, &q, a.client.AddWorkspaceIdHeader)
 	if err != nil {
 		return nil, err
 	}
@@ -502,12 +502,12 @@ func (a QueryAPI) Read(queryID string) (*api.Query, error) {
 
 // Update ...
 func (a QueryAPI) Update(queryID string, q *api.Query) error {
-	return a.client.Post(a.context, fmt.Sprintf("/preview/sql/queries/%s", queryID), q, nil)
+	return a.client.Post(a.context, fmt.Sprintf("/preview/sql/queries/%s", queryID), q, nil, a.client.AddWorkspaceIdHeader)
 }
 
 // Delete ...
 func (a QueryAPI) Delete(queryID string) error {
-	return a.client.Delete(a.context, fmt.Sprintf("/preview/sql/queries/%s", queryID), nil)
+	return a.client.Delete(a.context, fmt.Sprintf("/preview/sql/queries/%s", queryID), nil, a.client.AddWorkspaceIdHeader)
 }
 
 func ResourceSqlQuery() common.Resource {

--- a/sql/resource_sql_visualization.go
+++ b/sql/resource_sql_visualization.go
@@ -75,7 +75,7 @@ type VisualizationAPI struct {
 
 // Create ...
 func (a VisualizationAPI) Create(v *api.Visualization) error {
-	return a.client.Post(a.context, "/preview/sql/visualizations", v, &v)
+	return a.client.Post(a.context, "/preview/sql/visualizations", v, &v, a.client.AddWorkspaceIdHeader)
 }
 
 // Read ...
@@ -110,12 +110,12 @@ func (a VisualizationAPI) Read(queryID, visualizationID string) (*api.Visualizat
 
 // Update ...
 func (a VisualizationAPI) Update(visualizationID string, v *api.Visualization) error {
-	return a.client.Post(a.context, fmt.Sprintf("/preview/sql/visualizations/%s", visualizationID), &v, nil)
+	return a.client.Post(a.context, fmt.Sprintf("/preview/sql/visualizations/%s", visualizationID), &v, nil, a.client.AddWorkspaceIdHeader)
 }
 
 // Delete ...
 func (a VisualizationAPI) Delete(visualizationID string) error {
-	return a.client.Delete(a.context, fmt.Sprintf("/preview/sql/visualizations/%s", visualizationID), nil)
+	return a.client.Delete(a.context, fmt.Sprintf("/preview/sql/visualizations/%s", visualizationID), nil, a.client.AddWorkspaceIdHeader)
 }
 
 func jsonRemarshal(in []byte) ([]byte, error) {

--- a/sql/resource_sql_widget.go
+++ b/sql/resource_sql_widget.go
@@ -211,7 +211,7 @@ type WidgetAPI struct {
 
 // Create ...
 func (a WidgetAPI) Create(w *api.Widget) error {
-	return a.client.Post(a.context, "/preview/sql/widgets", w, &w)
+	return a.client.Post(a.context, "/preview/sql/widgets", w, &w, a.client.AddWorkspaceIdHeader)
 }
 
 // Read ...
@@ -246,12 +246,12 @@ func (a WidgetAPI) Read(dashboardID, widgetID string) (*api.Widget, error) {
 
 // Update ...
 func (a WidgetAPI) Update(widgetID string, w *api.Widget) error {
-	return a.client.Post(a.context, fmt.Sprintf("/preview/sql/widgets/%s", widgetID), w, nil)
+	return a.client.Post(a.context, fmt.Sprintf("/preview/sql/widgets/%s", widgetID), w, nil, a.client.AddWorkspaceIdHeader)
 }
 
 // Delete ...
 func (a WidgetAPI) Delete(widgetID string) error {
-	return a.client.Delete(a.context, fmt.Sprintf("/preview/sql/widgets/%s", widgetID), nil)
+	return a.client.Delete(a.context, fmt.Sprintf("/preview/sql/widgets/%s", widgetID), nil, a.client.AddWorkspaceIdHeader)
 }
 
 func ResourceSqlWidget() common.Resource {

--- a/storage/dbfs.go
+++ b/storage/dbfs.go
@@ -85,16 +85,16 @@ func (a DbfsAPI) Create(path string, contents []byte, overwrite bool) (err error
 
 func (a DbfsAPI) createHandle(path string, overwrite bool) (int64, error) {
 	var h handleResponse
-	err := a.client.Post(a.context, "/dbfs/create", createHandle{path, overwrite}, &h)
+	err := a.client.Post(a.context, "/dbfs/create", createHandle{path, overwrite}, &h, a.client.AddWorkspaceIdHeader)
 	return h.Handle, err
 }
 
 func (a DbfsAPI) addBlock(data string, handle int64) error {
-	return a.client.Post(a.context, "/dbfs/add-block", addBlock{data, handle}, nil)
+	return a.client.Post(a.context, "/dbfs/add-block", addBlock{data, handle}, nil, a.client.AddWorkspaceIdHeader)
 }
 
 func (a DbfsAPI) closeHandle(handle int64) error {
-	return a.client.Post(a.context, "/dbfs/close", handleResponse{handle}, nil)
+	return a.client.Post(a.context, "/dbfs/close", handleResponse{handle}, nil, a.client.AddWorkspaceIdHeader)
 }
 
 // List returns a list of files in DBFS and the recursive flag lets you recursively list files
@@ -132,7 +132,7 @@ func (a DbfsAPI) list(path string) ([]FileInfo, error) {
 	var dbfsList FileList
 	err := a.client.Get(a.context, "/dbfs/list", map[string]any{
 		"path": path,
-	}, &dbfsList)
+	}, &dbfsList, a.client.AddWorkspaceIdHeader)
 	if err != nil {
 		err = fmt.Errorf("cannot list %s: %w", path, err)
 	}
@@ -144,7 +144,7 @@ func (a DbfsAPI) Delete(path string, recursive bool) error {
 	return a.client.Post(a.context, "/dbfs/delete", dbfsRequest{
 		Path:      path,
 		Recursive: recursive,
-	}, nil)
+	}, nil, a.client.AddWorkspaceIdHeader)
 }
 
 type dbfsRequest struct {
@@ -189,7 +189,7 @@ func (a DbfsAPI) readString(path string, offset, length int64) (int64, string, e
 		Path:   path,
 		Offset: offset,
 		Length: length,
-	}, &readBytes)
+	}, &readBytes, a.client.AddWorkspaceIdHeader)
 	return readBytes.BytesRead, readBytes.Data, err
 }
 
@@ -197,6 +197,6 @@ func (a DbfsAPI) readString(path string, offset, length int64) (int64, string, e
 func (a DbfsAPI) Status(path string) (f FileInfo, err error) {
 	err = a.client.Get(a.context, "/dbfs/get-status", map[string]any{
 		"path": path,
-	}, &f)
+	}, &f, a.client.AddWorkspaceIdHeader)
 	return
 }

--- a/tokens/resource_obo_token.go
+++ b/tokens/resource_obo_token.go
@@ -26,17 +26,17 @@ type TokenManagementAPI struct {
 }
 
 func (a TokenManagementAPI) CreateTokenOnBehalfOfServicePrincipal(request OboToken) (token TokenResponse, err error) {
-	err = a.client.Post(a.context, "/token-management/on-behalf-of/tokens", request, &token)
+	err = a.client.Post(a.context, "/token-management/on-behalf-of/tokens", request, &token, a.client.AddWorkspaceIdHeader)
 	return
 }
 
 func (a TokenManagementAPI) Delete(tokenID string) error {
-	err := a.client.Delete(a.context, fmt.Sprintf("/token-management/tokens/%s", tokenID), map[string]any{})
+	err := a.client.Delete(a.context, fmt.Sprintf("/token-management/tokens/%s", tokenID), map[string]any{}, a.client.AddWorkspaceIdHeader)
 	return common.IgnoreNotFoundError(err) // ignore not found error on delete, as it is idempotent
 }
 
 func (a TokenManagementAPI) Read(tokenID string) (ti TokenResponse, err error) {
-	err = a.client.Get(a.context, fmt.Sprintf("/token-management/tokens/%s", tokenID), nil, &ti)
+	err = a.client.Get(a.context, fmt.Sprintf("/token-management/tokens/%s", tokenID), nil, &ti, a.client.AddWorkspaceIdHeader)
 	return
 }
 

--- a/tokens/resource_token.go
+++ b/tokens/resource_token.go
@@ -59,14 +59,14 @@ func (a TokensAPI) Create(tokenLifetime time.Duration, comment string) (r TokenR
 		request.Comment = comment
 	}
 
-	err = a.client.Post(a.context, "/token/create", request, &r)
+	err = a.client.Post(a.context, "/token/create", request, &r, a.client.AddWorkspaceIdHeader)
 	return
 }
 
 // List will list all the token metadata and not the content of the tokens in the workspace
 func (a TokensAPI) List() ([]TokenInfo, error) {
 	var tokenListResult TokenList
-	err := a.client.Get(a.context, "/token/list", nil, &tokenListResult)
+	err := a.client.Get(a.context, "/token/list", nil, &tokenListResult, a.client.AddWorkspaceIdHeader)
 	return tokenListResult.TokenInfos, err
 }
 
@@ -93,7 +93,7 @@ func (a TokensAPI) Read(tokenID string) (TokenInfo, error) {
 func (a TokensAPI) Delete(tokenID string) error {
 	err := a.client.Post(a.context, "/token/delete", map[string]string{
 		"token_id": tokenID,
-	}, nil)
+	}, nil, a.client.AddWorkspaceIdHeader)
 	return common.IgnoreNotFoundError(err) // ignore not found error on delete, as it is idempotent
 }
 

--- a/workspace/resource_notebook.go
+++ b/workspace/resource_notebook.go
@@ -112,7 +112,7 @@ func (a NotebooksAPI) Create(r ImportPath) (ImportResponse, error) {
 		defer mtx.Unlock()
 	}
 	var response ImportResponse
-	err := a.client.Post(a.context, "/workspace/import", r, &response)
+	err := a.client.Post(a.context, "/workspace/import", r, &response, a.client.AddWorkspaceIdHeader)
 	return response, err
 }
 
@@ -131,7 +131,7 @@ func (a NotebooksAPI) GetStatus(path string, returnGitInfo bool) (ObjectStatus, 
 		params["return_git_info"] = "true"
 	}
 	_, err := common.RetryOnTimeout(a.context, func(ctx context.Context) (*ObjectStatus, error) {
-		err := a.client.Get(a.context, "/workspace/get-status", params, &notebookInfo)
+		err := a.client.Get(a.context, "/workspace/get-status", params, &notebookInfo, a.client.AddWorkspaceIdHeader)
 		return nil, err
 	})
 	return notebookInfo, err
@@ -148,7 +148,7 @@ func (a NotebooksAPI) Export(path string, format string) (string, error) {
 	err := a.client.Get(a.context, "/workspace/export", workspacePathRequest{
 		Format: format,
 		Path:   path,
-	}, &notebookContent)
+	}, &notebookContent, a.client.AddWorkspaceIdHeader)
 	// TODO: return decoded []byte
 	return notebookContent.Content, err
 }
@@ -162,7 +162,7 @@ func (a NotebooksAPI) Mkdirs(path string) error {
 
 	return a.client.Post(a.context, "/workspace/mkdirs", map[string]string{
 		"path": path,
-	}, nil)
+	}, nil, a.client.AddWorkspaceIdHeader)
 }
 
 // List will list all objects in a path on the workspace
@@ -205,7 +205,7 @@ func (a NotebooksAPI) ListInternalImpl(path string) ([]ObjectStatus, error) {
 	var notebookList ObjectList
 	err := a.client.Get(a.context, "/workspace/list", map[string]string{
 		"path": path,
-	}, &notebookList)
+	}, &notebookList, a.client.AddWorkspaceIdHeader)
 	return notebookList.Objects, err
 }
 
@@ -219,7 +219,7 @@ func (a NotebooksAPI) Delete(path string, recursive bool) error {
 	return a.client.Post(a.context, "/workspace/delete", DeletePath{
 		Path:      path,
 		Recursive: recursive,
-	}, nil)
+	}, nil, a.client.AddWorkspaceIdHeader)
 }
 
 func SetWorkspaceObjectComputedProperties(d *schema.ResourceData, c *common.DatabricksClient) {


### PR DESCRIPTION
 ## Changes

  Resources that don't use the Go SDK to make API calls go through `common.DatabricksClient`'s raw HTTP path (`Get`/`Post`/`Patch`/`Delete`/`Put`/`Scim`) rather than a generated `w.<Service>.<Method>(...)` call. Eg: repos, pools, sharing, access, catalog, workspace/notebook, clusters, storage/dbfs, aws/instance_profile,
   commands, tokens, sql/*, scim/*, jobs legacy 2.0, exporter, etc.

Until now, those calls sent no workspace routing header — on a unified host the gateway has no way to dispatch the request to the right workspace, so these resources either failed outright or routed to the wrong workspace.

This PR adds per-request `X-Databricks-Workspace-Id` injection to those callsites, gated on `Config.WorkspaceID` being non-empty. 

**Design choice:** injection is per-callsite, not centralized in the helpers. A central "always inject when `Config.WorkspaceID != ""`" hook is fragile because the same client config can carry a `WorkspaceID` even when the call targets an account endpoint (mws_* on a unified host, or a dual SCIM resource at `api=account`). Per-callsite control makes the intent explicit and auditable: workspace-only resources opt in; account-only resources never do; dual SCIM is handled inside the `Scim` helper based on `apiLevel`.

  ## Summary of main changes

  ### `common/client.go`
  - New visitor `AddWorkspaceIdHeader` that sets `X-Databricks-Workspace-Id: <Config.WorkspaceID>` when `WorkspaceID` is non-empty (no-op otherwise).
  - `Get/Post/Patch/Delete/Put/PatchWithResponse/DeleteWithResponse` made variadic on visitors. `addApiPrefix` still runs first.
  - `Scim` helper injects the header conditionally based on `apiLevel`: workspace-level SCIM injects; account-level SCIM does not (path is rewritten to
  `/api/2.0/accounts/{aid}/scim/v2/...` and must not be workspace-tagged).
  - The old centralized injection on every helper has been removed.

  ### Per-resource classification

  | Class | Files | Action |
  |---|---|---|
  | **Workspace-only** | repos, pools, sharing/provider, access/{permission_assignment,sql_permissions}, catalog/{table,sql_table,update}, workspace/notebook, clusters, storage/dbfs, aws/instance_profile, commands, tokens/{token,obo_token}, sql/{query,widget,dashboard,visualization,global_config}, jobs (legacy API 2.0 paths), exporter/util | Every callsite passes `c.AddWorkspaceIdHeader` |
  | **Account-only** | mws/* — every path under `/accounts/{aid}/...` | Untouched. `grep AddWorkspaceIdHeader mws/` → empty |
  | **Dual** | scim/* | Handled inside `Scim` helper based on `apiLevel`. No per-callsite hardcoding |

  Classification was based on the actual API endpoints the resources hit (paths starting with `/accounts/` → account-only; everything else → workspace-only) and a sweep of the docs.

  ## Tests

  ### Unit (`common/client_test.go`)
  - `TestWorkspaceIdHeader_OmittedByDefault` — guard against accidental re-centralization: helpers no longer inject the header on their own.
  - `TestWorkspaceIdHeader_InjectedWithVisitor` — opt-in works on `Get/Post/Patch/Delete/Put` when `AddWorkspaceIdHeader` is passed.
  - `TestWorkspaceIdHeader_VisitorNoOpWhenWorkspaceIDEmpty` — passing the visitor is safe when `Config.WorkspaceID` is empty.
  - `TestScim_WorkspaceLevel_InjectsHeader` — dual SCIM at `api=workspace` carries the header and SCIM `Content-Type`.
  - `TestScim_AccountLevel_OmitsHeader` — dual SCIM at `api=account` omits the header **and** the path is rewritten to `/accounts/{aid}/scim/v2/...`.

  The tests use an `httptest.Server` that captures each outbound request's headers and URL.

  ### Integration (`internal/acceptance/unified_host_acc_test.go`)
  - Existing `TestMwsAccUnifiedHostCreateJobs` / `TestAccUnifiedHostWorkspaceCreateJobs` — Go SDK path (jobs) on unified host. Unchanged.
  - `TestMwsAccUnifiedHostCreateRepo` / `TestAccUnifiedHostWorkspaceCreateRepo` / `TestMwsAccAccountHostCreateRepo` — workspace-only raw-HTTP path (databricks_repo) on unified host.
  Mirrors the jobs trio so the contrast is direct: same shape, different code path.

  ## Verification

  - `go build ./...` — clean
  - `go test ./...` — all packages pass
  - `make fmt lint ws` — clean
  - `grep AddWorkspaceIdHeader mws/ scim/` — empty (account-only files untouched; dual SCIM handled in helper, not per-callsite)

  NO_CHANGELOG=true
