### PR TITLE
Make notification destination acceptance tests robust to list eventual consistency

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -15,3 +15,5 @@
 ### Exporter
 
 ### Internal Changes
+
+* Make notification destination acceptance tests robust to the eventual consistency of the notification destinations list API.

--- a/internal/providers/pluginfw/products/notificationdestinations/data_notification_destinations_acc_test.go
+++ b/internal/providers/pluginfw/products/notificationdestinations/data_notification_destinations_acc_test.go
@@ -6,68 +6,66 @@ import (
 	"testing"
 
 	"github.com/databricks/terraform-provider-databricks/internal/acceptance"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/stretchr/testify/require"
 )
 
-func CheckDataSourceNotificationsPopulated(t *testing.T) func(s *terraform.State) error {
-	return func(s *terraform.State) error {
-		ds, ok := s.Modules[0].Resources["data.databricks_notification_destinations.this"]
-		require.True(t, ok, "data.databricks_notification_destinations.this has to be there")
-
-		emailNotif := s.Modules[0].Resources["databricks_notification_destination.email_notification"]
-		slackNotif := s.Modules[0].Resources["databricks_notification_destination.slack_notification"]
-
-		emailId := emailNotif.Primary.ID
-		slackId := slackNotif.Primary.ID
-
-		notificationsCount := ds.Primary.Attributes["notification_destinations.#"]
-		notificationsCountInt, err := strconv.Atoi(notificationsCount)
-		require.NoError(t, err, "notification destinations count is not a number")
-		require.NotEqual(t, 0, notificationsCountInt, "notification destinations list is empty")
-
-		foundEmailId := false
-		foundSlackId := false
-		for i := 0; i < notificationsCountInt; i++ {
-			id := ds.Primary.Attributes[fmt.Sprintf("notification_destinations.%d.id", i)]
-			if id == emailId {
-				foundEmailId = true
-			}
-			if id == slackId {
-				foundSlackId = true
-			}
-		}
-		require.True(t, foundEmailId, "email notification id not found in destinations")
-		require.True(t, foundSlackId, "email notification id not found in destinations")
-		return nil
-	}
-}
-
-func TestAccNotificationsCreation(t *testing.T) {
+// Notification destinations are created and read back by ID, which is
+// read-after-write consistent, so creation can be asserted directly against the
+// resource state.
+func TestAccNotificationDestinationCreate(t *testing.T) {
 	acceptance.WorkspaceLevel(t, acceptance.Step{
 		Template: `
-			resource "databricks_notification_destination" "email_notification" {
-				display_name = "email notification destination"
+			resource "databricks_notification_destination" "email" {
+				display_name = "tf-test-{var.STICKY_RANDOM}-email"
 				config {
 					email {
-					addresses = ["abc@gmail.com"]
+						addresses = ["abc@gmail.com"]
 					}
 				}
 			}
 
-			resource "databricks_notification_destination" "slack_notification" {
-				display_name = "slack notification destination"
+			resource "databricks_notification_destination" "slack" {
+				display_name = "tf-test-{var.STICKY_RANDOM}-slack"
 				config {
 					slack {
-					url = "https://hooks.slack.com/services/..."
+						url = "https://hooks.slack.com/services/..."
 					}
 				}
 			}
-
-			data "databricks_notification_destinations" "this" {
-				depends_on = [databricks_notification_destination.email_notification, databricks_notification_destination.slack_notification]
-			}
 		`,
-		Check: CheckDataSourceNotificationsPopulated(t),
+		Check: resource.ComposeTestCheckFunc(
+			resource.TestCheckResourceAttrSet("databricks_notification_destination.email", "id"),
+			resource.TestCheckResourceAttr("databricks_notification_destination.email", "destination_type", "EMAIL"),
+			resource.TestCheckResourceAttrSet("databricks_notification_destination.slack", "id"),
+			resource.TestCheckResourceAttr("databricks_notification_destination.slack", "destination_type", "SLACK"),
+		),
+	})
+}
+
+// The notification destinations list API is eventually consistent, so the data
+// source is validated against a destination that already exists on the workspace
+// (TEST_NOTIFICATION_DESTINATION_ID) rather than one created by the test: a
+// freshly created destination may not yet appear in the list response.
+func TestAccNotificationDestinationsDataSource(t *testing.T) {
+	destinationID := acceptance.GetEnvOrSkipTest(t, "TEST_NOTIFICATION_DESTINATION_ID")
+	acceptance.WorkspaceLevel(t, acceptance.Step{
+		Template: `data "databricks_notification_destinations" "this" {}`,
+		Check: func(s *terraform.State) error {
+			ds, ok := s.Modules[0].Resources["data.databricks_notification_destinations.this"]
+			if !ok {
+				return fmt.Errorf("data.databricks_notification_destinations.this is missing from the state")
+			}
+			count, err := strconv.Atoi(ds.Primary.Attributes["notification_destinations.#"])
+			if err != nil {
+				return fmt.Errorf("notification_destinations count is not a number: %w", err)
+			}
+			for i := 0; i < count; i++ {
+				if ds.Primary.Attributes[fmt.Sprintf("notification_destinations.%d.id", i)] == destinationID {
+					return nil
+				}
+			}
+			return fmt.Errorf("notification destination %s not returned by the data source (%d listed)", destinationID, count)
+		},
 	})
 }


### PR DESCRIPTION
## Changes

`TestAccNotificationsCreation` created a notification destination and then asserted it appeared in the `databricks_notification_destinations` data source within the same apply. The list API is eventually consistent, so the list can lag the create: the just-created destination is not returned yet and the assertion fails, which has made these acceptance tests fail consistently.

This splits the test so neither path depends on a freshly created destination being listed:

- `TestAccNotificationDestinationCreate` verifies creation through the get-by-id path, which is read-after-write consistent, asserting directly on resource state.
- `TestAccNotificationDestinationsDataSource` validates the data source against a destination already present on the workspace (`TEST_NOTIFICATION_DESTINATION_ID`); it skips when that fixture is not configured.

## Tests

- [x] covered with integration tests in `internal/acceptance`
- [x] using TF Plugin Framework
- [x] has entry in `NEXT_CHANGELOG.md` file

`TestAccNotificationDestinationCreate` passes against a live workspace. `TestAccNotificationDestinationsDataSource` runs once the fixture destination is present and skips otherwise.
