### PR TITLE
[Internal] Use Go SDK for `databricks_mws_log_delivery`

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -19,3 +19,5 @@
 * Rewrote Exporter logging so it works with Databricks Go SDK logging ([#5805](https://github.com/databricks/terraform-provider-databricks/pull/5805)).
 
 ### Internal Changes
+
+* Use Go SDK for `databricks_mws_log_delivery` ([#5807](https://github.com/databricks/terraform-provider-databricks/pull/5807)).

--- a/mws/resource_mws_log_delivery.go
+++ b/mws/resource_mws_log_delivery.go
@@ -4,120 +4,111 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/databricks/terraform-provider-databricks/common"
-
+	"github.com/databricks/databricks-sdk-go/apierr"
+	"github.com/databricks/databricks-sdk-go/service/billing"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/databricks/terraform-provider-databricks/common"
 )
-
-// LogDelivery wrapper
-type LogDelivery struct {
-	LogDeliveryConfiguration LogDeliveryConfiguration `json:"log_delivery_configuration"`
-}
-
-// LogDeliveryConfiguration describes log delivery
-type LogDeliveryConfiguration struct {
-	AccountID              string  `json:"account_id" tf:"force_new"`
-	ConfigID               string  `json:"config_id,omitempty" tf:"computed,force_new"`
-	CredentialsID          string  `json:"credentials_id" tf:"force_new"`
-	StorageConfigurationID string  `json:"storage_configuration_id" tf:"force_new"`
-	WorkspaceIdsFilter     []int64 `json:"workspace_ids_filter,omitempty" tf:"force_new"`
-	ConfigName             string  `json:"config_name,omitempty" tf:"force_new"`
-	Status                 string  `json:"status,omitempty" tf:"computed"`
-	LogType                string  `json:"log_type" tf:"force_new"`
-	OutputFormat           string  `json:"output_format" tf:"force_new"`
-	DeliveryPathPrefix     string  `json:"delivery_path_prefix,omitempty" tf:"force_new"`
-	DeliveryStartTime      string  `json:"delivery_start_time,omitempty" tf:"computed,force_new"`
-}
-
-// LogDeliveryAPI ...
-type LogDeliveryAPI struct {
-	client  *common.DatabricksClient
-	context context.Context
-}
-
-// NewLogDeliveryAPI ...
-func NewLogDeliveryAPI(ctx context.Context, m any) LogDeliveryAPI {
-	return LogDeliveryAPI{m.(*common.DatabricksClient), ctx}
-}
-
-// Read reads log delivery configuration
-func (a LogDeliveryAPI) Read(accountID, configID string) (LogDeliveryConfiguration, error) {
-	var ld LogDelivery
-	err := a.client.Get(a.context, fmt.Sprintf("/accounts/%s/log-delivery/%s", accountID, configID), nil, &ld)
-	return ld.LogDeliveryConfiguration, err
-}
-
-// Create new log delivery configuration
-func (a LogDeliveryAPI) Create(ldc LogDeliveryConfiguration) (string, error) {
-	var ld LogDelivery
-	err := a.client.Post(a.context, fmt.Sprintf("/accounts/%s/log-delivery", ldc.AccountID), LogDelivery{
-		LogDeliveryConfiguration: ldc,
-	}, &ld)
-	// todo: verify with empty response - structs should have empty default strings
-	return ld.LogDeliveryConfiguration.ConfigID, err
-}
-
-// patch log delivery configuration - i.e. can only enable or disable it
-func (a LogDeliveryAPI) Patch(accountID, configID string, status string) error {
-	return a.client.Patch(a.context, fmt.Sprintf("/accounts/%s/log-delivery/%s", accountID, configID), map[string]string{
-		"status": status,
-	})
-}
 
 func ResourceMwsLogDelivery() common.Resource {
 	p := common.NewPairID("account_id", "config_id")
-	s := common.StructToSchema(LogDeliveryConfiguration{},
+	s := common.StructToSchema(billing.CreateLogDeliveryConfigurationParams{},
 		func(s map[string]*schema.Schema) map[string]*schema.Schema {
-			// nolint
-			s["config_name"].ValidateFunc = validation.StringLenBetween(0, 255)
-			s["delivery_start_time"].DiffSuppressFunc = func(
+			s["account_id"] = &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			}
+			s["config_id"] = &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+				ForceNew: true,
+			}
+
+			for _, field := range []string{
+				"config_name",
+				"credentials_id",
+				"delivery_path_prefix",
+				"delivery_start_time",
+				"log_type",
+				"output_format",
+				"storage_configuration_id",
+				"workspace_ids_filter",
+			} {
+				common.CustomizeSchemaPath(s, field).SetForceNew()
+			}
+			common.CustomizeSchemaPath(s, "config_name").SetValidateFunc(validation.StringLenBetween(0, 255))
+			common.CustomizeSchemaPath(s, "delivery_start_time").SetComputed().SetCustomSuppressDiff(func(
 				k, old, new string, d *schema.ResourceData) bool {
 				return false
-			}
+			})
+			common.CustomizeSchemaPath(s, "status").SetComputed()
 			return s
 		})
 	return common.Resource{
 		Schema: s,
 		Create: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
-			var ldc LogDeliveryConfiguration
-			common.DataToStructPointer(d, s, &ldc)
-			configID, err := NewLogDeliveryAPI(ctx, c).Create(ldc)
+			acc, err := c.AccountClientWithAccountIdFromConfig(d)
 			if err != nil {
 				return err
 			}
-			if err = d.Set("config_id", configID); err != nil {
+			var create billing.CreateLogDeliveryConfigurationParams
+			common.DataToStructPointer(d, s, &create)
+			response, err := acc.LogDelivery.Create(ctx, billing.WrappedCreateLogDeliveryConfiguration{
+				LogDeliveryConfiguration: create,
+			})
+			if err != nil {
+				return err
+			}
+			if response.LogDeliveryConfiguration == nil {
+				return fmt.Errorf("empty log delivery configuration response")
+			}
+			if err = d.Set("config_id", response.LogDeliveryConfiguration.ConfigId); err != nil {
 				return err
 			}
 			p.Pack(d)
 			return nil
 		},
 		Update: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
-			var ldc LogDeliveryConfiguration
-			common.DataToStructPointer(d, s, &ldc)
-			err := NewLogDeliveryAPI(ctx, c).Patch(ldc.AccountID, ldc.ConfigID, ldc.Status)
+			acc, configID, err := c.AccountClientWithAccountIdFromPair(d, p)
 			if err != nil {
 				return err
 			}
-			return common.StructToData(ldc, s, d)
+			return acc.LogDelivery.PatchStatus(ctx, billing.UpdateLogDeliveryConfigurationStatusRequest{
+				LogDeliveryConfigurationId: configID,
+				Status:                     billing.LogDeliveryConfigStatus(d.Get("status").(string)),
+			})
 		},
 		Read: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
-			accountID, configID, err := p.Unpack(d)
+			acc, configID, err := c.AccountClientWithAccountIdFromPair(d, p)
 			if err != nil {
 				return err
 			}
-			ldc, err := NewLogDeliveryAPI(ctx, c).Read(accountID, configID)
+			response, err := acc.LogDelivery.GetByLogDeliveryConfigurationId(ctx, configID)
 			if err != nil {
 				return err
 			}
-			return common.StructToData(ldc, s, d)
+			if response.LogDeliveryConfiguration == nil {
+				return fmt.Errorf("log delivery configuration not found: %w", apierr.ErrNotFound)
+			}
+			if response.LogDeliveryConfiguration.ConfigId == "" &&
+				response.LogDeliveryConfiguration.Status == billing.LogDeliveryConfigStatusDisabled {
+				d.SetId("")
+				return nil
+			}
+			return common.StructToData(response.LogDeliveryConfiguration, s, d)
 		},
 		Delete: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
-			accountID, configID, err := p.Unpack(d)
+			acc, configID, err := c.AccountClientWithAccountIdFromPair(d, p)
 			if err != nil {
 				return err
 			}
-			return NewLogDeliveryAPI(ctx, c).Patch(accountID, configID, "DISABLED")
+			return acc.LogDelivery.PatchStatus(ctx, billing.UpdateLogDeliveryConfigurationStatusRequest{
+				LogDeliveryConfigurationId: configID,
+				Status:                     billing.LogDeliveryConfigStatusDisabled,
+			})
 		},
 	}
 }

