### PR TITLE
[Fix] List all workspace_id sources in unified-provider error message

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bug Fixes
 
+* Expand the "workspace-level resource requires a workspace_id" error to list all sources checked (resource `provider_config`, provider `workspace_id`, the configured profile, and the `DATABRICKS_WORKSPACE_ID` environment variable) so users know where to set it ([#5763](https://github.com/databricks/terraform-provider-databricks/pull/5763)).
+
 ### Documentation
 
 ### Exporter

--- a/common/client.go
+++ b/common/client.go
@@ -135,7 +135,9 @@ func (c *DatabricksClient) getWorkspaceClientForAccountUnifiedHost(
 	}
 	if workspaceID == "" {
 		return nil, fmt.Errorf("managing workspace-level resources requires a workspace_id, " +
-			"but none was found in the resource's provider_config block or the provider's workspace_id attribute")
+			"but none was found in any of the following sources (checked in order): the resource's " +
+			"provider_config block, the provider's workspace_id attribute, the workspace_id in the " +
+			"configured profile, or the DATABRICKS_WORKSPACE_ID environment variable")
 	}
 
 	// Validate the workspace ID is non-empty (parseWorkspaceID accepts both

--- a/common/unified_provider.go
+++ b/common/unified_provider.go
@@ -166,7 +166,9 @@ func namespaceForceNew(ctx context.Context, d *schema.ResourceDiff, c *Databrick
 			// or returned zero. Either way, workspace_id is required but missing.
 			return fmt.Errorf("resource has provider_config.workspace_id = %q in state, "+
 				"but managing workspace-level resources requires a workspace_id and "+
-				"none was found in the resource's provider_config block or the provider's workspace_id attribute", oldEffective)
+				"none was found in any of the following sources (checked in order): the resource's "+
+				"provider_config block, the provider's workspace_id attribute, the workspace_id in the "+
+				"configured profile, or the DATABRICKS_WORKSPACE_ID environment variable", oldEffective)
 		}
 		newEffective = strconv.FormatInt(resolvedID, 10)
 	}

--- a/common/unified_provider_test.go
+++ b/common/unified_provider_test.go
@@ -347,7 +347,7 @@ func TestWorkspaceClientUnifiedProvider(t *testing.T) {
 				},
 			},
 			expectError:   true,
-			errorContains: "managing workspace-level resources requires a workspace_id, but none was found in the resource's provider_config block or the provider's workspace_id attribute",
+			errorContains: "managing workspace-level resources requires a workspace_id, but none was found in any of the following sources (checked in order): the resource's provider_config block, the provider's workspace_id attribute, the workspace_id in the configured profile, or the DATABRICKS_WORKSPACE_ID environment variable",
 			description:   "Account-level provider requires workspace_id to be set",
 		},
 	}


### PR DESCRIPTION
On a unified (SPOG) host, a workspace-level resource needs a workspace_id resolved from one of: the resource's provider_config block, the provider's workspace_id attribute, the configured profile, or the DATABRICKS_WORKSPACE_ID environment variable. The "requires a workspace_id" errors only named the first two sources, so users with a profile- or env-based setup did not know where to look. Both copies of the message (the client-side resolver and the plan-time CustomizeDiff guard) now enumerate all four sources in lookup order.

Co-authored-by: Isaac

## Changes
<!-- Summary of your changes that are easy to understand -->

## Tests
<!--
How is this tested? Please see the checklist below and also describe any other relevant tests
-->

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] using Go SDK
- [ ] using TF Plugin Framework
- [ ] has entry in `NEXT_CHANGELOG.md` file
