### PR TITLE
Fixed inconsistent plans for `databricks_pipeline` when `catalog` or `schema` only differ from configuration by case

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bug Fixes
 
+* Fixed inconsistent plans for `databricks_pipeline` when `catalog` or `schema` only differ from configuration by case ([#5785](https://github.com/databricks/terraform-provider-databricks/issues/5785)).
+
 ### Documentation
 
 ### Exporter

--- a/pipelines/resource_pipeline.go
+++ b/pipelines/resource_pipeline.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/databricks/databricks-sdk-go"
@@ -64,6 +65,15 @@ func Read(w *databricks.WorkspaceClient, ctx context.Context, id string) (*pipel
 	return w.Pipelines.Get(ctx, pipelines.GetPipelineRequest{
 		PipelineId: id,
 	})
+}
+
+func preserveOriginalPipelineCatalogAndSchema(d *schema.ResourceData, p *Pipeline) {
+	if catalog, ok := d.GetOk("catalog"); ok && strings.EqualFold(catalog.(string), p.Catalog) {
+		p.Catalog = catalog.(string)
+	}
+	if schema, ok := d.GetOk("schema"); ok && strings.EqualFold(schema.(string), p.Schema) {
+		p.Schema = schema.(string)
+	}
 }
 
 func Update(w *databricks.WorkspaceClient, ctx context.Context, d *schema.ResourceData, timeout time.Duration) error {
@@ -320,6 +330,7 @@ func ResourcePipeline() common.Resource {
 				// Provides the URL to the pipeline in the Databricks UI.
 				URL: c.FormatURL("#joblist/pipelines/", d.Id()),
 			}
+			preserveOriginalPipelineCatalogAndSchema(d, &p)
 			return common.StructToData(p, pipelineSchema, d)
 		},
 		Update: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {

--- a/pipelines/resource_pipeline_test.go
+++ b/pipelines/resource_pipeline_test.go
@@ -347,6 +347,45 @@ func TestResourcePipelineRead(t *testing.T) {
 	})
 }
 
+func TestResourcePipelineReadPreservesCatalogAndSchemaCase(t *testing.T) {
+	spec := basicPipelineSpec
+	spec.Catalog = "my_catalog"
+	spec.Schema = "my_schema"
+
+	qa.ResourceFixture{
+		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
+			e := w.GetMockPipelinesAPI().EXPECT()
+			e.Get(mock.Anything, pipelines.GetPipelineRequest{
+				PipelineId: "abcd",
+			}).Return(&pipelines.GetPipelineResponse{
+				PipelineId: "abcd",
+				Spec:       &spec,
+			}, nil)
+		},
+		Resource: ResourcePipeline(),
+		Read:     true,
+		ID:       "abcd",
+		HCL: `
+		name = "test-pipeline"
+		catalog = "My_Catalog"
+		schema = "My_Schema"
+		library {
+			notebook {
+				path = "/Test"
+			}
+		}
+		`,
+		InstanceState: map[string]string{
+			"name":    "test-pipeline",
+			"catalog": "My_Catalog",
+			"schema":  "My_Schema",
+		},
+	}.ApplyAndExpectData(t, map[string]any{
+		"catalog": "My_Catalog",
+		"schema":  "My_Schema",
+	})
+}
+
 func TestResourcePipelineRead_NotFound(t *testing.T) {
 	qa.ResourceFixture{
 		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {


### PR DESCRIPTION


Fixes #5785

## Changes
<!-- Summary of your changes that are easy to understand -->

## Tests
<!--
How is this tested? Please see the checklist below and also describe any other relevant tests
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] using Go SDK
- [ ] using TF Plugin Framework
- [x] has entry in `NEXT_CHANGELOG.md` file
