### PR TITLE
Send zero-value photon/serverless/continuous/development for pipelines

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bug Fixes
 
-* Fix `databricks_pipeline` so that `photon`, `serverless`, `continuous` and `development` set to `false` are sent in the create/update request. Previously these fields were silently dropped (Go SDK marshals the bool with `omitempty`), so the server applied its own default instead of the configured `false` ([#5806](https://github.com/databricks/terraform-provider-databricks/pull/5806)).
+* Fix `databricks_pipeline` so that `photon`, `serverless`, `continuous` and `development` set to `false` are sent in the create/update request if specified ([#5806](https://github.com/databricks/terraform-provider-databricks/pull/5806)).
 
 ### Documentation
 

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bug Fixes
 
+* Fix `databricks_pipeline` so that `photon`, `serverless`, `continuous` and `development` set to `false` are sent in the create/update request. Previously these fields were silently dropped (Go SDK marshals the bool with `omitempty`), so the server applied its own default instead of the configured `false` ([#5806](https://github.com/databricks/terraform-provider-databricks/pull/5806)).
+
 ### Documentation
 
 ### Exporter

--- a/pipelines/resource_pipeline.go
+++ b/pipelines/resource_pipeline.go
@@ -21,6 +21,12 @@ import (
 // DefaultTimeout is the default amount of time that Terraform will wait when creating, updating and deleting pipelines.
 const DefaultTimeout = 20 * time.Minute
 
+// booleanForceSendFields are optional boolean fields whose zero value (false)
+// is meaningful and must be sent to the platform. Without ForceSendFields the
+// Go SDK omits them, so an explicit `photon = false` (etc.) would be dropped
+// and the platform would apply its own default instead.
+var booleanForceSendFields = []string{"photon", "serverless", "continuous", "development"}
+
 func adjustForceSendFields(clusterList *[]pipelines.PipelineCluster) {
 	for i := range *clusterList {
 		cluster := &((*clusterList)[i])
@@ -39,6 +45,7 @@ func Create(w *databricks.WorkspaceClient, ctx context.Context, d *schema.Resour
 	var createPipelineRequest createPipelineRequestStruct
 	common.DataToStructPointer(d, pipelineSchema, &createPipelineRequest)
 	adjustForceSendFields(&createPipelineRequest.Clusters)
+	common.SetForceSendFields(&createPipelineRequest.CreatePipeline, d, booleanForceSendFields)
 
 	createdPipeline, err := w.Pipelines.Create(ctx, createPipelineRequest.CreatePipeline)
 	if err != nil {
@@ -71,6 +78,7 @@ func Update(w *databricks.WorkspaceClient, ctx context.Context, d *schema.Resour
 	common.DataToStructPointer(d, pipelineSchema, &updatePipelineRequest)
 	updatePipelineRequest.EditPipeline.PipelineId = d.Id()
 	adjustForceSendFields(&updatePipelineRequest.Clusters)
+	common.SetForceSendFields(&updatePipelineRequest.EditPipeline, d, booleanForceSendFields)
 	err := w.Pipelines.Update(ctx, updatePipelineRequest.EditPipeline)
 	if err != nil {
 		return err

--- a/pipelines/resource_pipeline_test.go
+++ b/pipelines/resource_pipeline_test.go
@@ -47,7 +47,7 @@ var createRequest = pipelines.CreatePipeline{
 	},
 	Edition: "ADVANCED",
 	Channel: "CURRENT",
-	// continuous = false is set explicitly in the HCL, so it is force-sent.
+	// TestResourcePipelineCreate sets continuous = false in its HCL, so it is force-sent.
 	ForceSendFields: []string{"Continuous"},
 }
 

--- a/pipelines/resource_pipeline_test.go
+++ b/pipelines/resource_pipeline_test.go
@@ -47,6 +47,8 @@ var createRequest = pipelines.CreatePipeline{
 	},
 	Edition: "ADVANCED",
 	Channel: "CURRENT",
+	// continuous = false is set explicitly in the HCL, so it is force-sent.
+	ForceSendFields: []string{"Continuous"},
 }
 
 var updateRequest = pipelines.EditPipeline{


### PR DESCRIPTION
## Changes

These optional boolean fields have meaningful false values, but the Go SDK omits them unless they are listed in ForceSendFields. As a result an explicit `photon = false` (or serverless/continuous/development) in the config was dropped from the create/update request and the platform applied its own default instead.

Call SetForceSendFields for these fields in Create and Update so that a user-specified false value is sent to the platform.

## Tests
Tested with DABs: https://github.com/databricks/terraform-provider-databricks/pull/5806#issuecomment-4702895436

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] using Go SDK
- [ ] using TF Plugin Framework
- [x] has entry in `NEXT_CHANGELOG.md` file
