### PR TITLE
Add stale workflow to auto-close inactive pull requests

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -31,7 +31,7 @@ jobs:
           days-before-pr-close: 30
           stale-pr-label: "stale"
           exempt-pr-labels: "merge-hold"
-          operations-per-run: 100
+          operations-per-run: 30
           ascending: true
           debug-only: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run }}
           stale-pr-message: |

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,42 @@
+name: Close stale pull requests
+
+on:
+  schedule:
+    - cron: "30 5 * * *"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Log actions without commenting or closing PRs"
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on:
+      group: databricks-deco-testing-runner-group
+      labels: ubuntu-latest-deco
+
+    steps:
+      - uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10.3.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          days-before-issue-stale: -1
+          days-before-issue-close: -1
+          days-before-pr-stale: 180
+          days-before-pr-close: 30
+          stale-pr-label: "stale"
+          exempt-pr-labels: "merge-hold"
+          operations-per-run: 100
+          ascending: true
+          debug-only: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run }}
+          stale-pr-message: |
+            Marking this pull request as stale because it has been open for 180 days with no activity. This helps our maintainers find and focus on the active pull requests. If this pull request receives no comments or updates in the next 30 days it will automatically be closed. Maintainers can also remove the stale label.
+
+            If this pull request was automatically closed and you feel this pull request should be reopened, we encourage creating a new pull request linking back to this one for added context. Thank you!
+          close-pr-message: |
+            Closing this pull request due to inactivity. If you feel this pull request should be reopened, we encourage creating a new pull request linking back to this one for added context. Thank you!


### PR DESCRIPTION
## Changes

Adds a scheduled GitHub Actions workflow using the GitHub-maintained [actions/stale](https://github.com/actions/stale) action to manage the backlog of inactive pull requests (currently ~169 open PRs, many untouched for years).

Behavior:

- PRs with **180 days** of no activity get a `stale` label and a warning comment.
- After **30 more days** with no activity, the PR is closed with a closing comment. Any comment or push removes the label and resets the clock.
- PRs labeled `merge-hold` are exempt. Issues are not affected (`days-before-issue-stale: -1`).
- `operations-per-run: 30` with `ascending: true` processes the oldest PRs first and limits API churn while working through the existing backlog.
- The workflow can be triggered manually via `workflow_dispatch` with a `dry_run` flag (`debug-only` mode) to preview actions without commenting or closing.

The messaging and structure follow the stale workflows used by the [AWS](https://github.com/hashicorp/terraform-provider-aws/blob/main/.github/workflows/stale.yml) and [Google](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/workflows/stale.yml) Terraform providers.

## Tests

Not exercised by CI; the action is pinned to v10.3.0 by commit SHA. Plan is to run the workflow manually with `dry_run: true` after merge to verify the candidate set before the first scheduled run.

This pull request and its description were written by Isaac.
NO_CHANGELOG=true
