### PR TITLE
Update served entities limit for model serving endpoints from 10 to 15

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -15,6 +15,8 @@
 
 ### Documentation
 
+* Correct the maximum number of served entities per `databricks_model_serving` endpoint from 10 to 15 ([#5898](https://github.com/databricks/terraform-provider-databricks/pull/5898)).
+
 ### Exporter
 
 ### Internal Changes

--- a/docs/resources/model_serving.md
+++ b/docs/resources/model_serving.md
@@ -125,8 +125,8 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the model serving endpoint. This field is required and must be unique across a workspace. An endpoint name can consist of alphanumeric characters, dashes, and underscores. NOTE: Changing this name will delete the existing endpoint and create a new endpoint with the updated name.
 * `config` - The model serving endpoint configuration. This is optional and can be added and modified after creation. If `config` was provided in a previous apply but is not provided in the current apply, no change to the model serving endpoint will occur. To recreate the model serving endpoint without the `config` block, the model serving endpoint must be destroyed and recreated.
-  * `served_entities` - A list of served entities for the endpoint to serve. A serving endpoint can have up to 10 served entities.
-  * `served_models` - (Deprecated, use `served_entities` instead) Each block represents a served model for the endpoint to serve. A model serving endpoint can have up to 10 served models.
+  * `served_entities` - A list of served entities for the endpoint to serve. A serving endpoint can have up to 15 served entities.
+  * `served_models` - (Deprecated, use `served_entities` instead) Each block represents a served model for the endpoint to serve. A model serving endpoint can have up to 15 served models.
   * `traffic_config` - A single block represents the traffic split configuration amongst the served models.
   * `auto_capture_config` - Configuration for Inference Tables which automatically logs requests and responses to Unity Catalog.
 * `tags` - Tags to be attached to the serving endpoint and automatically propagated to billing logs.


### PR DESCRIPTION
## Changes

In practice and from errors we have seen in production, the limit is actually 15. 

## Tests
N/A

- [ ] `make test` run locally
- [X] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] using Go SDK
- [ ] using TF Plugin Framework
- [x] has entry in `NEXT_CHANGELOG.md` file
