### PR TITLE
[Fix] Send enabled=false on databricks_ip_access_list create and update

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bug Fixes
 
 * Fix permanent permissions drift when `user_name` casing in `databricks_permissions` `access_control` blocks differs from the API response ([#5757](hattps://github.com/databricks/terraform-provider-databricks/issues/5757)).
+* Fix `databricks_ip_access_list` ignoring `enabled = false` on create and update ([#5829](https://github.com/databricks/terraform-provider-databricks/pull/5829))
 
 ### Documentation
 

--- a/access/resource_ip_access_list.go
+++ b/access/resource_ip_access_list.go
@@ -2,7 +2,9 @@ package access
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/databricks/databricks-sdk-go"
 	"github.com/databricks/databricks-sdk-go/service/settings"
 	"github.com/databricks/terraform-provider-databricks/common"
 
@@ -16,6 +18,18 @@ type ipAccessListUpdateRequest struct {
 	IpAddresses []string          `json:"ip_addresses"`
 	Enabled     bool              `json:"enabled,omitempty" tf:"default:true"`
 	common.Namespace
+}
+
+// updateIPAccessList issues the update (PATCH) for an IP access list. `enabled`
+// is force-sent because the SDK marshaler omits zero-valued fields unless they
+// are named in ForceSendFields; without it a configured `enabled = false` is
+// dropped from the request and the list is left enabled.
+func updateIPAccessList(ctx context.Context, w *databricks.WorkspaceClient, d *schema.ResourceData, s map[string]*schema.Schema) error {
+	var iacl settings.UpdateIpAccessList
+	common.DataToStructPointer(d, s, &iacl)
+	iacl.IpAccessListId = d.Id()
+	iacl.ForceSendFields = append(iacl.ForceSendFields, "Enabled")
+	return w.IpAccessLists.Update(ctx, iacl)
 }
 
 // ResourceIPAccessList manages IP access lists
@@ -47,6 +61,16 @@ func ResourceIPAccessList() common.Resource {
 				return err
 			}
 			d.SetId(status.IpAccessList.ListId)
+			// The create API has no `enabled` field, so a new list is always
+			// created enabled. Honor an explicit `enabled = false` with a
+			// follow-up update. The list already exists, so the ID is kept and
+			// the error is wrapped to make clear it was created but not disabled;
+			// a subsequent apply reconciles the state through the update path.
+			if !d.Get("enabled").(bool) {
+				if err := updateIPAccessList(ctx, w, d, s); err != nil {
+					return fmt.Errorf("IP access list %s created but could not be disabled: %w", d.Id(), err)
+				}
+			}
 			return nil
 		},
 		Read: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
@@ -66,10 +90,7 @@ func ResourceIPAccessList() common.Resource {
 			if err != nil {
 				return err
 			}
-			var iacl settings.UpdateIpAccessList
-			common.DataToStructPointer(d, s, &iacl)
-			iacl.IpAccessListId = d.Id()
-			return w.IpAccessLists.Update(ctx, iacl)
+			return updateIPAccessList(ctx, w, d, s)
 		},
 		Delete: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
 			w, err := c.WorkspaceClientUnifiedProvider(ctx, d)

--- a/access/resource_ip_access_list_test.go
+++ b/access/resource_ip_access_list_test.go
@@ -87,6 +87,120 @@ func TestIPACLCreate(t *testing.T) {
 	assert.Equal(t, 2, d.Get("ip_addresses.#"))
 }
 
+func TestIPACLCreate_Disabled(t *testing.T) {
+	d, err := qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   http.MethodPost,
+				Resource: "/api/2.0/ip-access-lists",
+				ExpectedRequest: settings.CreateIpAccessList{
+					Label:       TestingLabel,
+					ListType:    TestingListType,
+					IpAddresses: TestingIpAddresses,
+				},
+				Response: settings.CreateIpAccessListResponse{
+					IpAccessList: &settings.IpAccessListInfo{
+						ListId:      TestingId,
+						Label:       TestingLabel,
+						ListType:    TestingListType,
+						IpAddresses: TestingIpAddresses,
+						Enabled:     true,
+					},
+				},
+			},
+			{
+				Method:   http.MethodPatch,
+				Resource: "/api/2.0/ip-access-lists/" + TestingId,
+				ExpectedRequest: map[string]any{
+					"label":        TestingLabel,
+					"list_type":    TestingListTypeString,
+					"ip_addresses": TestingIpAddresses,
+					"enabled":      false,
+				},
+				Response: settings.CreateIpAccessListResponse{
+					IpAccessList: &settings.IpAccessListInfo{
+						ListId:      TestingId,
+						Label:       TestingLabel,
+						ListType:    TestingListType,
+						IpAddresses: TestingIpAddresses,
+						Enabled:     false,
+					},
+				},
+			},
+			{
+				Method:   http.MethodGet,
+				Resource: "/api/2.0/ip-access-lists/" + TestingId + "?",
+				Response: settings.CreateIpAccessListResponse{
+					IpAccessList: &settings.IpAccessListInfo{
+						ListId:      TestingId,
+						Label:       TestingLabel,
+						ListType:    TestingListType,
+						IpAddresses: TestingIpAddresses,
+						Enabled:     false,
+					},
+				},
+			},
+		},
+		Resource: ResourceIPAccessList(),
+		State: map[string]any{
+			"label":        TestingLabel,
+			"list_type":    TestingListTypeString,
+			"ip_addresses": TestingIpAddressesState,
+			"enabled":      false,
+		},
+		Create: true,
+	}.Apply(t)
+	assert.NoError(t, err)
+	assert.Equal(t, TestingId, d.Id())
+	assert.Equal(t, false, d.Get("enabled"))
+}
+
+func TestIPACLCreate_Disabled_UpdateError(t *testing.T) {
+	d, err := qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   http.MethodPost,
+				Resource: "/api/2.0/ip-access-lists",
+				ExpectedRequest: settings.CreateIpAccessList{
+					Label:       TestingLabel,
+					ListType:    TestingListType,
+					IpAddresses: TestingIpAddresses,
+				},
+				Response: settings.CreateIpAccessListResponse{
+					IpAccessList: &settings.IpAccessListInfo{
+						ListId:      TestingId,
+						Label:       TestingLabel,
+						ListType:    TestingListType,
+						IpAddresses: TestingIpAddresses,
+						Enabled:     true,
+					},
+				},
+			},
+			{
+				Method:   http.MethodPatch,
+				Resource: "/api/2.0/ip-access-lists/" + TestingId,
+				Response: apierr.APIError{
+					ErrorCode: "SERVER_ERROR",
+					Message:   "Something unexpected happened",
+				},
+				Status: 500,
+			},
+		},
+		Resource: ResourceIPAccessList(),
+		State: map[string]any{
+			"label":        TestingLabel,
+			"list_type":    TestingListTypeString,
+			"ip_addresses": TestingIpAddressesState,
+			"enabled":      false,
+		},
+		Create: true,
+	}.Apply(t)
+	qa.AssertErrorStartsWith(t, err, "IP access list "+TestingId+" created but could not be disabled")
+	// The list exists on the backend, so its ID is retained for the next apply
+	// to reconcile rather than orphaning it with a duplicate create.
+	assert.Equal(t, TestingId, d.Id())
+}
+
 func TestAPIACLCreate_Error(t *testing.T) {
 	d, err := qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
@@ -174,6 +288,57 @@ func TestIPACLUpdate(t *testing.T) {
 	assert.Equal(t, TestingListTypeString, d.Get("list_type"))
 	assert.Equal(t, TestingEnabled, d.Get("enabled"))
 	assert.Equal(t, 2, d.Get("ip_addresses.#"))
+}
+
+func TestIPACLUpdate_Disabled(t *testing.T) {
+	d, err := qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   http.MethodPatch,
+				Resource: "/api/2.0/ip-access-lists/" + TestingId,
+				ExpectedRequest: map[string]any{
+					"label":        TestingLabel,
+					"list_type":    TestingListTypeString,
+					"ip_addresses": TestingIpAddresses,
+					"enabled":      false,
+				},
+				Response: settings.CreateIpAccessListResponse{
+					IpAccessList: &settings.IpAccessListInfo{
+						ListId:      TestingId,
+						Label:       TestingLabel,
+						ListType:    TestingListType,
+						IpAddresses: TestingIpAddresses,
+						Enabled:     false,
+					},
+				},
+			},
+			{
+				Method:   http.MethodGet,
+				Resource: "/api/2.0/ip-access-lists/" + TestingId + "?",
+				Response: settings.CreateIpAccessListResponse{
+					IpAccessList: &settings.IpAccessListInfo{
+						ListId:      TestingId,
+						Label:       TestingLabel,
+						ListType:    TestingListType,
+						IpAddresses: TestingIpAddresses,
+						Enabled:     false,
+					},
+				},
+			},
+		},
+		Resource: ResourceIPAccessList(),
+		State: map[string]any{
+			"label":        TestingLabel,
+			"list_type":    TestingListTypeString,
+			"ip_addresses": TestingIpAddressesState,
+			"enabled":      false,
+		},
+		Update: true,
+		ID:     TestingId,
+	}.Apply(t)
+	assert.NoError(t, err)
+	assert.Equal(t, TestingId, d.Id())
+	assert.Equal(t, false, d.Get("enabled"))
 }
 
 func TestIPACLUpdate_Error(t *testing.T) {


### PR DESCRIPTION
## Changes

`databricks_ip_access_list` silently ignored `enabled = false`. The attribute was dropped from both the create (`POST`) and update (`PATCH`) request bodies, so a list configured as disabled was created — and left — enabled. Because the API defaults `enabled` to `true`, this produced a permanent plan diff (`true -> false`) that `apply` never resolved: the corrective `PATCH` also omitted `enabled`.

There are two distinct causes:

- **Update:** `settings.UpdateIpAccessList.Enabled` is a `bool` tagged `omitempty`. The SDK marshaler omits a zero-valued field (`false`) unless its name is listed in `ForceSendFields`, and the resource never force-sent it — so `enabled: false` never reached the wire. (`enabled: true` was unaffected: a non-zero value isn't subject to `omitempty`.)
- **Create:** `settings.CreateIpAccessList` has no `Enabled` field at all — the create API always creates a list enabled, so disabling requires a follow-up update.

### Fix

- **Update:** force-send `enabled`, so the configured value is always written.
- **Create:** after creating, if the list is configured `enabled = false`, issue a follow-up update to disable it. This mirrors `databricks_external_location`, which sets `owner`/`isolation_mode` through a follow-up update because the create call cannot carry them. If the follow-up fails, the error is wrapped to make clear the list was created but not disabled, and the resource ID is retained so a later apply reconciles it (rather than orphaning the created list).

### Why force-sending `enabled` is safe

`enabled` has a schema default of `true`, so the value handed to the SDK is always the effective desired state — never an accidental zero value:

| User config | Resolved value | Sent to API |
|---|---|---|
| (omitted) | `true` (schema default) | `true` |
| `enabled = true` | `true` | `true` |
| `enabled = false` | `false` | `false` |

For `true` (explicit or via the default) the request body is unchanged from before this PR — a non-zero bool was always serialized. The only behavioral change is that `false` is now sent instead of being dropped. The create-side follow-up update likewise fires only when the resolved value is `false`, so no extra request is made in the common (enabled) case.

## Tests

- [x] `make test` run locally (`access` package; new unit tests below)
- [ ] relevant change in `docs/` folder (not needed — the docs already document `enabled` defaulting to `true`; this restores that documented behavior)
- [ ] covered with integration tests in `internal/acceptance`
- [x] using Go SDK
- [ ] using TF Plugin Framework
- [x] has entry in `NEXT_CHANGELOG.md` file

New unit tests assert the exact request bodies via `assert.JSONEq`:

- `TestIPACLUpdate_Disabled` — the `PATCH` body now contains `"enabled": false` (this test fails before the fix).
- `TestIPACLCreate_Disabled` — create issues the `POST`, then a follow-up `PATCH` carrying `"enabled": false`.
- `TestIPACLCreate_Disabled_UpdateError` — when the follow-up update fails, the wrapped error surfaces and the resource ID is retained.
