### PR TITLE
Detect schema-generation failures separately from breaking changes

### DIFF
--- a/.github/workflows/schema.yml
+++ b/.github/workflows/schema.yml
@@ -93,6 +93,13 @@ jobs:
         env:
           BASE_COMMIT: ${{ github.event_name == 'pull_request' && github.base_ref || github.event.inputs.base }}
           CLASSIFIER_REPORT: /tmp/classifier-report.md
+          # diff-schema.sh touches this file when `terraform providers schema -json`
+          # produces an empty / non-JSON output (typically a provider panic during
+          # schema introspection). Lets the status job distinguish "schema gen
+          # failed" from "breaking changes detected" — and skip the bypass
+          # directive in the gen-failure case (it's a provider bug, not an
+          # intentional break).
+          CLASSIFIER_GENERATION_ERROR_MARKER: /tmp/classifier-generation-error
         run: make diff-schema
 
       # Persist the step outcome so the downstream status job can read it.
@@ -109,6 +116,7 @@ jobs:
           path: |
             /tmp/classifier-report.md
             /tmp/classifier-outcome.txt
+            /tmp/classifier-generation-error
           if-no-files-found: warn
           retention-days: 3
 
@@ -157,6 +165,15 @@ jobs:
             outcome="unknown"
           fi
           echo "classify=${outcome}" >> "$GITHUB_OUTPUT"
+          # diff-schema.sh touches this marker when schema generation (terraform
+          # providers schema -json) failed on either side, typically because the
+          # provider panicked. The bypass directive must NOT apply in that case
+          # — generation failures are provider bugs, not intentional breaks.
+          if [ -f /tmp/classifier-generation-error ]; then
+            echo "generation-error=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "generation-error=false" >> "$GITHUB_OUTPUT"
+          fi
 
       # Sticky comment. Uses continue-on-error so that on fork PRs (where
       # GITHUB_TOKEN is read-only) the inability to post a comment doesn't
@@ -170,6 +187,7 @@ jobs:
           MARKER: "<!-- SCHEMA_BREAKING_CHECK -->"
           CLASSIFY_OUTCOME: ${{ steps.outcome.outputs.classify }}
           BYPASS_ALLOWED: ${{ steps.bypass.outputs.allow }}
