### PR TITLE
Add git_credential_id attribute to databricks_repo resource

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### New Features and Improvements
 
+* Add optional `git_credential_id` attribute to `databricks_repo` resource to allow explicit credential selection when automatic selection fails (`GIT_CLI_CANNOT_CHOOSE_CREDENTIAL`).
 * Deprecate the SDKv2 fallback implementations of `databricks_library`, `databricks_quality_monitor`, and `databricks_share` resources, and the `databricks_share`, `databricks_shares`, and `databricks_volumes` data sources. These resources have been served by the Plugin Framework by default since their migration; the SDKv2 implementations remain only as opt-in fallbacks via the `USE_SDK_V2_RESOURCES` / `USE_SDK_V2_DATA_SOURCES` environment variables. Setting either environment variable for any of these names now emits a runtime warning (visible with `TF_LOG=WARN` or higher), and the SDKv2 implementations will be removed in the next major release of the provider.
 
 ### Bug Fixes

--- a/docs/resources/repo.md
+++ b/docs/resources/repo.md
@@ -30,6 +30,7 @@ The following arguments are supported:
 
 * `url` -  (Required) The URL of the Git Repository to clone from. If the value changes, Git folder is re-created.
 * `git_provider` - (Optional, if it's possible to detect Git provider by host name) case insensitive name of the Git provider.  Following values are supported right now (could be a subject for a change, consult [Repos API documentation](https://docs.databricks.com/dev-tools/api/latest/repos.html)): `gitHub`, `gitHubEnterprise`, `bitbucketCloud`, `bitbucketServer`, `azureDevOpsServices`, `gitLab`, `gitLabEnterpriseEdition`, `awsCodeCommit`.
+* `git_credential_id` - (Optional) The ID of the Git credential (`databricks_git_credential`) to use for this repo.  Required when the workspace has multiple credentials or when automatic credential selection fails (`GIT_CLI_CANNOT_CHOOSE_CREDENTIAL`).  If the value changes, the Git folder is re-created.
 * `path` - (Optional) path to put the checked out Git folder. If not specified, , then the Git folder will be created in the default location.  If the value changes, Git folder is re-created.
 * `branch` - (Optional) name of the branch for initial checkout. If not specified, the default branch of the repository will be used.  Conflicts with `tag`.  If `branch` is removed, and `tag` isn't specified, then the repository will stay at the previously checked out state.
 * `tag` - (Optional) name of the tag for initial checkout.  Conflicts with `branch`.

--- a/repos/repo_git_credential_test.go
+++ b/repos/repo_git_credential_test.go
@@ -1,0 +1,25 @@
+package repos_test
+
+import (
+	"testing"
+
+	"github.com/databricks/terraform-provider-databricks/internal/acceptance"
+)
+
+func TestAccRepo_WithGitCredentialID(t *testing.T) {
+	acceptance.WorkspaceLevel(t, acceptance.Step{
+		Template: `
+		resource "databricks_git_credential" "this" {
+			git_username          = "test"
+			git_provider          = "gitHub"
+			personal_access_token = "ghp_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+			force                 = true
+		}
+
+		resource "databricks_repo" "this" {
+			url               = "https://github.com/databricks/databricks-sdk-go"
+			git_credential_id = databricks_git_credential.this.id
+		}
+		`,
+	})
+}

--- a/repos/resource_repo.go
+++ b/repos/resource_repo.go
@@ -46,10 +46,11 @@ func (r ReposInformation) RepoID() string {
 }
 
 type reposCreateRequest struct {
-	Url            string               `json:"url"`
-	Provider       string               `json:"provider"`
-	Path           string               `json:"path,omitempty"`
-	SparseCheckout *ReposSparseCheckout `json:"sparse_checkout,omitempty"`
+	Url             string               `json:"url"`
+	Provider        string               `json:"provider"`
+	Path            string               `json:"path,omitempty"`
+	SparseCheckout  *ReposSparseCheckout `json:"sparse_checkout,omitempty"`
+	GitCredentialID int64                `json:"git_credential_id,omitempty"`
 }
 
 func (a ReposAPI) Create(r reposCreateRequest) (ReposInformation, error) {
@@ -177,6 +178,11 @@ func ResourceRepo() common.Resource {
 			ConflictsWith: []string{"branch"},
 			ValidateFunc:  validation.StringIsNotWhiteSpace,
 		}
+		s["git_credential_id"] = &schema.Schema{
+			Type:     schema.TypeInt,
+			Optional: true,
+			ForceNew: true,
+		}
 		s["workspace_path"] = &schema.Schema{
 			Type:     schema.TypeString,
 			Computed: true,
@@ -204,7 +210,8 @@ func ResourceRepo() common.Resource {
 			common.DataToStructPointer(d, s, &repo)
 
 			req := reposCreateRequest{Path: repo.Path, Provider: repo.Provider,
-				Url: repo.Url, SparseCheckout: repo.SparseCheckout}
+				Url: repo.Url, SparseCheckout: repo.SparseCheckout,
+				GitCredentialID: int64(d.Get("git_credential_id").(int))}
 			resp, err := reposAPI.Create(req)
 			if err != nil {
 				return err

--- a/repos/resource_repo_test.go
+++ b/repos/resource_repo_test.go
@@ -128,6 +128,45 @@ func TestResourceRepoCreateNoBranch(t *testing.T) {
 			"git_provider": resp.Provider, "url": resp.Url, "commit_hash": resp.HeadCommitID})
 }
 
+func TestResourceRepoCreateWithGitCredentialID(t *testing.T) {
+	resp := ReposInformation{
+		ID:           121232342,
+		Url:          "https://github.com/user/test.git",
+		Provider:     "gitHub",
+		Branch:       "main",
+		Path:         "/Repos/user@domain/test",
+		HeadCommitID: "1124323423abc23424",
+	}
+	qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "POST",
+				Resource: "/api/2.0/repos",
+				ExpectedRequest: reposCreateRequest{
+					Url:             "https://github.com/user/test.git",
+					Provider:        "gitHub",
+					GitCredentialID: 388825371666399,
+				},
+				Response: resp,
+			},
+			{
+				Method:   "GET",
+				Resource: "/api/2.0/repos/121232342",
+				Response: resp,
+			},
+		},
+		Resource: ResourceRepo(),
+		State: map[string]any{
+			"url":               "https://github.com/user/test.git",
+			"git_credential_id": 388825371666399,
+		},
+		Create: true,
+	}.ApplyAndExpectData(t,
+		map[string]any{"id": resp.RepoID(), "path": resp.Path, "branch": resp.Branch,
+			"git_provider": resp.Provider, "url": resp.Url, "commit_hash": resp.HeadCommitID,
+			"git_credential_id": 388825371666399})
+}
+
 func TestResourceRepoCreateCustomDirectory(t *testing.T) {
 	resp := ReposInformation{
 		ID:           121232342,


### PR DESCRIPTION
The Databricks platform now requires explicit credential selection when creating repos via the API (GIT_CLI_CANNOT_CHOOSE_CREDENTIAL error). The Repos API accepts an undocumented git_credential_id parameter that resolves this, but the databricks_repo resource does not expose it.

This adds an optional git_credential_id attribute (ForceNew) that is passed through to POST /api/2.0/repos on resource creation. When unset, behavior is unchanged (omitempty ensures the field is not serialized).

## Changes

- Added `GitCredentialID int64` to `reposCreateRequest` struct with `json:"git_credential_id,omitempty"`
- Added `git_credential_id` as an optional, ForceNew `schema.TypeInt` field in the resource schema
- Wired the field into the Create function
- Added `TestResourceRepoCreateWithGitCredentialID` unit test
- Added `TestAccRepo_WithGitCredentialID` acceptance test
- Added docs for the new attribute in `docs/resources/repo.md`
- Added changelog entry in `NEXT_CHANGELOG.md`

**Future consideration:** A `databricks_git_credentials` data source would allow looking up the credential ID dynamically rather than hardcoding it. Not included here to keep scope tight, but would be a natural follow-up.

## Tests

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [x] covered with integration tests in `internal/acceptance`
- [ ] using Go SDK
- [ ] using TF Plugin Framework
- [x] has entry in `NEXT_CHANGELOG.md` file

Unit test added (`TestResourceRepoCreateWithGitCredentialID`). Acceptance test added (`TestAccRepo_WithGitCredentialID`) -- creates a `databricks_git_credential` and references its ID in `databricks_repo`. End-to-end tested against a production workspace exhibiting the GIT_CLI_CANNOT_CHOOSE_CREDENTIAL error -- repo creation succeeds with the credential ID specified.

Note: This uses the legacy SDKv2 resource pattern, matching the existing `databricks_repo` implementation.