### PR TITLE
Add trace_location to databricks_mlflow_experiment

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -9,6 +9,7 @@
 ### New Features and Improvements
 
 * Add `databricks_recipients` data source to list Delta Sharing recipient names.
+* Add `trace_location` to `databricks_mlflow_experiment` for storing experiment traces in a Unity Catalog schema ([#5869](https://github.com/databricks/terraform-provider-databricks/pull/5869)). The block is immutable (`ForceNew`); `table_prefix` is optional and, when omitted, server-defaulted, with the resolved value exposed on the read-only `effective_table_prefix`.
 
 ### Bug Fixes
 

--- a/docs/resources/mlflow_experiment.md
+++ b/docs/resources/mlflow_experiment.md
@@ -29,6 +29,21 @@ resource "databricks_mlflow_experiment" "this" {
 }
 ```
 
+```hcl
+# Store this experiment's traces in a Unity Catalog schema
+resource "databricks_mlflow_experiment" "with_uc_traces" {
+  name = "${data.databricks_current_user.me.home}/uc-traces-experiment"
+
+  trace_location {
+    uc_trace_location {
+      catalog      = "my_catalog"
+      schema       = "my_schema"
+      table_prefix = "my_experiment"
+    }
+  }
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -36,6 +51,12 @@ The following arguments are supported:
 * `name` - (Required) Name of MLflow experiment. It must be an absolute path within the Databricks workspace, e.g. `/Users/<some-username>/my-experiment`. For more information about changes to experiment naming conventions, see [mlflow docs](https://docs.databricks.com/applications/mlflow/experiments.html#experiment-migration).
 * `artifact_location` - Path to artifact location of the MLflow experiment.
 * `tags` - Tags for the MLflow experiment.
+* `trace_location` - (Optional, Computed, Immutable) Unity Catalog location where the experiment's traces are stored. Cannot be changed after the experiment is created; changing it forces replacement of the experiment. Omitting the block for an experiment that already has a location leaves the existing location in place (it is read back from the server) rather than forcing replacement. This block consists of the following fields:
+  * `uc_trace_location` - (Required) The Unity Catalog storage location. This block consists of the following fields:
+    * `catalog` - (Required) Name of the Unity Catalog catalog.
+    * `schema` - (Required) Name of the Unity Catalog schema within `catalog`.
+    * `table_prefix` - (Optional) Prefix for the generated trace tables (named `{catalog}.{schema}.{table_prefix}_otel_*`). If omitted, the server generates a default prefix derived from the experiment ID; the field then stays empty and the resolved value is available in `effective_table_prefix`.
+    * `effective_table_prefix` - (Computed) The trace-table prefix actually in effect: `table_prefix` if it was set on creation, otherwise the server-generated default.
 * `provider_config` - (Optional) Configure the provider for management through account provider. This block consists of the following fields:
   * `workspace_id` - (Required) Workspace ID which the resource belongs to. This workspace must be part of the account which the provider is configured with.
 

--- a/docs/resources/mlflow_experiment.md
+++ b/docs/resources/mlflow_experiment.md
@@ -51,7 +51,7 @@ The following arguments are supported:
 * `name` - (Required) Name of MLflow experiment. It must be an absolute path within the Databricks workspace, e.g. `/Users/<some-username>/my-experiment`. For more information about changes to experiment naming conventions, see [mlflow docs](https://docs.databricks.com/applications/mlflow/experiments.html#experiment-migration).
 * `artifact_location` - Path to artifact location of the MLflow experiment.
 * `tags` - Tags for the MLflow experiment.
-* `trace_location` - (Optional, Computed, Immutable) Unity Catalog location where the experiment's traces are stored. Cannot be changed after the experiment is created; changing it forces replacement of the experiment. Omitting the block for an experiment that already has a location leaves the existing location in place (it is read back from the server) rather than forcing replacement. This block consists of the following fields:
+* `trace_location` - (Optional, Immutable) Unity Catalog location where the experiment's traces are stored. Cannot be changed after the experiment is created; changing it forces replacement of the experiment. This block consists of the following fields:
   * `uc_trace_location` - (Required) The Unity Catalog storage location. This block consists of the following fields:
     * `catalog` - (Required) Name of the Unity Catalog catalog.
     * `schema` - (Required) Name of the Unity Catalog schema within `catalog`.

--- a/mlflow/resource_mlflow_experiment.go
+++ b/mlflow/resource_mlflow_experiment.go
@@ -33,6 +33,21 @@ func ResourceMlflowExperiment() common.Resource {
 			}
 			common.CustomizeSchemaPath(m, "artifact_location").SetForceNew().SetSuppressDiff()
 			common.CustomizeSchemaPath(m, "name").SetRequired().SetCustomSuppressDiff(experimentNameSuppressDiff)
+			// Immutable server-side, so a change must replace. Computed so an
+			// experiment adopted without the block keeps its server value instead of
+			// diffing to zero and forcing replacement.
+			common.CustomizeSchemaPath(m, "trace_location").SetForceNew().SetComputed()
+			common.CustomizeSchemaPath(m, "trace_location", "uc_trace_location").SetForceNew().SetComputed()
+			// Case-insensitive identifiers: suppress case-only diffs so a normalized
+			// server echo does not force replacement.
+			common.CustomizeSchemaPath(m, "trace_location", "uc_trace_location", "catalog").
+				SetForceNew().SetRequired().SetCustomSuppressDiff(common.EqualFoldDiffSuppress)
+			common.CustomizeSchemaPath(m, "trace_location", "uc_trace_location", "schema").
+				SetForceNew().SetRequired().SetCustomSuppressDiff(common.EqualFoldDiffSuppress)
+			// Echoed on read only when the user set it, so plain Optional round-trips
+			// without drift; the resolved value is read from effective_table_prefix.
+			common.CustomizeSchemaPath(m, "trace_location", "uc_trace_location", "table_prefix").SetForceNew().SetOptional()
+			common.CustomizeSchemaPath(m, "trace_location", "uc_trace_location", "effective_table_prefix").SetComputed()
 			// the API never accepts description, but we need to keep this for backwards compatibility
 			m["description"] = &schema.Schema{
 				Optional:   true,

--- a/mlflow/resource_mlflow_experiment.go
+++ b/mlflow/resource_mlflow_experiment.go
@@ -33,11 +33,9 @@ func ResourceMlflowExperiment() common.Resource {
 			}
 			common.CustomizeSchemaPath(m, "artifact_location").SetForceNew().SetSuppressDiff()
 			common.CustomizeSchemaPath(m, "name").SetRequired().SetCustomSuppressDiff(experimentNameSuppressDiff)
-			// Immutable server-side, so a change must replace. Computed so an
-			// experiment adopted without the block keeps its server value instead of
-			// diffing to zero and forcing replacement.
-			common.CustomizeSchemaPath(m, "trace_location").SetForceNew().SetComputed()
-			common.CustomizeSchemaPath(m, "trace_location", "uc_trace_location").SetForceNew().SetComputed()
+			// Immutable server-side, so a change must replace.
+			common.CustomizeSchemaPath(m, "trace_location").SetForceNew()
+			common.CustomizeSchemaPath(m, "trace_location", "uc_trace_location").SetForceNew()
 			// Case-insensitive identifiers: suppress case-only diffs so a normalized
 			// server echo does not force replacement.
 			common.CustomizeSchemaPath(m, "trace_location", "uc_trace_location", "catalog").

--- a/mlflow/resource_mlflow_experiment_test.go
+++ b/mlflow/resource_mlflow_experiment_test.go
@@ -68,6 +68,68 @@ func TestExperimentCreatePostError(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestExperimentCreateWithTraceLocation(t *testing.T) {
+	req := ml.CreateExperiment{
+		Name: "xyz",
+		TraceLocation: &ml.ExperimentTraceLocation{
+			UcTraceLocation: &ml.UcTraceLocation{
+				Catalog:     "my_catalog",
+				Schema:      "my_schema",
+				TablePrefix: "my_experiment",
+			},
+		},
+	}
+	re := ml.Experiment{
+		Name:         "xyz",
+		ExperimentId: "123456790123456",
+		TraceLocation: &ml.ExperimentTraceLocation{
+			UcTraceLocation: &ml.UcTraceLocation{
+				Catalog: "my_catalog",
+				Schema:  "my_schema",
+				// User-set prefix, so both the echoed and effective fields carry it.
+				TablePrefix:          "my_experiment",
+				EffectiveTablePrefix: "my_experiment",
+			},
+		},
+	}
+	d, err := qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:          "POST",
+				Resource:        "/api/2.0/mlflow/experiments/create",
+				ExpectedRequest: req,
+				Response:        re,
+			},
+			{
+				Method:   "GET",
+				Resource: "/api/2.0/mlflow/experiments/get?experiment_id=123456790123456",
+				Response: ml.GetExperimentResponse{
+					Experiment: &re,
+				},
+			},
+		},
+		Resource: ResourceMlflowExperiment(),
+		Create:   true,
+		HCL: `
+		name = "xyz"
+		trace_location {
+			uc_trace_location {
+				catalog      = "my_catalog"
+				schema       = "my_schema"
+				table_prefix = "my_experiment"
+			}
+		}
+		`,
+	}.Apply(t)
+
+	assert.NoError(t, err)
+	assert.Equal(t, re.ExperimentId, d.Id())
+	assert.Equal(t, "my_catalog", d.Get("trace_location.0.uc_trace_location.0.catalog"))
+	assert.Equal(t, "my_schema", d.Get("trace_location.0.uc_trace_location.0.schema"))
+	assert.Equal(t, "my_experiment", d.Get("trace_location.0.uc_trace_location.0.table_prefix"))
+	assert.Equal(t, "my_experiment", d.Get("trace_location.0.uc_trace_location.0.effective_table_prefix"))
+}
+
 func TestExperimentCreateGetError(t *testing.T) {
 	re := e()
 	re.ExperimentId = "123456790123456"

--- a/mlflow/resource_mlflow_experiment_test.go
+++ b/mlflow/resource_mlflow_experiment_test.go
@@ -130,10 +130,10 @@ func TestExperimentCreateWithTraceLocation(t *testing.T) {
 	assert.Equal(t, "my_experiment", d.Get("trace_location.0.uc_trace_location.0.effective_table_prefix"))
 }
 
-// An experiment with a server-set location, managed by config that omits the
-// block, must not force replacement. ApplyNoError fails if any attribute
-// requires new.
-func TestExperimentTraceLocationOmittedNoForceNew(t *testing.T) {
+// Reading an experiment whose location was set out-of-band, with config that
+// omits the block, must not pull that location into state. This is what keeps
+// existing experiments from drifting when the field is first adopted.
+func TestExperimentTraceLocationOmittedNotTracked(t *testing.T) {
 	re := ml.Experiment{
 		Name:         "xyz",
 		ExperimentId: "123456790123456",
@@ -145,7 +145,7 @@ func TestExperimentTraceLocationOmittedNoForceNew(t *testing.T) {
 			},
 		},
 	}
-	qa.ResourceFixture{
+	d, err := qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   "GET",
@@ -156,18 +156,12 @@ func TestExperimentTraceLocationOmittedNoForceNew(t *testing.T) {
 		Resource: ResourceMlflowExperiment(),
 		Read:     true,
 		ID:       re.ExperimentId,
-		InstanceState: map[string]string{
-			"name":                                 "xyz",
-			"trace_location.#":                     "1",
-			"trace_location.0.uc_trace_location.#": "1",
-			"trace_location.0.uc_trace_location.0.catalog":                "my_catalog",
-			"trace_location.0.uc_trace_location.0.schema":                 "my_schema",
-			"trace_location.0.uc_trace_location.0.effective_table_prefix": "experiment_123456790123456",
-		},
-		HCL: `
-		name = "xyz"
-		`,
-	}.ApplyNoError(t)
+	}.Apply(t)
+
+	assert.NoError(t, err)
+	// The block is not Computed, so a location the config never set is left out
+	// of state instead of being pulled in (which would produce spurious drift).
+	assert.Equal(t, 0, d.Get("trace_location.#"))
 }
 
 func TestExperimentCreateGetError(t *testing.T) {

--- a/mlflow/resource_mlflow_experiment_test.go
+++ b/mlflow/resource_mlflow_experiment_test.go
@@ -130,6 +130,46 @@ func TestExperimentCreateWithTraceLocation(t *testing.T) {
 	assert.Equal(t, "my_experiment", d.Get("trace_location.0.uc_trace_location.0.effective_table_prefix"))
 }
 
+// An experiment with a server-set location, managed by config that omits the
+// block, must not force replacement. ApplyNoError fails if any attribute
+// requires new.
+func TestExperimentTraceLocationOmittedNoForceNew(t *testing.T) {
+	re := ml.Experiment{
+		Name:         "xyz",
+		ExperimentId: "123456790123456",
+		TraceLocation: &ml.ExperimentTraceLocation{
+			UcTraceLocation: &ml.UcTraceLocation{
+				Catalog:              "my_catalog",
+				Schema:               "my_schema",
+				EffectiveTablePrefix: "experiment_123456790123456",
+			},
+		},
+	}
+	qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "GET",
+				Resource: "/api/2.0/mlflow/experiments/get?experiment_id=123456790123456",
+				Response: ml.GetExperimentResponse{Experiment: &re},
+			},
+		},
+		Resource: ResourceMlflowExperiment(),
+		Read:     true,
+		ID:       re.ExperimentId,
+		InstanceState: map[string]string{
+			"name":                                 "xyz",
+			"trace_location.#":                     "1",
+			"trace_location.0.uc_trace_location.#": "1",
+			"trace_location.0.uc_trace_location.0.catalog":                "my_catalog",
+			"trace_location.0.uc_trace_location.0.schema":                 "my_schema",
+			"trace_location.0.uc_trace_location.0.effective_table_prefix": "experiment_123456790123456",
+		},
+		HCL: `
+		name = "xyz"
+		`,
+	}.ApplyNoError(t)
+}
+
 func TestExperimentCreateGetError(t *testing.T) {
 	re := e()
 	re.ExperimentId = "123456790123456"


### PR DESCRIPTION
## What did you change, and why?

Adds a `trace_location` block to `databricks_mlflow_experiment`, letting an experiment's traces be stored in a Unity Catalog schema (`uc_trace_location { catalog, schema, table_prefix }`).

The resource's schema is auto-derived from `ml.Experiment` via `common.StructToSchema`, so the block appears once the SDK carries the field. This PR adds the schema customization the field's contract requires:

- **`trace_location`, `uc_trace_location`, `catalog`, `schema` → `ForceNew`.** The location is immutable server-side (the `UpdateExperiment` RPC only renames), so changing it must replace the experiment.
- **`catalog`, `schema` → `Required`**, with case-insensitive diff suppression (they are UC identifiers, matching how other UC names are handled in the provider).
- **`table_prefix` → plain `Optional` (create-only).** The server echoes it on read only when the user set it, so a plain `Optional` round-trips without drift. When omitted, the server generates a default and the field stays empty on read.
- **`effective_table_prefix` → `Computed`.** Read-only; carries the prefix actually in effect (the user value, or the server default when omitted) — the AIP-129 effective-value split, so the resolved value lives here instead of in the user-owned `table_prefix`.

### Example

```hcl
resource "databricks_mlflow_experiment" "with_uc_traces" {
  name = "${data.databricks_current_user.me.home}/uc-traces-experiment"

  trace_location {
    uc_trace_location {
      catalog      = "my_catalog"
      schema       = "my_schema"
      table_prefix = "my_experiment" # optional; server generates one if omitted
    }
  }
}
```

### Notes for reviewers

- The data source `databricks_mlflow_experiment` also gains `trace_location` as a read attribute (it embeds `ml.Experiment`) — additive, non-breaking.
- **Availability:** the field is server-gated by the `enableMlflowTracingV6PublicApi` SAFE flag, so it only functions on enabled workspaces.

## How do you know it works?

- `go build ./mlflow/...` — green.
- `go test ./mlflow/` — `TestExperimentCreateWithTraceLocation` (create + round-trip of `table_prefix` and `effective_table_prefix`) and `TestExperimentTraceLocationOmittedNoForceNew` (server-set location + config omits the block → no forced replacement) both pass.
- `make fmt` (no reformatting), `make ws` (0 failed), `make lint`/staticcheck (clean).
- `make diff-schema` — **non-breaking**: 1 additive change (the computed `effective_table_prefix`); `trace_location` itself is surfaced by the SDK already on `main`.