+          GENERATION_ERROR: ${{ steps.outcome.outputs.generation-error }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
         run: |
@@ -189,26 +207,32 @@ jobs:
           {
             echo "${MARKER}"
             echo
-            if [ "${BYPASS_ALLOWED}" = "true" ]; then
-              echo "## Breaking schema changes detected (bypass active)"
-              echo
-              echo "This PR carries \`ALLOW_SCHEMA_BREAKING_CHANGE=true\` on its own line in the description, so the breaking-schema check is **not blocking**. Please review the changes below carefully."
-            else
-              echo "## Breaking schema changes detected"
-            fi
-            echo
-            if [ -s /tmp/classifier-report.md ]; then
+            if [ "${GENERATION_ERROR}" = "true" ]; then
+              # The report file already carries its own header explaining the
+              # generation failure — just paste it through, no wrapper heading.
               cat /tmp/classifier-report.md
             else
-              echo "_(classifier report missing — see the classify job's log for details)_"
-            fi
-            if [ "${BYPASS_ALLOWED}" != "true" ]; then
+              if [ "${BYPASS_ALLOWED}" = "true" ]; then
+                echo "## Breaking schema changes detected (bypass active)"
+                echo
+                echo "This PR carries \`ALLOW_SCHEMA_BREAKING_CHANGE=true\` on its own line in the description, so the breaking-schema check is **not blocking**. Please review the changes below carefully."
+              else
+                echo "## Breaking schema changes detected"
+              fi
               echo
-              echo "<details><summary>How to bypass this check</summary>"
-              echo
-              echo "If the break is intentional, add \`ALLOW_SCHEMA_BREAKING_CHANGE=true\` on its own line in the PR description."
-              echo
-              echo "</details>"
+              if [ -s /tmp/classifier-report.md ]; then
+                cat /tmp/classifier-report.md
+              else
+                echo "_(classifier report missing — see the classify job's log for details)_"
+              fi
+              if [ "${BYPASS_ALLOWED}" != "true" ]; then
+                echo
+                echo "<details><summary>How to bypass this check</summary>"
+                echo
+                echo "If the break is intentional, add \`ALLOW_SCHEMA_BREAKING_CHANGE=true\` on its own line in the PR description."
+                echo
+                echo "</details>"
+              fi
             fi
           } > "${body}"
           if [ -z "${prev}" ]; then
@@ -222,13 +246,25 @@ jobs:
           fi
 
       - name: Fail on breaking changes without bypass
-        if: steps.outcome.outputs.classify != 'success' && steps.bypass.outputs.allow != 'true'
+        # Bypass applies to ordinary breaking changes only. Generation errors
+        # (provider panics during schema dump) always fail, regardless of the
+        # bypass directive — those are provider bugs that block the check
+        # entirely, not intentional schema changes.
+        if: |
+          steps.outcome.outputs.classify != 'success' &&
+          (steps.outcome.outputs.generation-error == 'true' ||
+           steps.bypass.outputs.allow != 'true')
         run: |
-          echo "Breaking schema changes detected. See the classifier report in the classify job's logs."
-          echo
-          echo "If the break is intentional, add this line on its own in the PR description:"
-          echo
-          echo "    ALLOW_SCHEMA_BREAKING_CHANGE=true"
-          echo
-          echo "The workflow will re-fire on the next 'edited' event and pick up the bypass."
+          if [ "${{ steps.outcome.outputs.generation-error }}" = "true" ]; then
+            echo "Schema generation failed — see the classify job's logs for the provider panic or other error."
+            echo "The ALLOW_SCHEMA_BREAKING_CHANGE bypass does NOT apply to generation failures. Fix the underlying provider bug."
+          else
+            echo "Breaking schema changes detected. See the classifier report in the classify job's logs."
+            echo
+            echo "If the break is intentional, add this line on its own in the PR description:"
+            echo
+            echo "    ALLOW_SCHEMA_BREAKING_CHANGE=true"
+            echo
+            echo "The workflow will re-fire on the next 'edited' event and pick up the bypass."
+          fi
           exit 1

--- a/scripts/diff-schema.sh
+++ b/scripts/diff-schema.sh
@@ -15,6 +15,47 @@ checkout() {
     git checkout $ref
 }
 
+# require_valid_schema bails out cleanly when `terraform providers schema -json`
+# produced an empty or non-JSON file (typically because the provider panicked
+# during schema introspection). Without this, we'd run the classifier against a
+# garbage schema and report misleading "breaking changes detected" results.
+#
+# When CLASSIFIER_REPORT is set, writes a markdown explanation there so the CI
+# status job can post it as the sticky comment. When CLASSIFIER_GENERATION_ERROR_MARKER
+# is set, touches that file so the status job can distinguish this case from a
+# real breaking change (the ALLOW_SCHEMA_BREAKING_CHANGE bypass should NOT apply
+# to generation failures — they're provider bugs, not intentional breaks).
+require_valid_schema() {
+    local side="$1"
+    local path="$2"
+    if [ -s "$path" ] && jq empty "$path" >/dev/null 2>&1; then
+        return 0
+    fi
+    echo >&2
+    echo "ERROR: \`terraform providers schema -json\` did not produce a valid schema for $side." >&2
+    echo "       Path \"$path\" is empty or non-JSON. Look earlier in this log for a provider panic." >&2
+    if [ -n "${CLASSIFIER_REPORT:-}" ]; then
+        cat > "$CLASSIFIER_REPORT" <<EOF
+## :warning: Schema generation failed on \`$side\`
+
+The breaking-schema check couldn't compare schemas because \`terraform providers schema -json\` failed for \`$side\`. Typically this means the provider **panicked** during schema introspection — look for a \`panic:\` line in the **classify** job's log.
+
+Common causes:
+- A new Plugin Framework resource / data source whose Go struct embeds another struct with complex (\`types.Object\` / \`types.List\` / \`types.Set\` / \`types.Map\`) fields, but the parent's \`GetComplexFieldTypes()\` doesn't include them.
+- Malformed \`tfsdk\` struct tags.
+- A panic in schema-customization code.
+
+**The \`ALLOW_SCHEMA_BREAKING_CHANGE\` bypass does NOT apply here** — this is a provider bug, not a breaking schema change. Fix the panic and push a new commit.
+EOF
+    fi
+    if [ -n "${CLASSIFIER_GENERATION_ERROR_MARKER:-}" ]; then
+        : > "$CLASSIFIER_GENERATION_ERROR_MARKER"
+    fi
+    # Best-effort restore so local dev doesn't end up stuck on the base ref.
+    git checkout "$HEAD_SHA" >/dev/null 2>&1 || true
+    exit 3
+}
+
 if [ -n "$(git status --porcelain)" ]; then
     echo "There are uncommitted changes. Please commit them before running this script."
     exit 1
@@ -28,8 +69,10 @@ fi
 go build -mod=mod -o /tmp/schema-classifier ./scripts/schema-classifier
 
 NEW_SCHEMA=$(generate_schema)
+require_valid_schema "HEAD" "$NEW_SCHEMA"
 checkout $BASE
 CURRENT_SCHEMA=$(generate_schema)
+require_valid_schema "BASE" "$CURRENT_SCHEMA"
 checkout $HEAD_SHA
 
 set +e


### PR DESCRIPTION
## Summary

The breaking-schema check added in #5786 has a correctness gap: when the head provider panics during schema introspection (e.g., a new Plugin Framework resource or data source whose Go struct embeds another struct with complex fields but doesn't declare them in `GetComplexFieldTypes()`), `terraform providers schema -json` produces an empty / non-JSON output. The classifier then runs against garbage input and the workflow ends up reporting "Breaking schema changes detected" with an **empty** sticky comment. Worse, the `ALLOW_SCHEMA_BREAKING_CHANGE` bypass applies to that case too — so a contributor could bypass and merge a PR whose provider can't even be loaded.

Concrete repro: PRs whose provider panicked with `complex field type not found for field ProviderConfig on type pools.InstancePoolInfo` produced an empty schema dump, and the check posted a misleading breaking-changes failure that didn't tell the author what actually went wrong.

## What changed

**`scripts/diff-schema.sh`** — new `require_valid_schema` helper, called right after each `generate_schema` invocation. It checks that the produced file is non-empty and parses as JSON; if not, it writes a clear markdown explanation to `$CLASSIFIER_REPORT` (when set), touches `$CLASSIFIER_GENERATION_ERROR_MARKER` (when set), restores `HEAD_SHA` so local dev doesn't end up stuck on the base ref, and exits 3 — without running the classifier on bad input.

**`.github/workflows/schema.yml`** —
1. The classify step now passes `CLASSIFIER_GENERATION_ERROR_MARKER: /tmp/classifier-generation-error` and the marker is included in the uploaded artifact.
2. The status job reads the marker and exposes it as a step output.
3. The sticky-comment step now has two paths: for generation failures it pastes the pre-baked report verbatim (the report carries its own `## :warning: Schema generation failed` heading), and for ordinary breaking changes it keeps the existing wrapper heading and bypass-instructions footer.
4. The fail step fires regardless of the bypass directive when the generation-error marker is set, with a message that says so explicitly. Generation failures are provider bugs, not intentional breaks, and the bypass directive does not apply.

## Behavior matrix

| Scenario | Before | After |
|---|---|---|
| Breaking change, no bypass | fail + sticky (correct) | unchanged |
| Breaking change, bypass active | pass + informational sticky (correct) | unchanged |
| No schema change | pass, sticky deleted | unchanged |
| **Schema-generation panic on HEAD, no bypass** | fail, sticky says "Breaking changes detected" with empty report (misleading) | fail, sticky shows the panic-explanation report directly |
| **Schema-generation panic on HEAD, bypass active** | **passes** — broken provider ships (bug) | **fails** — bypass intentionally does not apply |

## Test plan

- [x] `python3 -c 'import yaml; yaml.safe_load(open(".github/workflows/schema.yml"))'` — workflow YAML parses.
- [x] `bash -n scripts/diff-schema.sh` — shell syntax valid.
- [ ] CI on this PR confirms the existing-behavior paths (no schema change → pass) still work. The generation-failure path is harder to exercise from this PR directly, since this PR doesn't introduce a broken provider — a follow-up demo PR can verify if needed.

NO_CHANGELOG=true