### PR TITLE
Demonstrate migrating databricks_repo to the Go SDK (follow-up to #5877)

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -15,3 +15,5 @@
 ### Exporter
 
 ### Internal Changes
+
+* Migrate `databricks_repo` resource off the hand-rolled `ReposAPI`/`reposCreateRequest` HTTP client onto the Go SDK `workspace.Repos` service, generating the schema directly from `workspace.RepoInfo` via field aliases.

--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -42,7 +42,6 @@ import (
 	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/databricks/terraform-provider-databricks/internal/service/workspace_tf"
 	"github.com/databricks/terraform-provider-databricks/qa"
-	"github.com/databricks/terraform-provider-databricks/repos"
 	"github.com/databricks/terraform-provider-databricks/scim"
 	tf_sql "github.com/databricks/terraform-provider-databricks/sql"
 	tf_workspace "github.com/databricks/terraform-provider-databricks/workspace"
@@ -330,7 +329,7 @@ var emptyRepos = qa.HTTPFixture{
 	Method:       "GET",
 	ReuseRequest: true,
 	Resource:     "/api/2.0/repos?path_prefix=%2FWorkspace",
-	Response:     repos.ReposListResponse{},
+	Response:     sdk_workspace.ListReposResponse{},
 }
 
 var emptyVectorSearch = qa.HTTPFixture{
@@ -1870,12 +1869,12 @@ func TestImportingUser(t *testing.T) {
 }
 
 func TestImportingRepos(t *testing.T) {
-	resp := repos.ReposInformation{
-		ID:           121232342,
+	resp := sdk_workspace.RepoInfo{
+		Id:           121232342,
 		Url:          "https://github.com/user/test.git",
 		Provider:     "gitHub",
 		Path:         "/Repos/user@domain/test",
-		HeadCommitID: "1124323423abc23424",
+		HeadCommitId: "1124323423abc23424",
 		Branch:       "releases",
 	}
 
@@ -1890,8 +1889,8 @@ func TestImportingRepos(t *testing.T) {
 			{
 				Method:   "GET",
 				Resource: "/api/2.0/repos?path_prefix=%2FWorkspace",
-				Response: repos.ReposListResponse{
-					Repos: []repos.ReposInformation{
+				Response: sdk_workspace.ListReposResponse{
+					Repos: []sdk_workspace.RepoInfo{
 						resp,
 					},
 				},
@@ -1899,7 +1898,7 @@ func TestImportingRepos(t *testing.T) {
 			emptyGitCredentials,
 			{
 				Method:   "GET",
-				Resource: "/api/2.0/repos/121232342",
+				Resource: "/api/2.0/repos/121232342?",
 				Response: resp,
 			},
 			{
@@ -2216,13 +2215,13 @@ func TestImportingDLTPipelines(t *testing.T) {
 			},
 			{
 				Method:   "GET",
-				Resource: "/api/2.0/repos/123",
-				Response: repos.ReposInformation{
-					ID:           123,
+				Resource: "/api/2.0/repos/123?",
+				Response: sdk_workspace.RepoInfo{
+					Id:           123,
 					Url:          "https://github.com/user/test.git",
 					Provider:     "gitHub",
 					Path:         "/Repos/user@domain.com/repo",
-					HeadCommitID: "1124323423abc23424",
+					HeadCommitId: "1124323423abc23424",
 					Branch:       "releases",
 				},
 				ReuseRequest: true,

--- a/internal/acceptance/unified_host_acc_test.go
+++ b/internal/acceptance/unified_host_acc_test.go
@@ -131,17 +131,13 @@ func TestMwsAccAccountHostCreateJobs(t *testing.T) {
 	createJobWithProviderConfig(t, workspaceID, nil)
 }
 
-// createRepoWithProviderConfig exercises a NewXYZAPI-style raw-HTTP resource
-// (databricks_repo → NewReposAPI → DatabricksClient.Post/Get/Delete) against a
-// unified host. The Go SDK only injects the X-Databricks-Workspace-Id routing header
-// from the generated per-service impl.go files (e.g. service/jobs/impl.go), so
-// resources that go through common.DatabricksClient's raw HTTP path send no
-// routing header at all. On a unified host that is fatal: the gateway has no
-// way to route the request to the right workspace.
+// createRepoWithProviderConfig exercises the databricks_repo resource against a
+// unified host. The resource now goes through the Go SDK (workspace.Repos), which
+// injects the X-Databricks-Workspace-Id routing header from its generated
+// per-service impl.go, so the gateway can route the request to the right workspace.
 //
-// Mirror of createJobWithProviderConfig — same shape, different resource — so
-// the contrast is direct: jobs (Go SDK) passes, repo (raw HTTP) is expected to
-// fail on the unified host.
+// Mirror of createJobWithProviderConfig — same shape, different resource — so both
+// jobs and repo exercise the Go SDK routing-header path on the unified host.
 func createRepoWithProviderConfig(t *testing.T, workspaceID string, providerFactories map[string]func() (tfprotov6.ProviderServer, error)) {
 	// Path validator on databricks_repo.path requires /Repos/<directory>/<repo>
 	// (3 components after the leading slash) — see repos/resource_repo.go's

--- a/repos/resource_repo.go
+++ b/repos/resource_repo.go
@@ -6,125 +6,55 @@ import (
 	"net/url"
 	"path"
 	"regexp"
+	"strconv"
 	"strings"
 
+	"github.com/databricks/databricks-sdk-go/service/workspace"
 	"github.com/databricks/terraform-provider-databricks/common"
-	"github.com/databricks/terraform-provider-databricks/workspace"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
-// ReposAPI exposes the Repos API
-type ReposAPI struct {
-	client  *common.DatabricksClient
-	context context.Context
+// repoInfo wraps the Go SDK workspace.RepoInfo so the databricks_repo schema can be
+// generated directly from the SDK struct. The Terraform-specific attribute names
+// (git_provider, commit_hash) are supplied via Aliases() rather than a parallel
+// hand-maintained struct.
+type repoInfo struct {
+	workspace.RepoInfo
+	common.Namespace
 }
 
-// NewReposAPI creates ReposAPI instance from provider meta
-func NewReposAPI(ctx context.Context, m any) ReposAPI {
-	return ReposAPI{m.(*common.DatabricksClient), ctx}
-}
-
-type ReposSparseCheckout struct {
-	Patterns []string `json:"patterns"`
-}
-
-// ReposInformation provides information about given repository
-type ReposInformation struct {
-	ID             int64                `json:"id"`
-	Url            string               `json:"url" tf:"force_new"`
-	Provider       string               `json:"provider,omitempty" tf:"computed,alias:git_provider,force_new"`
-	SparseCheckout *ReposSparseCheckout `json:"sparse_checkout,omitempty" tf:"force_new"`
-	Path           string               `json:"path,omitempty" tf:"computed,force_new"` // TODO: remove force_new after the Update API will support changing the path
-	Branch         string               `json:"branch,omitempty" tf:"computed"`
-	HeadCommitID   string               `json:"head_commit_id,omitempty" tf:"computed,alias:commit_hash"`
-}
-
-// RepoID returns job id as string
-func (r ReposInformation) RepoID() string {
-	return fmt.Sprintf("%d", r.ID)
-}
-
-type reposCreateRequest struct {
-	Url            string               `json:"url"`
-	Provider       string               `json:"provider"`
-	Path           string               `json:"path,omitempty"`
-	SparseCheckout *ReposSparseCheckout `json:"sparse_checkout,omitempty"`
-}
-
-func (a ReposAPI) Create(r reposCreateRequest) (ReposInformation, error) {
-	var resp ReposInformation
-	if r.Provider == "" { // trying to infer Git Provider from the URL
-		r.Provider = GetGitProviderFromUrl(r.Url)
+func (repoInfo) Aliases() map[string]map[string]string {
+	return map[string]map[string]string{
+		"repos.repoInfo": {
+			"provider":       "git_provider",
+			"head_commit_id": "commit_hash",
+		},
 	}
-	if r.Provider == "" {
-		return resp, fmt.Errorf("git_provider isn't specified and we can't detect provider from URL")
-	}
-	if r.Path != "" {
-		p := path.Dir(strings.TrimSuffix(r.Path, "/"))
-		if err := workspace.NewNotebooksAPI(a.context, a.client).Mkdirs(p); err != nil {
-			return resp, err
-		}
-	}
-
-	err := a.client.Post(a.context, "/repos", r, &resp, a.client.AddWorkspaceIdHeader)
-	return resp, err
 }
 
-func (a ReposAPI) Delete(id string) error {
-	return a.client.Delete(a.context, fmt.Sprintf("/repos/%s", id), nil, a.client.AddWorkspaceIdHeader)
-}
+func (repoInfo) CustomizeSchema(s *common.CustomizableSchema) *common.CustomizableSchema {
+	s.SchemaPath("url").SetForceNew().SetValidateFunc(validation.IsURLWithScheme([]string{"https", "http"}))
+	s.SchemaPath("git_provider").SetComputed().SetForceNew().SetCustomSuppressDiff(common.EqualFoldDiffSuppress)
+	s.SchemaPath("sparse_checkout").SetForceNew()
+	s.SchemaPath("path").SetComputed().SetForceNew().SetValidateFunc(validatePath)
+	s.SchemaPath("branch").SetComputed().SetConflictsWith([]string{"tag"}).SetValidateFunc(validation.StringIsNotWhiteSpace)
+	s.SchemaPath("commit_hash").SetComputed()
 
-func (a ReposAPI) Update(id string, r map[string]any) error {
-	if len(r) == 0 {
-		return nil
-	}
-	// TODO: update may change ONE OF (url AND provider (optional)), (path), or (branch OR tag).
-	// for URL/provider force re-create as there are limits on what could be done for changing URL/provider
-	if path, ok := r["path"]; ok {
-		err := a.client.Patch(a.context, fmt.Sprintf("/repos/%s", id), map[string]any{"path": path}, a.client.AddWorkspaceIdHeader)
-		if err != nil {
-			return err
-		}
-		delete(r, "path")
-	}
-	return a.client.Patch(a.context, fmt.Sprintf("/repos/%s", id), r, a.client.AddWorkspaceIdHeader)
-}
+	s.AddNewField("tag", &schema.Schema{
+		Type:          schema.TypeString,
+		Optional:      true,
+		ConflictsWith: []string{"branch"},
+		ValidateFunc:  validation.StringIsNotWhiteSpace,
+	})
+	s.AddNewField("workspace_path", &schema.Schema{
+		Type:     schema.TypeString,
+		Computed: true,
+	})
 
-func (a ReposAPI) Read(id string) (ReposInformation, error) {
-	var resp ReposInformation
-	err := a.client.Get(a.context, fmt.Sprintf("/repos/%s", id), nil, &resp, a.client.AddWorkspaceIdHeader)
-	return resp, err
-}
-
-type ReposListResponse struct {
-	NextPageToken string             `json:"next_page_token,omitempty"`
-	Repos         []ReposInformation `json:"repos"`
-}
-
-func (a ReposAPI) List(prefix string) ([]ReposInformation, error) {
-	req := map[string]string{}
-	if prefix != "" {
-		req["path_prefix"] = prefix
-	}
-	reposList := []ReposInformation{}
-	for {
-		var resp ReposListResponse
-		err := a.client.Get(a.context, "/repos", req, &resp, a.client.AddWorkspaceIdHeader)
-		if err != nil {
-			return nil, err
-		}
-		reposList = append(reposList, resp.Repos...)
-		if resp.NextPageToken == "" {
-			break
-		}
-		req["next_page_token"] = resp.NextPageToken
-	}
-	return reposList, nil
-}
-
-func (a ReposAPI) ListAll() ([]ReposInformation, error) {
-	return a.List("")
+	s.RemoveField("id")
+	common.NamespaceCustomizeSchema(s)
+	return s
 }
 
 var (
@@ -164,29 +94,7 @@ func validatePath(i interface{}, k string) (_ []string, errors []error) {
 }
 
 func ResourceRepo() common.Resource {
-	s := common.StructToSchema(ReposInformation{}, func(s map[string]*schema.Schema) map[string]*schema.Schema {
-		s["url"].ValidateFunc = validation.IsURLWithScheme([]string{"https", "http"})
-		s["git_provider"].DiffSuppressFunc = common.EqualFoldDiffSuppress
-		s["branch"].ConflictsWith = []string{"tag"}
-		s["branch"].ValidateFunc = validation.StringIsNotWhiteSpace
-		s["path"].ValidateFunc = validatePath
-
-		s["tag"] = &schema.Schema{
-			Type:          schema.TypeString,
-			Optional:      true,
-			ConflictsWith: []string{"branch"},
-			ValidateFunc:  validation.StringIsNotWhiteSpace,
-		}
-		s["workspace_path"] = &schema.Schema{
-			Type:     schema.TypeString,
-			Computed: true,
-		}
-
-		delete(s, "id")
-		common.AddNamespaceInSchema(s)
-		common.NamespaceCustomizeSchemaMap(s)
-		return s
-	})
+	s := common.StructToSchema(repoInfo{}, nil)
 
 	return common.Resource{
 		Schema:        s,
@@ -195,86 +103,131 @@ func ResourceRepo() common.Resource {
 			return common.NamespaceCustomizeDiff(ctx, d, c)
 		},
 		Create: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
-			newClient, err := c.DatabricksClientForUnifiedProvider(ctx, d)
+			w, err := c.WorkspaceClientUnifiedProvider(ctx, d)
 			if err != nil {
 				return err
 			}
-			reposAPI := NewReposAPI(ctx, newClient)
-			var repo ReposInformation
+			var repo repoInfo
 			common.DataToStructPointer(d, s, &repo)
 
-			req := reposCreateRequest{Path: repo.Path, Provider: repo.Provider,
-				Url: repo.Url, SparseCheckout: repo.SparseCheckout}
-			resp, err := reposAPI.Create(req)
+			provider := repo.Provider
+			if provider == "" { // trying to infer Git Provider from the URL
+				provider = GetGitProviderFromUrl(repo.Url)
+			}
+			if provider == "" {
+				return fmt.Errorf("git_provider isn't specified and we can't detect provider from URL")
+			}
+			if repo.Path != "" {
+				p := path.Dir(strings.TrimSuffix(repo.Path, "/"))
+				if err := w.Workspace.MkdirsByPath(ctx, p); err != nil {
+					return err
+				}
+			}
+
+			createReq := workspace.CreateRepoRequest{
+				Url:      repo.Url,
+				Provider: provider,
+				Path:     repo.Path,
+			}
+			if repo.SparseCheckout != nil {
+				createReq.SparseCheckout = &workspace.SparseCheckout{Patterns: repo.SparseCheckout.Patterns}
+			}
+			resp, err := w.Repos.Create(ctx, createReq)
 			if err != nil {
 				return err
 			}
-			d.SetId(resp.RepoID())
+			d.SetId(strconv.FormatInt(resp.Id, 10))
+
 			branch := d.Get("branch").(string)
 			tag := d.Get("tag").(string)
-			updateReq := map[string]any{}
+			updateReq := workspace.UpdateRepoRequest{RepoId: resp.Id}
+			needsUpdate := false
 			if tag != "" {
-				updateReq["tag"] = tag
+				updateReq.Tag = tag
+				needsUpdate = true
 			} else if branch != "" && branch != resp.Branch {
-				updateReq["branch"] = branch
+				updateReq.Branch = branch
+				needsUpdate = true
 			}
-			return reposAPI.Update(d.Id(), updateReq)
+			if !needsUpdate {
+				return nil
+			}
+			return w.Repos.Update(ctx, updateReq)
 		},
 		Read: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
-			newClient, err := c.DatabricksClientForUnifiedProvider(ctx, d)
+			w, err := c.WorkspaceClientUnifiedProvider(ctx, d)
 			if err != nil {
 				return err
 			}
-			reposAPI := NewReposAPI(ctx, newClient)
-			resp, err := reposAPI.Read(d.Id())
+			id, err := strconv.ParseInt(d.Id(), 10, 64)
 			if err != nil {
 				return err
 			}
-			err = common.StructToData(resp, s, d)
+			resp, err := w.Repos.GetByRepoId(ctx, id)
 			if err != nil {
+				return err
+			}
+			// GetByRepoId returns a GetRepoResponse; the schema is built from RepoInfo.
+			// The two are structurally identical, so copy across into the schema struct.
+			repo := repoInfo{RepoInfo: workspace.RepoInfo{
+				Id:              resp.Id,
+				Url:             resp.Url,
+				Provider:        resp.Provider,
+				Path:            resp.Path,
+				Branch:          resp.Branch,
+				HeadCommitId:    resp.HeadCommitId,
+				SparseCheckout:  resp.SparseCheckout,
+				ForceSendFields: resp.ForceSendFields,
+			}}
+			if err = common.StructToData(repo, s, d); err != nil {
 				return err
 			}
 			d.Set("workspace_path", "/Workspace"+resp.Path)
 			return nil
 		},
 		Update: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
-			newClient, err := c.DatabricksClientForUnifiedProvider(ctx, d)
+			w, err := c.WorkspaceClientUnifiedProvider(ctx, d)
 			if err != nil {
 				return err
 			}
-			var repo ReposInformation
+			var repo repoInfo
 			common.DataToStructPointer(d, s, &repo)
 
-			reposAPI := NewReposAPI(ctx, newClient)
-			req := map[string]any{}
-			// Not working yet, wait until API is ready
-			// if d.HasChange("path") {
-			// 	req["path"] = d.Get("path").(string)
-			// }
+			id, err := strconv.ParseInt(d.Id(), 10, 64)
+			if err != nil {
+				return err
+			}
+			req := workspace.UpdateRepoRequest{RepoId: id}
+			// Not working yet, wait until API is ready:
+			// path updates are gated on the Update API supporting them.
 			if d.HasChange("tag") {
-				req["tag"] = d.Get("tag").(string)
+				req.Tag = d.Get("tag").(string)
 				d.Set("branch", "")
 			} else if d.HasChange("branch") {
-				req["branch"] = repo.Branch
+				req.Branch = repo.Branch
 				d.Set("tag", "")
 			} else {
 				if repo.Branch != "" {
-					req["branch"] = repo.Branch
+					req.Branch = repo.Branch
 				} else if v := d.Get("tag").(string); v != "" {
-					req["tag"] = v
+					req.Tag = v
 				}
 			}
 			if repo.SparseCheckout != nil {
-				req["sparse_checkout"] = map[string]any{"patterns": repo.SparseCheckout.Patterns}
+				req.SparseCheckout = &workspace.SparseCheckoutUpdate{Patterns: repo.SparseCheckout.Patterns}
 			}
-			return reposAPI.Update(d.Id(), req)
+			return w.Repos.Update(ctx, req)
 		},
 		Delete: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
-			newClient, err := c.DatabricksClientForUnifiedProvider(ctx, d)
+			w, err := c.WorkspaceClientUnifiedProvider(ctx, d)
 			if err != nil {
 				return err
 			}
-			return NewReposAPI(ctx, newClient).Delete(d.Id())
+			id, err := strconv.ParseInt(d.Id(), 10, 64)
+			if err != nil {
+				return err
+			}
+			return w.Repos.DeleteByRepoId(ctx, id)
 		},
 	}
 }

--- a/repos/resource_repo_test.go
+++ b/repos/resource_repo_test.go
@@ -1,16 +1,15 @@
 package repos
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"testing"
 
 	"github.com/databricks/databricks-sdk-go/apierr"
+	"github.com/databricks/databricks-sdk-go/service/workspace"
 
 	"github.com/databricks/terraform-provider-databricks/qa"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestGetGitProviderFromUrl(t *testing.T) {
@@ -33,13 +32,13 @@ func TestResourceRepoRead(t *testing.T) {
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   http.MethodGet,
-				Resource: fmt.Sprintf("/api/2.0/repos/%d", repoID),
-				Response: ReposInformation{
-					ID:           int64(repoID),
+				Resource: fmt.Sprintf("/api/2.0/repos/%d?", repoID),
+				Response: workspace.RepoInfo{
+					Id:           int64(repoID),
 					Url:          url,
 					Provider:     provider,
 					Branch:       branch,
-					HeadCommitID: "7e0847ede61f07adede22e2bcce6050216489171",
+					HeadCommitId: "7e0847ede61f07adede22e2bcce6050216489171",
 					Path:         path,
 				},
 			},
@@ -60,7 +59,7 @@ func TestResourceRepoRead_NotFound(t *testing.T) {
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   http.MethodGet,
-				Resource: fmt.Sprintf("/api/2.0/repos/%s", repoID),
+				Resource: fmt.Sprintf("/api/2.0/repos/%s?", repoID),
 				Response: apierr.APIError{
 					ErrorCode: "RESOURCE_DOES_NOT_EXIST",
 					Message:   "Repo could not be found",
@@ -81,7 +80,7 @@ func TestResourceRepoDelete(t *testing.T) {
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   http.MethodDelete,
-				Resource: fmt.Sprintf("/api/2.0/repos/%s", repoID),
+				Resource: fmt.Sprintf("/api/2.0/repos/%s?", repoID),
 				Status:   http.StatusOK,
 			},
 		},
@@ -93,20 +92,20 @@ func TestResourceRepoDelete(t *testing.T) {
 }
 
 func TestResourceRepoCreateNoBranch(t *testing.T) {
-	resp := ReposInformation{
-		ID:           121232342,
+	resp := workspace.RepoInfo{
+		Id:           121232342,
 		Url:          "https://github.com/user/test.git",
 		Provider:     "gitHub",
 		Branch:       "main",
 		Path:         "/Repos/user@domain/test",
-		HeadCommitID: "1124323423abc23424",
+		HeadCommitId: "1124323423abc23424",
 	}
 	qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   "POST",
 				Resource: "/api/2.0/repos",
-				ExpectedRequest: reposCreateRequest{
+				ExpectedRequest: workspace.CreateRepoRequest{
 					Url:      "https://github.com/user/test.git",
 					Provider: "gitHub",
 				},
@@ -114,7 +113,7 @@ func TestResourceRepoCreateNoBranch(t *testing.T) {
 			},
 			{
 				Method:   "GET",
-				Resource: "/api/2.0/repos/121232342",
+				Resource: "/api/2.0/repos/121232342?",
 				Response: resp,
 			},
 		},
@@ -124,25 +123,25 @@ func TestResourceRepoCreateNoBranch(t *testing.T) {
 		},
 		Create: true,
 	}.ApplyAndExpectData(t,
-		map[string]any{"id": resp.RepoID(), "path": resp.Path, "branch": resp.Branch,
-			"git_provider": resp.Provider, "url": resp.Url, "commit_hash": resp.HeadCommitID})
+		map[string]any{"id": "121232342", "path": resp.Path, "branch": resp.Branch,
+			"git_provider": resp.Provider, "url": resp.Url, "commit_hash": resp.HeadCommitId})
 }
 
 func TestResourceRepoCreateCustomDirectory(t *testing.T) {
-	resp := ReposInformation{
-		ID:           121232342,
+	resp := workspace.RepoInfo{
+		Id:           121232342,
 		Url:          "https://github.com/user/test.git",
 		Provider:     "gitHub",
 		Branch:       "main",
 		Path:         "/Repos/user@domain/test",
-		HeadCommitID: "1124323423abc23424",
+		HeadCommitId: "1124323423abc23424",
 	}
 	qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   "POST",
 				Resource: "/api/2.0/repos",
-				ExpectedRequest: reposCreateRequest{
+				ExpectedRequest: workspace.CreateRepoRequest{
 					Url:      "https://github.com/user/test.git",
 					Provider: "gitHub",
 					Path:     "/Repos/Production/test/",
@@ -158,7 +157,7 @@ func TestResourceRepoCreateCustomDirectory(t *testing.T) {
 			},
 			{
 				Method:   "GET",
-				Resource: "/api/2.0/repos/121232342",
+				Resource: "/api/2.0/repos/121232342?",
 				Response: resp,
 			},
 		},
@@ -169,8 +168,8 @@ func TestResourceRepoCreateCustomDirectory(t *testing.T) {
 		},
 		Create: true,
 	}.ApplyAndExpectData(t,
-		map[string]any{"id": resp.RepoID(), "path": resp.Path, "branch": resp.Branch,
-			"git_provider": resp.Provider, "url": resp.Url, "commit_hash": resp.HeadCommitID})
+		map[string]any{"id": "121232342", "path": resp.Path, "branch": resp.Branch,
+			"git_provider": resp.Provider, "url": resp.Url, "commit_hash": resp.HeadCommitId})
 }
 
 func TestResourceRepoCreateCustomDirectoryError(t *testing.T) {
@@ -221,13 +220,13 @@ func TestResourceRepoCreateCustomDirectoryWrongPath(t *testing.T) {
 }
 
 func TestResourceRepoCreateWithBranch(t *testing.T) {
-	resp := ReposInformation{
-		ID:           121232342,
+	resp := workspace.RepoInfo{
+		Id:           121232342,
 		Url:          "https://github.com/user/test.git",
 		Provider:     "gitHub",
 		Branch:       "main",
 		Path:         "/Repos/user@domain/test",
-		HeadCommitID: "1124323423abc23424",
+		HeadCommitId: "1124323423abc23424",
 	}
 	respPatch := resp
 	respPatch.Branch = "releases"
@@ -236,7 +235,7 @@ func TestResourceRepoCreateWithBranch(t *testing.T) {
 			{
 				Method:   "POST",
 				Resource: "/api/2.0/repos",
-				ExpectedRequest: reposCreateRequest{
+				ExpectedRequest: workspace.CreateRepoRequest{
 					Url:      "https://github.com/user/test.git",
 					Provider: "gitHub",
 				},
@@ -250,7 +249,7 @@ func TestResourceRepoCreateWithBranch(t *testing.T) {
 			},
 			{
 				Method:   "GET",
-				Resource: "/api/2.0/repos/121232342",
+				Resource: "/api/2.0/repos/121232342?",
 				Response: respPatch,
 			},
 		},
@@ -261,18 +260,18 @@ func TestResourceRepoCreateWithBranch(t *testing.T) {
 		},
 		Create: true,
 	}.ApplyAndExpectData(t,
-		map[string]any{"id": resp.RepoID(), "path": resp.Path, "branch": respPatch.Branch,
-			"git_provider": resp.Provider, "url": resp.Url, "commit_hash": resp.HeadCommitID})
+		map[string]any{"id": "121232342", "path": resp.Path, "branch": respPatch.Branch,
+			"git_provider": resp.Provider, "url": resp.Url, "commit_hash": resp.HeadCommitId})
 }
 
 func TestResourceRepoCreateWithTag(t *testing.T) {
-	resp := ReposInformation{
-		ID:           121232342,
+	resp := workspace.RepoInfo{
+		Id:           121232342,
 		Url:          "https://github.com/user/test.git",
 		Provider:     "gitHub",
 		Branch:       "main",
 		Path:         "/Repos/user@domain/test",
-		HeadCommitID: "1124323423abc23424",
+		HeadCommitId: "1124323423abc23424",
 	}
 	respPatch := resp
 	respPatch.Branch = ""
@@ -281,7 +280,7 @@ func TestResourceRepoCreateWithTag(t *testing.T) {
 			{
 				Method:   "POST",
 				Resource: "/api/2.0/repos",
-				ExpectedRequest: reposCreateRequest{
+				ExpectedRequest: workspace.CreateRepoRequest{
 					Url:      "https://github.com/user/test.git",
 					Provider: "gitHub",
 				},
@@ -295,7 +294,7 @@ func TestResourceRepoCreateWithTag(t *testing.T) {
 			},
 			{
 				Method:   "GET",
-				Resource: "/api/2.0/repos/121232342",
+				Resource: "/api/2.0/repos/121232342?",
 				Response: respPatch,
 			},
 		},
@@ -306,8 +305,8 @@ func TestResourceRepoCreateWithTag(t *testing.T) {
 		},
 		Create: true,
 	}.ApplyAndExpectData(t,
-		map[string]any{"id": resp.RepoID(), "path": resp.Path,
-			"git_provider": resp.Provider, "url": resp.Url, "commit_hash": resp.HeadCommitID})
+		map[string]any{"id": "121232342", "path": resp.Path,
+			"git_provider": resp.Provider, "url": resp.Url, "commit_hash": resp.HeadCommitId})
 }
 
 func TestResourceRepoCreateError(t *testing.T) {
@@ -322,12 +321,12 @@ func TestResourceRepoCreateError(t *testing.T) {
 }
 
 func TestResourceReposUpdateSwitchToTag(t *testing.T) {
-	resp := ReposInformation{
-		ID:           121232342,
+	resp := workspace.RepoInfo{
+		Id:           121232342,
 		Url:          "https://github.com/user/test.git",
 		Provider:     "gitHub",
 		Path:         "/Repos/user@domain/test",
-		HeadCommitID: "1124323423abc23424",
+		HeadCommitId: "1124323423abc23424",
 	}
 	qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
@@ -339,7 +338,7 @@ func TestResourceReposUpdateSwitchToTag(t *testing.T) {
 			},
 			{
 				Method:   "GET",
-				Resource: "/api/2.0/repos/121232342",
+				Resource: "/api/2.0/repos/121232342?",
 				Response: resp,
 			},
 		},
@@ -363,12 +362,12 @@ func TestResourceReposUpdateSwitchToTag(t *testing.T) {
 }
 
 func TestResourceReposUpdateSwitchToBranch(t *testing.T) {
-	resp := ReposInformation{
-		ID:           121232342,
+	resp := workspace.RepoInfo{
+		Id:           121232342,
 		Url:          "https://github.com/user/test.git",
 		Provider:     "gitHub",
 		Path:         "/Repos/user@domain/test",
-		HeadCommitID: "1124323423abc23424",
+		HeadCommitId: "1124323423abc23424",
 		Branch:       "releases",
 	}
 	qa.ResourceFixture{
@@ -381,7 +380,7 @@ func TestResourceReposUpdateSwitchToBranch(t *testing.T) {
 			},
 			{
 				Method:   "GET",
-				Resource: "/api/2.0/repos/121232342",
+				Resource: "/api/2.0/repos/121232342?",
 				Response: resp,
 			},
 		},
@@ -404,12 +403,12 @@ func TestResourceReposUpdateSwitchToBranch(t *testing.T) {
 }
 
 func TestResourceReposUpdateSparseCheckout(t *testing.T) {
-	resp := ReposInformation{
-		ID:           121232342,
+	resp := workspace.RepoInfo{
+		Id:           121232342,
 		Url:          "https://github.com/user/test.git",
 		Provider:     "gitHub",
 		Path:         "/Repos/user@domain/test",
-		HeadCommitID: "1124323423abc23424",
+		HeadCommitId: "1124323423abc23424",
 	}
 	qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
@@ -423,7 +422,7 @@ func TestResourceReposUpdateSparseCheckout(t *testing.T) {
 			},
 			{
 				Method:   "GET",
-				Resource: "/api/2.0/repos/121232342",
+				Resource: "/api/2.0/repos/121232342?",
 				Response: resp,
 			},
 		},
@@ -448,76 +447,4 @@ func TestResourceReposUpdateSparseCheckout(t *testing.T) {
 		Update:      true,
 		RequiresNew: true,
 	}.ApplyAndExpectData(t, map[string]any{"branch": "main"})
-}
-
-func TestReposListAll(t *testing.T) {
-	resp := ReposInformation{
-		ID:           121232342,
-		Url:          "https://github.com/user/test.git",
-		Provider:     "gitHub",
-		Path:         "/Repos/user@domain/test",
-		HeadCommitID: "1124323423abc23424",
-		Branch:       "releases",
-	}
-
-	client, server, err := qa.HttpFixtureClient(t, []qa.HTTPFixture{
-		{
-			Method:   "GET",
-			Resource: "/api/2.0/repos?",
-			Response: ReposListResponse{
-				NextPageToken: "12312423442343242343",
-				Repos: []ReposInformation{
-					resp,
-				},
-			},
-		},
-		{
-			Method:   "GET",
-			Resource: "/api/2.0/repos?next_page_token=12312423442343242343",
-			Response: ReposListResponse{
-				Repos: []ReposInformation{
-					resp,
-				},
-			},
-		},
-	})
-	defer server.Close()
-	require.NoError(t, err)
-
-	ctx := context.Background()
-	reposList, err := NewReposAPI(ctx, client).ListAll()
-	require.NoError(t, err)
-	assert.Equal(t, len(reposList), 2)
-	assert.Equal(t, resp.Branch, reposList[1].Branch)
-}
-
-func TestReposListWithPrefix(t *testing.T) {
-	resp := ReposInformation{
-		ID:           121232342,
-		Url:          "https://github.com/user/test.git",
-		Provider:     "gitHub",
-		Path:         "/Repos/user@domain/test",
-		HeadCommitID: "1124323423abc23424",
-		Branch:       "releases",
-	}
-
-	client, server, err := qa.HttpFixtureClient(t, []qa.HTTPFixture{
-		{
-			Method:   "GET",
-			Resource: "/api/2.0/repos?path_prefix=%2FRepos%2Fabc",
-			Response: ReposListResponse{
-				Repos: []ReposInformation{
-					resp,
-				},
-			},
-		},
-	})
-	defer server.Close()
-	require.NoError(t, err)
-
-	ctx := context.Background()
-	reposList, err := NewReposAPI(ctx, client).List("/Repos/abc")
-	require.NoError(t, err)
-	assert.Equal(t, len(reposList), 1)
-	assert.Equal(t, resp.Branch, reposList[0].Branch)
 }


### PR DESCRIPTION
## What this is

A **demonstration PR** responding to review feedback on #5877, where @alexott suggested switching `databricks_repo` to the Go SDK structs:

> ideally we should just switch to Go SDK structs here
>
> we have a way of customizing aliases for Go SDK structs as well [...] but this may require wrapping the Go SDK struct into TF-bound struct

This branch does exactly that, using the `Aliases()` mechanism Alex pointed at. It's scoped **purely to the migration** — it does not include the `git_credential_id` field from #5877, so the diff is the migration and nothing else.

## Approach

Rather than keeping a parallel, hand-maintained schema struct, the schema is generated **directly from the Go SDK `workspace.RepoInfo`** via a thin wrapper:

```go
type repoInfo struct {
	workspace.RepoInfo
	common.Namespace
}

func (repoInfo) Aliases() map[string]map[string]string {
	return map[string]map[string]string{
		"repos.repoInfo": {
			"provider":       "git_provider",
			"head_commit_id": "commit_hash",
		},
	}
}
```

`CustomizeSchema()` re-applies the force-new/computed/validation attributes that the old `tf:` tags carried. CRUD then calls `w.Repos.*` with the SDK request structs (`CreateRepoRequest`, `UpdateRepoRequest`) and `w.Workspace.MkdirsByPath` for parent-directory creation.

Net: **+178 / −301** across 5 files (removes the whole hand-rolled `ReposAPI`).

## What changed

- Removed `ReposAPI`, `NewReposAPI`, `reposCreateRequest`, `ReposListResponse`, and the raw-HTTP `Create/Read/Update/Delete/List/ListAll` methods.
- Added the `repoInfo` wrapper + `Aliases()`/`CustomizeSchema()`.
- Updated unit tests, exporter tests, and the unified-host acceptance-test comment.

## Challenges / things to know

1. **The alias mechanism resolves the main obstacle.** Generating the schema from an SDK struct normally loses the TF attribute names (`git_provider`, `commit_hash`), because `workspace.RepoInfo` has no `tf:` alias tags. The `ResourceProviderWithAlias` interface (`Aliases()`) supplies those renames and — verified here — round-trips correctly through schema generation, `StructToData`, and `DataToStruct`. This is exactly what Alex referenced.

2. **It still requires a wrapper type + boilerplate.** As Alex noted, you wrap the SDK struct in a TF-bound struct and re-declare per-field customizations (force_new/computed/validators) in `CustomizeSchema()`, since those no longer come from struct tags. It's mechanical, but it's real code, and it has to stay in sync with the SDK struct.

3. **Read returns a different SDK type.** `w.Repos.GetByRepoId` returns `*GetRepoResponse`, not `*RepoInfo` (the schema struct). They're structurally identical, so `Read` copies field-by-field into `repoInfo`.

4. **SDK URL encoding differs, breaking every fixture.** The SDK appends a `?` query suffix to `GET`/`DELETE` URLs (e.g. `/api/2.0/repos/123?`). The old client did not. Every unit-test and exporter HTTP fixture stubbing a GET/DELETE by id had to be updated, or tests fail with "missing stub". Invisible until you run the tests.

5. **Second-order test breakage in the exporter.** `ReposInformation`/`ReposListResponse` were used as fixture bodies in `exporter/exporter_test.go`; those moved to `workspace.RepoInfo`/`workspace.ListReposResponse` and the now-unused `repos` import was dropped. No production exporter code changed (it already lists repos via the SDK).

6. **Dropped provider-local list helpers.** `ReposAPI.List/ListAll` + `ReposListResponse` were provider-only and used solely by unit tests; production listing already goes through the SDK iterator in the exporter. Those two unit tests were removed rather than rewritten.

7. **Acceptance-test intent drifted.** `internal/acceptance/unified_host_acc_test.go` contrasted a raw-HTTP resource (repo) against a Go SDK resource (jobs) on a unified host. Post-migration that contrast no longer holds, so the comment was rewritten.

## Risks of rolling this out

- **All `databricks_repo` users are affected.** This rewrites the entire CRUD path, so the risk/reward differs sharply from a small additive field — it deserves its own review and real acceptance-test runs against a workspace.
- **`CustomizeSchema()` must exactly reproduce the current schema.** A missed `SetComputed()`/`SetForceNew()` would silently change plan behavior. Unit tests cover the happy paths but not every diff scenario.
- **`ForceSendFields` semantics.** The SDK structs use `omitempty` + `ForceSendFields` to distinguish unset from zero. Not needed here, but any future need to send an explicit zero would require handling it — something the map-based client sidestepped.

## Recommendation

With the `Aliases()` approach this is cleaner than a parallel struct and is clearly the idiomatic direction — but it's still a wrapper + full CRUD rewrite touching all repo users, not a drop-in. Reasonable as a **standalone follow-up**; bundling it into #5877 would turn a small, low-risk feature into a full-path rewrite.

## Tests

- `go build ./...`, `go vet ./...` clean.
- `go test ./repos/... ./exporter/...` pass.
- Acceptance tests (`internal/acceptance`) not run here — they require a live workspace / unified host.

This pull request and its description were written by Isaac.
