### PR TITLE
[Exporter] Rewrote logging so it works with Databricks Go SDK logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -354,3 +354,4 @@ CLAUDE.local.md
 
 # JFrog CLI config
 .jfrog/
+/exporter/LOGGING_MIGRATION.md

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -16,4 +16,6 @@
 
 ### Exporter
 
+* Rewrote Exporter logging so it works with Databricks Go SDK logging ([#5805](https://github.com/databricks/terraform-provider-databricks/pull/5805)).
+
 ### Internal Changes

--- a/docs/guides/experimental-exporter.md
+++ b/docs/guides/experimental-exporter.md
@@ -134,10 +134,26 @@ All arguments are optional, and they tune what code is being generated.
 * `-updated-since` - timestamp (in ISO8601 format supported by Go language) for exporting of resources modified since a given timestamp. I.e., `2023-07-24T00:00:00Z`. If not specified, the exporter will try to load the last run timestamp from the `exporter-run-stats.json` file generated during the export and use it.
 * `-notebooksFormat` - optional format for exported notebooks. Supported values are `SOURCE` (default), `DBC`, `JUPYTER`.  This option could be used to export notebooks with embedded dashboards.
 * `-noformat` - optionally turn off the execution of `terraform fmt` on the exported files (enabled by default).
-* `-debug` - turn on debug output.
-* `-trace` - turn on trace output (includes debug level as well).
+* `-debug` - turn on debug output, including Databricks Go SDK HTTP request/response logs.
+* `-trace` - turn on trace output (includes debug level as well), including Databricks Go SDK HTTP request/response logs.
 * `-native-import` - turns on generation of [native import blocks](https://developer.hashicorp.com/terraform/language/import) (requires Terraform 1.5+).  This option is recommended for cases when you want to start managing an existing workspace.
 * `-export-secrets` - enables exporting of the secret values - they will be written into the `terraform.tfvars` file.  **Be very careful with this file!**
+
+### Logging
+
+The exporter also honors the standard `TF_LOG` environment variable:
+
+* `TF_LOG=DEBUG` - enables exporter debug output and Databricks Go SDK HTTP request/response logs.
+* `TF_LOG=TRACE` - enables trace output, debug output, and Databricks Go SDK HTTP request/response logs.
+* `TF_LOG=INFO`, `TF_LOG=WARN`, and `TF_LOG=ERROR` - restrict output to the corresponding level and above.
+
+The `-debug` and `-trace` flags take precedence over `TF_LOG` for backward compatibility. To increase the amount of request or response body included in SDK HTTP logs, set `DATABRICKS_DEBUG_TRUNCATE_BYTES`.
+
+```bash
+TF_LOG=DEBUG \
+DATABRICKS_DEBUG_TRUNCATE_BYTES=250000 \
+./terraform-provider-databricks exporter -skip-interactive -listing jobs -services jobs
+```
 
 ### Use of `-listing` and `-services` for granular resources selection
 

--- a/exporter/command.go
+++ b/exporter/command.go
@@ -8,29 +8,12 @@ import (
 	"os"
 	"slices"
 	"strings"
-	"time"
 
 	"github.com/databricks/databricks-sdk-go/client"
 	"github.com/databricks/databricks-sdk-go/config"
 	"github.com/databricks/terraform-provider-databricks/common"
 	"golang.org/x/exp/maps"
 )
-
-type levelWriter []string
-
-var logLevel = levelWriter{"[INFO]", "[ERROR]", "[WARN]"}
-
-func (lw *levelWriter) Write(p []byte) (n int, err error) {
-	a := string(p)
-	for _, l := range *lw {
-		if strings.HasPrefix(a, l) {
-			timeStr := time.Now().Local().Format(time.RFC3339Nano)
-			logStr := a[0:len(l)] + " " + timeStr + ": " + strings.TrimLeft(a[len(l):len(a)-1], " ") + "\n"
-			return os.Stdout.WriteString(logStr)
-		}
-	}
-	return
-}
 
 func (ic *importContext) interactivePrompts() string {
 	req, _ := http.NewRequest("GET", "/", nil)
@@ -75,15 +58,8 @@ func (ic *importContext) interactivePrompts() string {
 
 // Run import according to flags
 func Run(args ...string) error {
-	log.SetOutput(&logLevel)
-	log.Printf("[WARN] This tooling is experimental and provided as is. It has an evolving interface, which may change or be removed in future versions of the provider.")
-	client, err := client.New(&config.Config{})
-	if err != nil {
-		return err
-	}
-	ic := newImportContext(&common.DatabricksClient{
-		DatabricksClient: client,
-	})
+	databricksClient := &common.DatabricksClient{}
+	ic := newImportContext(databricksClient)
 
 	flags := flag.NewFlagSet("exporter", flag.ExitOnError)
 	flags.StringVar(&ic.Module, "module", "",
@@ -112,8 +88,8 @@ func Run(args ...string) error {
 	flags.BoolVar(&ic.nativeImportSupported, "native-import", false, "Generate native import blocks (requires Terraform 1.5+)")
 	flags.StringVar(&ic.updatedSinceStr, "updated-since", "",
 		"Include only resources updated since a given timestamp (in ISO8601 format, i.e. 2023-07-01T00:00:00Z)")
-	flags.BoolVar(&debug, "debug", false, "Print extra debug information.")
-	flags.BoolVar(&trace, "trace", false, "Print full debug information.")
+	flags.BoolVar(&debug, "debug", false, "Print debug information, including Databricks Go SDK HTTP logs.")
+	flags.BoolVar(&trace, "trace", false, "Print trace information, including debug information and Databricks Go SDK HTTP logs.")
 	flags.BoolVar(&ic.mounts, "mounts", false, "List DBFS mount points.")
 	flags.BoolVar(&ic.generateDeclaration, "generateProviderDeclaration", true,
 		"Generate Databricks provider declaration.")
@@ -157,6 +133,16 @@ func Run(args ...string) error {
 	if err != nil {
 		return err
 	}
+
+	configureExporterLogging(debug, trace)
+	log.Printf("[WARN] This tooling is experimental and provided as is. It has an evolving interface, which may change or be removed in future versions of the provider.")
+
+	client, err := client.New(&config.Config{})
+	if err != nil {
+		return err
+	}
+	databricksClient.DatabricksClient = client
+
 	if !skipInteractive {
 		configuredListing = ic.interactivePrompts()
 	}
@@ -181,11 +167,6 @@ func Run(args ...string) error {
 		}
 		ic.nodeTypeMappings = mappings
 		log.Printf("[INFO] Loaded %d node type mappings from %s", len(mappings.Mappings), nodeTypeMappingFile)
-	}
-	if trace {
-		logLevel = append(logLevel, "[DEBUG]", "[TRACE]")
-	} else if debug {
-		logLevel = append(logLevel, "[DEBUG]")
 	}
 	ic.enableServices(configuredServices)
 	ic.enableListing(configuredListing)

--- a/exporter/logging.go
+++ b/exporter/logging.go
@@ -1,0 +1,112 @@
+package exporter
+
+import (
+	"io"
+	"log"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	sdklogger "github.com/databricks/databricks-sdk-go/logger"
+)
+
+type levelWriter struct {
+	prefixes []string
+	output   io.Writer
+}
+
+type exporterLogLevel struct {
+	name     string
+	sdkLevel sdklogger.Level
+	prefixes []string
+}
+
+func (lw *levelWriter) Write(p []byte) (n int, err error) {
+	a := string(p)
+	msg := strings.TrimSuffix(a, "\n")
+	for _, l := range lw.prefixes {
+		if strings.HasPrefix(a, l) {
+			timeStr := time.Now().Local().Format(time.RFC3339Nano)
+			logStr := msg[0:len(l)] + " " + timeStr + ": " + strings.TrimLeft(msg[len(l):], " ") + "\n"
+			output := lw.output
+			if output == nil {
+				output = os.Stdout
+			}
+			_, err := output.Write([]byte(logStr))
+			return len(p), err
+		}
+	}
+	return len(p), nil
+}
+
+func configureExporterLogging(debug, trace bool) exporterLogLevel {
+	level, warning := determineExporterLogLevel(debug, trace, os.Getenv("TF_LOG"))
+	log.SetOutput(&levelWriter{
+		prefixes: level.prefixes,
+		output:   os.Stdout,
+	})
+	sdklogger.DefaultLogger = &sdklogger.SimpleLogger{Level: level.sdkLevel}
+	if warning != "" {
+		log.Printf("[WARN] %s", warning)
+	}
+	return level
+}
+
+func determineExporterLogLevel(debug, trace bool, tfLog string) (exporterLogLevel, string) {
+	if trace {
+		return traceExporterLogLevel(), ""
+	}
+	if debug {
+		return debugExporterLogLevel(), ""
+	}
+
+	switch strings.ToUpper(strings.TrimSpace(tfLog)) {
+	case "":
+		return infoExporterLogLevel(), ""
+	case "ERROR":
+		return exporterLogLevel{
+			name:     "ERROR",
+			sdkLevel: sdklogger.LevelError,
+			prefixes: []string{"[ERROR]"},
+		}, ""
+	case "WARN":
+		return exporterLogLevel{
+			name:     "WARN",
+			sdkLevel: sdklogger.LevelWarn,
+			prefixes: []string{"[WARN]", "[ERROR]"},
+		}, ""
+	case "INFO":
+		return infoExporterLogLevel(), ""
+	case "DEBUG":
+		return debugExporterLogLevel(), ""
+	case "TRACE":
+		return traceExporterLogLevel(), ""
+	default:
+		return infoExporterLogLevel(), "Invalid TF_LOG value " + strconv.Quote(tfLog) + "; defaulting exporter logging to INFO. Valid values are: TRACE, DEBUG, INFO, WARN, ERROR"
+	}
+}
+
+func infoExporterLogLevel() exporterLogLevel {
+	return exporterLogLevel{
+		name:     "INFO",
+		sdkLevel: sdklogger.LevelInfo,
+		prefixes: []string{"[INFO]", "[WARN]", "[ERROR]"},
+	}
+}
+
+func debugExporterLogLevel() exporterLogLevel {
+	return exporterLogLevel{
+		name:     "DEBUG",
+		sdkLevel: sdklogger.LevelDebug,
+		prefixes: []string{"[DEBUG]", "[INFO]", "[WARN]", "[ERROR]"},
+	}
+}
+
+func traceExporterLogLevel() exporterLogLevel {
+	return exporterLogLevel{
+		name:     "TRACE",
+		sdkLevel: sdklogger.LevelTrace,
+		prefixes: []string{"[TRACE]", "[DEBUG]", "[INFO]", "[WARN]", "[ERROR]"},
+	}
+}

--- a/exporter/logging_test.go
+++ b/exporter/logging_test.go
@@ -1,0 +1,131 @@
+package exporter
+
+import (
+	"bytes"
+	"context"
+	"log"
+	"testing"
+
+	sdklogger "github.com/databricks/databricks-sdk-go/logger"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDetermineExporterLogLevel(t *testing.T) {
+	tests := []struct {
+		name        string
+		debug       bool
+		trace       bool
+		tfLog       string
+		wantName    string
+		wantSDK     sdklogger.Level
+		wantPrefix  []string
+		wantWarning string
+	}{
+		{
+			name:       "default info",
+			wantName:   "INFO",
+			wantSDK:    sdklogger.LevelInfo,
+			wantPrefix: []string{"[INFO]", "[WARN]", "[ERROR]"},
+		},
+		{
+			name:       "tf log error",
+			tfLog:      "ERROR",
+			wantName:   "ERROR",
+			wantSDK:    sdklogger.LevelError,
+			wantPrefix: []string{"[ERROR]"},
+		},
+		{
+			name:       "tf log warn",
+			tfLog:      "warn",
+			wantName:   "WARN",
+			wantSDK:    sdklogger.LevelWarn,
+			wantPrefix: []string{"[WARN]", "[ERROR]"},
+		},
+		{
+			name:       "tf log debug",
+			tfLog:      "DEBUG",
+			wantName:   "DEBUG",
+			wantSDK:    sdklogger.LevelDebug,
+			wantPrefix: []string{"[DEBUG]", "[INFO]", "[WARN]", "[ERROR]"},
+		},
+		{
+			name:       "tf log trace",
+			tfLog:      "TRACE",
+			wantName:   "TRACE",
+			wantSDK:    sdklogger.LevelTrace,
+			wantPrefix: []string{"[TRACE]", "[DEBUG]", "[INFO]", "[WARN]", "[ERROR]"},
+		},
+		{
+			name:       "debug overrides tf log",
+			debug:      true,
+			tfLog:      "ERROR",
+			wantName:   "DEBUG",
+			wantSDK:    sdklogger.LevelDebug,
+			wantPrefix: []string{"[DEBUG]", "[INFO]", "[WARN]", "[ERROR]"},
+		},
+		{
+			name:       "trace overrides debug",
+			debug:      true,
+			trace:      true,
+			tfLog:      "ERROR",
+			wantName:   "TRACE",
+			wantSDK:    sdklogger.LevelTrace,
+			wantPrefix: []string{"[TRACE]", "[DEBUG]", "[INFO]", "[WARN]", "[ERROR]"},
+		},
+		{
+			name:        "invalid tf log",
+			tfLog:       "verbose",
+			wantName:    "INFO",
+			wantSDK:     sdklogger.LevelInfo,
+			wantPrefix:  []string{"[INFO]", "[WARN]", "[ERROR]"},
+			wantWarning: `Invalid TF_LOG value "verbose"; defaulting exporter logging to INFO. Valid values are: TRACE, DEBUG, INFO, WARN, ERROR`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, warning := determineExporterLogLevel(tc.debug, tc.trace, tc.tfLog)
+			assert.Equal(t, tc.wantName, got.name)
+			assert.Equal(t, tc.wantSDK, got.sdkLevel)
+			assert.Equal(t, tc.wantPrefix, got.prefixes)
+			assert.Equal(t, tc.wantWarning, warning)
+		})
+	}
+}
+
+func TestConfigureExporterLoggingConfiguresSdkLogger(t *testing.T) {
+	previousOutput := log.Writer()
+	previousLogger := sdklogger.DefaultLogger
+	t.Cleanup(func() {
+		log.SetOutput(previousOutput)
+		sdklogger.DefaultLogger = previousLogger
+	})
+
+	t.Setenv("TF_LOG", "DEBUG")
+	level := configureExporterLogging(false, false)
+
+	assert.Equal(t, "DEBUG", level.name)
+	assert.True(t, sdklogger.DefaultLogger.Enabled(context.Background(), sdklogger.LevelDebug))
+	assert.False(t, sdklogger.DefaultLogger.Enabled(context.Background(), sdklogger.LevelTrace))
+}
+
+func TestLevelWriterFiltersAndFormatsMessages(t *testing.T) {
+	var buf bytes.Buffer
+	writer := &levelWriter{
+		prefixes: []string{"[INFO]"},
+		output:   &buf,
+	}
+
+	message := []byte("[DEBUG] hidden\n")
+	n, err := writer.Write(message)
+	assert.NoError(t, err)
+	assert.Equal(t, len(message), n)
+	assert.Empty(t, buf.String())
+
+	message = []byte("[INFO] visible\n")
+	n, err = writer.Write(message)
+	assert.NoError(t, err)
+	assert.Equal(t, len(message), n)
+	assert.Contains(t, buf.String(), "[INFO] ")
+	assert.Contains(t, buf.String(), ": visible\n")
+}


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

After Go SDK switched to different way of logging the payload, exporter lost the ability to capture the REST API calls and that made debugging much harder.  This PR makes relevant changes to correctly work with Go SDK logging.

## Tests
<!--
How is this tested? Please see the checklist below and also describe any other relevant tests
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [x] using Go SDK
- [ ] using TF Plugin Framework
- [x] has entry in `NEXT_CHANGELOG.md` file
