### PR TITLE
Fix inert-path skip: use predicate-quantifier 'every' in detect-changes

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -45,15 +45,18 @@ jobs:
       labels: ubuntu-latest-deco
 
     outputs:
-      # paths-filter v3.0.2 doesn't support predicate-quantifier: 'every',
-      # so the filter computes "any non-inert file changed" and we invert
-      # here to expose the positive form the consumers want.
+      # non_inert lists changed files that are NOT inert; inert_only is the
+      # inverse. predicate-quantifier 'every' is required: a file is non_inert
+      # only if it matches ALL patterns ('**' AND none of the inert paths).
+      # The default 'some' would match any single pattern, and '**' matches
+      # everything, so non_inert would always be true and the skip never fire.
       inert_only: ${{ steps.filter.outputs.non_inert == 'false' }}
 
     steps:
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
         id: filter
         with:
+          predicate-quantifier: 'every'
           filters: |
             non_inert:
               - '**'

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -13,5 +13,3 @@
 ### Exporter
 
 ### Internal Changes
-
-* Fix the integration-test skip for inert-path PRs by setting `predicate-quantifier: 'every'` in the `detect-changes` paths filter ([#5816](https://github.com/databricks/terraform-provider-databricks/pull/5816)).

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -13,3 +13,5 @@
 ### Exporter
 
 ### Internal Changes
+
+* Fix the integration-test skip for inert-path PRs by setting `predicate-quantifier: 'every'` in the `detect-changes` paths filter ([#5816](https://github.com/databricks/terraform-provider-databricks/pull/5816)).


### PR DESCRIPTION
## What

Add `predicate-quantifier: 'every'` to the `detect-changes` paths-filter step so the inert-path skip actually works.

## Why

The `skip-integration-tests` job is meant to post a synthetic success for PRs that only touch inert paths (`docs/**`, root `*.md`, issue templates, `dependabot.yml`, `CODEOWNERS`, `LICENSE`) instead of running the full suite. It never fires.

`dorny/paths-filter` defaults to `predicate-quantifier: some`, where a file matches a filter if it matches **any** pattern in the list. The `non_inert` filter leads with `'**'`, which matches every file, so `non_inert` is always true and `inert_only` is always false. Every PR, including docs-only ones, runs the full integration suite.

With `predicate-quantifier: every`, a file matches `non_inert` only when it matches **all** patterns: `'**'` AND none of the negated inert paths. So `non_inert` is empty exactly when every changed file is inert, which is the intended behavior.

The prior comment claimed v3.0.2 does not support `every`. It does — the pinned SHA `de90cc6` reads the `predicate-quantifier` input and supports both quantifiers.

## Verification

Evaluated the filter patterns against the pinned picomatch with both quantifiers:

| Changed file | `some` (before) | `every` (after) |
| --- | --- | --- |
| `CONTRIBUTING.md` | non_inert → runs | inert → skips |
| `docs/resources/job.md` | non_inert → runs | inert → skips |
| `README.md` | non_inert → runs | inert → skips |
| `LICENSE`, `.github/dependabot.yml` | non_inert → runs | inert → skips |
| `catalog/resource.go` | non_inert → runs | non_inert → runs |

A docs-only change now skips; a code change still runs.

This pull request and its description were written by Isaac.

NO_CHANGELOG=true
