### PR TITLE
[Fix] `databricks_external_location`: send `enable_file_events = false` on create when user asks for it

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bug Fixes
 
+* Fix `databricks_external_location` so that creating a resource with `enable_file_events = false` is sent in the POST request. Previously the field was silently dropped (Go SDK marshals the bool with `omitempty`), so the server applied its `true` default and `effective_enable_file_events` came back `true`.
+
 ### Documentation
 
 ### Exporter

--- a/catalog/resource_external_location.go
+++ b/catalog/resource_external_location.go
@@ -82,6 +82,10 @@ func ResourceExternalLocation() common.Resource {
 			}
 			var createExternalLocationRequest catalog.CreateExternalLocation
 			common.DataToStructPointer(d, s, &createExternalLocationRequest)
+			// SDK marshals these bools with omitempty; force-send so an explicit
+			// false from HCL reaches the server instead of being elided.
+			common.SetForceSendFields(&createExternalLocationRequest, d,
+				[]string{"read_only", "fallback", "enable_file_events"})
 			el, err := w.ExternalLocations.Create(ctx, createExternalLocationRequest)
 			if err != nil {
 				return err

--- a/catalog/resource_external_location_test.go
+++ b/catalog/resource_external_location_test.go
@@ -272,6 +272,51 @@ func TestCreateExternalLocationReadOnly(t *testing.T) {
 	}.ApplyNoError(t)
 }
 
+func TestCreateExternalLocationEnableFileEventsFalse(t *testing.T) {
+	qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "POST",
+				Resource: "/api/2.1/unity-catalog/external-locations",
+				ExpectedRequest: catalog.CreateExternalLocation{
+					Name:             "abc",
+					Url:              "s3://foo/bar",
+					CredentialName:   "bcd",
+					Comment:          "def",
+					EnableFileEvents: false,
+					ForceSendFields:  []string{"EnableFileEvents"},
+				},
+				Response: catalog.ExternalLocationInfo{
+					Name:             "abc",
+					Url:              "s3://foo/bar",
+					CredentialName:   "bcd",
+					Comment:          "def",
+					EnableFileEvents: false,
+				},
+			},
+			{
+				Method:   "GET",
+				Resource: "/api/2.1/unity-catalog/external-locations/abc?",
+				Response: catalog.ExternalLocationInfo{
+					Owner:                     "efg",
+					MetastoreId:               "fgh",
+					EnableFileEvents:          false,
+					EffectiveEnableFileEvents: false,
+				},
+			},
+		},
+		Resource: ResourceExternalLocation(),
+		Create:   true,
+		HCL: `
+		name = "abc"
+		url = "s3://foo/bar"
+		credential_name = "bcd"
+		comment = "def"
+		enable_file_events = false
+		`,
+	}.ApplyNoError(t)
+}
+
 func TestCreateExternalLocationWithAPAndEncryptionDetails(t *testing.T) {
 	qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{


### PR DESCRIPTION
## Changes

Setting `enable_file_events = false` on a new `databricks_external_location` was a no-op: Terraform's plan showed the field being applied, but the POST body to `/api/2.1/unity-catalog/external-locations` never contained it, so the API silently fell back to its `true` default and `effective_enable_file_events` came back `true`.

Root cause: the Databricks Go SDK declares `EnableFileEvents bool` with `omitempty`, and its custom JSON marshaller treats `false` as the empty value for booleans — so `false` is dropped from the request payload unless the field name is also present in `ForceSendFields`. The Update path on this resource already handles `read_only`, `fallback`, and `enable_file_events` correctly (`catalog/resource_external_location.go:145-150`); the Create path did not.

This PR mirrors the Update path's three-field list onto Create using the existing `common.SetForceSendFields` helper. The helper uses `d.GetOkExists` + zero-value detection, so we only force-send the field when the user explicitly set it in HCL (`false` typed in config → forced; field omitted → still omitted from the wire). Same shape as the recent `databricks_metastore` fix in #5732.


## Tests

- [X] `make test` run locally
- [X] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [x] using Go SDK
- [ ] using TF Plugin Framework
- [x] has entry in `NEXT_CHANGELOG.md` file