--- a/mws/resource_mws_log_delivery_test.go
+++ b/mws/resource_mws_log_delivery_test.go
@@ -4,57 +4,50 @@ import (
 	"testing"
 
 	"github.com/databricks/databricks-sdk-go/apierr"
-	"github.com/databricks/terraform-provider-databricks/qa"
-
+	"github.com/databricks/databricks-sdk-go/experimental/mocks"
+	"github.com/databricks/databricks-sdk-go/service/billing"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/databricks/terraform-provider-databricks/qa"
 )
 
-func TestResourceLogDeliveryCreate(t *testing.T) {
-	d, err := qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:   "POST",
-				Resource: "/api/2.0/accounts/abc/log-delivery",
-				ExpectedRequest: LogDelivery{
-					LogDeliveryConfiguration: LogDeliveryConfiguration{
-						AccountID:              "abc",
-						ConfigName:             "Audit logs",
-						CredentialsID:          "bcd",
-						DeliveryPathPrefix:     "/a/b",
-						LogType:                "AUDIT_LOGS",
-						OutputFormat:           "JSON",
-						StorageConfigurationID: "def",
-						DeliveryStartTime:      "2020-10",
-						WorkspaceIdsFilter:     []int64{1111111111111111, 222222222222222},
-					},
-				},
-				Response: LogDelivery{
-					LogDeliveryConfiguration: LogDeliveryConfiguration{
-						ConfigID: "nid",
-					},
-				},
-			},
-			{
-				Method:   "GET",
-				Resource: "/api/2.0/accounts/abc/log-delivery/nid",
-				Response: LogDelivery{
-					LogDeliveryConfiguration: LogDeliveryConfiguration{
-						ConfigID:               "nid",
-						AccountID:              "abc",
-						ConfigName:             "Audit logs",
-						CredentialsID:          "bcd",
-						DeliveryPathPrefix:     "/a/b",
-						LogType:                "AUDIT_LOGS",
-						OutputFormat:           "JSON",
-						StorageConfigurationID: "def",
-						DeliveryStartTime:      "2020-10",
-						WorkspaceIdsFilter:     []int64{1111111111111111, 222222222222222},
-					},
-				},
-			},
+func testLogDeliveryCreateRequest(status billing.LogDeliveryConfigStatus) billing.WrappedCreateLogDeliveryConfiguration {
+	return billing.WrappedCreateLogDeliveryConfiguration{
+		LogDeliveryConfiguration: billing.CreateLogDeliveryConfigurationParams{
+			ConfigName:             "Audit logs",
+			CredentialsId:          "bcd",
+			DeliveryPathPrefix:     "/a/b",
+			LogType:                billing.LogTypeAuditLogs,
+			OutputFormat:           billing.OutputFormatJson,
+			StorageConfigurationId: "def",
+			DeliveryStartTime:      "2020-10",
+			Status:                 status,
+			WorkspaceIdsFilter:     []int64{1111111111111111, 222222222222222},
 		},
-		Resource: ResourceMwsLogDelivery(),
-		HCL: `
+	}
+}
+
+func testLogDeliveryResponse(status billing.LogDeliveryConfigStatus) *billing.GetLogDeliveryConfigurationResponse {
+	return &billing.GetLogDeliveryConfigurationResponse{
+		LogDeliveryConfiguration: &billing.LogDeliveryConfiguration{
+			ConfigId:               "nid",
+			AccountId:              "abc",
+			ConfigName:             "Audit logs",
+			CredentialsId:          "bcd",
+			DeliveryPathPrefix:     "/a/b",
+			LogType:                billing.LogTypeAuditLogs,
+			OutputFormat:           billing.OutputFormatJson,
+			StorageConfigurationId: "def",
+			DeliveryStartTime:      "2020-10",
+			Status:                 status,
+			WorkspaceIdsFilter:     []int64{1111111111111111, 222222222222222},
+		},
+	}
+}
+
+func testLogDeliveryHCL(status string) string {
+	hcl := `
 		account_id = "abc"
 		credentials_id = "bcd"
 		storage_configuration_id = "def"
@@ -63,155 +56,114 @@ func TestResourceLogDeliveryCreate(t *testing.T) {
 		output_format = "JSON"
 		delivery_path_prefix = "/a/b"
 		workspace_ids_filter = [1111111111111111, 222222222222222]
-		delivery_start_time = "2020-10"`,
-		Create: true,
-	}.Apply(t)
-	assert.NoError(t, err)
-	assert.Equal(t, "abc|nid", d.Id())
-	assert.Equal(t, "nid", d.Get("config_id"))
+		delivery_start_time = "2020-10"`
+	if status != "" {
+		hcl += `
+		status = "` + status + `"`
+	}
+	return hcl
+}
+
+func testLogDeliveryInstanceState(status string) map[string]string {
+	return map[string]string{
+		"account_id":               "abc",
+		"config_id":                "nid",
+		"config_name":              "Audit logs",
+		"credentials_id":           "bcd",
+		"delivery_path_prefix":     "/a/b",
+		"delivery_start_time":      "2020-10",
+		"id":                       "abc|nid",
+		"log_type":                 "AUDIT_LOGS",
+		"output_format":            "JSON",
+		"status":                   status,
+		"storage_configuration_id": "def",
+	}
+}
+
+func TestResourceLogDeliveryCreate(t *testing.T) {
+	qa.ResourceFixture{
+		MockAccountClientFunc: func(a *mocks.MockAccountClient) {
+			api := a.GetMockLogDeliveryAPI().EXPECT()
+			api.Create(mock.Anything, testLogDeliveryCreateRequest("")).
+				Return(&billing.WrappedLogDeliveryConfiguration{
+					LogDeliveryConfiguration: &billing.LogDeliveryConfiguration{ConfigId: "nid"},
+				}, nil)
+			api.GetByLogDeliveryConfigurationId(mock.Anything, "nid").Return(testLogDeliveryResponse(""), nil)
+		},
+		Resource: ResourceMwsLogDelivery(),
+		HCL:      testLogDeliveryHCL(""),
+		Create:   true,
+	}.ApplyAndExpectData(t, map[string]any{
+		"id":        "abc|nid",
+		"config_id": "nid",
+	})
 }
 
 func TestResourceLogDeliveryCreateDisabled(t *testing.T) {
-	d, err := qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:   "POST",
-				Resource: "/api/2.0/accounts/abc/log-delivery",
-				ExpectedRequest: LogDelivery{
-					LogDeliveryConfiguration: LogDeliveryConfiguration{
-						AccountID:              "abc",
-						ConfigName:             "Audit logs",
-						CredentialsID:          "bcd",
-						DeliveryPathPrefix:     "/a/b",
-						LogType:                "AUDIT_LOGS",
-						OutputFormat:           "JSON",
-						StorageConfigurationID: "def",
-						DeliveryStartTime:      "2020-10",
-						Status:                 "DISABLED",
-						WorkspaceIdsFilter:     []int64{1111111111111111, 222222222222222},
-					},
-				},
-				Response: LogDelivery{
-					LogDeliveryConfiguration: LogDeliveryConfiguration{
-						ConfigID: "nid",
-					},
-				},
-			},
-			{
-				Method:   "GET",
-				Resource: "/api/2.0/accounts/abc/log-delivery/nid",
-				Response: LogDelivery{
-					LogDeliveryConfiguration: LogDeliveryConfiguration{
-						ConfigID:               "nid",
-						AccountID:              "abc",
-						ConfigName:             "Audit logs",
-						CredentialsID:          "bcd",
-						DeliveryPathPrefix:     "/a/b",
-						LogType:                "AUDIT_LOGS",
-						OutputFormat:           "JSON",
-						StorageConfigurationID: "def",
-						DeliveryStartTime:      "2020-10",
-						Status:                 "DISABLED",
-						WorkspaceIdsFilter:     []int64{1111111111111111, 222222222222222},
-					},
-				},
-			},
+	qa.ResourceFixture{
+		MockAccountClientFunc: func(a *mocks.MockAccountClient) {
+			api := a.GetMockLogDeliveryAPI().EXPECT()
+			api.Create(mock.Anything, testLogDeliveryCreateRequest(billing.LogDeliveryConfigStatusDisabled)).
+				Return(&billing.WrappedLogDeliveryConfiguration{
+					LogDeliveryConfiguration: &billing.LogDeliveryConfiguration{ConfigId: "nid"},
+				}, nil)
+			api.GetByLogDeliveryConfigurationId(mock.Anything, "nid").
+				Return(testLogDeliveryResponse(billing.LogDeliveryConfigStatusDisabled), nil)
 		},
 		Resource: ResourceMwsLogDelivery(),
-		HCL: `
-		account_id = "abc"
-		credentials_id = "bcd"
-		storage_configuration_id = "def"
-		config_name = "Audit logs"
-		log_type = "AUDIT_LOGS"
-		output_format = "JSON"
-		delivery_path_prefix = "/a/b"
-		workspace_ids_filter = [1111111111111111, 222222222222222]
-		delivery_start_time = "2020-10"
-		status = "DISABLED"`,
-		Create: true,
-	}.Apply(t)
-	assert.NoError(t, err)
-	assert.Equal(t, "abc|nid", d.Id())
-	assert.Equal(t, "nid", d.Get("config_id"))
+		HCL:      testLogDeliveryHCL("DISABLED"),
+		Create:   true,
+	}.ApplyAndExpectData(t, map[string]any{
+		"id":        "abc|nid",
+		"config_id": "nid",
+		"status":    "DISABLED",
+	})
 }
 
 func TestResourceLogDeliveryCreate_Error(t *testing.T) {
 	d, err := qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:   "POST",
-				Resource: "/api/2.0/accounts/abc/log-delivery",
-				Response: apierr.APIError{
-					ErrorCode: "INVALID_REQUEST",
-					Message:   "Internal error happened",
-				},
-				Status: 400,
-			},
+		MockAccountClientFunc: func(a *mocks.MockAccountClient) {
+			a.GetMockLogDeliveryAPI().EXPECT().Create(mock.Anything, mock.Anything).
+				Return(nil, &apierr.APIError{
+					ErrorCode:  "INVALID_REQUEST",
+					Message:    "Internal error happened",
+					StatusCode: 400,
+				})
 		},
 		Resource: ResourceMwsLogDelivery(),
