### PR TITLE
[Fix] `databricks_mws_ncc_private_endpoint_rule`: mark `account_id` Computed to prevent spurious drift

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bug Fixes
 
+* Fix spurious `account_id` drift on `databricks_mws_ncc_private_endpoint_rule` ([#5347](https://github.com/databricks/terraform-provider-databricks/issues/5347)). The backend echoes `account_id` on read; the schema previously marked it as a plain `Optional` attribute, so once it landed in state (for example via `terraform import`) the next plan reported `account_id = "..." -> null` and a subsequent apply failed with `cannot update mws ncc private endpoint rule: Update mask must be specified.`. Marking `account_id` as `Computed` (matching the sibling `databricks_mws_network_connectivity_config` resource) preserves the server-provided value across refreshes and eliminates the spurious in-place update.
+
 ### Documentation
 
 ### Exporter

--- a/mws/resource_mws_ncc_private_endpoint_rule.go
+++ b/mws/resource_mws_ncc_private_endpoint_rule.go
@@ -19,7 +19,7 @@ func ResourceMwsNccPrivateEndpointRule() common.Resource {
 			common.CustomizeSchemaPath(m, p).SetForceNew()
 		}
 
-		for _, p := range []string{"rule_id", "endpoint_name", "connection_state", "creation_time", "updated_time", "vpc_endpoint_id"} {
+		for _, p := range []string{"account_id", "rule_id", "endpoint_name", "connection_state", "creation_time", "updated_time", "vpc_endpoint_id"} {
 			common.CustomizeSchemaPath(m, p).SetComputed()
 		}
 

--- a/mws/resource_mws_ncc_private_endpoint_rule_acc_test.go
+++ b/mws/resource_mws_ncc_private_endpoint_rule_acc_test.go
@@ -1,0 +1,94 @@
+package mws_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/databricks/terraform-provider-databricks/internal/acceptance"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+// Reproduces ES-1957213 / #5347.
+//
+// Step 1 sets account_id explicitly in HCL — necessary in CI because
+// common.StructToData (common/reflect_resource.go:715) deliberately skips
+// writing API-returned values to state for non-Computed, non-bool fields the
+// user didn't configure. Without the explicit set, account_id never lands in
+// state in this environment and the bug can't manifest here. The customer
+// hits the bug because their state has account_id from a path that bypasses
+// that skip-logic (terraform import goes through MarkNewResource, an older
+// provider version, etc.); the fix below addresses the underlying schema bug
+// regardless of how account_id got into state.
+//
+// Step 2 removes account_id from HCL. Before the fix the Update CRUD is
+// invoked but the spurious account_id drift isn't one of the updatable fields
+// (enabled/domain_names/resource_names), so the request goes out with an
+// empty update_mask and the backend rejects with "Update mask must be
+// specified" — exactly the customer-reported error. After the fix the schema
+// is Optional+Computed, the diff engine preserves state, no Update fires.
+//
+// Step 3 re-plans with the same HCL — asserts the plan stays empty on
+// subsequent runs.
+func TestMwsAccNccPrivateEndpointRule_NoSpuriousAccountIdDrift(t *testing.T) {
+	var ncc, ruleBase string
+	switch {
+	case acceptance.IsAzure(t):
+		ncc = `
+		resource "databricks_mws_network_connectivity_config" "this" {
+			name = "tf-{var.STICKY_RANDOM}"
+			region = "eastus2"
+		}`
+		ruleBase = `
+		resource "databricks_mws_ncc_private_endpoint_rule" "this" {
+			network_connectivity_config_id = databricks_mws_network_connectivity_config.this.network_connectivity_config_id
+			resource_id                    = "/subscriptions/2a5a4578-9ca9-47e2-ba46-f6ee6cc731f2/resourceGroups/deco-prod-azure-eastus2-rg/providers/Microsoft.Storage/storageAccounts/decotestprodunity"
+			group_id                       = "blob"`
+	case acceptance.IsAws(t):
+		ncc = `
+		resource "databricks_mws_network_connectivity_config" "this" {
+			account_id = "{env.DATABRICKS_ACCOUNT_ID}"
+			name       = "tf-{var.STICKY_RANDOM}"
+			region     = "{env.AWS_REGION}"
+		}`
+		ruleBase = `
+		resource "databricks_mws_ncc_private_endpoint_rule" "this" {
+			network_connectivity_config_id = databricks_mws_network_connectivity_config.this.network_connectivity_config_id
+			resource_names                 = ["{env.TEST_LOGDELIVERY_BUCKET}"]`
+	case acceptance.IsGcp(t):
+		// databricks_mws_ncc_private_endpoint_rule is documented as Azure-GA /
+		// AWS-Public-Preview only (docs/resources/mws_ncc_private_endpoint_rule.md).
+		// No GCP form factor today, so skip cleanly.
+		acceptance.Skipf(t)("NCC private endpoint rule not supported on GCP")
+	default:
+		acceptance.Skipf(t)("unrecognized cloud env for NCC private endpoint rule")
+	}
+	withAccountID := ncc + ruleBase + `
+			account_id                     = "{env.DATABRICKS_ACCOUNT_ID}"
+		}
+		`
+	withoutAccountID := ncc + ruleBase + `
+		}
+		`
+	acceptance.AccountLevel(t,
+		acceptance.Step{
+			Template: withAccountID,
+			Check: func(s *terraform.State) error {
+				r, ok := s.RootModule().Resources["databricks_mws_ncc_private_endpoint_rule.this"]
+				if !ok {
+					return fmt.Errorf("resource not found in state")
+				}
+				if r.Primary.Attributes["account_id"] == "" {
+					return fmt.Errorf("account_id not populated in state after Step 1; bug precondition not met. attrs: %v", r.Primary.Attributes)
+				}
+				return nil
+			},
+		},
+		acceptance.Step{
+			Template: withoutAccountID,
+		},
+		acceptance.Step{
+			Template: withoutAccountID,
+			PlanOnly: true,
+		},
+	)
+}

--- a/mws/resource_mws_ncc_private_endpoint_rule_test.go
+++ b/mws/resource_mws_ncc_private_endpoint_rule_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/databricks/databricks-sdk-go/service/settings"
 	"github.com/databricks/terraform-provider-databricks/qa"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -293,4 +294,50 @@ func TestResourceNccPrivateEndpointRuleDelete_Error(t *testing.T) {
 	}.Apply(t)
 	qa.AssertErrorStartsWith(t, err, "error")
 	assert.Equal(t, "ncc_id/rule_id", d.Id())
+}
+
+// account_id must be Computed so that a value populated by the backend on Read
+// does not register as user-driven drift. The sibling
+// databricks_mws_network_connectivity_config marks account_id Computed for the
+// same reason; the omission here is the root cause of ES-1957213 / #5347.
+func TestResourceNccPrivateEndpointRule_AccountIdIsComputed(t *testing.T) {
+	s := ResourceMwsNccPrivateEndpointRule().Schema
+	accountID, ok := s["account_id"]
+	assert.True(t, ok, "account_id should be present in the schema")
+	assert.True(t, accountID.Computed,
+		"account_id must be Computed; otherwise a backend-populated value triggers spurious drift and an empty-update-mask error")
+}
+
+// Reproduces the customer-facing symptom of ES-1957213 / #5347: when a prior
+// Read has populated account_id into state (the backend intermittently returns
+// it) but HCL doesn't set it, no in-place update should be planned. Before the
+// fix the diff plans account_id = "..." -> null, which then triggers an Update
+// API call with an empty update_mask, which the backend rejects with
+// "Update mask must be specified".
+func TestResourceNccPrivateEndpointRule_NoDriftWhenBackendReturnsAccountId(t *testing.T) {
+	qa.ResourceFixture{
+		Resource:  ResourceMwsNccPrivateEndpointRule(),
+		AccountID: "abc",
+		Host:      "https://accounts.cloud.databricks.com",
+		ID:        "ncc_id/rule_id",
+		InstanceState: map[string]string{
+			"network_connectivity_config_id": "ncc_id",
+			"rule_id":                        "rule_id",
+			"account_id":                     "abc",
+			"group_id":                       "blob",
+			"resource_id":                    "resource_id",
+			"endpoint_name":                  "endpoint_name",
+			"connection_state":               "PENDING",
+			"creation_time":                  "0",
+			"updated_time":                   "0",
+			"vpc_endpoint_id":                "",
+			"enabled":                        "false",
+		},
+		HCL: `
+		network_connectivity_config_id = "ncc_id"
+		resource_id = "resource_id"
+		group_id = "blob"
+		`,
+		ExpectedDiff: map[string]*terraform.ResourceAttrDiff{},
+	}.ApplyNoError(t)
 }


### PR DESCRIPTION
## Changes

The `databricks_mws_ncc_private_endpoint_rule` resource has been intermittently planning a spurious `account_id` change that fails on apply.

**Symptom.** After a successful create, a subsequent plan shows:

```
~ account_id = "<some-account-id>" -> null
```

…and the follow-up apply fails with:

```
Error: cannot update mws ncc private endpoint rule: Update mask must be specified.
```

**Root cause.** The schema for this resource is auto-generated from the SDK response struct `settings.NccPrivateEndpointRule`, whose `AccountId` field is tagged `json:"account_id,omitempty"` (the field has `PUBLIC_UNDOCUMENTED` visibility on the Create/Update input schemas in the API spec — it's an output-only field). The provider's reflection layer at `common/reflect_resource.go:287` treats every `omitempty` JSON tag as `Optional: true`, so `account_id` ended up `Optional` in the schema. The resource's `SetComputed()` list at `mws/resource_mws_ncc_private_endpoint_rule.go:22` already covers other output-only fields (`rule_id`, `endpoint_name`, `connection_state`, etc.) but missed `account_id`.

When the backend's GET response populates `account_id` into state (e.g. after `terraform import`, or in any other path that bypasses `common.StructToData`'s "skip non-Computed, non-bool fields the user didn't configure" check) and HCL doesn't set `account_id`, the diff engine sees state value vs. null config and plans `account_id = "..." -> null`. The Update CRUD body only includes `enabled`, `domain_names`, and `resource_names`, so the spurious drift produces an empty `update_mask`, which the backend rejects.

**Fix.** Add `account_id` to the `SetComputed()` list, matching the sibling `databricks_mws_network_connectivity_config` resource. With `Optional + Computed`, the diff engine preserves the server-provided value across refreshes and never plans the spurious in-place update.

## Tests

- [x] `make test` run locally — new unit tests `TestResourceNccPrivateEndpointRule_AccountIdIsComputed` (schema invariant) and `TestResourceNccPrivateEndpointRule_NoDriftWhenBackendReturnsAccountId` (diff-engine behavioral) fail before the fix and pass after. Full mws unit suite still green.
- [x] covered with integration tests in `internal/acceptance` — new `TestMwsAccNccPrivateEndpointRule_NoSpuriousAccountIdDrift` (Azure / AWS branches, GCP explicitly skipped per the resource docs). Verified end-to-end against a real Azure account:
  - Before fix: Step 2 (apply with `account_id` removed) fails with the customer-reported `cannot update mws ncc private endpoint rule: Update mask must be specified.` from the backend.
  - After fix: all 3 steps pass; the no-op Update is skipped, plan stays empty.
- [x] has entry in `NEXT_CHANGELOG.md` file
- [ ] relevant change in `docs/` folder — `account_id` was never documented in the Argument Reference, so no doc change is needed.
- [ ] using Go SDK — n/a, schema customization only
- [ ] using TF Plugin Framework — n/a, this resource is SDKv2

Closes #5347.

This pull request and its description were written by Isaac.