### PR TITLE
[Exporter] Generate code in `import.sh` more safely

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -14,6 +14,8 @@
 
 ### Exporter
 
+* Generate code in `import.sh` more safely ([#5848](hattps://github.com/databricks/terraform-provider-databricks/issues/5848)).
+
 ### Internal Changes
 
 * Make notification destination acceptance tests robust to the eventual consistency of the notification destinations list API.

--- a/exporter/codegen.go
+++ b/exporter/codegen.go
@@ -32,9 +32,24 @@ func (ic *importContext) generateVariableName(attrName, name string) string {
 	return fmt.Sprintf("%s_%s", attrName, name)
 }
 
+// maybeAddQuoteCharacter escapes a string so that it is safe to emit as a
+// literal segment inside a double-quoted HCL string when building tokens
+// manually (i.e. not through hclwrite.TokensForValue, which escapes on its
+// own). It handles the four sequences that would otherwise let attacker
+// controlled values break out of the string literal or inject expressions:
+// backslashes, double quotes, `${` interpolations, `%{` template directives
+// and raw control characters (newlines/CR/tab, which are not allowed literally
+// inside a quoted HCL string). Without this, values such as file names derived
+// from workspace or DBFS object paths could inject arbitrary HCL into generated
+// *.tf files.
 func maybeAddQuoteCharacter(s string) string {
 	s = strings.ReplaceAll(s, "\\", "\\\\")
 	s = strings.ReplaceAll(s, "\"", "\\\"")
+	s = strings.ReplaceAll(s, "${", "$${")
+	s = strings.ReplaceAll(s, "%{", "%%{")
+	s = strings.ReplaceAll(s, "\n", "\\n")
+	s = strings.ReplaceAll(s, "\r", "\\r")
+	s = strings.ReplaceAll(s, "\t", "\\t")
 	return s
 }
 
@@ -229,7 +244,10 @@ func (ic *importContext) reference(i importable, path []string, value string, ct
 			continue
 		}
 		if d.File {
-			relativeFile := fmt.Sprintf("${path.module}/%s", value)
+			// `${path.module}/` must stay a real interpolation, but `value` is a
+			// file name derived from an attacker-controlled object path, so it
+			// must be escaped to prevent breaking out of the string literal.
+			relativeFile := "${path.module}/" + maybeAddQuoteCharacter(value)
 			return hclwrite.Tokens{
 				&hclwrite.Token{Type: hclsyntax.TokenOQuote, Bytes: []byte{'"'}},
 				&hclwrite.Token{Type: hclsyntax.TokenQuotedLit, Bytes: []byte(relativeFile)},

--- a/exporter/codegen_test.go
+++ b/exporter/codegen_test.go
@@ -1,0 +1,97 @@
+package exporter
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestMaybeAddQuoteCharacter(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{`plain`, `plain`},
+		{`with"quote`, `with\"quote`},
+		{`with\backslash`, `with\\backslash`},
+		{`inter${polation}`, `inter$${polation}`},
+		{`template%{if}`, `template%%{if}`},
+		{`a"b\c${d}%{e}`, `a\"b\\c$${d}%%{e}`},
+	}
+	for _, c := range cases {
+		assert.Equal(t, c.want, maybeAddQuoteCharacter(c.in))
+	}
+}
+
+// TestReferenceFileHclInjection is a regression test for the HCL injection
+// sibling of SEC-21613 (H1-3750315): a file name derived from an attacker
+// controlled object path flows into a `File` reference and is emitted into a
+// generated *.tf file. The value must be escaped so it cannot break out of the
+// string literal and inject arbitrary HCL, while `${path.module}` must remain a
+// real interpolation.
+func TestReferenceFileHclInjection(t *testing.T) {
+	ic := &importContext{}
+	i := importable{
+		Depends: []reference{{Path: "source", File: true}},
+	}
+
+	// A benign file name still renders as a path.module-relative reference.
+	benign := "dbfs_files/_0cc175b9c0f1b6a831c399e269772661_a"
+	benignTokens := ic.reference(i, []string{"source"}, benign, cty.StringVal(benign), &resource{})
+	assert.Equal(t, `"${path.module}/dbfs_files/_0cc175b9c0f1b6a831c399e269772661_a"`,
+		renderTokens(t, benignTokens))
+
+	// A malicious file name attempting to break out of the string literal and
+	// inject a resource block must be neutralized.
+	malicious := "dbfs_files/_md5_evil\"}\nresource \"null_resource\" \"x\" {}\n#"
+	tokens := ic.reference(i, []string{"source"}, malicious, cty.StringVal(malicious), &resource{})
+	rendered := renderTokens(t, tokens)
+
+	// The embedded quote must be escaped, so no bare `"}` closes the string.
+	assert.Contains(t, rendered, `\"}`)
+	// path.module interpolation is preserved.
+	assert.True(t, strings.HasPrefix(rendered, `"${path.module}/`))
+
+	// Most importantly: parsing an attribute built from these tokens must not
+	// yield any injected block.
+	f := hclwrite.NewEmptyFile()
+	f.Body().SetAttributeRaw("source", tokens)
+	parsed, diags := hclwrite.ParseConfig(f.Bytes(), "test.tf", hcl.Pos{Line: 1, Column: 1})
+	require.False(t, diags.HasErrors(), "generated HCL failed to parse: %s", diags.Error())
+	assert.Empty(t, parsed.Body().Blocks(),
+		"HCL injection succeeded: an unexpected block was generated from the file name")
+	assert.NotNil(t, parsed.Body().GetAttribute("source"))
+}
+
+// TestReferenceFileHclInterpolationInjection ensures a file name that tries to
+// inject an HCL interpolation (`${...}`) is escaped and rendered literally.
+func TestReferenceFileHclInterpolationInjection(t *testing.T) {
+	ic := &importContext{}
+	i := importable{Depends: []reference{{Path: "source", File: true}}}
+
+	malicious := `dbfs_files/${file("/etc/passwd")}`
+	tokens := ic.reference(i, []string{"source"}, malicious, cty.StringVal(malicious), &resource{})
+	rendered := renderTokens(t, tokens)
+
+	// The injected interpolation must be escaped to a literal `$${`.
+	assert.Contains(t, rendered, `$${file(`)
+	assert.NotContains(t, rendered, `/${file(`)
+	// The intended path.module interpolation is still present exactly once.
+	assert.Equal(t, 1, strings.Count(rendered, "${path.module}"))
+}
+
+func renderTokens(t *testing.T, tokens hclwrite.Tokens) string {
+	t.Helper()
+	f := hclwrite.NewEmptyFile()
+	f.Body().SetAttributeRaw("v", tokens)
+	src := string(hclwrite.Format(f.Bytes()))
+	// Extract the value after `v = `.
+	_, rhs, ok := strings.Cut(src, "= ")
+	require.True(t, ok, "unexpected rendered attribute: %q", src)
+	return strings.TrimSpace(rhs)
+}

--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -2983,8 +2983,8 @@ func TestIncrementalDLTAndMLflowWebhooks(t *testing.T) {
 			defer os.RemoveAll(tmpDir)
 			os.Mkdir(tmpDir, 0700)
 			os.WriteFile(tmpDir+"/import.sh", []byte(
-				`terraform import databricks_pipeline.abc "abc"
-terraform import databricks_pipeline.def "def"
+				`terraform import databricks_pipeline.abc 'abc'
+terraform import databricks_pipeline.def 'def'
 `), 0700)
 
 			os.WriteFile(tmpDir+"/import.tf", []byte(
@@ -3025,8 +3025,8 @@ resource "databricks_pipeline" "def" {
 			content, err := os.ReadFile(tmpDir + "/import.sh")
 			assert.NoError(t, err)
 			contentStr := string(content)
-			assert.True(t, strings.Contains(contentStr, `import databricks_pipeline.abc "abc"`))
-			assert.True(t, strings.Contains(contentStr, `import databricks_pipeline.def "def"`))
+			assert.True(t, strings.Contains(contentStr, `import databricks_pipeline.abc 'abc'`))
+			assert.True(t, strings.Contains(contentStr, `import databricks_pipeline.def 'def'`))
 
 			content, err = os.ReadFile(tmpDir + "/import.tf")
 			assert.NoError(t, err)

--- a/exporter/model.go
+++ b/exporter/model.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"regexp"
 	"sort"
+	"strings"
 	"sync"
 
 	"github.com/databricks/terraform-provider-databricks/common"
@@ -290,12 +291,26 @@ func (r *resource) String() string {
 	return fmt.Sprintf("%s[%s] (%s: %s)", r.Resource, n, k, v)
 }
 
+// shellQuote wraps s in POSIX single quotes so that a shell treats it as a
+// literal string. This prevents command substitution ($(...), backticks),
+// variable expansion (${...}) and interpretation of any other metacharacters
+// when the generated import.sh is executed. Embedded single quotes are escaped
+// as '\”. Attacker-controlled values (e.g. workspace object paths) end up in
+// r.ID, so the ID must always be quoted before it is written to import.sh.
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
 func (r *resource) ImportCommand(ic *importContext) string {
 	m := ""
 	if ic.Module != "" {
 		m = ic.Module + "."
 	}
-	return fmt.Sprintf(`terraform import %s%s.%s "%s"`, m, r.Resource, r.Name, r.ID)
+	// r.Resource and r.Name are normalized identifiers (see nameNormalizationRegex),
+	// so only r.ID is attacker-controlled and needs shell escaping. Keeping the
+	// resource address unquoted also preserves the whitespace-split parsing in
+	// writeShellImports used for incremental/deleted-resource handling.
+	return fmt.Sprintf("terraform import %s%s.%s %s", m, r.Resource, r.Name, shellQuote(r.ID))
 }
 
 func (r *resource) ImportResource(ic *importContext) {

--- a/exporter/model_test.go
+++ b/exporter/model_test.go
@@ -1,6 +1,11 @@
 package exporter
 
 import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -29,4 +34,110 @@ func TestExtraDataGet(t *testing.T) {
 	v, found := r.GetExtraData("test")
 	require.True(t, found)
 	assert.Equal(t, "42", v.(string))
+}
+
+// TestImportCommandShellEscaping is a regression test for SEC-21613
+// (H1-3750124): attacker-controlled workspace object paths flow into r.ID and
+// are interpolated into the generated import.sh. The ID must be POSIX
+// single-quote-escaped so that shell metacharacters are treated as literals.
+func TestImportCommandShellEscaping(t *testing.T) {
+	ic := &importContext{}
+	cases := []struct {
+		name string
+		id   string
+		want string
+	}{
+		{
+			name: "benign path",
+			id:   "/Users/me/notebook",
+			want: `terraform import databricks_notebook.foo '/Users/me/notebook'`,
+		},
+		{
+			name: "command substitution",
+			id:   "/Shared/$(touch pwned).py",
+			want: `terraform import databricks_notebook.foo '/Shared/$(touch pwned).py'`,
+		},
+		{
+			name: "backtick substitution",
+			id:   "/a/`touch pwned`.py",
+			want: "terraform import databricks_notebook.foo '/a/`touch pwned`.py'",
+		},
+		{
+			name: "variable expansion",
+			id:   "/a/${HOME}.py",
+			want: `terraform import databricks_notebook.foo '/a/${HOME}.py'`,
+		},
+		{
+			name: "double quotes",
+			id:   `/a/"b".py`,
+			want: `terraform import databricks_notebook.foo '/a/"b".py'`,
+		},
+		{
+			name: "embedded single quotes",
+			id:   `/a/'b'.py`,
+			want: `terraform import databricks_notebook.foo '/a/'\''b'\''.py'`,
+		},
+		{
+			name: "backslash",
+			id:   `/a/\b.py`,
+			want: `terraform import databricks_notebook.foo '/a/\b.py'`,
+		},
+		{
+			name: "newline",
+			id:   "/a/\nrm -rf x\n.py",
+			want: "terraform import databricks_notebook.foo '/a/\nrm -rf x\n.py'",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			r := &resource{Resource: "databricks_notebook", Name: "foo", ID: c.id}
+			assert.Equal(t, c.want, r.ImportCommand(ic))
+		})
+	}
+
+	// The module prefix must still be emitted for the resource address.
+	r := &resource{Resource: "databricks_notebook", Name: "foo", ID: "/a/b"}
+	icMod := &importContext{Module: "mymod"}
+	assert.Equal(t, `terraform import mymod.databricks_notebook.foo '/a/b'`, r.ImportCommand(icMod))
+}
+
+// TestImportCommandNoShellInjectionWhenExecuted executes a generated import.sh
+// containing malicious workspace paths and asserts that no marker file is
+// created, i.e. the embedded commands do not run. Regression test for SEC-21613.
+func TestImportCommandNoShellInjectionWhenExecuted(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("import.sh is a POSIX shell script")
+	}
+	dir := t.TempDir()
+
+	// Stub `terraform` on PATH so the script's `set -e` doesn't abort and no
+	// real CLI is required; the stub is a no-op.
+	stub := filepath.Join(dir, "terraform")
+	require.NoError(t, os.WriteFile(stub, []byte("#!/bin/sh\nexit 0\n"), 0o755))
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	dollarMarker := filepath.Join(dir, "pwned_dollar")
+	backtickMarker := filepath.Join(dir, "pwned_backtick")
+
+	ic := &importContext{}
+	payloads := []string{
+		"/Shared/$(touch " + dollarMarker + ").py",
+		"/Shared/`touch " + backtickMarker + "`.py",
+	}
+	var lines []string
+	for _, p := range payloads {
+		r := &resource{Resource: "databricks_notebook", Name: "foo", ID: p}
+		lines = append(lines, r.ImportCommand(ic))
+	}
+	// Mirror the real import.sh header (context.go).
+	script := "#!/bin/sh\n\nset -e\n\n" + strings.Join(lines, "\n") + "\n"
+	shPath := filepath.Join(dir, "import.sh")
+	require.NoError(t, os.WriteFile(shPath, []byte(script), 0o755))
+
+	out, err := exec.Command("/bin/sh", shPath).CombinedOutput()
+	require.NoError(t, err, "import.sh failed to run: %s", out)
+
+	markers, err := filepath.Glob(filepath.Join(dir, "pwned_*"))
+	require.NoError(t, err)
+	assert.Empty(t, markers, "command injection executed; marker files were created: %v", markers)
 }


### PR DESCRIPTION
Resolves reported security issue. 

Also escape file names referenced from generated `*.tf` files to prevent HCL injection. File names derived from attacker-controlled object paths (e.g. DBFS files) are now escaped when emitted into `${path.module}/...` references, so they cannot break out of the string literal or inject interpolations/template directives.

## Changes
<!-- Summary of your changes that are easy to understand -->

## Tests
<!--
How is this tested? Please see the checklist below and also describe any other relevant tests
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] using Go SDK
- [ ] using TF Plugin Framework
- [x] has entry in `NEXT_CHANGELOG.md` file
