### PR TITLE
[Internal] Extend skip on AiBi/DBFS/legacy-access settings; add SCIM entitlements to ignored_tests; add unit-level lifecycle coverage

### DIFF
--- a/internal/acceptance/aibi_embedding_settings_test.go
+++ b/internal/acceptance/aibi_embedding_settings_test.go
@@ -5,9 +5,17 @@ import (
 	"time"
 )
 
+// Resource-level expected-behavior coverage that does not require a real API
+// is provided by the package-internal unit tests in
+// settings/resource_aibi_dashboard_embedding_access_policy_setting_test.go and
+// settings/resource_aibi_dashboard_embedding_approved_domains_setting_test.go
+// (TestCreate/TestRead/TestUpdate/TestDelete for each resource, plus the
+// lifecycle scenarios TestAiBiEmbeddingAccessPolicySettingLifecycle and
+// TestAiBiEmbeddingApprovedDomainsLifecycle which mirror the two steps of
+// this acceptance test against mocked SDK calls).
 func TestAccAiBiEmbeddings(t *testing.T) {
-	if time.Now().Before(time.Date(2026, 6, 3, 0, 0, 0, 0, time.UTC)) {
-		t.Skip("temporarily skipped until 2026-06-03: workspace-settings API is eventually consistent so Get after Update may return stale values. Please see ES-1928456 for details.")
+	if time.Now().Before(time.Date(2026, 6, 24, 0, 0, 0, 0, time.UTC)) {
+		t.Skip("temporarily skipped until 2026-06-24: workspace-settings API is eventually consistent so Get after Update may return stale values; tracked internally.")
 	}
 	WorkspaceLevel(t, Step{
 		Template: `

--- a/settings/disable_legacy_access_setting_test.go
+++ b/settings/disable_legacy_access_setting_test.go
@@ -13,9 +13,21 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// Resource-level expected-behavior coverage that does not require a real API
+// is provided by the package-internal unit tests in
+// settings/resource_disable_legacy_access_setting_test.go:
+//   - TestCreateDisableLegacyAccess
+//   - TestReadDisableLegacyAccess
+//   - TestUpdateDisableLegacyAccess
+//   - TestUpdateDisableLegacyAccessWithConflict
+//   - TestDeleteDisableLegacyAccess
+//   - TestDeleteDisableLegacyAccessWithConflict
+//
+// plus the lifecycle scenario TestDisableLegacyAccessSettingLifecycle, which
+// mirrors the steps of this acceptance test against mocked SDK calls.
 func TestAccDisableLegacyAccessSetting(t *testing.T) {
-	if time.Now().Before(time.Date(2026, 6, 3, 0, 0, 0, 0, time.UTC)) {
-		t.Skip("temporarily skipped until 2026-06-03: workspace-settings API is eventually consistent so Get after Update may return stale values. Please see ES-1928456 for details.")
+	if time.Now().Before(time.Date(2026, 6, 24, 0, 0, 0, 0, time.UTC)) {
+		t.Skip("temporarily skipped until 2026-06-24: workspace-settings API is eventually consistent so Get after Update may return stale values; tracked internally.")
 	}
 	template := `
  	resource "databricks_disable_legacy_access_setting" "this" {

--- a/settings/disable_legacy_dbfs_setting_test.go
+++ b/settings/disable_legacy_dbfs_setting_test.go
@@ -13,9 +13,21 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// Resource-level expected-behavior coverage that does not require a real API
+// is provided by the package-internal unit tests in
+// settings/resource_disable_legacy_dbfs_setting_test.go:
+//   - TestCreateDisableLegacyDbfs
+//   - TestReadDisableLegacyDbfs
+//   - TestUpdateDisableLegacyDbfs
+//   - TestUpdateDisableLegacyDbfsWithConflict
+//   - TestDeleteDisableLegacyDbfs
+//   - TestDeleteDisableLegacyDbfsWithConflict
+//
+// plus the lifecycle scenario TestDisableLegacyDbfsSettingLifecycle, which
+// mirrors the steps of this acceptance test against mocked SDK calls.
 func TestAccDisableLegacyDbfsSetting(t *testing.T) {
-	if time.Now().Before(time.Date(2026, 6, 3, 0, 0, 0, 0, time.UTC)) {
-		t.Skip("temporarily skipped until 2026-06-03: workspace-settings API is eventually consistent so Get after Update may return stale values. Please see ES-1928456 for details.")
+	if time.Now().Before(time.Date(2026, 6, 24, 0, 0, 0, 0, time.UTC)) {
+		t.Skip("temporarily skipped until 2026-06-24: workspace-settings API is eventually consistent so Get after Update may return stale values; tracked internally.")
 	}
 	template := `
  	resource "databricks_disable_legacy_dbfs_setting" "this" {

--- a/settings/resource_aibi_dashboard_embedding_access_policy_setting_test.go
+++ b/settings/resource_aibi_dashboard_embedding_access_policy_setting_test.go
@@ -248,6 +248,58 @@ func TestDeleteAiBiEmbeddingAccessPolicySetting(t *testing.T) {
 	})
 }
 
+// TestAiBiEmbeddingAccessPolicySettingLifecycle mirrors the access-policy half
+// of TestAccAiBiEmbeddings (in internal/acceptance/aibi_embedding_settings_test.go).
+// The acceptance test sets access_policy_type = ALLOW_APPROVED_DOMAINS as a
+// dependency of the approved-domains resource; this exercises Create against
+// mocked SDK calls. Use this as the per-resource expected-behavior check
+// while the acceptance test is skipped.
+func TestAiBiEmbeddingAccessPolicySettingLifecycle(t *testing.T) {
+	t.Run("create with ALLOW_APPROVED_DOMAINS persists into state", func(t *testing.T) {
+		d, err := qa.ResourceFixture{
+			MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
+				e := w.GetMockAibiDashboardEmbeddingAccessPolicyAPI().EXPECT()
+				e.Update(mock.Anything, settings.UpdateAibiDashboardEmbeddingAccessPolicySettingRequest{
+					AllowMissing: true,
+					FieldMask:    "aibi_dashboard_embedding_access_policy.access_policy_type",
+					Setting: settings.AibiDashboardEmbeddingAccessPolicySetting{
+						AibiDashboardEmbeddingAccessPolicy: settings.AibiDashboardEmbeddingAccessPolicy{
+							AccessPolicyType: "ALLOW_APPROVED_DOMAINS",
+						},
+						SettingName: "default",
+					},
+				}).Return(&settings.AibiDashboardEmbeddingAccessPolicySetting{
+					Etag: "etag-after-create",
+					AibiDashboardEmbeddingAccessPolicy: settings.AibiDashboardEmbeddingAccessPolicy{
+						AccessPolicyType: "ALLOW_APPROVED_DOMAINS",
+					},
+					SettingName: "default",
+				}, nil)
+				e.Get(mock.Anything, settings.GetAibiDashboardEmbeddingAccessPolicySettingRequest{
+					Etag: "etag-after-create",
+				}).Return(&settings.AibiDashboardEmbeddingAccessPolicySetting{
+					Etag: "etag-after-create",
+					AibiDashboardEmbeddingAccessPolicy: settings.AibiDashboardEmbeddingAccessPolicy{
+						AccessPolicyType: "ALLOW_APPROVED_DOMAINS",
+					},
+					SettingName: "default",
+				}, nil)
+			},
+			Resource: testAiBiEmbeddingAccessPolicySetting,
+			Create:   true,
+			HCL: `
+				aibi_dashboard_embedding_access_policy {
+					access_policy_type = "ALLOW_APPROVED_DOMAINS"
+				}
+			`,
+		}.Apply(t)
+		assert.NoError(t, err)
+		assert.Equal(t, defaultSettingId, d.Id())
+		assert.Equal(t, "etag-after-create", d.Get(etagAttrName).(string))
+		assert.Equal(t, "ALLOW_APPROVED_DOMAINS", d.Get("aibi_dashboard_embedding_access_policy.0.access_policy_type"))
+	})
+}
+
 func TestDeleteAiBiEmbeddingAccessPolicySettingWithConflict(t *testing.T) {
 	qa.ResourceFixture{
 		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {

--- a/settings/resource_aibi_dashboard_embedding_approved_domains_setting_test.go
+++ b/settings/resource_aibi_dashboard_embedding_approved_domains_setting_test.go
@@ -247,6 +247,107 @@ func TestDeleteRestrictAiBiEmbeddingAllowedDomainsSetting(t *testing.T) {
 	})
 }
 
+// TestAiBiEmbeddingApprovedDomainsLifecycle mirrors TestAccAiBiEmbeddings
+// (in internal/acceptance/aibi_embedding_settings_test.go) at the unit level
+// for the approved-domains resource: the acceptance test applies ["test.com"]
+// then updates to ["test.com", "test2.com"]; this exercises the same two
+// transitions against mocked SDK calls. Use this as the per-resource
+// expected-behavior check while the acceptance test is skipped.
+// The companion access-policy resource is covered by
+// TestAiBiEmbeddingAccessPolicySettingLifecycle in its own _test.go.
+func TestAiBiEmbeddingApprovedDomainsLifecycle(t *testing.T) {
+	t.Run("create with single domain persists into state", func(t *testing.T) {
+		d, err := qa.ResourceFixture{
+			MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
+				e := w.GetMockAibiDashboardEmbeddingApprovedDomainsAPI().EXPECT()
+				e.Update(mock.Anything, settings.UpdateAibiDashboardEmbeddingApprovedDomainsSettingRequest{
+					AllowMissing: true,
+					FieldMask:    "aibi_dashboard_embedding_approved_domains.approved_domains",
+					Setting: settings.AibiDashboardEmbeddingApprovedDomainsSetting{
+						AibiDashboardEmbeddingApprovedDomains: settings.AibiDashboardEmbeddingApprovedDomains{
+							ApprovedDomains: []string{"test.com"},
+						},
+						SettingName: "default",
+					},
+				}).Return(&settings.AibiDashboardEmbeddingApprovedDomainsSetting{
+					Etag: "etag-after-create",
+					AibiDashboardEmbeddingApprovedDomains: settings.AibiDashboardEmbeddingApprovedDomains{
+						ApprovedDomains: []string{"test.com"},
+					},
+					SettingName: "default",
+				}, nil)
+				e.Get(mock.Anything, settings.GetAibiDashboardEmbeddingApprovedDomainsSettingRequest{
+					Etag: "etag-after-create",
+				}).Return(&settings.AibiDashboardEmbeddingApprovedDomainsSetting{
+					Etag: "etag-after-create",
+					AibiDashboardEmbeddingApprovedDomains: settings.AibiDashboardEmbeddingApprovedDomains{
+						ApprovedDomains: []string{"test.com"},
+					},
+					SettingName: "default",
+				}, nil)
+			},
+			Resource: testAiBiEmbeddingAllowedDomainsSetting,
+			Create:   true,
+			HCL: `
+				aibi_dashboard_embedding_approved_domains {
+					approved_domains = ["test.com"]
+				}
+			`,
+		}.Apply(t)
+		assert.NoError(t, err)
+		assert.Equal(t, defaultSettingId, d.Id())
+		assert.Equal(t, "etag-after-create", d.Get(etagAttrName).(string))
+		assert.Equal(t, []any{"test.com"}, d.Get("aibi_dashboard_embedding_approved_domains.0.approved_domains"))
+	})
+
+	t.Run("update appends a second domain", func(t *testing.T) {
+		d, err := qa.ResourceFixture{
+			MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
+				e := w.GetMockAibiDashboardEmbeddingApprovedDomainsAPI().EXPECT()
+				e.Update(mock.Anything, settings.UpdateAibiDashboardEmbeddingApprovedDomainsSettingRequest{
+					AllowMissing: true,
+					FieldMask:    "aibi_dashboard_embedding_approved_domains.approved_domains",
+					Setting: settings.AibiDashboardEmbeddingApprovedDomainsSetting{
+						Etag: "etag-after-create",
+						AibiDashboardEmbeddingApprovedDomains: settings.AibiDashboardEmbeddingApprovedDomains{
+							ApprovedDomains: []string{"test.com", "test2.com"},
+						},
+						SettingName: "default",
+					},
+				}).Return(&settings.AibiDashboardEmbeddingApprovedDomainsSetting{
+					Etag: "etag-after-update",
+					AibiDashboardEmbeddingApprovedDomains: settings.AibiDashboardEmbeddingApprovedDomains{
+						ApprovedDomains: []string{"test.com", "test2.com"},
+					},
+					SettingName: "default",
+				}, nil)
+				e.Get(mock.Anything, settings.GetAibiDashboardEmbeddingApprovedDomainsSettingRequest{
+					Etag: "etag-after-update",
+				}).Return(&settings.AibiDashboardEmbeddingApprovedDomainsSetting{
+					Etag: "etag-after-update",
+					AibiDashboardEmbeddingApprovedDomains: settings.AibiDashboardEmbeddingApprovedDomains{
+						ApprovedDomains: []string{"test.com", "test2.com"},
+					},
+					SettingName: "default",
+				}, nil)
+			},
+			Resource: testAiBiEmbeddingAllowedDomainsSetting,
+			Update:   true,
+			HCL: `
+				aibi_dashboard_embedding_approved_domains {
+					approved_domains = ["test.com", "test2.com"]
+				}
+				etag = "etag-after-create"
+			`,
+			ID: defaultSettingId,
+		}.Apply(t)
+		assert.NoError(t, err)
+		assert.Equal(t, defaultSettingId, d.Id())
+		assert.Equal(t, "etag-after-update", d.Get(etagAttrName).(string))
+		assert.Equal(t, []any{"test.com", "test2.com"}, d.Get("aibi_dashboard_embedding_approved_domains.0.approved_domains"))
+	})
+}
+
 func TestDeleteRestrictAiBiEmbeddingAllowedDomainsSettingWithConflict(t *testing.T) {
 	qa.ResourceFixture{
 		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {

--- a/settings/resource_disable_legacy_access_setting_test.go
+++ b/settings/resource_disable_legacy_access_setting_test.go
@@ -248,6 +248,73 @@ func TestDeleteDisableLegacyAccess(t *testing.T) {
 	})
 }
 
+// TestDisableLegacyAccessSettingLifecycle mirrors TestAccDisableLegacyAccessSetting
+// (in settings/disable_legacy_access_setting_test.go) at the unit level: the
+// acceptance test applies value=true and then destroys; this exercises the
+// same two transitions against mocked SDK calls. Use this as the per-resource
+// expected-behavior check while the acceptance test is skipped.
+func TestDisableLegacyAccessSettingLifecycle(t *testing.T) {
+	t.Run("create with value=true persists into state", func(t *testing.T) {
+		d, err := qa.ResourceFixture{
+			MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
+				e := w.GetMockDisableLegacyAccessAPI().EXPECT()
+				e.Update(mock.Anything, settings.UpdateDisableLegacyAccessRequest{
+					AllowMissing: true,
+					FieldMask:    "disable_legacy_access.value",
+					Setting: settings.DisableLegacyAccess{
+						DisableLegacyAccess: settings.BooleanMessage{Value: true},
+						SettingName:         "disable_legacy_access",
+					},
+				}).Return(&settings.DisableLegacyAccess{
+					Etag:                "etag-after-create",
+					DisableLegacyAccess: settings.BooleanMessage{Value: true},
+					SettingName:         "disable_legacy_access",
+				}, nil)
+				e.Get(mock.Anything, settings.GetDisableLegacyAccessRequest{
+					Etag: "etag-after-create",
+				}).Return(&settings.DisableLegacyAccess{
+					Etag:                "etag-after-create",
+					DisableLegacyAccess: settings.BooleanMessage{Value: true},
+					SettingName:         "disable_legacy_access",
+				}, nil)
+			},
+			Resource: testDisableLegacyAccess,
+			Create:   true,
+			HCL: `
+				disable_legacy_access {
+					value = "true"
+				}
+			`,
+		}.Apply(t)
+		assert.NoError(t, err)
+		assert.Equal(t, defaultSettingId, d.Id())
+		assert.Equal(t, "etag-after-create", d.Get(etagAttrName).(string))
+		assert.Equal(t, true, d.Get("disable_legacy_access.0.value"))
+	})
+
+	t.Run("destroy resets to default", func(t *testing.T) {
+		qa.ResourceFixture{
+			MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
+				w.GetMockDisableLegacyAccessAPI().EXPECT().Delete(mock.Anything, settings.DeleteDisableLegacyAccessRequest{
+					Etag: "etag-after-create",
+				}).Return(&settings.DeleteDisableLegacyAccessResponse{Etag: "etag-after-delete"}, nil)
+			},
+			Resource: testDisableLegacyAccess,
+			Delete:   true,
+			HCL: `
+				disable_legacy_access {
+					value = "true"
+				}
+				etag = "etag-after-create"
+			`,
+			ID: defaultSettingId,
+		}.ApplyAndExpectData(t, map[string]any{
+			"id":         defaultSettingId,
+			etagAttrName: "etag-after-delete",
+		})
+	})
+}
+
 func TestDeleteDisableLegacyAccessWithConflict(t *testing.T) {
 	qa.ResourceFixture{
 		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {

--- a/settings/resource_disable_legacy_dbfs_setting_test.go
+++ b/settings/resource_disable_legacy_dbfs_setting_test.go
@@ -248,6 +248,73 @@ func TestDeleteDisableLegacyDbfs(t *testing.T) {
 	})
 }
 
+// TestDisableLegacyDbfsSettingLifecycle mirrors TestAccDisableLegacyDbfsSetting
+// (in settings/disable_legacy_dbfs_setting_test.go) at the unit level: the
+// acceptance test applies value=true and then destroys; this exercises the
+// same two transitions against mocked SDK calls. Use this as the per-resource
+// expected-behavior check while the acceptance test is skipped.
+func TestDisableLegacyDbfsSettingLifecycle(t *testing.T) {
+	t.Run("create with value=true persists into state", func(t *testing.T) {
+		d, err := qa.ResourceFixture{
+			MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
+				e := w.GetMockDisableLegacyDbfsAPI().EXPECT()
+				e.Update(mock.Anything, settings.UpdateDisableLegacyDbfsRequest{
+					AllowMissing: true,
+					FieldMask:    "disable_legacy_dbfs.value",
+					Setting: settings.DisableLegacyDbfs{
+						DisableLegacyDbfs: settings.BooleanMessage{Value: true},
+						SettingName:       "disable_legacy_dbfs",
+					},
+				}).Return(&settings.DisableLegacyDbfs{
+					Etag:              "etag-after-create",
+					DisableLegacyDbfs: settings.BooleanMessage{Value: true},
+					SettingName:       "disable_legacy_dbfs",
+				}, nil)
+				e.Get(mock.Anything, settings.GetDisableLegacyDbfsRequest{
+					Etag: "etag-after-create",
+				}).Return(&settings.DisableLegacyDbfs{
+					Etag:              "etag-after-create",
+					DisableLegacyDbfs: settings.BooleanMessage{Value: true},
+					SettingName:       "disable_legacy_dbfs",
+				}, nil)
+			},
+			Resource: testDisableLegacyDbfs,
+			Create:   true,
+			HCL: `
+				disable_legacy_dbfs {
+					value = "true"
+				}
+			`,
+		}.Apply(t)
+		assert.NoError(t, err)
+		assert.Equal(t, defaultSettingId, d.Id())
+		assert.Equal(t, "etag-after-create", d.Get(etagAttrName).(string))
+		assert.Equal(t, true, d.Get("disable_legacy_dbfs.0.value"))
+	})
+
+	t.Run("destroy resets to default", func(t *testing.T) {
+		qa.ResourceFixture{
+			MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
+				w.GetMockDisableLegacyDbfsAPI().EXPECT().Delete(mock.Anything, settings.DeleteDisableLegacyDbfsRequest{
+					Etag: "etag-after-create",
+				}).Return(&settings.DeleteDisableLegacyDbfsResponse{Etag: "etag-after-delete"}, nil)
+			},
+			Resource: testDisableLegacyDbfs,
+			Delete:   true,
+			HCL: `
+				disable_legacy_dbfs {
+					value = "true"
+				}
+				etag = "etag-after-create"
+			`,
+			ID: defaultSettingId,
+		}.ApplyAndExpectData(t, map[string]any{
+			"id":         defaultSettingId,
+			etagAttrName: "etag-after-delete",
+		})
+	})
+}
+
 func TestDeleteDisableLegacyDbfsWithConflict(t *testing.T) {
 	qa.ResourceFixture{
 		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {

--- a/test-config.yaml
+++ b/test-config.yaml
@@ -16,7 +16,16 @@ ignored_tests:
       test_name: TestAccEntitlementsSomeTrueSomeFalse
       comment: Failures due to read-after-write inconsistency in the SCIM API; tracked internally.
     - package: github.com/databricks/terraform-provider-databricks/scim
+      test_name: TestAccEntitlementsSomeTrueSomeFalse/user
+      comment: Failures due to read-after-write inconsistency in the SCIM API; tracked internally.
+    - package: github.com/databricks/terraform-provider-databricks/scim
+      test_name: TestAccEntitlementsSomeTrueSomeFalse/service_principal
+      comment: Failures due to read-after-write inconsistency in the SCIM API; tracked internally.
+    - package: github.com/databricks/terraform-provider-databricks/scim
       test_name: TestAccEntitlementsRemoveExisting
+      comment: Failures due to read-after-write inconsistency in the SCIM API; tracked internally.
+    - package: github.com/databricks/terraform-provider-databricks/scim
+      test_name: TestAccEntitlementsRemoveExisting/service_principal
       comment: Failures due to read-after-write inconsistency in the SCIM API; tracked internally.
     - package: github.com/databricks/terraform-provider-databricks/mws
       test_name: TestUcAccAssignGroupToWorkspace

--- a/test-config.yaml
+++ b/test-config.yaml
@@ -12,6 +12,12 @@ ignored_tests:
     - package: github.com/databricks/terraform-provider-databricks/scim
       test_name: TestMwsAccServicePrincipalResourceOnAws
       comment: Failures due to read-after-write inconsistency. Tracked in https://databricks.atlassian.net/browse/ES-1100061
+    - package: github.com/databricks/terraform-provider-databricks/scim
+      test_name: TestAccEntitlementsSomeTrueSomeFalse
+      comment: Failures due to read-after-write inconsistency in the SCIM API; tracked internally.
+    - package: github.com/databricks/terraform-provider-databricks/scim
+      test_name: TestAccEntitlementsRemoveExisting
+      comment: Failures due to read-after-write inconsistency in the SCIM API; tracked internally.
     - package: github.com/databricks/terraform-provider-databricks/mws
       test_name: TestUcAccAssignGroupToWorkspace
       comment: Failures due to read-after-write inconsistency. Tracked in https://databricks.atlassian.net/browse/ES-1100061


### PR DESCRIPTION
## Summary

Two test-only changes to handle the eventually-consistent backends that have been breaking nightly tests since early June:

**Commit 1** — `Extend skip on AiBi/DBFS/legacy-access settings + lifecycle unit tests`
- The eventual-consistency behavior in the workspace-settings APIs (a `Get` shortly after an `Update` may return the stale prior value, with a ~60s window) is still present after the 2026-06-03 skip set by #5733 expired. Extend the skip on `TestAccAiBiEmbeddings`, `TestAccDisableLegacyDbfsSetting`, and `TestAccDisableLegacyAccessSetting` until **2026-06-24** to give the platform team more time.
- Add explicit unit-level lifecycle tests that mirror each acceptance scenario against mocked SDK calls via `qa.ResourceFixture`, so the per-resource expected behavior stays covered while the acceptance tests are skipped:
  - `TestAiBiEmbeddingApprovedDomainsLifecycle` — create with `["test.com"]`, then update to `["test.com", "test2.com"]`.
  - `TestAiBiEmbeddingAccessPolicySettingLifecycle` — create with `ALLOW_APPROVED_DOMAINS` (the dependency the AiBi acceptance test sets up).
  - `TestDisableLegacyDbfsSettingLifecycle` — create with `value = true`, then destroy back to default.
  - `TestDisableLegacyAccessSettingLifecycle` — create with `value = true`, then destroy back to default.
- The acceptance tests now carry a comment block pointing at their unit-level cover so the gap is documented when readers find them skipped.

**Commit 2** — `Add SCIM entitlements tests to ignored_tests`
- `TestAccEntitlementsSomeTrueSomeFalse` and `TestAccEntitlementsRemoveExisting` started failing reliably on `azure-prod-is` around 2026-06-07. The failure is a separate SCIM read-after-write inconsistency (different backend, much shorter ~400ms staleness window) that's azure-only.
- Empirical probing on azure-prod across 5 fresh user creations measured a 344-1071ms convergence window — every PATCH eventually propagates, but the test framework's post-apply read fires inside the window deterministically for the user subtest.
- aws-prod and gcp-prod show zero observed staleness on the same probe.
- Adds the two tests to `test-config.yaml` under the existing SCIM staleness group, mirroring the pattern used for `TestAccGroupsUpdateDisplayName` and `TestMwsAccServicePrincipalResourceOnAws`.

Test-only change; no user-facing behavior change.

## Test plan

- [x] `go test ./settings/...` — all unit tests pass, including the four new lifecycle tests.
- [x] `go test -skip '^TestAcc|^TestMwsAcc|^TestUcAcc' ./settings/... ./internal/acceptance/...` — full non-acceptance run passes.
- [x] `make fmt lint ws` — clean.
- [x] Empirical staleness measurement on azure-prod via 5-run probe confirms eventual consistency (~400ms median window) and reproduces the failure rates that the nightly is seeing.

NO_CHANGELOG=true