### PR TITLE
[Internal] Re-enable AiBi/DBFS/legacy-access settings acceptance tests

### DIFF
--- a/internal/acceptance/aibi_embedding_settings_test.go
+++ b/internal/acceptance/aibi_embedding_settings_test.go
@@ -2,21 +2,9 @@ package acceptance
 
 import (
 	"testing"
-	"time"
 )
 
-// Resource-level expected-behavior coverage that does not require a real API
-// is provided by the package-internal unit tests in
-// settings/resource_aibi_dashboard_embedding_access_policy_setting_test.go and
-// settings/resource_aibi_dashboard_embedding_approved_domains_setting_test.go
-// (TestCreate/TestRead/TestUpdate/TestDelete for each resource, plus the
-// lifecycle scenarios TestAiBiEmbeddingAccessPolicySettingLifecycle and
-// TestAiBiEmbeddingApprovedDomainsLifecycle which mirror the two steps of
-// this acceptance test against mocked SDK calls).
 func TestAccAiBiEmbeddings(t *testing.T) {
-	if time.Now().Before(time.Date(2026, 6, 24, 0, 0, 0, 0, time.UTC)) {
-		t.Skip("temporarily skipped until 2026-06-24: workspace-settings API is eventually consistent so Get after Update may return stale values; tracked internally.")
-	}
 	WorkspaceLevel(t, Step{
 		Template: `
 resource "databricks_aibi_dashboard_embedding_access_policy_setting" "this" {

--- a/settings/disable_legacy_access_setting_test.go
+++ b/settings/disable_legacy_access_setting_test.go
@@ -3,7 +3,6 @@ package settings_test
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/databricks/databricks-sdk-go/service/settings"
 	"github.com/databricks/terraform-provider-databricks/common"
@@ -13,22 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// Resource-level expected-behavior coverage that does not require a real API
-// is provided by the package-internal unit tests in
-// settings/resource_disable_legacy_access_setting_test.go:
-//   - TestCreateDisableLegacyAccess
-//   - TestReadDisableLegacyAccess
-//   - TestUpdateDisableLegacyAccess
-//   - TestUpdateDisableLegacyAccessWithConflict
-//   - TestDeleteDisableLegacyAccess
-//   - TestDeleteDisableLegacyAccessWithConflict
-//
-// plus the lifecycle scenario TestDisableLegacyAccessSettingLifecycle, which
-// mirrors the steps of this acceptance test against mocked SDK calls.
 func TestAccDisableLegacyAccessSetting(t *testing.T) {
-	if time.Now().Before(time.Date(2026, 6, 24, 0, 0, 0, 0, time.UTC)) {
-		t.Skip("temporarily skipped until 2026-06-24: workspace-settings API is eventually consistent so Get after Update may return stale values; tracked internally.")
-	}
 	template := `
  	resource "databricks_disable_legacy_access_setting" "this" {
  		disable_legacy_access {

--- a/settings/disable_legacy_dbfs_setting_test.go
+++ b/settings/disable_legacy_dbfs_setting_test.go
@@ -3,7 +3,6 @@ package settings_test
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/databricks/databricks-sdk-go/service/settings"
 	"github.com/databricks/terraform-provider-databricks/common"
@@ -13,22 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// Resource-level expected-behavior coverage that does not require a real API
-// is provided by the package-internal unit tests in
-// settings/resource_disable_legacy_dbfs_setting_test.go:
-//   - TestCreateDisableLegacyDbfs
-//   - TestReadDisableLegacyDbfs
-//   - TestUpdateDisableLegacyDbfs
-//   - TestUpdateDisableLegacyDbfsWithConflict
-//   - TestDeleteDisableLegacyDbfs
-//   - TestDeleteDisableLegacyDbfsWithConflict
-//
-// plus the lifecycle scenario TestDisableLegacyDbfsSettingLifecycle, which
-// mirrors the steps of this acceptance test against mocked SDK calls.
 func TestAccDisableLegacyDbfsSetting(t *testing.T) {
-	if time.Now().Before(time.Date(2026, 6, 24, 0, 0, 0, 0, time.UTC)) {
-		t.Skip("temporarily skipped until 2026-06-24: workspace-settings API is eventually consistent so Get after Update may return stale values; tracked internally.")
-	}
 	template := `
  	resource "databricks_disable_legacy_dbfs_setting" "this" {
  		disable_legacy_dbfs {


### PR DESCRIPTION
## Summary

- The workspace-settings backend team has confirmed that the read-after-write staleness which caused `TestAccAiBiEmbeddings`, `TestAccDisableLegacyDbfsSetting`, and `TestAccDisableLegacyAccessSetting` to fail nightly since 2026-06-03 is resolved.
- Verified empirically: each test ran **3/3 PASS** against the azure-prod workspace where the failures were previously deterministic. Zero observed staleness across all 9 runs.
- Removes the time-gated `t.Skip` blocks added in #5733 / #5791 along with the now-stale comment blocks that pointed at the unit-level lifecycle coverage. The lifecycle unit tests themselves (`TestDisableLegacyDbfsSettingLifecycle`, `TestDisableLegacyAccessSettingLifecycle`, `TestAiBiEmbeddingApprovedDomainsLifecycle`, `TestAiBiEmbeddingAccessPolicySettingLifecycle`) stay in place as permanent regression coverage.

Test-only change; no user-facing behavior change.

## Test plan

- [x] `go build ./settings/... ./internal/acceptance/...` — clean.
- [x] `make fmt lint ws` — clean.
- [x] Manual: 3 runs each of the three acceptance tests against azure-prod via the deco runner — all 9 PASS.

NO_CHANGELOG=true