### PR TITLE
Share the inert-path classifier so fork/manual integration runs can skip docs-only PRs

### DIFF
--- a/.github/scripts/classify_inert.mjs
+++ b/.github/scripts/classify_inert.mjs
@@ -1,22 +1,11 @@
-// Shared inert-path classifier — the single source of truth for which changed
-// files are "inert" (documentation and repository metadata that can never
-// affect an integration-test outcome). It is consumed in three places:
-//
-//   1. integration-tests.yml `detect-changes` (this repo, via github-script)
-//   2. integration-tests.yml `carry-forward`  (this repo, via github-script)
-//   3. The internal fork-PR / manual-dispatch integration-test workflow, which
-//      sparse-checks this exact file out of `main` and imports it so those runs
-//      share the same allowlist.
-//
-// Keeping the allowlist and the matching logic here — and nowhere else — stops
-// the call sites from drifting apart. The file is intentionally dependency-free
-// (pure Node, no npm) so every caller can run it without an install step.
+// Shared inert-path classifier: the single source of truth for which changed
+// files are "inert" (docs and repo metadata that can't affect an integration
+// test). Imported by integration-tests.yml's `detect-changes` and
+// `carry-forward` jobs and by the internal fork/manual integration-test
+// workflow (which checks this file out of `main`), so the allowlist lives in
+// one place. Dependency-free so every caller can import it without an install.
 