-		HCL: `
-		account_id = "abc"
-		credentials_id = "bcd"
-		storage_configuration_id = "def"
-		config_name = "Audit logs"
-		log_type = "AUDIT_LOGS"
-		output_format = "JSON"
-		delivery_path_prefix = "/a/b"
-		workspace_ids_filter = [1111111111111111, 222222222222222]
-		delivery_start_time = "2020-10"`,
-		Create: true,
+		HCL:      testLogDeliveryHCL(""),
+		Create:   true,
 	}.Apply(t)
 	qa.AssertErrorStartsWith(t, err, "Internal error happened")
 	assert.Equal(t, "", d.Id(), "Id should be empty for error creates")
 }
 
 func TestResourceLogDeliveryRead(t *testing.T) {
-	d, err := qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:   "GET",
-				Resource: "/api/2.0/accounts/abc/log-delivery/nid",
-				Response: LogDelivery{
-					LogDeliveryConfiguration: LogDeliveryConfiguration{
-						ConfigID:               "nid",
-						Status:                 "ENABLED",
-						AccountID:              "abc",
-						ConfigName:             "Audit logs",
-						CredentialsID:          "bcd",
-						DeliveryPathPrefix:     "/a/b",
-						LogType:                "AUDIT_LOGS",
-						OutputFormat:           "JSON",
-						StorageConfigurationID: "def",
-						DeliveryStartTime:      "2020-10",
-						WorkspaceIdsFilter:     []int64{1111111111111111, 222222222222222},
-					},
-				},
-			},
+	qa.ResourceFixture{
+		MockAccountClientFunc: func(a *mocks.MockAccountClient) {
+			a.GetMockLogDeliveryAPI().EXPECT().GetByLogDeliveryConfigurationId(mock.Anything, "nid").
+				Return(testLogDeliveryResponse(billing.LogDeliveryConfigStatusEnabled), nil)
 		},
 		Resource: ResourceMwsLogDelivery(),
 		Read:     true,
 		New:      true,
 		ID:       "abc|nid",
-	}.Apply(t)
-	assert.NoError(t, err)
-	assert.Equal(t, "abc|nid", d.Id(), "Id should not be empty")
-	assert.Equal(t, "bcd", d.Get("credentials_id"))
-	assert.Equal(t, "def", d.Get("storage_configuration_id"))
+	}.ApplyAndExpectData(t, map[string]any{
+		"id":                       "abc|nid",
+		"credentials_id":           "bcd",
+		"storage_configuration_id": "def",
+	})
 }
 
 func TestResourceLogDeliveryRead_NotFound(t *testing.T) {
 	qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:   "GET",
-				Resource: "/api/2.0/accounts/abc/log-delivery/nid",
-				Response: LogDelivery{
-					LogDeliveryConfiguration: LogDeliveryConfiguration{
-						Status: "DISABLED",
+		MockAccountClientFunc: func(a *mocks.MockAccountClient) {
+			a.GetMockLogDeliveryAPI().EXPECT().GetByLogDeliveryConfigurationId(mock.Anything, "nid").
+				Return(&billing.GetLogDeliveryConfigurationResponse{
+					LogDeliveryConfiguration: &billing.LogDeliveryConfiguration{
+						Status: billing.LogDeliveryConfigStatusDisabled,
 					},
-				},
-			},
+				}, nil)
 		},
 		Resource: ResourceMwsLogDelivery(),
 		Read:     true,
@@ -222,16 +174,13 @@ func TestResourceLogDeliveryRead_NotFound(t *testing.T) {
 
 func TestResourceLogDeliveryRead_Error(t *testing.T) {
 	d, err := qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:   "GET",
-				Resource: "/api/2.0/accounts/abc/log-delivery/nid",
-				Response: apierr.APIError{
-					ErrorCode: "INVALID_REQUEST",
-					Message:   "Internal error happened",
-				},
-				Status: 400,
-			},
+		MockAccountClientFunc: func(a *mocks.MockAccountClient) {
+			a.GetMockLogDeliveryAPI().EXPECT().GetByLogDeliveryConfigurationId(mock.Anything, "nid").
+				Return(nil, &apierr.APIError{
+					ErrorCode:  "INVALID_REQUEST",
+					Message:    "Internal error happened",
+					StatusCode: 400,
+				})
 		},
 		Resource: ResourceMwsLogDelivery(),
 		Read:     true,
@@ -243,138 +192,74 @@ func TestResourceLogDeliveryRead_Error(t *testing.T) {
 
 func TestUpdateLogDelivery(t *testing.T) {
 	qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:   "PATCH",
-				Resource: "/api/2.0/accounts/abc/log-delivery/nid",
-				ExpectedRequest: map[string]any{
-					"status": "ENABLED",
-				},
-			},
-			{
-				Method:   "GET",
-				Resource: "/api/2.0/accounts/abc/log-delivery/nid",
-				Response: LogDelivery{
-					LogDeliveryConfiguration: LogDeliveryConfiguration{
-						ConfigID:               "nid",
-						Status:                 "ENABLED",
-						AccountID:              "abc",
-						ConfigName:             "Audit logs",
-						CredentialsID:          "bcd",
-						DeliveryPathPrefix:     "/a/b",
-						LogType:                "AUDIT_LOGS",
-						OutputFormat:           "JSON",
-						StorageConfigurationID: "def",
-						DeliveryStartTime:      "2020-10",
-					},
-				},
-			},
+		MockAccountClientFunc: func(a *mocks.MockAccountClient) {
+			api := a.GetMockLogDeliveryAPI().EXPECT()
+			api.PatchStatus(mock.Anything, billing.UpdateLogDeliveryConfigurationStatusRequest{
+				LogDeliveryConfigurationId: "nid",
+				Status:                     billing.LogDeliveryConfigStatusEnabled,
+			}).Return(nil)
+			api.GetByLogDeliveryConfigurationId(mock.Anything, "nid").
+				Return(testLogDeliveryResponse(billing.LogDeliveryConfigStatusEnabled), nil)
 		},
-		Resource:    ResourceMwsLogDelivery(),
-		ID:          "abc|nid",
-		Update:      true,
-		RequiresNew: true,
-		InstanceState: map[string]string{
-			"account_id":               "abc",
-			"config_id":                "nid",
-			"config_name":              "Audit logs",
-			"credentials_id":           "bcd",
-			"delivery_path_prefix":     "/a/b",
-			"delivery_start_time":      "2020-10",
-			"id":                       "abc|nid",
-			"log_type":                 "AUDIT_LOGS",
-			"output_format":            "JSON",
-			"status":                   "DISABLED",
-			"storage_configuration_id": "def",
-		},
-		HCL: `
-		account_id = "abc"
-		credentials_id = "bcd"
-		storage_configuration_id = "def"
-		config_name = "Audit logs"
-		log_type = "AUDIT_LOGS"
-		output_format = "JSON"
-		delivery_path_prefix = "/a/b"
-		delivery_start_time = "2020-10"
-		status = "ENABLED"
-		`,
-	}.ApplyNoError(t)
+		Resource:      ResourceMwsLogDelivery(),
+		ID:            "abc|nid",
+		Update:        true,
+		RequiresNew:   true,
+		InstanceState: testLogDeliveryInstanceState("DISABLED"),
+		HCL:           testLogDeliveryHCL("ENABLED"),
+	}.ApplyAndExpectData(t, map[string]any{
+		"id":     "abc|nid",
+		"status": "ENABLED",
+	})
 }
 
 func TestUpdateLogDeliveryError(t *testing.T) {
 	_, err := qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:   "PATCH",
-				Resource: "/api/2.0/accounts/abc/log-delivery/nid",
-				Response: apierr.APIError{
-					ErrorCode: "INVALID_REQUEST",
-					Message:   "Internal error happened",
-				},
-				Status: 400,
-			},
+		MockAccountClientFunc: func(a *mocks.MockAccountClient) {
+			a.GetMockLogDeliveryAPI().EXPECT().PatchStatus(mock.Anything, billing.UpdateLogDeliveryConfigurationStatusRequest{
+				LogDeliveryConfigurationId: "nid",
+				Status:                     billing.LogDeliveryConfigStatusEnabled,
+			}).Return(&apierr.APIError{
+				ErrorCode:  "INVALID_REQUEST",
+				Message:    "Internal error happened",
+				StatusCode: 400,
+			})
 		},
