### PR TITLE
[Fix] Fix column nullability handling on a VIEW in databricks_sql_table

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -21,6 +21,7 @@
 ### Bug Fixes
 
 * Fix import for jobs with >100 tasks ([#5417](https://github.com/databricks/terraform-provider-databricks/pull/5417)).
+* Fix handling of column nullability on a `VIEW` in `databricks_sql_table` (#PLACEHOLDER). A view column's nullability is derived from the view query and can't be set independently. The provider previously emitted `NOT NULL` in `CREATE VIEW` (which Databricks rejects) and `ALTER VIEW ... ALTER COLUMN ... SET/DROP NOT NULL` on update (which fails with `PARSE_SYNTAX_ERROR`), and it reported a permanent diff when the server-derived nullability differed from the configured value. The `NOT NULL` constraint and the `ALTER` are no longer emitted for views, and nullability diffs are suppressed for view columns.
 
 ### Documentation
 

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -21,7 +21,7 @@
 ### Bug Fixes
 
 * Fix import for jobs with >100 tasks ([#5417](https://github.com/databricks/terraform-provider-databricks/pull/5417)).
-* Fix handling of column nullability on a `VIEW` in `databricks_sql_table` (#PLACEHOLDER). A view column's nullability is derived from the view query and can't be set independently. The provider previously emitted `NOT NULL` in `CREATE VIEW` (which Databricks rejects) and `ALTER VIEW ... ALTER COLUMN ... SET/DROP NOT NULL` on update (which fails with `PARSE_SYNTAX_ERROR`), and it reported a permanent diff when the server-derived nullability differed from the configured value. The `NOT NULL` constraint and the `ALTER` are no longer emitted for views, and nullability diffs are suppressed for view columns.
+* Fix handling of column nullability on a `VIEW` in `databricks_sql_table` ([#5856](https://github.com/databricks/terraform-provider-databricks/pull/5856)). A view column's nullability is derived from the view query and can't be set independently. The provider previously emitted `NOT NULL` in `CREATE VIEW` (which Databricks rejects) and `ALTER VIEW ... ALTER COLUMN ... SET/DROP NOT NULL` on update (which fails with `PARSE_SYNTAX_ERROR`), and it reported a permanent diff when the server-derived nullability differed from the configured value. The `NOT NULL` constraint and the `ALTER` are no longer emitted for views, and nullability diffs are suppressed for view columns.
 
 ### Documentation
 

--- a/catalog/resource_sql_table.go
+++ b/catalog/resource_sql_table.go
@@ -94,6 +94,12 @@ func (ti SqlTableInfo) CustomizeSchema(s *common.CustomizableSchema) *common.Cus
 	s.SchemaPath("column", "type").SetCustomSuppressDiff(func(k, old, new string, d *schema.ResourceData) bool {
 		return getColumnType(old) == getColumnType(new)
 	})
+	s.SchemaPath("column", "nullable").SetCustomSuppressDiff(func(k, old, new string, d *schema.ResourceData) bool {
+		// A view column's nullability is derived from the view query and can't be
+		// set independently, so ignore diffs on it for views (the server-reported
+		// value would otherwise produce a permanent diff).
+		return d.Get("table_type") == "VIEW"
+	})
 	common.NamespaceCustomizeSchema(s)
 	return s
 }
@@ -232,7 +238,10 @@ func (ti *SqlTableInfo) serializeColumnInfo(col SqlColumnInfo) string {
 	var colType = col.getColumnType()
 
 	notNull := ""
-	if !col.Nullable {
+	// Views don't support NOT NULL column constraints; a view column's
+	// nullability is derived from the view query, so CREATE VIEW ... (col NOT NULL)
+	// is rejected by Databricks.
+	if !col.Nullable && ti.TableType != "VIEW" {
 		notNull = " NOT NULL"
 	}
 
@@ -416,7 +425,10 @@ func (ti *SqlTableInfo) alterExistingColumnStatements(oldti *SqlTableInfo, state
 		if ci.Comment != oldCi.Comment {
 			statements = append(statements, fmt.Sprintf("ALTER %s %s ALTER COLUMN %s COMMENT '%s'", typestring, ti.SQLFullName(), ci.getWrappedColumnName(), parseComment(ci.Comment)))
 		}
-		if ci.Nullable != oldCi.Nullable {
+		// A view column's nullability is derived from the view query and cannot be
+		// changed with ALTER VIEW ... ALTER COLUMN ... (Databricks rejects it with a
+		// PARSE_SYNTAX_ERROR), so only emit the statement for tables.
+		if ci.Nullable != oldCi.Nullable && ti.TableType != "VIEW" {
 			var keyWord string
 			if ci.Nullable {
 				keyWord = "DROP"

--- a/catalog/resource_sql_table_test.go
+++ b/catalog/resource_sql_table_test.go
@@ -114,11 +114,45 @@ func TestResourceSqlTableCreateStatement_ViewWithComments(t *testing.T) {
 	}
 	stmt := ti.buildTableCreateStatement()
 	assert.Contains(t, stmt, "CREATE VIEW `main`.`foo`.`bar`")
-	assert.Contains(t, stmt, "(`id`  NOT NULL, `name`  NOT NULL COMMENT 'a comment')")
+	// Views don't support NOT NULL column constraints, so it must not be emitted.
+	assert.Contains(t, stmt, "(`id` , `name`  COMMENT 'a comment')")
+	assert.NotContains(t, stmt, "NOT NULL")
 	assert.NotContains(t, stmt, "USING DELTA")
 	assert.NotContains(t, stmt, "LOCATION 's3://ext-main/foo/bar1' WITH CREDENTIAL somecred")
 	assert.Contains(t, stmt, "COMMENT 'terraform managed'")
 	assert.Contains(t, stmt, "'one'='two'")
+}
+
+func TestResourceSqlTableView_NullableColumnHandling(t *testing.T) {
+	view := &SqlTableInfo{
+		Name:           "v",
+		CatalogName:    "main",
+		SchemaName:     "foo",
+		TableType:      "VIEW",
+		ViewDefinition: "SELECT 1 AS id",
+		ColumnInfos:    []SqlColumnInfo{{Name: "id", Nullable: false}},
+	}
+	// CREATE VIEW must not emit a NOT NULL constraint, which views don't support.
+	create := view.buildTableCreateStatement()
+	assert.Contains(t, create, "CREATE VIEW `main`.`foo`.`v`")
+	assert.NotContains(t, create, "NOT NULL")
+
+	// A change in a view column's nullability must not emit
+	// ALTER VIEW ... ALTER COLUMN ... (Databricks rejects it); nullability is
+	// derived from the view query.
+	old := &SqlTableInfo{
+		Name:           "v",
+		CatalogName:    "main",
+		SchemaName:     "foo",
+		TableType:      "VIEW",
+		ViewDefinition: "SELECT 1 AS id",
+		ColumnInfos:    []SqlColumnInfo{{Name: "id", Nullable: true}},
+	}
+	stmts, err := view.diff(old)
+	assert.NoError(t, err)
+	for _, s := range stmts {
+		assert.NotContains(t, s, "ALTER COLUMN")
+	}
 }
 
 func TestResourceSqlTableCreateStatement_Partition(t *testing.T) {


### PR DESCRIPTION
## Changes

A view column's nullability is **derived from the view query** and cannot be set independently — but `databricks_sql_table` treated it like a table column, which broke views in three ways:

1. **`CREATE` emitted `NOT NULL` for view columns.** `serializeColumnInfo` appended `NOT NULL` whenever `nullable = false`, so the provider generated:

   ```sql
   CREATE VIEW `cat`.`sch`.`v` (`id`  NOT NULL COMMENT '...') AS ...
   ```

   Views don't support `NOT NULL` column constraints, so the create failed.

2. **`UPDATE` emitted an invalid `ALTER VIEW ... ALTER COLUMN`.** When the configured nullability differed from the server's, `alterExistingColumnStatements` generated:

   ```sql
   ALTER VIEW `cat`.`sch`.`v` ALTER COLUMN `id` DROP NOT NULL
   ```

   `ALTER VIEW` has no `ALTER COLUMN` clause, so this fails with `[PARSE_SYNTAX_ERROR] SQLSTATE: 42601` — the same class of bug as #4250, but on the nullability path.

3. **Permanent plan diff.** A view column's server-reported nullability often differs from the configured value (e.g. `SELECT 1 AS id` yields a `NOT NULL` column, while the schema default is `nullable = true`), so every plan showed a nullability diff that could never be applied cleanly.

### Fix

- `serializeColumnInfo`: don't append `NOT NULL` for views.
- `alterExistingColumnStatements`: don't emit the nullability `ALTER` for views.
- Add a diff suppression on `column.nullable` for views, so the server-derived value doesn't produce a permanent diff.

Nullability handling for **tables** is unchanged (`NOT NULL` in `CREATE`, `ALTER TABLE ... ALTER COLUMN ... SET/DROP NOT NULL` on update).

> Note: this is a sibling of #5855, which fixes the column **comment** path on views (`COMMENT ON COLUMN`). The two are independent — this PR only touches nullability — but together they make view columns behave correctly.

## Verified against a live workspace

Built this branch and pointed Terraform at it with a `dev_overrides` block, then ran real plan/apply cycles against a live workspace with a view whose column is `NOT NULL`-inferred (`SELECT 1 AS id`) and `nullable = false` in config — the exact shape that failed before:

- **Create** → `CREATE VIEW … (`id`  COMMENT '…')` (no `NOT NULL`); `Apply complete! 1 added`. *(Previously: create failed.)*
- **Re-apply (no config change)** → `No changes. Your infrastructure matches the configuration.` *(Previously: a permanent `nullable` diff.)*
- **Change `view_definition`** → only `ALTER VIEW … AS …` is emitted, never `ALTER VIEW … ALTER COLUMN … NOT NULL`; `Apply complete! 1 changed`. *(Previously: the nullability `ALTER` failed with `PARSE_SYNTAX_ERROR`.)*

## Tests

Added `TestResourceSqlTableView_NullableColumnHandling`, asserting that `CREATE VIEW` for a view omits `NOT NULL` and that a nullability change on a view column produces no `ALTER ... ALTER COLUMN` statement. Updated `TestResourceSqlTableCreateStatement_ViewWithComments`, which previously asserted the (invalid) `NOT NULL` output for a view.

- [x] `make test` run locally (`go test ./catalog/`, `go vet ./catalog/`, `gofmt` — all clean; full `catalog` suite passes)
- [ ] relevant change in `docs/` folder <!-- no schema change; behavior fix -->
- [ ] covered with integration tests in `internal/acceptance` <!-- no resource-level acc test exists for databricks_sql_table; verified end-to-end against a live workspace instead (see above) -->
- [x] using Go SDK
- [ ] using TF Plugin Framework <!-- resource is SDKv2 -->
- [x] has entry in `NEXT_CHANGELOG.md` file