-import { readFileSync } from "node:fs";
-import { pathToFileURL } from "node:url";
-
-// Inert allowlist. A PR is inert-only when every changed file matches one of
-// these globs. Globs use the small vocabulary understood by globToRegExp below.
+// A PR is inert-only when every changed file matches one of these globs.
 export const INERT_GLOBS = [
   "docs/**",
   "*.md",
@@ -29,9 +18,8 @@ export const INERT_GLOBS = [
 
 const escapeRegex = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 
-// Translate the three glob shapes the allowlist uses into anchored regexes.
-// Anything outside that vocabulary throws so callers can fail open (treat the
-// change as non-inert and run the full suite) rather than silently mismatch.
+// Translate the glob shapes the allowlist uses into anchored regexes. Anything
+// outside that vocabulary throws, so callers fail open rather than mismatch.
 export const globToRegExp = (glob) => {
   let m = glob.match(/^([^*?{}\[\]]+)\/\*\*$/); // "<dir>/**"
   if (m) return new RegExp("^" + escapeRegex(m[1]) + "/");
@@ -43,30 +31,7 @@ export const globToRegExp = (glob) => {
 
 const INERT_MATCHERS = INERT_GLOBS.map(globToRegExp);
 
-// True when `path` matches any inert glob.
 export const isInert = (path) => INERT_MATCHERS.some((re) => re.test(path));
 
-// True only when there is at least one path and every path is inert. An empty
-// list is treated as non-inert: with nothing to classify we cannot prove the
-// change is safe to skip.
+// Empty list is non-inert: with nothing to classify we can't prove it's safe to skip.
 export const allInert = (paths) => paths.length > 0 && paths.every(isInert);
-
-// CLI entrypoint for non-JS callers and tests:
-//   node classify_inert.mjs <changed_files.txt>
-//   node classify_inert.mjs            # reads the list from stdin
-// Reads a newline-delimited file list and prints exactly `inert_only=true` or
-// `inert_only=false`. A parse error (e.g. an unsupported glob) throws and exits
-// non-zero so the caller can fail open.
-function main(argv) {
-  const arg = argv[2];
-  const raw = readFileSync(arg ?? 0, "utf8");
-  const paths = raw
-    .split("\n")
-    .map((line) => line.trim())
-    .filter(Boolean);
-  process.stdout.write(`inert_only=${allInert(paths)}\n`);
-}
-
-if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
-  main(process.argv);
-}

--- a/.github/scripts/classify_inert.mjs
+++ b/.github/scripts/classify_inert.mjs
@@ -1,0 +1,72 @@
+// Shared inert-path classifier — the single source of truth for which changed
+// files are "inert" (documentation and repository metadata that can never
+// affect an integration-test outcome). It is consumed in three places:
+//
+//   1. integration-tests.yml `detect-changes` (this repo, via github-script)
+//   2. integration-tests.yml `carry-forward`  (this repo, via github-script)
+//   3. databricks-eng/eng-dev-ecosystem terraform-isolated-pr.yml, which
+//      sparse-checks this exact file out of `main` and imports it so fork PRs
+//      and manual dispatches share the same allowlist.
+//
+// Keeping the allowlist and the matching logic here — and nowhere else — stops
+// the call sites from drifting apart. The file is intentionally dependency-free
+// (pure Node, no npm) so every caller can run it without an install step.
+
+import { readFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+// Inert allowlist. A PR is inert-only when every changed file matches one of
+// these globs. Globs use the small vocabulary understood by globToRegExp below.
+export const INERT_GLOBS = [
+  "docs/**",
+  "*.md",
+  ".github/ISSUE_TEMPLATE/**",
+  ".github/PULL_REQUEST_TEMPLATE.md",
+  ".github/dependabot.yml",
+  "CODEOWNERS",
+  "LICENSE",
+];
+
+const escapeRegex = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+// Translate the three glob shapes the allowlist uses into anchored regexes.
+// Anything outside that vocabulary throws so callers can fail open (treat the
+// change as non-inert and run the full suite) rather than silently mismatch.
+export const globToRegExp = (glob) => {
+  let m = glob.match(/^([^*?{}\[\]]+)\/\*\*$/); // "<dir>/**"
+  if (m) return new RegExp("^" + escapeRegex(m[1]) + "/");
+  m = glob.match(/^\*(\.[A-Za-z0-9.]+)$/); // root "*.<ext>"
+  if (m) return new RegExp("^[^/]*" + escapeRegex(m[1]) + "$");
+  if (!/[*?{}\[\]]/.test(glob)) return new RegExp("^" + escapeRegex(glob) + "$"); // literal
+  throw new Error(`Unsupported glob: ${glob}`);
+};
+
+const INERT_MATCHERS = INERT_GLOBS.map(globToRegExp);
+
+// True when `path` matches any inert glob.
+export const isInert = (path) => INERT_MATCHERS.some((re) => re.test(path));
+
+// True only when there is at least one path and every path is inert. An empty
+// list is treated as non-inert: with nothing to classify we cannot prove the
+// change is safe to skip.
+export const allInert = (paths) => paths.length > 0 && paths.every(isInert);
+
+// CLI entrypoint for non-JS callers and tests:
+//   node classify_inert.mjs <changed_files.txt>
+//   node classify_inert.mjs            # reads the list from stdin
+// Reads a newline-delimited file list and prints exactly `inert_only=true` or
+// `inert_only=false`. A parse error (e.g. an unsupported glob) throws and exits
+// non-zero so the caller can fail open.
+function main(argv) {
+  const arg = argv[2];
+  const raw = readFileSync(arg ?? 0, "utf8");
+  const paths = raw
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+  process.stdout.write(`inert_only=${allInert(paths)}\n`);
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  main(process.argv);
+}

--- a/.github/scripts/classify_inert.mjs
+++ b/.github/scripts/classify_inert.mjs
@@ -35,3 +35,16 @@ export const isInert = (path) => INERT_MATCHERS.some((re) => re.test(path));
 
 // Empty list is non-inert: with nothing to classify we can't prove it's safe to skip.
 export const allInert = (paths) => paths.length > 0 && paths.every(isInert);
+
+// Classify a pull request by its changed file paths. Receives the
+// github-script `github` client. Returns { inertOnly, fileCount, capped }.
+// Above maxFiles we decline to classify (capped) and report non-inert so the
+// caller runs the full suite. Throws on API error — callers fail open.
+export async function classifyPullRequest(octokit, { owner, repo, pull_number, maxFiles = 300 }) {
+  const files = await octokit.paginate(octokit.rest.pulls.listFiles, {
+    owner, repo, pull_number, per_page: 100,
+  });
+  if (files.length > maxFiles) return { inertOnly: false, fileCount: files.length, capped: true };
+  const paths = files.flatMap((f) => [f.filename, f.previous_filename].filter(Boolean));
+  return { inertOnly: allInert(paths), fileCount: files.length, capped: false };
+}

--- a/.github/scripts/classify_inert.mjs
+++ b/.github/scripts/classify_inert.mjs
@@ -4,9 +4,9 @@
 //
 //   1. integration-tests.yml `detect-changes` (this repo, via github-script)
 //   2. integration-tests.yml `carry-forward`  (this repo, via github-script)
-//   3. databricks-eng/eng-dev-ecosystem terraform-isolated-pr.yml, which
-//      sparse-checks this exact file out of `main` and imports it so fork PRs
-//      and manual dispatches share the same allowlist.
+//   3. The internal fork-PR / manual-dispatch integration-test workflow, which
+//      sparse-checks this exact file out of `main` and imports it so those runs
+//      share the same allowlist.
 //
 // Keeping the allowlist and the matching logic here — and nowhere else — stops
 // the call sites from drifting apart. The file is intentionally dependency-free

--- a/.github/scripts/classify_inert.test.mjs
+++ b/.github/scripts/classify_inert.test.mjs
@@ -3,7 +3,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
-import { isInert, allInert, globToRegExp, INERT_GLOBS } from "./classify_inert.mjs";
+import { isInert, allInert, globToRegExp, INERT_GLOBS, classifyPullRequest } from "./classify_inert.mjs";
 
 test("docs-only change is inert", () => {
   assert.equal(allInert(["docs/index.md", "docs/resources/job.md"]), true);
@@ -76,4 +76,48 @@ test("a rename within inert paths is inert", () => {
 test("a large all-inert file set is inert", () => {
   const many = Array.from({ length: 250 }, (_, i) => `docs/page-${i}.md`);
   assert.equal(allInert(many), true);
+});
+
+// classifyPullRequest: a mock octokit whose paginate() ignores the listFiles
+// sentinel and returns a preset file array, so these exercise the pagination +
+// cap + rename glue with no network.
+const mockOctokit = (files) => ({
+  rest: { pulls: { listFiles: "listFiles-sentinel" } },
+  async paginate(fn, params) {
+    assert.equal(fn, "listFiles-sentinel");
+    assert.equal(params.per_page, 100);
+    return files;
+  },
+});
+
+test("classifyPullRequest: all-inert files -> inertOnly, not capped", async () => {
+  const octokit = mockOctokit([{ filename: "docs/a.md" }, { filename: "README.md" }]);
+  const r = await classifyPullRequest(octokit, { owner: "o", repo: "r", pull_number: 1 });
+  assert.deepEqual(r, { inertOnly: true, fileCount: 2, capped: false });
+});
+
+test("classifyPullRequest: one non-inert file -> not inert", async () => {
+  const octokit = mockOctokit([{ filename: "docs/a.md" }, { filename: "internal/x.go" }]);
+  const r = await classifyPullRequest(octokit, { owner: "o", repo: "r", pull_number: 1 });
+  assert.equal(r.inertOnly, false);
+  assert.equal(r.capped, false);
+});
+
+test("classifyPullRequest: rename out of a non-inert path -> not inert", async () => {
+  // filename is inert but previous_filename was code, so the PR is not inert.
+  const octokit = mockOctokit([{ filename: "docs/x.md", previous_filename: "internal/x.go" }]);
+  const r = await classifyPullRequest(octokit, { owner: "o", repo: "r", pull_number: 1 });
+  assert.equal(r.inertOnly, false);
+});
+
+test("classifyPullRequest: above maxFiles -> capped, not inert", async () => {
+  const octokit = mockOctokit([{ filename: "docs/a.md" }, { filename: "docs/b.md" }, { filename: "docs/c.md" }]);
+  const r = await classifyPullRequest(octokit, { owner: "o", repo: "r", pull_number: 1, maxFiles: 2 });
+  assert.deepEqual(r, { inertOnly: false, fileCount: 3, capped: true });
+});
+
+test("classifyPullRequest: empty file list -> not inert (allInert([]) is false)", async () => {
+  const octokit = mockOctokit([]);
+  const r = await classifyPullRequest(octokit, { owner: "o", repo: "r", pull_number: 1 });
+  assert.deepEqual(r, { inertOnly: false, fileCount: 0, capped: false });
 });

--- a/.github/scripts/classify_inert.test.mjs
+++ b/.github/scripts/classify_inert.test.mjs
@@ -1,4 +1,5 @@
-// Tests for the shared inert-path classifier. Run with: node --test .github/scripts/
+// Tests for the shared inert-path classifier.
+// Run with: node --test .github/scripts/classify_inert.test.mjs
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
@@ -53,4 +54,26 @@ test("every allowlist glob compiles to a regex", () => {
 
 test("unsupported glob throws", () => {
   assert.throws(() => globToRegExp("src/**/*.go"));
+});
+
+// Renames: the workflows classify both the new and old path of a renamed file
+// (`[f.filename, f.previous_filename]`) through this same `allInert`, so a file
+// renamed OUT OF a code path into docs must still count as non-inert, while a
+// rename that stays entirely within inert paths is inert.
+test("a rename from a non-inert path is not inert", () => {
+  // previous_filename "internal/x.go" -> filename "docs/x.md"
+  assert.equal(allInert(["docs/x.md", "internal/x.go"]), false);
+});
+
+test("a rename within inert paths is inert", () => {
+  // previous_filename "docs/old.md" -> filename "docs/new.md"
+  assert.equal(allInert(["docs/new.md", "docs/old.md"]), true);
+});
+
+// The >300-file cap is a workflow-level fail-open guard (the github-script
+// callers force non-inert above the cap before this module is consulted), not
+// module logic. Below the cap, a large all-inert set still classifies as inert.
+test("a large all-inert file set is inert", () => {
+  const many = Array.from({ length: 250 }, (_, i) => `docs/page-${i}.md`);
+  assert.equal(allInert(many), true);
 });

--- a/.github/scripts/classify_inert.test.mjs
+++ b/.github/scripts/classify_inert.test.mjs
@@ -1,0 +1,56 @@
+// Tests for the shared inert-path classifier. Run with: node --test .github/scripts/
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { isInert, allInert, globToRegExp, INERT_GLOBS } from "./classify_inert.mjs";
+
+test("docs-only change is inert", () => {
+  assert.equal(allInert(["docs/index.md", "docs/resources/job.md"]), true);
+});
+
+test("mixed docs + go is not inert", () => {
+  assert.equal(allInert(["docs/index.md", "internal/service/jobs.go"]), false);
+});
+
+test("root CHANGELOG.md is inert", () => {
+  assert.equal(isInert("CHANGELOG.md"), true);
+  assert.equal(allInert(["CHANGELOG.md"]), true);
+});
+
+test("internal go file is not inert", () => {
+  assert.equal(isInert("internal/foo.go"), false);
+});
+
+test(".github/dependabot.yml is inert", () => {
+  assert.equal(isInert(".github/dependabot.yml"), true);
+});
+
+test("empty list is not inert", () => {
+  assert.equal(allInert([]), false);
+});
+
+test("a path a naive prefix matcher would mis-accept is not inert", () => {
+  // "docs/**" must require the directory boundary: "docsrc/..." and a file
+  // literally named "docs" must NOT match. A naive startsWith("docs") would.
+  assert.equal(isInert("docsrc/secret.go"), false);
+  assert.equal(isInert("docs"), false);
+  // root "*.md" must not match markdown nested in a non-docs subtree, and must
+  // not match a file that merely contains ".md" before another extension.
+  assert.equal(isInert("internal/notes.md"), false);
+  assert.equal(isInert("notes.md.go"), false);
+});
+
+test("issue templates and PR template are inert", () => {
+  assert.equal(isInert(".github/ISSUE_TEMPLATE/bug.md"), true);
+  assert.equal(isInert(".github/PULL_REQUEST_TEMPLATE.md"), true);
+});
+
+test("every allowlist glob compiles to a regex", () => {
+  for (const glob of INERT_GLOBS) {
+    assert.ok(globToRegExp(glob) instanceof RegExp, glob);
+  }
+});
+
+test("unsupported glob throws", () => {
+  assert.throws(() => globToRegExp("src/**/*.go"));
+});

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -32,13 +32,9 @@ jobs:
               echo "has_token=true" >> $GITHUB_OUTPUT
             fi
 
-  # Classify the PR diff. `inert_only` is 'true' iff every changed file is in
-  # the inert allowlist (docs, root *.md, issue templates, dependabot.yml,
-  # CODEOWNERS, LICENSE); in that case we skip the long integration-test
-  # dispatch in favor of posting a synthetic success check. The allowlist and
-  # matching logic live in .github/scripts/classify_inert.mjs — the single
-  # source of truth shared with the carry-forward job below and with the
-  # internal fork-PR / manual-dispatch integration-test workflow.
+  # Classify the PR diff via the shared classifier (.github/scripts/classify_inert.mjs).
+  # inert_only == 'true' means every changed file is inert (docs/metadata), so the
+  # integration suite is skipped in favor of a synthetic success check.
   detect-changes:
     name: Detect inert-only changes
     if: github.event_name == 'pull_request'
@@ -55,8 +51,7 @@ jobs:
       inert_only: ${{ steps.classify.outputs.inert_only }}
 
     steps:
-      # github-script imports the classifier from the checkout, so the file
-      # must be present on disk. Sparse-checkout keeps this fast.
+      # github-script imports the classifier from disk, so check it out first.
       - name: Check out the inert classifier
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
@@ -86,8 +81,7 @@ jobs:
                 core.setOutput('inert_only', 'false');
                 return;
               }
-              // Include previous_filename so a rename out of a non-inert path
-              // (e.g. internal/foo.go -> docs/foo.md) is still seen as non-inert.
+              // previous_filename catches a rename out of a non-inert path.
               const paths = files.flatMap((f) => [f.filename, f.previous_filename].filter(Boolean));
               const inert = allInert(paths);
               core.info(`Changed files: ${files.length}; inert_only=${inert}`);
@@ -152,7 +146,6 @@ jobs:
               core.setOutput('carried', 'false');
             };
             try {
-              // Shared inert classifier — the only copy of the allowlist.
               const { pathToFileURL } = require('node:url');
               const path = require('node:path');
               const modPath = path.join(process.env.GITHUB_WORKSPACE, '.github/scripts/classify_inert.mjs');

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -9,24 +9,6 @@ on:
   merge_group:
 
 
-# Single source of truth for the inert-path allowlist. Consumed BOTH by the
-# `detect-changes` paths-filter (as its YAML filter definition) and by the
-# `carry-forward` job (parsed in github-script). Defining it once here keeps
-# the two classifiers from drifting apart. `non_inert` matches every changed
-# file that is NOT inert, so an empty match means the change is inert-only.
-env:
-  INERT_PATHS_FILTER: |
-    non_inert:
-      - '**'
-      - '!docs/**'
-      - '!*.md'
-      - '!.github/ISSUE_TEMPLATE/**'
-      - '!.github/PULL_REQUEST_TEMPLATE.md'
-      - '!.github/dependabot.yml'
-      - '!CODEOWNERS'
-      - '!LICENSE'
-
-
 jobs:
   check-token:
     name: Check secrets access
@@ -53,7 +35,10 @@ jobs:
   # Classify the PR diff. `inert_only` is 'true' iff every changed file is in
   # the inert allowlist (docs, root *.md, issue templates, dependabot.yml,
   # CODEOWNERS, LICENSE); in that case we skip the long integration-test
-  # dispatch in favor of posting a synthetic success check.
+  # dispatch in favor of posting a synthetic success check. The allowlist and
+  # matching logic live in .github/scripts/classify_inert.mjs — the single
+  # source of truth shared with the carry-forward job below and with the
+  # eng-dev-ecosystem fork-PR workflow.
   detect-changes:
     name: Detect inert-only changes
     if: github.event_name == 'pull_request'
@@ -62,20 +47,55 @@ jobs:
       group: databricks-deco-testing-runner-group
       labels: ubuntu-latest-deco
 
+    permissions:
+      contents: read
+      pull-requests: read
+
     outputs:
-      # non_inert lists changed files that are NOT inert; inert_only is the
-      # inverse. predicate-quantifier 'every' is required: a file is non_inert
-      # only if it matches ALL patterns ('**' AND none of the inert paths).
-      # The default 'some' would match any single pattern, and '**' matches
-      # everything, so non_inert would always be true and the skip never fire.
-      inert_only: ${{ steps.filter.outputs.non_inert == 'false' }}
+      inert_only: ${{ steps.classify.outputs.inert_only }}
 
     steps:
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
-        id: filter
+      # github-script imports the classifier from the checkout, so the file
+      # must be present on disk. Sparse-checkout keeps this fast.
+      - name: Check out the inert classifier
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
-          predicate-quantifier: 'every'
-          filters: ${{ env.INERT_PATHS_FILTER }}
+          sparse-checkout: .github/scripts
+          sparse-checkout-cone-mode: false
+
+      - name: Classify changed files
+        id: classify
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        with:
+          script: |
+            // Fail open: any error here -> inert_only=false -> full suite runs.
+            try {
+              const { pathToFileURL } = require('node:url');
+              const path = require('node:path');
+              const modPath = path.join(process.env.GITHUB_WORKSPACE, '.github/scripts/classify_inert.mjs');
+              const { allInert } = await import(pathToFileURL(modPath).href);
+
+              const files = await github.paginate(github.rest.pulls.listFiles, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.issue.number,
+                per_page: 100,
+              });
+              if (files.length > 300) {
+                core.info(`PR touches ${files.length} files (>300); treating as non-inert.`);
+                core.setOutput('inert_only', 'false');
+                return;
+              }
+              // Include previous_filename so a rename out of a non-inert path
+              // (e.g. internal/foo.go -> docs/foo.md) is still seen as non-inert.
+              const paths = files.flatMap((f) => [f.filename, f.previous_filename].filter(Boolean));
+              const inert = allInert(paths);
+              core.info(`Changed files: ${files.length}; inert_only=${inert}`);
+              core.setOutput('inert_only', String(inert));
+            } catch (e) {
+              core.warning(`inert classification failed, running full suite: ${e.message}`);
+              core.setOutput('inert_only', 'false');
+            }
 
   # For PRs that contain code (inert_only == 'false'), a follow-up push that
   # only touches inert paths (e.g. a NEXT_CHANGELOG.md bump after the code
@@ -92,7 +112,8 @@ jobs:
   #   4. The PR targets main (trigger-level branches filter + base.ref guard).
   # Any error or ambiguity (>=300 files in the compare, empty diff, rename
   # from a non-inert path) falls through to carried=false and the full suite
-  # runs. Fail-open to running tests, never to skipping them.
+  # runs. Fail-open to running tests, never to skipping them. The inert test
+  # uses the shared classifier (.github/scripts/classify_inert.mjs).
   carry-forward:
     name: Carry forward prior Integration Tests success
 
@@ -114,6 +135,13 @@ jobs:
       carried: ${{ steps.carry.outputs.carried }}
 
     steps:
+      # The github-script step imports the shared classifier from disk.
+      - name: Check out the inert classifier
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          sparse-checkout: .github/scripts
+          sparse-checkout-cone-mode: false
+
       - name: Evaluate and carry forward
         id: carry
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
@@ -124,6 +152,12 @@ jobs:
               core.setOutput('carried', 'false');
             };
             try {
+              // Shared inert classifier — the only copy of the allowlist.
+              const { pathToFileURL } = require('node:url');
+              const path = require('node:path');
+              const modPath = path.join(process.env.GITHUB_WORKSPACE, '.github/scripts/classify_inert.mjs');
+              const { isInert } = await import(pathToFileURL(modPath).href);
+
               if (context.payload.action !== 'synchronize') {
                 return fail('not a synchronize push');
               }
@@ -150,26 +184,6 @@ jobs:
                 return fail('too many files in incremental diff to classify confidently');
               }
 
-              // Derive the inert matchers from the SAME allowlist the
-              // detect-changes paths-filter uses (env.INERT_PATHS_FILTER), so
-              // the two classifiers cannot drift. We translate only the small
-              // glob vocabulary that allowlist uses; anything unrecognized
-              // throws and falls through to a full test run (fail-safe).
-              const escapeRegex = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-              const globToRegExp = (glob) => {
-                let m = glob.match(/^([^*?{}\[\]]+)\/\*\*$/); // "<dir>/**"
-                if (m) return new RegExp('^' + escapeRegex(m[1]) + '/');
-                m = glob.match(/^\*(\.[A-Za-z0-9.]+)$/);      // root "*.<ext>"
-                if (m) return new RegExp('^[^/]*' + escapeRegex(m[1]) + '$');
-                if (!/[*?{}\[\]]/.test(glob)) return new RegExp('^' + escapeRegex(glob) + '$'); // literal
-                throw new Error(`Unsupported glob in INERT_PATHS_FILTER: ${glob}`);
-              };
-              const inertMatchers = [...(process.env.INERT_PATHS_FILTER || '').matchAll(/^\s*-\s*'!(.+)'\s*$/gm)]
-                .map((m) => globToRegExp(m[1]));
-              if (inertMatchers.length === 0) {
-                return fail('no inert patterns parsed from INERT_PATHS_FILTER');
-              }
-              const isInert = (p) => inertMatchers.some((re) => re.test(p));
               for (const f of files) {
                 const paths = [f.filename, f.previous_filename].filter(Boolean);
                 if (!paths.every(isInert)) {

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -68,24 +68,13 @@ jobs:
               const { pathToFileURL } = require('node:url');
               const path = require('node:path');
               const modPath = path.join(process.env.GITHUB_WORKSPACE, '.github/scripts/classify_inert.mjs');
-              const { allInert } = await import(pathToFileURL(modPath).href);
-
-              const files = await github.paginate(github.rest.pulls.listFiles, {
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                pull_number: context.issue.number,
-                per_page: 100,
+              const { classifyPullRequest } = await import(pathToFileURL(modPath).href);
+              const { inertOnly, fileCount, capped } = await classifyPullRequest(github, {
+                owner: context.repo.owner, repo: context.repo.repo, pull_number: context.issue.number,
               });
-              if (files.length > 300) {
-                core.info(`PR touches ${files.length} files (>300); treating as non-inert.`);
-                core.setOutput('inert_only', 'false');
-                return;
-              }
-              // previous_filename catches a rename out of a non-inert path.
-              const paths = files.flatMap((f) => [f.filename, f.previous_filename].filter(Boolean));
-              const inert = allInert(paths);
-              core.info(`Changed files: ${files.length}; inert_only=${inert}`);
-              core.setOutput('inert_only', String(inert));
+              if (capped) core.info(`PR touches ${fileCount} files (>300); treating as non-inert.`);
+              core.info(`Changed files: ${fileCount}; inert_only=${inertOnly}`);
+              core.setOutput('inert_only', String(inertOnly));
             } catch (e) {
               core.warning(`inert classification failed, running full suite: ${e.message}`);
               core.setOutput('inert_only', 'false');

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -55,6 +55,10 @@ jobs:
       - name: Check out the inert classifier
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
+          # Use the base (trusted) ref, never the PR merge commit: a PR must not
+          # be able to rewrite classify_inert.mjs to skip/carry its own required
+          # check. Absent on the bootstrap PR -> import throws -> fail-open below.
+          ref: ${{ github.event.pull_request.base.sha }}
           sparse-checkout: .github/scripts
           sparse-checkout-cone-mode: false
 
@@ -122,6 +126,10 @@ jobs:
       - name: Check out the inert classifier
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
+          # Use the base (trusted) ref, never the PR merge commit: a PR must not
+          # be able to rewrite classify_inert.mjs to skip/carry its own required
+          # check. Absent on the bootstrap PR -> import throws -> fail-open below.
+          ref: ${{ github.event.pull_request.base.sha }}
           sparse-checkout: .github/scripts
           sparse-checkout-cone-mode: false
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -38,7 +38,7 @@ jobs:
   # dispatch in favor of posting a synthetic success check. The allowlist and
   # matching logic live in .github/scripts/classify_inert.mjs — the single
   # source of truth shared with the carry-forward job below and with the
-  # eng-dev-ecosystem fork-PR workflow.
+  # internal fork-PR / manual-dispatch integration-test workflow.
   detect-changes:
     name: Detect inert-only changes
     if: github.event_name == 'pull_request'
@@ -193,7 +193,7 @@ jobs:
 
               // Validate the prior head's check by PROVENANCE, not just name.
               // Many actors post a check named "Integration Tests" (the real
-              // eng-dev-ecosystem run, the skip job, a previous carry-forward).
+              // integration-test run, the skip job, a previous carry-forward).
               // Exclude our own synthetic runs (marked via external_id) so a
               // synthetic green can never be laundered forward, then require
               // the most recent *real* run to be a completed success — closing

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -15,5 +15,3 @@
 ### Exporter
 
 ### Internal Changes
-
-* Move the integration-test inert-path allowlist into a single shared classifier (`.github/scripts/classify_inert.mjs`) consumed by both the `detect-changes` and `carry-forward` jobs, replacing the duplicated `dorny/paths-filter` definition and inline glob matcher so the two classifiers can no longer drift.

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -15,3 +15,5 @@
 ### Exporter
 
 ### Internal Changes
+
+* Move the integration-test inert-path allowlist into a single shared classifier (`.github/scripts/classify_inert.mjs`) consumed by both the `detect-changes` and `carry-forward` jobs, replacing the duplicated `dorny/paths-filter` definition and inline glob matcher so the two classifiers can no longer drift.


### PR DESCRIPTION
## What

Extracts the inert-path allowlist + matcher into one shared script, `.github/scripts/classify_inert.mjs` (+ tests), and points the existing `integration-tests.yml` jobs (`detect-changes`, `carry-forward`) at it instead of each keeping its own copy.

## Why

Skip tests was working for maintainer prs but not for contributor prs via the manual integration test workflow. This allows me to extend this to the contributor prs as well.

## Notes

- `detect-changes` classifies the PR's changed files (paginated `listFiles`, >300 files ⇒ non-inert); `carry-forward` imports the same `isInert`. All other behavior is unchanged.
- Fail-open: any error classifies as non-inert, so a bug can never mint a false "passed" check.
- Tests 13/13; actionlint + conftest pass.


NO_CHANGELOG=true