-		Resource:    ResourceMwsLogDelivery(),
-		ID:          "abc|nid",
-		Update:      true,
-		RequiresNew: true,
-		InstanceState: map[string]string{
-			"account_id":               "abc",
-			"config_id":                "nid",
-			"config_name":              "Audit logs",
-			"credentials_id":           "bcd",
-			"delivery_path_prefix":     "/a/b",
-			"delivery_start_time":      "2020-10",
-			"id":                       "abc|nid",
-			"log_type":                 "AUDIT_LOGS",
-			"output_format":            "JSON",
-			"status":                   "DISABLED",
-			"storage_configuration_id": "def",
-		},
-		HCL: `
-		account_id = "abc"
-		credentials_id = "bcd"
-		storage_configuration_id = "def"
-		config_name = "Audit logs"
-		log_type = "AUDIT_LOGS"
-		output_format = "JSON"
-		delivery_path_prefix = "/a/b"
-		delivery_start_time = "2020-10"
-		status = "ENABLED"
-		`,
+		Resource:      ResourceMwsLogDelivery(),
+		ID:            "abc|nid",
+		Update:        true,
+		RequiresNew:   true,
+		InstanceState: testLogDeliveryInstanceState("DISABLED"),
+		HCL:           testLogDeliveryHCL("ENABLED"),
 	}.Apply(t)
 	qa.AssertErrorStartsWith(t, err, "Internal error happened")
 }
 
 func TestResourceLogDeliveryDelete(t *testing.T) {
 	qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:   "PATCH",
-				Resource: "/api/2.0/accounts/abc/log-delivery/nid",
-				ExpectedRequest: map[string]string{
-					"status": "DISABLED",
-				},
-			},
+		MockAccountClientFunc: func(a *mocks.MockAccountClient) {
+			a.GetMockLogDeliveryAPI().EXPECT().PatchStatus(mock.Anything, billing.UpdateLogDeliveryConfigurationStatusRequest{
+				LogDeliveryConfigurationId: "nid",
+				Status:                     billing.LogDeliveryConfigStatusDisabled,
+			}).Return(nil)
 		},
 		Resource: ResourceMwsLogDelivery(),
 		Delete:   true,
 		ID:       "abc|nid",
