### PR TITLE
Add `databricks_mws_permission_assignments` data source

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### New Features and Improvements
 
+* Added `databricks_mws_permission_assignments` data source to list all workspace permission assignments for a workspace via the account API ([#5853](https://github.com/databricks/terraform-provider-databricks/pull/5853)).
+
 ### Bug Fixes
 
 ### Documentation

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### New Features and Improvements
 
+* Added `databricks_mws_permission_assignments` data source to list all workspace permission assignments for a workspace via the account API ([#5853](https://github.com/databricks/terraform-provider-databricks/pull/5853)).
+
 ### Bug Fixes
 
 ### Documentation

--- a/docs/data-sources/mws_permission_assignments.md
+++ b/docs/data-sources/mws_permission_assignments.md
@@ -1,0 +1,58 @@
+---
+subcategory: "Security"
+---
+# databricks_mws_permission_assignments Data Source
+
+[API Documentation](https://docs.databricks.com/api/account/workspaceassignment/list)
+
+This data source lists all workspace permission assignments for a given workspace, using the Databricks account API. It is the read-only, symmetric counterpart of the [databricks_mws_permission_assignment](../resources/mws_permission_assignment.md) resource, which manages a single assignment.
+
+-> This data source can only be used with an account-level provider!
+
+## Example Usage
+
+In account context, listing all permission assignments for a workspace:
+
+```hcl
+provider "databricks" {
+  // <other properties>
+  account_id = "<databricks account id>"
+}
+
+data "databricks_mws_permission_assignments" "this" {
+  workspace_id = databricks_mws_workspaces.this.workspace_id
+}
+
+output "assignments" {
+  value = data.databricks_mws_permission_assignments.this.permission_assignments
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `workspace_id` - (Required) The numeric ID of the workspace to list permission assignments for.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `permission_assignments` - A list of all workspace permission assignments. Each element contains the following attributes:
+    * `error` - Error response associated with a workspace permission assignment, if any.
+    * `permissions` - The permission levels of the principal. Possible values are `USER` and `ADMIN`.
+    * `principal` - Information about the principal assigned to the workspace:
+        * `principal_id` - The unique, opaque ID of the principal.
+        * `display_name` - The display name of the principal.
+        * `group_name` - The group name of the group. Present only if the principal is a group.
+        * `service_principal_name` - The name of the service principal. Present only if the principal is a service principal.
+        * `user_name` - The username of the user. Present only if the principal is a user.
+
+If the workspace has no permission assignments, an empty list will be returned.
+
+## Related Resources
+
+The following resources are used in the same context:
+
+* [databricks_mws_permission_assignment](../resources/mws_permission_assignment.md) to manage a single workspace permission assignment in the account context.
+* [databricks_permission_assignment](../resources/permission_assignment.md) to manage a single workspace permission assignment in the workspace context.

--- a/internal/providers/pluginfw/pluginfw_rollout_utils.go
+++ b/internal/providers/pluginfw/pluginfw_rollout_utils.go
@@ -19,6 +19,7 @@ import (
 	"github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/products/cluster"
 	"github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/products/dashboards"
 	"github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/products/library"
+	"github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/products/mws_permission_assignments"
 	"github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/products/notificationdestinations"
 	"github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/products/qualitymonitor"
 	"github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/products/registered_model"
@@ -68,6 +69,7 @@ var pluginFwOnlyDataSources = append(
 		app.DataSourceApps,
 		catalog.DataSourceFunctions,
 		dashboards.DataSourceDashboards,
+		mws_permission_assignments.DataSourceMwsPermissionAssignments,
 		notificationdestinations.DataSourceNotificationDestinations,
 		registered_model.DataSourceRegisteredModel,
 		registered_model.DataSourceRegisteredModelVersions,

--- a/internal/providers/pluginfw/pluginfw_rollout_utils.go
+++ b/internal/providers/pluginfw/pluginfw_rollout_utils.go
@@ -31,6 +31,7 @@ import (
 	"github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/products/cluster"
 	"github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/products/dashboards"
 	"github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/products/library"
+	"github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/products/mws_permission_assignments"
 	"github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/products/networks/privateendpointrule"
 	"github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/products/notificationdestinations"
 	"github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/products/qualitymonitor"
@@ -95,6 +96,7 @@ var pluginFwOnlyDataSources = append(
 		app.DataSourceApps,
 		catalog.DataSourceFunctions,
 		dashboards.DataSourceDashboards,
+		mws_permission_assignments.DataSourceMwsPermissionAssignments,
 		notificationdestinations.DataSourceNotificationDestinations,
 		registered_model.DataSourceRegisteredModel,
 		registered_model.DataSourceRegisteredModelVersions,

--- a/internal/providers/pluginfw/products/mws_permission_assignments/data_mws_permission_assignments.go
+++ b/internal/providers/pluginfw/products/mws_permission_assignments/data_mws_permission_assignments.go
@@ -1,0 +1,121 @@
+package mws_permission_assignments
+
+import (
+	"context"
+	"reflect"
+
+	"github.com/databricks/databricks-sdk-go/service/iam"
+	"github.com/databricks/terraform-provider-databricks/common"
+	pluginfwcommon "github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/common"
+	pluginfwcontext "github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/context"
+	"github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/converters"
+	"github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/tfschema"
+	"github.com/databricks/terraform-provider-databricks/internal/service/iam_tf"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+const dataSourceName = "mws_permission_assignments"
+
+func DataSourceMwsPermissionAssignments() datasource.DataSource {
+	return &MwsPermissionAssignmentsDataSource{}
+}
+
+var _ datasource.DataSourceWithConfigure = &MwsPermissionAssignmentsDataSource{}
+
+type MwsPermissionAssignmentsDataSource struct {
+	Client *common.DatabricksClient
+}
+
+// MwsPermissionAssignmentsInfo is the Terraform schema for the
+// databricks_mws_permission_assignments data source. WorkspaceId is the only
+// input; PermissionAssignments holds the list read back from the account API.
+type MwsPermissionAssignmentsInfo struct {
+	WorkspaceId           types.Int64 `tfsdk:"workspace_id"`
+	PermissionAssignments types.List  `tfsdk:"permission_assignments"`
+}
+
+func (MwsPermissionAssignmentsInfo) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
+	attrs["workspace_id"] = attrs["workspace_id"].SetRequired()
+	attrs["permission_assignments"] = attrs["permission_assignments"].SetComputed()
+	return attrs
+}
+
+func (MwsPermissionAssignmentsInfo) GetComplexFieldTypes(context.Context) map[string]reflect.Type {
+	return map[string]reflect.Type{
+		"permission_assignments": reflect.TypeOf(iam_tf.PermissionAssignment{}),
+	}
+}
+
+func (d *MwsPermissionAssignmentsDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = pluginfwcommon.GetDatabricksProductionName(dataSourceName)
+}
+
+func (d *MwsPermissionAssignmentsDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	attrs, blocks := tfschema.DataSourceStructToSchemaMap(ctx, MwsPermissionAssignmentsInfo{}, nil)
+	resp.Schema = schema.Schema{
+		Description: "Lists all workspace permission assignments for a workspace via the Databricks account API. This data source can only be used with an account-level provider.",
+		Attributes:  attrs,
+		Blocks:      blocks,
+	}
+}
+
+func (d *MwsPermissionAssignmentsDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if d.Client == nil {
+		d.Client = pluginfwcommon.ConfigureDataSource(req, resp)
+	}
+}
+
+// flattenPermissionAssignments converts the SDK response into the list of
+// Terraform SDK objects used in the data source state. It is kept separate from
+// Read so the flatten/convert logic can be unit tested without a live client.
+func flattenPermissionAssignments(ctx context.Context, assignments *iam.PermissionAssignments) ([]attr.Value, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	result := []attr.Value{}
+	if assignments == nil {
+		return result, diags
+	}
+	for _, assignment := range assignments.PermissionAssignments {
+		var tfAssignment iam_tf.PermissionAssignment
+		diags.Append(converters.GoSdkToTfSdkStruct(ctx, assignment, &tfAssignment)...)
+		if diags.HasError() {
+			return result, diags
+		}
+		result = append(result, tfAssignment.ToObjectValue(ctx))
+	}
+	return result, diags
+}
+
+func (d *MwsPermissionAssignmentsDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	ctx = pluginfwcontext.SetUserAgentInDataSourceContext(ctx, dataSourceName)
+
+	var info MwsPermissionAssignmentsInfo
+	resp.Diagnostics.Append(req.Config.Get(ctx, &info)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	a, diags := d.Client.GetAccountClient()
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	assignments, err := a.WorkspaceAssignment.ListByWorkspaceId(ctx, info.WorkspaceId.ValueInt64())
+	if err != nil {
+		resp.Diagnostics.AddError("failed to list workspace permission assignments", err.Error())
+		return
+	}
+
+	tfAssignments, flattenDiags := flattenPermissionAssignments(ctx, assignments)
+	resp.Diagnostics.Append(flattenDiags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	info.PermissionAssignments = types.ListValueMust(iam_tf.PermissionAssignment{}.Type(ctx), tfAssignments)
+	resp.Diagnostics.Append(resp.State.Set(ctx, info)...)
+}

--- a/internal/providers/pluginfw/products/mws_permission_assignments/data_mws_permission_assignments_acc_test.go
+++ b/internal/providers/pluginfw/products/mws_permission_assignments/data_mws_permission_assignments_acc_test.go
@@ -1,0 +1,64 @@
+package mws_permission_assignments_test
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/databricks/terraform-provider-databricks/internal/acceptance"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+// TestUcAccPermissionAssignmentsDataSource creates a workspace permission
+// assignment for a freshly created group and asserts the
+// databricks_mws_permission_assignments data source lists it back. Runs against
+// an account-level (Unity) provider; DUMMY_WORKSPACE_ID must point at a
+// workspace the account can manage assignments for. The TestUcAcc prefix pairs
+// with UnityAccountLevel (TEST_ENVIRONMENT_TYPE=UC_ACCOUNT); a TestMwsAcc name
+// would be skipped by skipIfNotEnvironmentType in the non-UC account env.
+func TestUcAccPermissionAssignmentsDataSource(t *testing.T) {
+	acceptance.UnityAccountLevel(t, acceptance.Step{
+		Template: `
+		resource "databricks_group" "this" {
+			display_name = "TF {var.RANDOM}"
+		}
+
+		resource "databricks_mws_permission_assignment" "this" {
+			workspace_id = {env.DUMMY_WORKSPACE_ID}
+			principal_id = databricks_group.this.id
+			permissions  = ["USER"]
+		}
+
+		data "databricks_mws_permission_assignments" "this" {
+			workspace_id = {env.DUMMY_WORKSPACE_ID}
+			depends_on   = [databricks_mws_permission_assignment.this]
+		}`,
+		Check: func(s *terraform.State) error {
+			group, ok := s.RootModule().Resources["databricks_group.this"]
+			if !ok {
+				return fmt.Errorf("databricks_group.this is missing from the state")
+			}
+			principalID := group.Primary.ID
+
+			ds, ok := s.RootModule().Resources["data.databricks_mws_permission_assignments.this"]
+			if !ok {
+				return fmt.Errorf("data.databricks_mws_permission_assignments.this is missing from the state")
+			}
+			count, err := strconv.Atoi(ds.Primary.Attributes["permission_assignments.#"])
+			if err != nil {
+				return fmt.Errorf("permission_assignments count is not a number: %w", err)
+			}
+			for i := 0; i < count; i++ {
+				id := ds.Primary.Attributes[fmt.Sprintf("permission_assignments.%d.principal.principal_id", i)]
+				if id != principalID {
+					continue
+				}
+				if perm := ds.Primary.Attributes[fmt.Sprintf("permission_assignments.%d.permissions.0", i)]; perm != "USER" {
+					return fmt.Errorf("expected principal %s to have USER permission, got %q", principalID, perm)
+				}
+				return nil
+			}
+			return fmt.Errorf("assigned principal %s not returned by the data source (%d listed)", principalID, count)
+		},
+	})
+}

--- a/internal/providers/pluginfw/products/mws_permission_assignments/data_mws_permission_assignments_test.go
+++ b/internal/providers/pluginfw/products/mws_permission_assignments/data_mws_permission_assignments_test.go
@@ -1,0 +1,121 @@
+package mws_permission_assignments
+
+import (
+	"context"
+	"testing"
+
+	"github.com/databricks/databricks-sdk-go/service/iam"
+	"github.com/databricks/terraform-provider-databricks/internal/service/iam_tf"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFlattenPermissionAssignments_Nil(t *testing.T) {
+	result, diags := flattenPermissionAssignments(context.Background(), nil)
+	require.False(t, diags.HasError())
+	assert.Empty(t, result)
+}
+
+func TestFlattenPermissionAssignments_Empty(t *testing.T) {
+	result, diags := flattenPermissionAssignments(context.Background(), &iam.PermissionAssignments{})
+	require.False(t, diags.HasError())
+	assert.Empty(t, result)
+}
+
+func TestFlattenPermissionAssignments(t *testing.T) {
+	ctx := context.Background()
+	sdkResponse := &iam.PermissionAssignments{
+		PermissionAssignments: []iam.PermissionAssignment{
+			{
+				Permissions: []iam.WorkspacePermission{iam.WorkspacePermissionAdmin},
+				Principal: &iam.PrincipalOutput{
+					PrincipalId: 100,
+					GroupName:   "data-engineers",
+					DisplayName: "Data Engineers",
+				},
+			},
+			{
+				Permissions: []iam.WorkspacePermission{iam.WorkspacePermissionUser},
+				Principal: &iam.PrincipalOutput{
+					PrincipalId: 200,
+					UserName:    "user@example.com",
+					DisplayName: "Example User",
+				},
+			},
+			{
+				// Service-principal variant, plus a non-empty error, to cover the
+				// service_principal_name and error attributes end-to-end.
+				Error:       "principal not found",
+				Permissions: []iam.WorkspacePermission{iam.WorkspacePermissionUser, iam.WorkspacePermissionAdmin},
+				Principal: &iam.PrincipalOutput{
+					PrincipalId:          300,
+					ServicePrincipalName: "my-service-principal",
+					DisplayName:          "My Service Principal",
+				},
+			},
+		},
+	}
+
+	result, diags := flattenPermissionAssignments(ctx, sdkResponse)
+	require.False(t, diags.HasError(), "flatten should not error: %v", diags)
+	require.Len(t, result, 3)
+
+	// Convert the first flattened element back into the TF model and assert its
+	// fields survived the SDK -> TF conversion.
+	first := attrValueToPermissionAssignment(t, ctx, result[0])
+	assert.Equal(t, int64(100), first.principalID)
+	assert.Equal(t, "data-engineers", first.groupName)
+	assert.Equal(t, []string{"ADMIN"}, first.permissions)
+	assert.Empty(t, first.errorMessage)
+
+	second := attrValueToPermissionAssignment(t, ctx, result[1])
+	assert.Equal(t, int64(200), second.principalID)
+	assert.Equal(t, "user@example.com", second.userName)
+	assert.Equal(t, []string{"USER"}, second.permissions)
+
+	third := attrValueToPermissionAssignment(t, ctx, result[2])
+	assert.Equal(t, int64(300), third.principalID)
+	assert.Equal(t, "my-service-principal", third.servicePrincipalName)
+	assert.Equal(t, []string{"USER", "ADMIN"}, third.permissions)
+	assert.Equal(t, "principal not found", third.errorMessage)
+}
+
+type flattenedAssignment struct {
+	principalID          int64
+	groupName            string
+	userName             string
+	servicePrincipalName string
+	errorMessage         string
+	permissions          []string
+}
+
+// attrValueToPermissionAssignment converts a flattened attr.Value back into the
+// iam_tf model and extracts the fields the test asserts on.
+func attrValueToPermissionAssignment(t *testing.T, ctx context.Context, v attr.Value) flattenedAssignment {
+	obj, ok := v.(types.Object)
+	require.True(t, ok, "expected a types.Object, got %T", v)
+
+	var pa iam_tf.PermissionAssignment
+	diags := obj.As(ctx, &pa, basetypes.ObjectAsOptions{})
+	require.False(t, diags.HasError(), "obj.As should not error: %v", diags)
+
+	var principal iam_tf.PrincipalOutput
+	principalDiags := pa.Principal.As(ctx, &principal, basetypes.ObjectAsOptions{})
+	require.False(t, principalDiags.HasError(), "principal As should not error: %v", principalDiags)
+
+	var perms []string
+	permDiags := pa.Permissions.ElementsAs(ctx, &perms, false)
+	require.False(t, permDiags.HasError(), "permissions ElementsAs should not error: %v", permDiags)
+
+	return flattenedAssignment{
+		principalID:          principal.PrincipalId.ValueInt64(),
+		groupName:            principal.GroupName.ValueString(),
+		userName:             principal.UserName.ValueString(),
+		servicePrincipalName: principal.ServicePrincipalName.ValueString(),
+		errorMessage:         pa.Error.ValueString(),
+		permissions:          perms,
+	}
+}


### PR DESCRIPTION
## Changes

Adds a new read-only, account-level data source **`databricks_mws_permission_assignments`** that lists all workspace permission assignments for a workspace via the Databricks account API (`GET /accounts/{account_id}/workspaces/{workspace_id}/permissionassignments`, through `acc.WorkspaceAssignment.ListByWorkspaceId`).

It is the symmetric read counterpart of the existing `databricks_mws_permission_assignment` write resource, and reuses the generated `internal/service/iam_tf` `PermissionAssignment` / `PrincipalOutput` models. Input is `workspace_id`; output is `permission_assignments` (each with `principal` + `permissions`).

Implemented as a Plugin Framework data source under `internal/providers/pluginfw/products/mws_permission_assignments/`, following the existing `notificationdestinations` / `cluster` pattern, and registered in `pluginfw_rollout_utils.go`.

Closes #5852

## Tests

- [x] `make test` run locally (unit tests + `make fmt lint ws`)
- [x] relevant change in `docs/` folder — `docs/data-sources/mws_permission_assignments.md`
- [x] covered with integration tests (`TestUcAccPermissionAssignmentsDataSource`, in the data source's package per the plugin-framework convention)
- [x] using Go SDK
- [x] using TF Plugin Framework
- [x] has entry in `NEXT_CHANGELOG.md` file

The acceptance test was run against a live AWS Databricks **account** and passes end-to-end (creates a group, assigns it `USER` on a workspace, lists it back through the data source and asserts the principal + permission, then tears down):

```
--- PASS: TestUcAccPermissionAssignmentsDataSource (9.59s)
ok  github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/products/mws_permission_assignments
```

### AI assistance

This change was developed with AI assistance (Claude Code, Anthropic Opus 4.8); the commit carries an `Assisted-by:` trailer.

- **AI (Claude Code):** drafted the data source, unit + acceptance tests, docs, and changelog following the existing plugin-framework data-source patterns; ran the local build/lint/test loop.
- **Me:** directed the design and scope, provisioned the Databricks account, ran the acceptance test against a live account, and reviewed/verified the diff before submitting.
