### PR TITLE
Allow setting `user_api_scopes = []` on `databricks_app` to disable OBO authorization

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -9,6 +9,9 @@
 ### Bug Fixes
 
 * Fix permanent permissions drift when `user_name` casing in `databricks_permissions` `access_control` blocks differs from the API response ([#5757](hattps://github.com/databricks/terraform-provider-databricks/issues/5757)).
+* Allow setting `user_api_scopes = []` on `databricks_app` to disable OBO (On-Behalf-Of) user authorization ([#5834](https://github.com/databricks/terraform-provider-databricks/pull/5834)).
+
+  The Apps API omits `user_api_scopes` from its response when OBO is inactive, so a configured empty list previously failed with `Provider produced inconsistent result after apply`. The provider now preserves a configured empty list in state, mirroring the reconciliation used by `databricks_app_space`.
 
 ### Documentation
 

--- a/internal/providers/pluginfw/products/app/resource_app.go
+++ b/internal/providers/pluginfw/products/app/resource_app.go
@@ -125,6 +125,22 @@ func (a *resourceApp) ModifyPlan(ctx context.Context, req resource.ModifyPlanReq
 	tfschema.ValidateWorkspaceID(ctx, a.client, req, resp)
 }
 
+// reconcileEmptyUserApiScopes preserves a user-configured empty user_api_scopes list
+// when the Apps API omits the field from its response. The API only echoes
+// user_api_scopes back while OBO authorization is active, so an app created or updated
+// with `user_api_scopes = []` (to disable OBO) deserializes back to a null list.
+// Terraform treats a known empty list and null as distinct values, so without this the
+// provider reports "inconsistent result after apply" (and then a perpetual diff). An
+// empty list is indistinguishable from "unset" on the wire, so we only restore when the
+// configured value is a known, non-null, empty list. This mirrors the SyncFields
+// reconciliation generated for databricks_app_space.
+func reconcileEmptyUserApiScopes(configured, fromAPI types.List) types.List {
+	if !configured.IsNull() && !configured.IsUnknown() && fromAPI.IsNull() && len(configured.Elements()) == 0 {
+		return configured
+	}
+	return fromAPI
+}
+
 func (a *resourceApp) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	ctx = pluginfwcontext.SetUserAgentInResourceContext(ctx, resourceName)
 
@@ -175,6 +191,7 @@ func (a *resourceApp) Create(ctx context.Context, req resource.CreateRequest, re
 	}
 	newApp.NoCompute = app.NoCompute
 	newApp.ProviderConfig = app.ProviderConfig
+	newApp.UserApiScopes = reconcileEmptyUserApiScopes(app.UserApiScopes, newApp.UserApiScopes)
 	resp.Diagnostics.Append(resp.State.Set(ctx, newApp)...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -193,6 +210,7 @@ func (a *resourceApp) Create(ctx context.Context, req resource.CreateRequest, re
 		return
 	}
 	newApp.ProviderConfig = app.ProviderConfig
+	newApp.UserApiScopes = reconcileEmptyUserApiScopes(app.UserApiScopes, newApp.UserApiScopes)
 	resp.Diagnostics.Append(resp.State.Set(ctx, newApp)...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -279,6 +297,7 @@ func (a *resourceApp) Read(ctx context.Context, req resource.ReadRequest, resp *
 	}
 	newApp.NoCompute = app.NoCompute
 	newApp.ProviderConfig = app.ProviderConfig
+	newApp.UserApiScopes = reconcileEmptyUserApiScopes(app.UserApiScopes, newApp.UserApiScopes)
 	resp.Diagnostics.Append(resp.State.Set(ctx, newApp)...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -331,6 +350,7 @@ func (a *resourceApp) Update(ctx context.Context, req resource.UpdateRequest, re
 	// Modifying no_compute after creation has no effect.
 	newApp.NoCompute = app.NoCompute
 	newApp.ProviderConfig = app.ProviderConfig
+	newApp.UserApiScopes = reconcileEmptyUserApiScopes(app.UserApiScopes, newApp.UserApiScopes)
 	resp.Diagnostics.Append(resp.State.Set(ctx, newApp)...)
 	// No PopulateProviderConfigInState needed for Update: provider_config.workspace_id
 	// is already in state from a previous Create, and if the workspace ID had changed,

--- a/internal/providers/pluginfw/products/app/resource_app_acc_test.go
+++ b/internal/providers/pluginfw/products/app/resource_app_acc_test.go
@@ -200,6 +200,53 @@ func TestAccAppResource_NoCompute(t *testing.T) {
 	})
 }
 
+// TestAccAppResource_EmptyUserApiScopes is a regression test for ES-1857512 / #4760:
+// setting user_api_scopes = [] (to disable OBO authorization) must not produce
+// "inconsistent result after apply" or a perpetual diff, even though the Apps API omits
+// user_api_scopes from its response when OBO is inactive.
+func TestAccAppResource_EmptyUserApiScopes(t *testing.T) {
+	acceptance.LoadWorkspaceEnv(t)
+	if acceptance.IsGcp(t) {
+		acceptance.Skipf(t)("not available on GCP")
+	}
+	template := `
+	resource "databricks_secret_scope" "this" {
+		name = "tf-{var.STICKY_RANDOM}"
+	}
+
+	resource "databricks_secret" "this" {
+	    scope = databricks_secret_scope.this.name
+		key = "tf-{var.STICKY_RANDOM}"
+		string_value = "secret"
+	}
+	resource "databricks_app" "this" {
+		no_compute      = true
+		name            = "tf-{var.STICKY_RANDOM}"
+		description     = "empty user_api_scopes"
+		user_api_scopes = []
+		resources = [{
+			name = "secret"
+			description = "secret for app"
+			secret = {
+				scope = databricks_secret_scope.this.name
+				key = databricks_secret.this.key
+				permission = "MANAGE"
+			}
+		}]
+	}`
+	acceptance.WorkspaceLevel(t, acceptance.Step{
+		Template: template,
+		Check: func(s *terraform.State) error {
+			// State must hold a known empty list (count "0"), not null/absent.
+			assert.Equal(t, "0", s.RootModule().Resources["databricks_app.this"].Primary.Attributes["user_api_scopes.#"])
+			return nil
+		},
+	}, acceptance.Step{
+		// Re-applying the same config must be a no-op (no perpetual diff).
+		Template: template,
+	})
+}
+
 var deletedOutsideTemplate = `
 	resource "databricks_secret_scope" "this" {
 		name = "tf-{var.STICKY_RANDOM}"

--- a/internal/providers/pluginfw/products/app/resource_app_test.go
+++ b/internal/providers/pluginfw/products/app/resource_app_test.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -61,6 +63,39 @@ func TestResourceApp_SchemaPreserved(t *testing.T) {
 	assert.True(t, wsStr.Computed, "workspace_id should be computed")
 	assert.Len(t, wsStr.PlanModifiers, 1, "workspace_id should have RequiresReplaceIf plan modifier")
 	assert.Len(t, wsStr.Validators, 1, "workspace_id should have LengthAtLeast(1) validator only")
+}
+
+func TestReconcileEmptyUserApiScopes(t *testing.T) {
+	empty := types.ListValueMust(types.StringType, []attr.Value{})
+	null := types.ListNull(types.StringType)
+	unknown := types.ListUnknown(types.StringType)
+	sql := types.ListValueMust(types.StringType, []attr.Value{types.StringValue("sql")})
+
+	cases := []struct {
+		name       string
+		configured types.List
+		fromAPI    types.List
+		want       types.List
+	}{
+		// The fix: user configured [] but the API omitted the field (null) -> restore [].
+		{"configured empty, api null -> restore empty", empty, null, empty},
+		// API reports values (e.g. OBO active / out-of-band change) -> trust the API.
+		{"configured empty, api has values -> keep api", empty, sql, sql},
+		{"configured empty, api empty -> keep api empty", empty, empty, empty},
+		// Narrow guard: a non-empty configured value is never restored from null.
+		{"configured non-empty, api null -> keep api null", sql, null, null},
+		// Unset stays unset; we must not invent an empty list.
+		{"configured null, api null -> keep api null", null, null, null},
+		{"configured null, api has values -> keep api", null, sql, sql},
+		// Unknown (e.g. interpolated) is not treated as a known empty list.
+		{"configured unknown, api null -> keep api null", unknown, null, null},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := reconcileEmptyUserApiScopes(tc.configured, tc.fromAPI)
+			assert.True(t, got.Equal(tc.want), "got %v, want %v", got, tc.want)
+		})
+	}
 }
 
 func TestResourceApp_ModifyPlan_SkipsDestroyPlan(t *testing.T) {

--- a/internal/providers/pluginfw/products/app/resource_app_test.go
+++ b/internal/providers/pluginfw/products/app/resource_app_test.go
@@ -78,17 +78,52 @@ func TestReconcileEmptyUserApiScopes(t *testing.T) {
 		want       types.List
 	}{
 		// The fix: user configured [] but the API omitted the field (null) -> restore [].
-		{"configured empty, api null -> restore empty", empty, null, empty},
+		{
+			name:       "configured empty, api null -> restore empty",
+			configured: empty,
+			fromAPI:    null,
+			want:       empty,
+		},
 		// API reports values (e.g. OBO active / out-of-band change) -> trust the API.
-		{"configured empty, api has values -> keep api", empty, sql, sql},
-		{"configured empty, api empty -> keep api empty", empty, empty, empty},
+		{
+			name:       "configured empty, api has values -> keep api",
+			configured: empty,
+			fromAPI:    sql,
+			want:       sql,
+		},
+		{
+			name:       "configured empty, api empty -> keep api empty",
+			configured: empty,
+			fromAPI:    empty,
+			want:       empty,
+		},
 		// Narrow guard: a non-empty configured value is never restored from null.
-		{"configured non-empty, api null -> keep api null", sql, null, null},
+		{
+			name:       "configured non-empty, api null -> keep api null",
+			configured: sql,
+			fromAPI:    null,
+			want:       null,
+		},
 		// Unset stays unset; we must not invent an empty list.
-		{"configured null, api null -> keep api null", null, null, null},
-		{"configured null, api has values -> keep api", null, sql, sql},
+		{
+			name:       "configured null, api null -> keep api null",
+			configured: null,
+			fromAPI:    null,
+			want:       null,
+		},
+		{
+			name:       "configured null, api has values -> keep api",
+			configured: null,
+			fromAPI:    sql,
+			want:       sql,
+		},
 		// Unknown (e.g. interpolated) is not treated as a known empty list.
-		{"configured unknown, api null -> keep api null", unknown, null, null},
+		{
+			name:       "configured unknown, api null -> keep api null",
+			configured: unknown,
+			fromAPI:    null,
+			want:       null,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
## Changes

`databricks_app` could not set `user_api_scopes = []` (to disable On-Behalf-Of user authorization). The apply failed with `Provider produced inconsistent result after apply ... user_api_scopes: was [], but now null`, and the configured empty list otherwise produced a perpetual diff.

**Root cause:** the Apps API does not echo `user_api_scopes` back in its response when OBO authorization is inactive, so the response deserializes to a null list. Terraform treats a known empty list and `null` as different values, and `user_api_scopes` is an `Optional` (non-`Computed`) attribute, so the post-apply state (`null`) does not match the configured value (`[]`), which Core rejects.

This change reconciles the configured value into state when the API omits the field, mirroring the `SyncFields` reconciliation generated for `databricks_app_space`. The guard is intentionally **narrow** — it only restores a known, non-null, **empty** list (an empty list is indistinguishable from "unset" on the wire, so we never invent one) — and it is applied in Create, Read, and Update.

## Tests

- Unit test `TestReconcileEmptyUserApiScopes` covering all branches (configured empty / non-empty / null / unknown × API null / empty / values).
- Acceptance test `TestAccAppResource_EmptyUserApiScopes` creating a `databricks_app` with `user_api_scopes = []` and asserting a stable, empty plan (no inconsistent-result error, no perpetual diff).

_This pull request and its description were written by Isaac, a Claude Code AI agent._