-	}.ApplyNoError(t)
+	}.ApplyAndExpectData(t, nil)
 }
 
 func TestResourceLogDeliveryDelete_Error(t *testing.T) {
 	d, err := qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{
-			{
-				Method:   "PATCH",
-				Resource: "/api/2.0/accounts/abc/log-delivery/nid",
-				Response: apierr.APIError{
-					ErrorCode: "INVALID_REQUEST",
-					Message:   "Internal error happened",
-				},
-				Status: 400,
-			},
+		MockAccountClientFunc: func(a *mocks.MockAccountClient) {
+			a.GetMockLogDeliveryAPI().EXPECT().PatchStatus(mock.Anything, billing.UpdateLogDeliveryConfigurationStatusRequest{
+				LogDeliveryConfigurationId: "nid",
+				Status:                     billing.LogDeliveryConfigStatusDisabled,
+			}).Return(&apierr.APIError{
+				ErrorCode:  "INVALID_REQUEST",
+				Message:    "Internal error happened",
+				StatusCode: 400,
+			})
 		},
 		Resource: ResourceMwsLogDelivery(),
 		Delete:   true,


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

It's better to use Go SDK instead of using manually written structs/APIs

ALLOW_SCHEMA_BREAKING_CHANGE=true

`config_id` was never settable by users

## Tests
<!--
How is this tested? Please see the checklist below and also describe any other relevant tests
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [x] using Go SDK
- [ ] using TF Plugin Framework
- [x] has entry in `NEXT_CHANGELOG.md` file
