### PR TITLE
[Fix] Retry on potential eventual consistency case in permissions

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bug Fixes
 
+* Fix intermittent inconsistent final plan errors in `databricks_permissions` for SQL warehouse access control reads after permission updates ([#5837](https://github.com/databricks/terraform-provider-databricks/issues/5837)).
 * Fix permanent permissions drift when `user_name` casing in `databricks_permissions` `access_control` blocks differs from the API response ([#5757](hattps://github.com/databricks/terraform-provider-databricks/issues/5757)).
 
 ### Documentation

--- a/permissions/resource_permissions.go
+++ b/permissions/resource_permissions.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"path"
 	"strings"
+	"time"
 
 	"github.com/databricks/databricks-sdk-go/apierr"
 	"github.com/databricks/databricks-sdk-go/service/iam"
@@ -28,6 +29,12 @@ type PermissionsAPI struct {
 	client  *common.DatabricksClient
 	context context.Context
 }
+
+const (
+	permissionsReadConsistencyMaxRetries   = 5
+	permissionsReadConsistencyInitialDelay = 100 * time.Millisecond
+	permissionsReadConsistencyMaxDelay     = time.Second
+)
 
 // safePutWithOwner is a workaround for the limitation where warehouse without owners cannot have IS_OWNER set
 func (a PermissionsAPI) safePutWithOwner(objectID string, objectACL []iam.AccessControlRequest, mapping resourcePermissions, ownerOpt string) error {
@@ -157,11 +164,61 @@ func (a PermissionsAPI) readRaw(objectID string, mapping resourcePermissions) (*
 
 // Read gets all relevant permissions for the object, including inherited ones
 func (a PermissionsAPI) Read(objectID string, mapping resourcePermissions, existing entity.PermissionsEntity, me string) (entity.PermissionsEntity, error) {
-	permissions, err := a.readRaw(objectID, mapping)
-	if err != nil {
-		return entity.PermissionsEntity{}, err
+	for attempt := 0; ; attempt++ {
+		permissions, err := a.readRaw(objectID, mapping)
+		if err != nil {
+			return entity.PermissionsEntity{}, err
+		}
+		entity, err := mapping.prepareResponse(objectID, permissions, existing, me)
+		if err != nil {
+			return entity, err
+		}
+		if !permissionsReadMissingExistingAcl(existing, entity) || attempt >= permissionsReadConsistencyMaxRetries {
+			return entity, nil
+		}
+		if err := sleepPermissionsReadRetry(a.context, attempt); err != nil {
+			return entity, err
+		}
 	}
-	return mapping.prepareResponse(objectID, permissions, existing, me)
+}
+
+func permissionsReadMissingExistingAcl(expected, actual entity.PermissionsEntity) bool {
+	if len(expected.AccessControlList) == 0 {
+		return false
+	}
+	for _, expectedAcl := range expected.AccessControlList {
+		if !containsAccessControl(actual.AccessControlList, expectedAcl) {
+			return true
+		}
+	}
+	return false
+}
+
+func containsAccessControl(list []iam.AccessControlRequest, expected iam.AccessControlRequest) bool {
+	for _, actual := range list {
+		if actual.GroupName == expected.GroupName &&
+			strings.EqualFold(actual.UserName, expected.UserName) &&
+			strings.EqualFold(actual.ServicePrincipalName, expected.ServicePrincipalName) &&
+			actual.PermissionLevel == expected.PermissionLevel {
+			return true
+		}
+	}
+	return false
+}
+
+func sleepPermissionsReadRetry(ctx context.Context, attempt int) error {
+	delay := permissionsReadConsistencyInitialDelay << attempt
+	if delay > permissionsReadConsistencyMaxDelay {
+		delay = permissionsReadConsistencyMaxDelay
+	}
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
 }
 
 // PermissionsSchemaStruct is used to generate schema with provider_config

--- a/permissions/resource_permissions_test.go
+++ b/permissions/resource_permissions_test.go
@@ -892,6 +892,101 @@ func TestResourcePermissionsCreate_SQLA_Endpoint(t *testing.T) {
 	assert.Equal(t, "CAN_USE", firstElem["permission_level"])
 }
 
+func TestResourcePermissionsCreate_SQLA_Endpoint_RetriesStaleRead(t *testing.T) {
+	qa.ResourceFixture{
+		MockWorkspaceClientFunc: func(mwc *mocks.MockWorkspaceClient) {
+			mwc.GetMockCurrentUserAPI().EXPECT().Me(mock.Anything, mock.Anything).Return(&iam.User{UserName: "admin"}, nil)
+			e := mwc.GetMockPermissionsAPI().EXPECT()
+			e.Set(mock.Anything, iam.SetObjectPermissions{
+				RequestObjectId:   "abc",
+				RequestObjectType: "sql/warehouses",
+				AccessControlList: []iam.AccessControlRequest{
+					{
+						ServicePrincipalName: "sp-application-id",
+						PermissionLevel:      "CAN_USE",
+					},
+					{
+						GroupName:       "users",
+						PermissionLevel: "CAN_USE",
+					},
+					{
+						UserName:        "admin",
+						PermissionLevel: "CAN_MANAGE",
+					},
+					{
+						UserName:        "admin",
+						PermissionLevel: "IS_OWNER",
+					},
+				},
+			}).Return(nil, nil)
+			e.Get(mock.Anything, iam.GetPermissionRequest{
+				RequestObjectId:   "abc",
+				RequestObjectType: "sql/warehouses",
+			}).Return(&iam.ObjectPermissions{
+				ObjectId:   "warehouses/abc",
+				ObjectType: "warehouses",
+				AccessControlList: []iam.AccessControlResponse{
+					{
+						ServicePrincipalName: "sp-application-id",
+						AllPermissions:       []iam.Permission{{PermissionLevel: iam.PermissionLevelCanUse}},
+					},
+					{
+						UserName:       "admin",
+						AllPermissions: []iam.Permission{{PermissionLevel: iam.PermissionLevelCanManage}},
+					},
+				},
+			}, nil).Once()
+			e.Get(mock.Anything, iam.GetPermissionRequest{
+				RequestObjectId:   "abc",
+				RequestObjectType: "sql/warehouses",
+			}).Return(&iam.ObjectPermissions{
+				ObjectId:   "warehouses/abc",
+				ObjectType: "warehouses",
+				AccessControlList: []iam.AccessControlResponse{
+					{
+						GroupName:      "users",
+						AllPermissions: []iam.Permission{{PermissionLevel: iam.PermissionLevelCanUse}},
+					},
+					{
+						ServicePrincipalName: "sp-application-id",
+						AllPermissions:       []iam.Permission{{PermissionLevel: iam.PermissionLevelCanUse}},
+					},
+					{
+						UserName:       "admin",
+						AllPermissions: []iam.Permission{{PermissionLevel: iam.PermissionLevelCanManage}},
+					},
+				},
+			}, nil).Once()
+		},
+		Resource: ResourcePermissions(),
+		State: map[string]any{
+			"sql_endpoint_id": "abc",
+			"access_control": []any{
+				map[string]any{
+					"group_name":       "users",
+					"permission_level": "CAN_USE",
+				},
+				map[string]any{
+					"service_principal_name": "sp-application-id",
+					"permission_level":       "CAN_USE",
+				},
+			},
+		},
+		Create: true,
+	}.ApplyAndExpectData(t, map[string]any{
+		"access_control": []any{
+			map[string]any{
+				"group_name":       "users",
+				"permission_level": "CAN_USE",
+			},
+			map[string]any{
+				"service_principal_name": "sp-application-id",
+				"permission_level":       "CAN_USE",
+			},
+		},
+	})
+}
+
 func TestResourcePermissionsCreate_SQLA_Endpoint_WithOwnerError(t *testing.T) {
 	d, err := qa.ResourceFixture{
 		MockWorkspaceClientFunc: func(mwc *mocks.MockWorkspaceClient) {


### PR DESCRIPTION

## Changes
<!-- Summary of your changes that are easy to understand -->

@tanmay-db it looks like another case of eventual consistency in #5827

Resolves #5827


## Tests
<!--
How is this tested? Please see the checklist below and also describe any other relevant tests
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] using Go SDK
- [ ] using TF Plugin Framework
- [x] has entry in `NEXT_CHANGELOG.md` file
