### PR TITLE
Fix `databricks_instance_pool` ignoring `enable_elastic_disk = false`

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -10,7 +10,7 @@
 
 
 ### Bug Fixes
-* Fixed `databricks_instance_pool` ignoring `enable_elastic_disk = false` due to `omitempty` JSON tag, which caused an infinite plan/replace cycle ([#NNNN](https://github.com/databricks/terraform-provider-databricks/pull/NNNN)).
+* Fixed `databricks_instance_pool` ignoring `enable_elastic_disk = false` due to `omitempty` JSON tag, which caused an infinite plan/replace cycle ([#5802](https://github.com/databricks/terraform-provider-databricks/pull/5802)).
 
 ### Documentation
 * Added `disabled` field to `task` block in `databricks_job` resource, allowing individual tasks to be disabled ([#5767](https://github.com/databricks/terraform-provider-databricks/pull/5767)).

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -10,6 +10,7 @@
 
 
 ### Bug Fixes
+* Fixed `databricks_instance_pool` ignoring `enable_elastic_disk = false` due to `omitempty` JSON tag, which caused an infinite plan/replace cycle ([#NNNN](https://github.com/databricks/terraform-provider-databricks/pull/NNNN)).
 
 ### Documentation
 * Added `disabled` field to `task` block in `databricks_job` resource, allowing individual tasks to be disabled ([#5767](https://github.com/databricks/terraform-provider-databricks/pull/5767)).

--- a/pools/resource_instance_pool.go
+++ b/pools/resource_instance_pool.go
@@ -89,7 +89,7 @@ type InstancePool struct {
 	GcpAttributes                      *InstancePoolGcpAttributes      `json:"gcp_attributes,omitempty" tf:"force_new,suppress_diff"`
 	NodeTypeID                         string                          `json:"node_type_id,omitempty" tf:"suppress_diff,force_new,conflicts:instance_pool_fleet_attributes"`
 	CustomTags                         map[string]string               `json:"custom_tags" tf:"optional"`
-	EnableElasticDisk                  bool                            `json:"enable_elastic_disk,omitempty" tf:"force_new,suppress_diff"`
+	EnableElasticDisk                  bool                            `json:"enable_elastic_disk" tf:"optional,force_new,suppress_diff"`
 	DiskSpec                           *InstancePoolDiskSpec           `json:"disk_spec,omitempty" tf:"force_new"`
 	PreloadedSparkVersions             []string                        `json:"preloaded_spark_versions,omitempty" tf:"force_new"`
 	PreloadedDockerImages              []clusters.DockerImage          `json:"preloaded_docker_images,omitempty" tf:"force_new,slice_set,alias:preloaded_docker_image"`
@@ -118,7 +118,7 @@ type InstancePoolAndStats struct {
 	DefaultTags                        map[string]string                `json:"default_tags,omitempty" tf:"computed"`
 	CustomTags                         map[string]string                `json:"custom_tags,omitempty"`
 	IdleInstanceAutoTerminationMinutes int32                            `json:"idle_instance_autotermination_minutes"`
-	EnableElasticDisk                  bool                             `json:"enable_elastic_disk,omitempty"`
+	EnableElasticDisk                  bool                             `json:"enable_elastic_disk"`
 	DiskSpec                           *InstancePoolDiskSpec            `json:"disk_spec,omitempty"`
 	PreloadedSparkVersions             []string                         `json:"preloaded_spark_versions,omitempty"`
 	State                              string                           `json:"state,omitempty"`

--- a/pools/resource_instance_pool.go
+++ b/pools/resource_instance_pool.go
@@ -118,7 +118,7 @@ type InstancePoolAndStats struct {
 	DefaultTags                        map[string]string                `json:"default_tags,omitempty" tf:"computed"`
 	CustomTags                         map[string]string                `json:"custom_tags,omitempty"`
 	IdleInstanceAutoTerminationMinutes int32                            `json:"idle_instance_autotermination_minutes"`
-	EnableElasticDisk                  bool                             `json:"enable_elastic_disk"`
+	EnableElasticDisk                  bool                             `json:"enable_elastic_disk" tf:"optional"`
 	DiskSpec                           *InstancePoolDiskSpec            `json:"disk_spec,omitempty"`
 	PreloadedSparkVersions             []string                         `json:"preloaded_spark_versions,omitempty"`
 	State                              string                           `json:"state,omitempty"`

--- a/pools/resource_instance_pool_acc_test.go
+++ b/pools/resource_instance_pool_acc_test.go
@@ -1,0 +1,33 @@
+package pools_test
+
+import (
+	"testing"
+
+	"github.com/databricks/terraform-provider-databricks/internal/acceptance"
+)
+
+// TestAccInstancePool_EnableElasticDiskFalse is the live-API counterpart of
+// TestResourceInstancePoolCreate_ElasticDiskDisabled. Before the omitempty fix,
+// the Create request dropped enable_elastic_disk, the server applied its
+// default of true, and the post-apply refresh-plan saw a true -> false diff
+// that wanted to recreate the pool — an infinite loop. The implicit
+// refresh-plan after Step.Apply fails the test on any non-empty diff, so
+// reaching the end of this step verifies the fix end-to-end.
+func TestAccInstancePool_EnableElasticDiskFalse(t *testing.T) {
+	acceptance.WorkspaceLevel(t, acceptance.Step{
+		Template: `
+			data "databricks_node_type" "smallest" {
+				local_disk = true
+			}
+
+			resource "databricks_instance_pool" "this" {
+				instance_pool_name                    = "test-elastic-disk-false-{var.RANDOM}"
+				min_idle_instances                    = 0
+				max_capacity                          = 1
+				node_type_id                          = data.databricks_node_type.smallest.id
+				idle_instance_autotermination_minutes = 10
+				enable_elastic_disk                   = false
+			}
+		`,
+	})
+}

--- a/pools/resource_instance_pool_test.go
+++ b/pools/resource_instance_pool_test.go
@@ -280,3 +280,56 @@ func TestResourceInstancePoolDelete_Error(t *testing.T) {
 	qa.AssertErrorStartsWith(t, err, "Internal error happened")
 	assert.Equal(t, "abc", d.Id())
 }
+
+// Regression test: the Create request body must carry
+// "enable_elastic_disk": false when the user opts out. A map[string]any
+// ExpectedRequest is used so the comparison does not depend on the
+// InstancePool struct's own JSON tags.
+func TestResourceInstancePoolCreate_ElasticDiskDisabled(t *testing.T) {
+	qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "POST",
+				Resource: "/api/2.0/instance-pools/create",
+				ExpectedRequest: map[string]any{
+					"custom_tags":                           nil,
+					"enable_elastic_disk":                   false,
+					"idle_instance_autotermination_minutes": 15,
+					"instance_pool_name":                    "Shared Pool",
+					"max_capacity":                          1000,
+					"min_idle_instances":                    10,
+					"node_type_id":                          "i3.xlarge",
+				},
+				Response: InstancePoolAndStats{
+					InstancePoolID: "abc",
+				},
+			},
+			{
+				Method:   "GET",
+				Resource: "/api/2.0/instance-pools/get?instance_pool_id=abc",
+				Response: InstancePoolAndStats{
+					InstancePoolID:                     "abc",
+					InstancePoolName:                   "Shared Pool",
+					MinIdleInstances:                   10,
+					MaxCapacity:                        1000,
+					NodeTypeID:                         "i3.xlarge",
+					IdleInstanceAutoTerminationMinutes: 15,
+					EnableElasticDisk:                  false,
+				},
+			},
+		},
+		Resource: ResourceInstancePool(),
+		State: map[string]any{
+			"enable_elastic_disk":                   false,
+			"idle_instance_autotermination_minutes": 15,
+			"instance_pool_name":                    "Shared Pool",
+			"max_capacity":                          1000,
+			"min_idle_instances":                    10,
+			"node_type_id":                          "i3.xlarge",
+		},
+		Create: true,
+	}.ApplyAndExpectData(t, map[string]any{
+		"id":                  "abc",
+		"enable_elastic_disk": false,
+	})
+}


### PR DESCRIPTION
## Summary

`enable_elastic_disk = false` on `databricks_instance_pool` is silently ignored, causing an infinite plan/replace cycle. This PR removes the `omitempty` JSON tag on the `EnableElasticDisk` field so `false` is explicitly serialized to the API.

## Credit

This re-submits @Bafff's fix from #5454. CI tests can't run on PRs from forks, which is why the original got stalled — I'm re-opening from an upstream branch so the test suite can run. The diagnosis, code change, and unit test are all theirs. Thanks @Bafff!

## Root cause

The `EnableElasticDisk` field in both `InstancePool` and `InstancePoolAndStats` was tagged `json:"enable_elastic_disk,omitempty"`. Because `false` is the zero value for `bool` in Go, `omitempty` omits it from the serialized JSON. The API never receives `enable_elastic_disk: false` and defaults to `true`.

Combined with `tf:"force_new"`, this creates an infinite cycle:

1. User sets `enable_elastic_disk = false`.
2. Terraform creates the pool — but `omitempty` drops the field from the request.
3. API defaults to `true`.
4. Next `terraform plan` sees drift (`true → false`), wants to recreate.
5. Repeat forever.

Direct REST API calls confirm Databricks **does** accept and persist `enable_elastic_disk: false`:

```bash
# Create with false
curl -X POST ".../api/2.0/instance-pools/create" \
  -d '{"instance_pool_name":"test","node_type_id":"Standard_F4","enable_elastic_disk":false,...}'

# Read back — confirmed false
curl ".../api/2.0/instance-pools/get?instance_pool_id=..."
# Returns: "enable_elastic_disk": false
```

So the bug is purely client-side serialization.

## Fix

- Remove `omitempty` from the JSON tag on `EnableElasticDisk` in both `InstancePool` and `InstancePoolAndStats` so `false` is sent explicitly.
- Add `tf:"optional"` on `InstancePool.EnableElasticDisk`. The schema generator's `isOptional()` (in `common/reflect_resource.go`) checks for either `omitempty` on the JSON tag *or* `optional` in the `tf` tag — without the new tag, removing `omitempty` would flip the schema to Required, which would itself be a breaking change. The pre-existing `s["enable_elastic_disk"].Default = true` is preserved, so users who omit the attribute see no behavior change.

## Test plan

- [x] `go test ./pools/...` passes.
- [x] New regression test `TestResourceInstancePoolCreate_ElasticDiskDisabled` asserts the outgoing Create request body contains `"enable_elastic_disk": false`. It uses a `map[string]any` `ExpectedRequest` so the assertion does not depend on the struct's own JSON tags.
- [x] Existing tests are unaffected (they already populated `EnableElasticDisk: true` in their `ExpectedRequest`, so removing `omitempty` is a no-op for them).
- [x] `make fmt lint ws` clean.

Fixes #5462