### PR TITLE
Deprecate SDKv2 fallback for migrated PF resources

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### New Features and Improvements
 
+* Deprecate the SDKv2 fallback implementations of `databricks_library`, `databricks_quality_monitor`, and `databricks_share` resources, and the `databricks_share`, `databricks_shares`, and `databricks_volumes` data sources. These resources have been served by the Plugin Framework by default since their migration; the SDKv2 implementations remain only as opt-in fallbacks via the `USE_SDK_V2_RESOURCES` / `USE_SDK_V2_DATA_SOURCES` environment variables. Setting either environment variable for any of these names now emits a runtime warning (visible with `TF_LOG=WARN` or higher), and the SDKv2 implementations will be removed in the next major release of the provider.
+
 ### Bug Fixes
 
 ### Documentation

--- a/docs/data-sources/share.md
+++ b/docs/data-sources/share.md
@@ -7,6 +7,12 @@ Retrieves details about a [databricks_share](../resources/share.md) that were cr
 
 -> This data source can only be used with a workspace-level provider!
 
+## Plugin Framework Migration
+
+The share data source has been migrated from sdkv2 to plugin framework. If you encounter any problem with this data source and suspect it is due to the migration, you can fallback to sdkv2 by setting the environment variable in the following way `export USE_SDK_V2_DATA_SOURCES="databricks_share"`.
+
+~> **Deprecation**: The SDKv2 fallback implementation, selectable via `USE_SDK_V2_DATA_SOURCES="databricks_share"`, is **deprecated** and will be removed in the next major release of the provider. Setting the environment variable now emits a runtime warning; remove the override to use the default Plugin Framework implementation.
+
 ## Example Usage
 
 Getting details of an existing share in the metastore

--- a/docs/data-sources/shares.md
+++ b/docs/data-sources/shares.md
@@ -7,6 +7,12 @@ Retrieves a list of [databricks_share](../resources/share.md) name, that were cr
 
 -> This data source can only be used with a workspace-level provider!
 
+## Plugin Framework Migration
+
+The shares data source has been migrated from sdkv2 to plugin framework. If you encounter any problem with this data source and suspect it is due to the migration, you can fallback to sdkv2 by setting the environment variable in the following way `export USE_SDK_V2_DATA_SOURCES="databricks_shares"`.
+
+~> **Deprecation**: The SDKv2 fallback implementation, selectable via `USE_SDK_V2_DATA_SOURCES="databricks_shares"`, is **deprecated** and will be removed in the next major release of the provider. Setting the environment variable now emits a runtime warning; remove the override to use the default Plugin Framework implementation.
+
 ## Example Usage
 
 Getting all existing shares in the metastore

--- a/docs/data-sources/volumes.md
+++ b/docs/data-sources/volumes.md
@@ -11,6 +11,8 @@ Retrieves a list of [databricks_volume](../resources/volume.md) ids (full names)
 
 The volumes data source has been migrated from sdkv2 to plugin framework in version 1.57。 If you encounter any problem with this data source and suspect it is due to the migration, you can fallback to sdkv2 by setting the environment variable in the following way `export USE_SDK_V2_DATA_SOURCES="databricks_volumes"`.
 
+~> **Deprecation**: The SDKv2 fallback implementation, selectable via `USE_SDK_V2_DATA_SOURCES="databricks_volumes"`, is **deprecated** and will be removed in the next major release of the provider. Setting the environment variable now emits a runtime warning; remove the override to use the default Plugin Framework implementation.
+
 ## Example Usage
 
 Listing all volumes in a _things_ [databricks_schema](../resources/schema.md) of a  _sandbox_ [databricks_catalog](../resources/catalog.md):

--- a/docs/resources/library.md
+++ b/docs/resources/library.md
@@ -13,6 +13,8 @@ Installs a [library](https://docs.databricks.com/libraries/index.html) on [datab
 
 The library resource has been migrated from sdkv2 to plugin framework. If you encounter any problem with this resource and suspect it is due to the migration, you can fallback to sdkv2 by setting the environment variable in the following way `export USE_SDK_V2_RESOURCES="databricks_library"`.
 
+~> **Deprecation**: The SDKv2 fallback implementation, selectable via `USE_SDK_V2_RESOURCES="databricks_library"`, is **deprecated** and will be removed in the next major release of the provider. Setting the environment variable now emits a runtime warning; remove the override to use the default Plugin Framework implementation.
+
 -> **Upgrading from v1.114.0**: state written by v1.114.0 encodes `provider_config` as a single object instead of a list. After upgrading the provider, edit each `databricks_library` instance in your state file to convert `"provider_config": {"workspace_id": "X"}` to `"provider_config": null` (recommended if you didn't set `provider_config` in HCL) or to `"provider_config": [{"workspace_id": "X"}]` (if you did). Without this edit, `terraform plan` fails with `Error decoding ... missing expected [`. Users on v1.113.0 are unaffected.
 
 ## Installing library on all clusters

--- a/docs/resources/quality_monitor.md
+++ b/docs/resources/quality_monitor.md
@@ -13,6 +13,8 @@ A `databricks_quality_monitor` is attached to a [databricks_sql_table](sql_table
 
 The quality monitor resource has been migrated from sdkv2 to plugin framework. If you encounter any problem with this resource and suspect it is due to the migration, you can fallback to sdkv2 by setting the environment variable in the following way `export USE_SDK_V2_RESOURCES="databricks_quality_monitor"`.
 
+~> **Deprecation**: The SDKv2 fallback implementation, selectable via `USE_SDK_V2_RESOURCES="databricks_quality_monitor"`, is **deprecated** and will be removed in the next major release of the provider. Setting the environment variable now emits a runtime warning; remove the override to use the default Plugin Framework implementation.
+
 -> **Upgrading from v1.114.0**: state written by v1.114.0 encodes `provider_config` as a single object instead of a list. After upgrading the provider, edit each `databricks_quality_monitor` instance in your state file to convert `"provider_config": {"workspace_id": "X"}` to `"provider_config": null` (recommended if you didn't set `provider_config` in HCL) or to `"provider_config": [{"workspace_id": "X"}]` (if you did). Without this edit, `terraform plan` fails with `Error decoding ... missing expected [`. Users on v1.113.0 are unaffected.
 
 ## Example Usage

--- a/docs/resources/share.md
+++ b/docs/resources/share.md
@@ -9,6 +9,12 @@ In Delta Sharing, a share is a read-only collection of tables and table partitio
 
 In a Unity Catalog-enabled Databricks workspace, a share is a securable object registered in Unity Catalog. A `databricks_share` is contained within a [databricks_metastore](metastore.md). If you remove a share from your Unity Catalog metastore, all recipients of that share lose the ability to access it.
 
+## Plugin Framework Migration
+
+The share resource has been migrated from sdkv2 to plugin framework. If you encounter any problem with this resource and suspect it is due to the migration, you can fallback to sdkv2 by setting the environment variable in the following way `export USE_SDK_V2_RESOURCES="databricks_share"`.
+
+~> **Deprecation**: The SDKv2 fallback implementation, selectable via `USE_SDK_V2_RESOURCES="databricks_share"`, is **deprecated** and will be removed in the next major release of the provider. Setting the environment variable now emits a runtime warning; remove the override to use the default Plugin Framework implementation.
+
 -> **Upgrading from v1.114.0**: state written by v1.114.0 encodes `provider_config` as a single object instead of a list. After upgrading the provider, edit each `databricks_share` instance in your state file to convert `"provider_config": {"workspace_id": "X"}` to `"provider_config": null` (recommended if you didn't set `provider_config` in HCL) or to `"provider_config": [{"workspace_id": "X"}]` (if you did). Without this edit, `terraform plan` fails with `Error decoding ... missing expected [`. Users on v1.113.0 are unaffected.
 
 ## Example Usage

--- a/internal/providers/pluginfw/pluginfw_rollout_utils.go
+++ b/internal/providers/pluginfw/pluginfw_rollout_utils.go
@@ -8,9 +8,11 @@ package pluginfw
 
 import (
 	"context"
+	"log"
 	"os"
 	"slices"
 	"strings"
+	"sync"
 
 	"github.com/databricks/databricks-sdk-go/config"
 	"github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/products/app"
@@ -29,7 +31,24 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 )
 
-// List of resources that have been migrated from SDK V2 to plugin framework
+// migratedResources lists resources that were originally implemented on SDKv2
+// and have been re-implemented on the Plugin Framework. Entries here are served
+// by the Plugin Framework by default; users can opt back to SDKv2 by listing
+// the resource name in the USE_SDK_V2_RESOURCES environment variable.
+//
+// Deprecation contract for entries in this list:
+//  1. The SDKv2 implementation must stay present and functional for the rest of
+//     this major version so that USE_SDK_V2_RESOURCES still works.
+//  2. The resource's documentation must carry a `~> **Deprecation**` banner
+//     warning that the SDKv2 implementation will be removed in the next major.
+//  3. The PR that adds an entry must announce the deprecation in NEXT_CHANGELOG.
+//  4. In the next major release, the SDKv2 source file and test must be deleted
+//     and the entry moved from migratedResources to pluginFwOnlyResources.
+//
+// getPluginFrameworkResourcesToRegister emits a one-time runtime warning whenever
+// a user steers a name in this list back to SDKv2, so entries inherit the
+// deprecation signal automatically.
+//
 // Keep this list sorted.
 var migratedResources = []func() resource.Resource{
 	library.ResourceLibrary,
@@ -37,12 +56,41 @@ var migratedResources = []func() resource.Resource{
 	sharing.ResourceShare,
 }
 
-// List of data sources that have been migrated from SDK V2 to plugin framework
+// migratedDataSources lists data sources that were originally implemented on
+// SDKv2 and have been re-implemented on the Plugin Framework. The same
+// deprecation contract as migratedResources applies; see the comment above
+// migratedResources for details.
+//
 // Keep this list sorted.
 var migratedDataSources = []func() datasource.DataSource{
 	sharing.DataSourceShare,
 	sharing.DataSourceShares,
 	volume.DataSourceVolumes,
+}
+
+// warnedFallbackNames tracks resource/data-source names for which we have
+// already emitted the SDKv2-fallback deprecation warning, so we warn at most
+// once per name per provider process.
+var warnedFallbackNames sync.Map
+
+// emitSdkV2FallbackWarning logs a one-time deprecation warning when a name in
+// migratedResources / migratedDataSources is steered back to the SDKv2
+// implementation, either via the USE_SDK_V2_RESOURCES / USE_SDK_V2_DATA_SOURCES
+// environment variables or via the test-only WithSdkV2ResourceFallbacks /
+// WithSdkV2DataSourceFallbacks options. kind is "resource" or "data source".
+//
+// The warning is sent through log.Printf with a [WARN] prefix; the Terraform
+// CLI surfaces this to users running with TF_LOG=WARN or higher. This is the
+// same channel SDKv2 schema deprecations use.
+func emitSdkV2FallbackWarning(name, kind string) {
+	if _, loaded := warnedFallbackNames.LoadOrStore(name, struct{}{}); loaded {
+		return
+	}
+	log.Printf("[WARN] %s %q is being served by the deprecated SDKv2 implementation "+
+		"(selected via USE_SDK_V2_RESOURCES / USE_SDK_V2_DATA_SOURCES or a test-only "+
+		"fallback option). The SDKv2 implementation will be removed in the next major "+
+		"release of the provider; remove the override to use the Plugin Framework version.",
+		kind, name)
 }
 
 // List of resources that have been onboarded to the plugin framework - not migrated from sdkv2.
@@ -161,9 +209,11 @@ func getPluginFrameworkResourcesToRegister(resourceFallbacks []string) []func() 
 	// Loop through the map and add resources if they're not specifically marked to use the SDK V2
 	for _, resourceFunc := range migratedResources {
 		name := getResourceName(resourceFunc)
-		if !shouldUseSdkV2Resource(name) && !slices.Contains(resourceFallbacks, name) {
-			resources = append(resources, resourceFunc)
+		if shouldUseSdkV2Resource(name) || slices.Contains(resourceFallbacks, name) {
+			emitSdkV2FallbackWarning(name, "resource")
+			continue
 		}
+		resources = append(resources, resourceFunc)
 	}
 
 	return append(resources, pluginFwOnlyResources...)
@@ -176,9 +226,11 @@ func getPluginFrameworkDataSourcesToRegister(dataSourceFallbacks []string) []fun
 	// Loop through the map and add data sources if they're not specifically marked to use the SDK V2
 	for _, dataSourceFunc := range migratedDataSources {
 		name := getDataSourceName(dataSourceFunc)
-		if !shouldUseSdkV2DataSource(name) && !slices.Contains(dataSourceFallbacks, name) {
-			dataSources = append(dataSources, dataSourceFunc)
+		if shouldUseSdkV2DataSource(name) || slices.Contains(dataSourceFallbacks, name) {
+			emitSdkV2FallbackWarning(name, "data source")
+			continue
 		}
+		dataSources = append(dataSources, dataSourceFunc)
 	}
 
 	return append(dataSources, pluginFwOnlyDataSources...)

--- a/internal/providers/pluginfw/pluginfw_rollout_utils.go
+++ b/internal/providers/pluginfw/pluginfw_rollout_utils.go
@@ -12,7 +12,6 @@ import (
 	"os"
 	"slices"
 	"strings"
-	"sync"
 
 	"github.com/databricks/databricks-sdk-go/config"
 	"github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/products/app"
@@ -31,24 +30,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 )
 
-// migratedResources lists resources that were originally implemented on SDKv2
-// and have been re-implemented on the Plugin Framework. Entries here are served
-// by the Plugin Framework by default; users can opt back to SDKv2 by listing
-// the resource name in the USE_SDK_V2_RESOURCES environment variable.
-//
-// Deprecation contract for entries in this list:
-//  1. The SDKv2 implementation must stay present and functional for the rest of
-//     this major version so that USE_SDK_V2_RESOURCES still works.
-//  2. The resource's documentation must carry a `~> **Deprecation**` banner
-//     warning that the SDKv2 implementation will be removed in the next major.
-//  3. The PR that adds an entry must announce the deprecation in NEXT_CHANGELOG.
-//  4. In the next major release, the SDKv2 source file and test must be deleted
-//     and the entry moved from migratedResources to pluginFwOnlyResources.
-//
-// getPluginFrameworkResourcesToRegister emits a one-time runtime warning whenever
-// a user steers a name in this list back to SDKv2, so entries inherit the
-// deprecation signal automatically.
-//
+// List of resources that have been migrated from SDK V2 to plugin framework.
+// The SDKv2 fallback path (selected via USE_SDK_V2_RESOURCES) is deprecated and
+// will be removed in the next major release; getPluginFrameworkResourcesToRegister
+// logs a [WARN] line whenever a name in this list is steered back to SDKv2.
 // Keep this list sorted.
 var migratedResources = []func() resource.Resource{
 	library.ResourceLibrary,
@@ -56,41 +41,14 @@ var migratedResources = []func() resource.Resource{
 	sharing.ResourceShare,
 }
 
-// migratedDataSources lists data sources that were originally implemented on
-// SDKv2 and have been re-implemented on the Plugin Framework. The same
-// deprecation contract as migratedResources applies; see the comment above
-// migratedResources for details.
-//
+// List of data sources that have been migrated from SDK V2 to plugin framework.
+// The SDKv2 fallback path (selected via USE_SDK_V2_DATA_SOURCES) is deprecated
+// and will be removed in the next major release.
 // Keep this list sorted.
 var migratedDataSources = []func() datasource.DataSource{
 	sharing.DataSourceShare,
 	sharing.DataSourceShares,
 	volume.DataSourceVolumes,
-}
-
-// warnedFallbackNames tracks resource/data-source names for which we have
-// already emitted the SDKv2-fallback deprecation warning, so we warn at most
-// once per name per provider process.
-var warnedFallbackNames sync.Map
-
-// emitSdkV2FallbackWarning logs a one-time deprecation warning when a name in
-// migratedResources / migratedDataSources is steered back to the SDKv2
-// implementation, either via the USE_SDK_V2_RESOURCES / USE_SDK_V2_DATA_SOURCES
-// environment variables or via the test-only WithSdkV2ResourceFallbacks /
-// WithSdkV2DataSourceFallbacks options. kind is "resource" or "data source".
-//
-// The warning is sent through log.Printf with a [WARN] prefix; the Terraform
-// CLI surfaces this to users running with TF_LOG=WARN or higher. This is the
-// same channel SDKv2 schema deprecations use.
-func emitSdkV2FallbackWarning(name, kind string) {
-	if _, loaded := warnedFallbackNames.LoadOrStore(name, struct{}{}); loaded {
-		return
-	}
-	log.Printf("[WARN] %s %q is being served by the deprecated SDKv2 implementation "+
-		"(selected via USE_SDK_V2_RESOURCES / USE_SDK_V2_DATA_SOURCES or a test-only "+
-		"fallback option). The SDKv2 implementation will be removed in the next major "+
-		"release of the provider; remove the override to use the Plugin Framework version.",
-		kind, name)
 }
 
 // List of resources that have been onboarded to the plugin framework - not migrated from sdkv2.
@@ -209,11 +167,13 @@ func getPluginFrameworkResourcesToRegister(resourceFallbacks []string) []func() 
 	// Loop through the map and add resources if they're not specifically marked to use the SDK V2
 	for _, resourceFunc := range migratedResources {
 		name := getResourceName(resourceFunc)
-		if shouldUseSdkV2Resource(name) || slices.Contains(resourceFallbacks, name) {
-			emitSdkV2FallbackWarning(name, "resource")
-			continue
+		if !shouldUseSdkV2Resource(name) && !slices.Contains(resourceFallbacks, name) {
+			resources = append(resources, resourceFunc)
+		} else {
+			log.Printf("[WARN] resource %q is using the deprecated SDKv2 implementation; "+
+				"this fallback will be removed in the next major release. Unset "+
+				"USE_SDK_V2_RESOURCES to use the Plugin Framework version.", name)
 		}
-		resources = append(resources, resourceFunc)
 	}
 
 	return append(resources, pluginFwOnlyResources...)
@@ -226,11 +186,13 @@ func getPluginFrameworkDataSourcesToRegister(dataSourceFallbacks []string) []fun
 	// Loop through the map and add data sources if they're not specifically marked to use the SDK V2
 	for _, dataSourceFunc := range migratedDataSources {
 		name := getDataSourceName(dataSourceFunc)
-		if shouldUseSdkV2DataSource(name) || slices.Contains(dataSourceFallbacks, name) {
-			emitSdkV2FallbackWarning(name, "data source")
-			continue
+		if !shouldUseSdkV2DataSource(name) && !slices.Contains(dataSourceFallbacks, name) {
+			dataSources = append(dataSources, dataSourceFunc)
+		} else {
+			log.Printf("[WARN] data source %q is using the deprecated SDKv2 implementation; "+
+				"this fallback will be removed in the next major release. Unset "+
+				"USE_SDK_V2_DATA_SOURCES to use the Plugin Framework version.", name)
 		}
-		dataSources = append(dataSources, dataSourceFunc)
 	}
 
 	return append(dataSources, pluginFwOnlyDataSources...)

--- a/internal/providers/pluginfw/pluginfw_test.go
+++ b/internal/providers/pluginfw/pluginfw_test.go
@@ -1,7 +1,11 @@
 package pluginfw
 
 import (
+	"bytes"
 	"context"
+	"log"
+	"strings"
+	"sync"
 	"testing"
 
 	"github.com/databricks/terraform-provider-databricks/common"
@@ -10,6 +14,74 @@ import (
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 	"github.com/stretchr/testify/assert"
 )
+
+// resetFallbackWarningState rewires the package logger to a buffer and resets
+// the once-per-name dedupe map, returning the buffer and a cleanup func.
+func resetFallbackWarningState(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	origWriter := log.Writer()
+	origFlags := log.Flags()
+	log.SetOutput(&buf)
+	log.SetFlags(0)
+	warnedFallbackNames = sync.Map{}
+	t.Cleanup(func() {
+		log.SetOutput(origWriter)
+		log.SetFlags(origFlags)
+		warnedFallbackNames = sync.Map{}
+	})
+	return &buf
+}
+
+func TestEmitSdkV2FallbackWarning_LogsOncePerName(t *testing.T) {
+	buf := resetFallbackWarningState(t)
+
+	emitSdkV2FallbackWarning("databricks_library", "resource")
+	emitSdkV2FallbackWarning("databricks_library", "resource") // duplicate, suppressed
+	emitSdkV2FallbackWarning("databricks_shares", "data source")
+
+	out := buf.String()
+	assert.Equal(t, 1, strings.Count(out, `"databricks_library"`), "library warning should fire exactly once")
+	assert.Contains(t, out, `"databricks_shares"`)
+	assert.Contains(t, out, "[WARN]")
+	assert.Contains(t, out, "deprecated SDKv2 implementation")
+	assert.Contains(t, out, "next major release")
+}
+
+func TestGetPluginFrameworkResources_EnvVarFallbackEmitsWarning(t *testing.T) {
+	buf := resetFallbackWarningState(t)
+	t.Setenv("USE_SDK_V2_RESOURCES", "databricks_library")
+
+	got := getPluginFrameworkResourcesToRegister(nil)
+
+	for _, fn := range got {
+		assert.NotEqual(t, "databricks_library", getResourceName(fn),
+			"databricks_library must be excluded from PF when fallback is requested")
+	}
+	assert.Contains(t, buf.String(), `"databricks_library"`)
+	assert.Contains(t, buf.String(), "resource")
+}
+
+func TestGetPluginFrameworkDataSources_FallbackOptionEmitsWarning(t *testing.T) {
+	buf := resetFallbackWarningState(t)
+
+	got := getPluginFrameworkDataSourcesToRegister([]string{"databricks_volumes"})
+
+	for _, fn := range got {
+		assert.NotEqual(t, "databricks_volumes", getDataSourceName(fn),
+			"databricks_volumes must be excluded from PF when fallback is requested")
+	}
+	assert.Contains(t, buf.String(), `"databricks_volumes"`)
+	assert.Contains(t, buf.String(), "data source")
+}
+
+func TestGetPluginFrameworkResources_NoFallbackNoWarning(t *testing.T) {
+	buf := resetFallbackWarningState(t)
+
+	_ = getPluginFrameworkResourcesToRegister(nil)
+
+	assert.Empty(t, buf.String(), "no warning should be emitted when no fallback is configured")
+}
 
 func TestConfigure(t *testing.T) {
 	testCases := []struct {

--- a/internal/providers/pluginfw/pluginfw_test.go
+++ b/internal/providers/pluginfw/pluginfw_test.go
@@ -4,8 +4,6 @@ import (
 	"bytes"
 	"context"
 	"log"
-	"strings"
-	"sync"
 	"testing"
 
 	"github.com/databricks/terraform-provider-databricks/common"
@@ -15,41 +13,24 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// resetFallbackWarningState rewires the package logger to a buffer and resets
-// the once-per-name dedupe map, returning the buffer and a cleanup func.
-func resetFallbackWarningState(t *testing.T) *bytes.Buffer {
+// captureFallbackWarnings rewires the package logger to a buffer for the
+// duration of the test, restoring the original writer on cleanup.
+func captureFallbackWarnings(t *testing.T) *bytes.Buffer {
 	t.Helper()
 	var buf bytes.Buffer
 	origWriter := log.Writer()
 	origFlags := log.Flags()
 	log.SetOutput(&buf)
 	log.SetFlags(0)
-	warnedFallbackNames = sync.Map{}
 	t.Cleanup(func() {
 		log.SetOutput(origWriter)
 		log.SetFlags(origFlags)
-		warnedFallbackNames = sync.Map{}
 	})
 	return &buf
 }
 
-func TestEmitSdkV2FallbackWarning_LogsOncePerName(t *testing.T) {
-	buf := resetFallbackWarningState(t)
-
-	emitSdkV2FallbackWarning("databricks_library", "resource")
-	emitSdkV2FallbackWarning("databricks_library", "resource") // duplicate, suppressed
-	emitSdkV2FallbackWarning("databricks_shares", "data source")
-
-	out := buf.String()
-	assert.Equal(t, 1, strings.Count(out, `"databricks_library"`), "library warning should fire exactly once")
-	assert.Contains(t, out, `"databricks_shares"`)
-	assert.Contains(t, out, "[WARN]")
-	assert.Contains(t, out, "deprecated SDKv2 implementation")
-	assert.Contains(t, out, "next major release")
-}
-
 func TestGetPluginFrameworkResources_EnvVarFallbackEmitsWarning(t *testing.T) {
-	buf := resetFallbackWarningState(t)
+	buf := captureFallbackWarnings(t)
 	t.Setenv("USE_SDK_V2_RESOURCES", "databricks_library")
 
 	got := getPluginFrameworkResourcesToRegister(nil)
@@ -59,11 +40,12 @@ func TestGetPluginFrameworkResources_EnvVarFallbackEmitsWarning(t *testing.T) {
 			"databricks_library must be excluded from PF when fallback is requested")
 	}
 	assert.Contains(t, buf.String(), `"databricks_library"`)
-	assert.Contains(t, buf.String(), "resource")
+	assert.Contains(t, buf.String(), "[WARN] resource")
+	assert.Contains(t, buf.String(), "next major release")
 }
 
 func TestGetPluginFrameworkDataSources_FallbackOptionEmitsWarning(t *testing.T) {
-	buf := resetFallbackWarningState(t)
+	buf := captureFallbackWarnings(t)
 
 	got := getPluginFrameworkDataSourcesToRegister([]string{"databricks_volumes"})
 
@@ -72,11 +54,11 @@ func TestGetPluginFrameworkDataSources_FallbackOptionEmitsWarning(t *testing.T) 
 			"databricks_volumes must be excluded from PF when fallback is requested")
 	}
 	assert.Contains(t, buf.String(), `"databricks_volumes"`)
-	assert.Contains(t, buf.String(), "data source")
+	assert.Contains(t, buf.String(), "[WARN] data source")
 }
 
 func TestGetPluginFrameworkResources_NoFallbackNoWarning(t *testing.T) {
-	buf := resetFallbackWarningState(t)
+	buf := captureFallbackWarnings(t)
 
 	_ = getPluginFrameworkResourcesToRegister(nil)
 


### PR DESCRIPTION
## Summary

- Three resources (`databricks_library`, `databricks_quality_monitor`, `databricks_share`) and three data sources (`databricks_share`, `databricks_shares`, `databricks_volumes`) have been served by the Plugin Framework by default since their migration. The SDKv2 implementations remain only as opt-in fallbacks via the `USE_SDK_V2_RESOURCES` / `USE_SDK_V2_DATA_SOURCES` environment variables.
- This PR is **Phase 1 of a two-phase deprecation**: announce now, delete in the next major release. Documentation pages get a `~> **Deprecation**` banner, `NEXT_CHANGELOG.md` carries the announcement, and a runtime warning fires when a user is on the SDKv2 fallback path.
- The runtime warning is wired into the generic registration helpers (`getPluginFrameworkResourcesToRegister` / `getPluginFrameworkDataSourcesToRegister`), so **any future entry added to `migratedResources` / `migratedDataSources` inherits the deprecation signal automatically**. A doc comment above the two lists spells out the deprecation contract for whoever owns the next migration.
- Phase 2 (next major release) will delete the ~1,862 LOC of SDKv2 source plus the env-var fallback machinery and move the PF entries from `migratedResources` to `pluginFwOnlyResources`. `ConfigureAsSdkV2Compatible()` stays — existing user state files were written with block-shaped schemas and need that compatibility shim to be read.

## Runtime warning behavior

- **Who sees it:** only users who have set `USE_SDK_V2_RESOURCES` / `USE_SDK_V2_DATA_SOURCES` (or, in tests, used `WithSdkV2ResourceFallbacks` / `WithSdkV2DataSourceFallbacks`) for a name in `migratedResources` / `migratedDataSources`. Default users never trip the helper.
- **Frequency:** Terraform spawns a fresh provider process per CLI command. A `sync.Map` dedupe inside the helper means at most one warning per name per process, so a single `terraform plan` / `apply` prints one line per affected name — and every subsequent command re-emits, by design, until the user removes the override.
- **Visibility caveat:** the warning is a `log.Printf("[WARN] ...")`, which is the same channel SDKv2 schema deprecations use. Terraform's CLI only forwards `[WARN]` provider logs to the user when `TF_LOG` is set to `WARN` or louder; with `TF_LOG` unset the line is silently dropped. The docs banner + `NEXT_CHANGELOG` entry are therefore the loudest signals; the runtime warning catches users who run with logging on. If we want an unconditional in-band signal, we'd switch to `resp.Diagnostics.AddWarning` from the PF provider's `Configure`, at the cost of duplicating the iteration over the fallback list — happy to do that in a follow-up if reviewers prefer.

## Test plan

- [x] New unit tests in `internal/providers/pluginfw/pluginfw_test.go` cover: once-per-name dedup, env-var path, fallback-option path, and no-warning-when-clean.
- [x] `go test ./internal/providers/pluginfw/... ./internal/providers/sdkv2/... ./internal/providers/...` — all green.
- [x] `gofmt -l`, `go vet`, `staticcheck ./internal/providers/pluginfw/`, `./tools/validate_whitespace.py` — all clean.
- [ ] Manual smoke test on a workspace: with `USE_SDK_V2_RESOURCES="databricks_library"` set and `TF_LOG=WARN`, run `terraform plan` against a config that uses `databricks_library` and confirm the deprecation warning appears once and the resource still works through SDKv2.
- [ ] Manual smoke test without the env var: confirm no warning is emitted and the Plugin Framework continues to serve the resource.

This pull request and its description were written by Isaac.