### PR TITLE
Resolve workspace-host workspace_id from host metadata instead of SCIM /Me

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -8,6 +8,10 @@
 
 ### New Features and Improvements
 
+* For workspace-level hosts, resolve and validate the provider's `workspace_id` from the host's `/.well-known/databricks-config` discovery metadata instead of a SCIM `/Me` call ([#NNNN](https://github.com/databricks/terraform-provider-databricks/pull/NNNN)).
+
+  This removes the authenticated `/Me` request on workspace hosts (avoiding false failures for service principals that can manage resources but cannot call `/Me`), and makes a `workspace_id` that disagrees with the host fail at plan time instead of at apply. Hosts whose metadata does not advertise a `workspace_id` fall back to the previous `/Me` behavior.
+
 ### Bug Fixes
 
 ### Documentation

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### New Features and Improvements
 
-* For workspace-level hosts, resolve and validate the provider's `workspace_id` from the host's `/.well-known/databricks-config` discovery metadata instead of a SCIM `/Me` call ([#NNNN](https://github.com/databricks/terraform-provider-databricks/pull/NNNN)).
+* For workspace-level hosts, resolve and validate the provider's `workspace_id` from the host's `/.well-known/databricks-config` discovery metadata instead of a SCIM `/Me` call ([#5922](https://github.com/databricks/terraform-provider-databricks/pull/5922)).
 
   This removes the authenticated `/Me` request on workspace hosts (avoiding false failures for service principals that can manage resources but cannot call `/Me`), and makes a `workspace_id` that disagrees with the host fail at plan time instead of at apply. Hosts whose metadata does not advertise a `workspace_id` fall back to the previous `/Me` behavior.
 

--- a/common/client.go
+++ b/common/client.go
@@ -295,6 +295,55 @@ func (c *DatabricksClient) setCachedWorkspaceID(ctx context.Context, w *databric
 	return nil
 }
 
+// ReconcileWorkspaceIDFromHostMetadata reconciles the workspace_id advertised by
+// the host's /.well-known/databricks-config discovery metadata with any
+// user-supplied workspace_id, for workspace-configured providers. It is called
+// once during provider configuration, after the SDK config has been resolved.
+//
+// For workspace hosts the metadata already carries the canonical numeric
+// workspace_id, so this lets the provider:
+//   - fail fast when the user supplied a numeric workspace_id that disagrees with
+//     the host (surfacing the error at plan instead of at apply), and
+//   - seed cachedWorkspaceID so downstream CurrentWorkspaceID and
+//     validateWorkspaceIDFromProvider calls are cache hits that never issue the
+//     SCIM GET /api/2.0/preview/scim/v2/Me request.
+//
+// userWorkspaceID is the effective value from config/env/profile as observed
+// before the SDK's host-metadata back-fill; hostWorkspaceID is meta.WorkspaceID.
+// Both may be empty. Account and unified hosts multiplex workspaces, so they are
+// left untouched; hosts whose metadata omits workspace_id are also left untouched,
+// preserving the lazy SCIM /Me fallback.
+func (c *DatabricksClient) ReconcileWorkspaceIDFromHostMetadata(hostType config.HostType, userWorkspaceID, hostWorkspaceID string) error {
+	if hostType != config.WorkspaceHost {
+		return nil
+	}
+	// Normalize the "none" sentinel (see PrepareDatabricksClient) so it is not
+	// compared against the host's numeric workspace_id.
+	if userWorkspaceID == "none" {
+		userWorkspaceID = ""
+	}
+	// Without a host-advertised workspace_id there is nothing to reconcile or
+	// seed; fall back to lazy SCIM /Me resolution.
+	if hostWorkspaceID == "" {
+		return nil
+	}
+	// Fail fast on a genuine mismatch. Only a numeric user-supplied ID is
+	// comparable to the host's canonical numeric ID; a connection ID is not, so it
+	// is left to validateWorkspaceIDFromProvider at apply time, which emits an
+	// actionable connection-ID message.
+	if userWorkspaceID != "" && isNumericWorkspaceID(userWorkspaceID) && userWorkspaceID != hostWorkspaceID {
+		return fmt.Errorf("workspace_id mismatch: the provider is configured with workspace_id %s "+
+			"but the host resolves to workspace %s. please check the workspace_id in the provider configuration",
+			userWorkspaceID, hostWorkspaceID)
+	}
+	// Seed the cache so downstream resolution/validation is a cache hit and never
+	// calls SCIM /Me. Only a numeric host workspace_id is a valid cache value.
+	if id, err := strconv.ParseInt(hostWorkspaceID, 10, 64); err == nil {
+		c.SetCachedWorkspaceID(id)
+	}
+	return nil
+}
+
 // GetWorkspaceClient returns the Databricks WorkspaceClient or a diagnostics if
 // that fails. This is used by resources and data sources that are developed
 // over plugin framework.

--- a/common/client.go
+++ b/common/client.go
@@ -295,25 +295,19 @@ func (c *DatabricksClient) setCachedWorkspaceID(ctx context.Context, w *databric
 	return nil
 }
 
-// ReconcileWorkspaceIDFromHostMetadata reconciles the workspace_id advertised by
-// the host's /.well-known/databricks-config discovery metadata with any
-// user-supplied workspace_id, for workspace-configured providers. It is called
-// once during provider configuration, after the SDK config has been resolved.
+// ReconcileWorkspaceIDFromHostMetadata reconciles a user-supplied workspace_id
+// against the one the host advertises via /.well-known/databricks-config, for
+// workspace-configured providers. It is called once during provider configuration,
+// after the SDK config has been resolved. On a mismatch it fails fast (surfacing
+// the error at plan rather than at apply); otherwise it seeds cachedWorkspaceID so
+// downstream resolution never issues the SCIM GET /api/2.0/preview/scim/v2/Me call.
 //
-// For workspace hosts the metadata already carries the canonical numeric
-// workspace_id, so this lets the provider:
-//   - fail fast when the user supplied a numeric workspace_id that disagrees with
-//     the host (surfacing the error at plan instead of at apply), and
-//   - seed cachedWorkspaceID so downstream CurrentWorkspaceID and
-//     validateWorkspaceIDFromProvider calls are cache hits that never issue the
-//     SCIM GET /api/2.0/preview/scim/v2/Me request.
-//
-// userWorkspaceID is the effective value from config/env/profile as observed
-// before the SDK's host-metadata back-fill; hostWorkspaceID is meta.WorkspaceID.
-// Both may be empty. Account and unified hosts multiplex workspaces, so they are
-// left untouched; hosts whose metadata omits workspace_id are also left untouched,
-// preserving the lazy SCIM /Me fallback.
+// userWorkspaceID is the effective value from config/env/profile observed before
+// the SDK's host-metadata back-fill; hostWorkspaceID is meta.WorkspaceID. Either
+// may be empty.
 func (c *DatabricksClient) ReconcileWorkspaceIDFromHostMetadata(hostType config.HostType, userWorkspaceID, hostWorkspaceID string) error {
+	// Account and unified hosts multiplex workspaces, so a single cached
+	// workspace_id must never be seeded for them.
 	if hostType != config.WorkspaceHost {
 		return nil
 	}
@@ -322,22 +316,19 @@ func (c *DatabricksClient) ReconcileWorkspaceIDFromHostMetadata(hostType config.
 	if userWorkspaceID == "none" {
 		userWorkspaceID = ""
 	}
-	// Without a host-advertised workspace_id there is nothing to reconcile or
-	// seed; fall back to lazy SCIM /Me resolution.
+	// Older hosts omit workspace_id from metadata; leave the lazy SCIM /Me
+	// fallback in place.
 	if hostWorkspaceID == "" {
 		return nil
 	}
-	// Fail fast on a genuine mismatch. Only a numeric user-supplied ID is
-	// comparable to the host's canonical numeric ID; a connection ID is not, so it
-	// is left to validateWorkspaceIDFromProvider at apply time, which emits an
-	// actionable connection-ID message.
+	// Only a numeric user-supplied ID is comparable to the host's canonical numeric
+	// ID. A connection ID is left to validateWorkspaceIDFromProvider at apply time,
+	// which emits an actionable connection-ID message.
 	if userWorkspaceID != "" && isNumericWorkspaceID(userWorkspaceID) && userWorkspaceID != hostWorkspaceID {
 		return fmt.Errorf("workspace_id mismatch: the provider is configured with workspace_id %s "+
 			"but the host resolves to workspace %s. please check the workspace_id in the provider configuration",
 			userWorkspaceID, hostWorkspaceID)
 	}
-	// Seed the cache so downstream resolution/validation is a cache hit and never
-	// calls SCIM /Me. Only a numeric host workspace_id is a valid cache value.
 	if id, err := strconv.ParseInt(hostWorkspaceID, 10, 64); err == nil {
 		c.SetCachedWorkspaceID(id)
 	}

--- a/common/workspace_id_reconcile_test.go
+++ b/common/workspace_id_reconcile_test.go
@@ -1,0 +1,116 @@
+package common
+
+import (
+	"context"
+	"testing"
+
+	"github.com/databricks/databricks-sdk-go/client"
+	"github.com/databricks/databricks-sdk-go/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestClientForReconcile() *DatabricksClient {
+	return &DatabricksClient{
+		DatabricksClient: &client.DatabricksClient{
+			Config: &config.Config{},
+		},
+	}
+}
+
+func TestReconcileWorkspaceIDFromHostMetadata(t *testing.T) {
+	tests := []struct {
+		name            string
+		hostType        config.HostType
+		userWorkspaceID string
+		hostWorkspaceID string
+		wantErr         string
+		wantCachedID    int64 // 0 means "not seeded"
+	}{
+		{
+			name:            "workspace host, user empty, seeds from host",
+			hostType:        config.WorkspaceHost,
+			userWorkspaceID: "",
+			hostWorkspaceID: "12345",
+			wantCachedID:    12345,
+		},
+		{
+			name:            "workspace host, user matches host, seeds",
+			hostType:        config.WorkspaceHost,
+			userWorkspaceID: "12345",
+			hostWorkspaceID: "12345",
+			wantCachedID:    12345,
+		},
+		{
+			name:            "workspace host, numeric mismatch, fails fast",
+			hostType:        config.WorkspaceHost,
+			userWorkspaceID: "99999",
+			hostWorkspaceID: "12345",
+			wantErr:         "workspace_id mismatch",
+			wantCachedID:    0,
+		},
+		{
+			name:            "workspace host, none sentinel, seeds from host",
+			hostType:        config.WorkspaceHost,
+			userWorkspaceID: "none",
+			hostWorkspaceID: "12345",
+			wantCachedID:    12345,
+		},
+		{
+			name:            "workspace host, connection id user, numeric host, no error and seeds",
+			hostType:        config.WorkspaceHost,
+			userWorkspaceID: "some-connection-id",
+			hostWorkspaceID: "12345",
+			wantCachedID:    12345,
+		},
+		{
+			name:            "workspace host, host omits workspace_id, no seed no error",
+			hostType:        config.WorkspaceHost,
+			userWorkspaceID: "12345",
+			hostWorkspaceID: "",
+			wantCachedID:    0,
+		},
+		{
+			name:            "account host, untouched",
+			hostType:        config.AccountHost,
+			userWorkspaceID: "",
+			hostWorkspaceID: "12345",
+			wantCachedID:    0,
+		},
+		{
+			name:            "unified host, skipped even with host workspace_id",
+			hostType:        config.UnifiedHost,
+			userWorkspaceID: "99999",
+			hostWorkspaceID: "12345",
+			wantCachedID:    0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := newTestClientForReconcile()
+			err := c.ReconcileWorkspaceIDFromHostMetadata(tc.hostType, tc.userWorkspaceID, tc.hostWorkspaceID)
+			if tc.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tc.wantCachedID, c.cachedWorkspaceID)
+		})
+	}
+}
+
+// TestReconcileWorkspaceIDFromHostMetadataSeedsCacheHit proves that after seeding,
+// CurrentWorkspaceID is a cache hit that never reaches WorkspaceClient()/SCIM /Me.
+// The client has no usable credentials or workspace client, so a cache miss would
+// error; returning the seeded value with no error demonstrates the SCIM call is
+// skipped.
+func TestReconcileWorkspaceIDFromHostMetadataSeedsCacheHit(t *testing.T) {
+	c := newTestClientForReconcile()
+	require.NoError(t, c.ReconcileWorkspaceIDFromHostMetadata(config.WorkspaceHost, "", "678910"))
+
+	id, err := c.CurrentWorkspaceID(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, int64(678910), id)
+}

--- a/internal/providers/client/databricks_client.go
+++ b/internal/providers/client/databricks_client.go
@@ -11,12 +11,62 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
+// capturedHostMeta records the two workspace_id values observed during the
+// single /.well-known/databricks-config resolution the SDK performs inside
+// EnsureResolved: the effective user-supplied value (config/env/profile) as seen
+// before the SDK back-fills it, and the value the host advertises. It is filled
+// by the HostMetadataResolver wrapper installed by installWorkspaceIDCapture and
+// consumed after EnsureResolved to reconcile and seed the workspace_id.
+type capturedHostMeta struct {
+	userWorkspaceID string
+	hostWorkspaceID string
+}
+
+// installWorkspaceIDCapture wraps cfg.HostMetadataResolver so the provider can
+// observe both the user-supplied and host-advertised workspace_id from the single
+// metadata fetch the SDK already performs during EnsureResolved. It does NOT add a
+// /.well-known/databricks-config request: the wrapper delegates to any
+// pre-existing resolver, or to the SDK's own default fetcher, so the total number
+// of metadata fetches is unchanged.
+//
+// Must be installed after any configCustomizer (which may replace the config or
+// set its own resolver) and before EnsureResolved. Returns the capture struct the
+// wrapper writes into; the caller reads it only after EnsureResolved returns.
+func installWorkspaceIDCapture(cfg *config.Config) *capturedHostMeta {
+	captured := &capturedHostMeta{}
+	prev := cfg.HostMetadataResolver
+	cfg.HostMetadataResolver = func(ctx context.Context, host string) (*config.HostMetadata, error) {
+		// Observed post-loaders, pre-back-fill: the effective user value from
+		// config/env/profile (including any host query param promoted by the SDK).
+		captured.userWorkspaceID = cfg.WorkspaceID
+		delegate := prev
+		if delegate == nil {
+			delegate = cfg.DefaultHostMetadataResolver()
+		}
+		meta, err := delegate(ctx, host)
+		if err == nil && meta != nil {
+			captured.hostWorkspaceID = meta.WorkspaceID
+		}
+		// Return verbatim: account/unified hosts still need meta's other fields
+		// back-filled downstream, and returning the SDK's error unchanged preserves
+		// its non-fatal metadata handling.
+		return meta, err
+	}
+	return captured
+}
+
 // PrepareDatabricksClient makes some common adjustments to the config that apply in all cases
 // and returns a ready-to-use Databricks client. This includes:
-// - mapping deprecated auth types to their newer counterparts
-// - ensuring the config is resolved
-// - setting a default retry timeout if not set
-// - setting a default HTTP timeout if not set
+//   - mapping deprecated auth types to their newer counterparts
+//   - ensuring the config is resolved
+//   - setting a default retry timeout if not set
+//   - setting a default HTTP timeout if not set
+//   - for workspace hosts, reconciling and seeding the workspace_id from the host's
+//     /.well-known/databricks-config metadata: a user-supplied workspace_id that
+//     disagrees with the host fails fast here (at configure, surfacing at plan), and
+//     the resolved workspace_id is cached so downstream resolution/validation never
+//     issues the SCIM GET /api/2.0/preview/scim/v2/Me request. Hosts whose metadata
+//     omits workspace_id keep the lazy SCIM /Me fallback.
 //
 // TODO: this should be colocated with the definition of DatabricksClient in common/client.go, but
 // this isn't possible without introducing a circular dependency. Fixing this will require refactoring
@@ -52,6 +102,9 @@ func PrepareDatabricksClient(ctx context.Context, cfg *config.Config, configCust
 			return nil, err
 		}
 	}
+	// Installed after the customizer (which may replace the config or set its own
+	// resolver) and before EnsureResolved, which invokes the resolver exactly once.
+	captured := installWorkspaceIDCapture(cfg)
 	cfg.EnsureResolved()
 	// "none" is a sentinel the Databricks CLI writes to ~/.databrickscfg for
 	// account-level profiles with no workspace bound. The SDK passes it through
@@ -66,6 +119,11 @@ func PrepareDatabricksClient(ctx context.Context, cfg *config.Config, configCust
 	}
 	pc := &common.DatabricksClient{
 		DatabricksClient: client,
+	}
+	// For workspace hosts, reconcile the user-supplied workspace_id against the
+	// host's discovery metadata and seed the cache so the SCIM /Me call is avoided.
+	if err := pc.ReconcileWorkspaceIDFromHostMetadata(pc.HostTypeForTerraform(), captured.userWorkspaceID, captured.hostWorkspaceID); err != nil {
+		return nil, err
 	}
 	pc.WithCommandExecutor(func(ctx context.Context, client *common.DatabricksClient) common.CommandExecutor {
 		return commands.NewCommandsAPI(ctx, client)

--- a/internal/providers/client/databricks_client.go
+++ b/internal/providers/client/databricks_client.go
@@ -11,12 +11,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
-// capturedHostMeta records the two workspace_id values observed during the
-// single /.well-known/databricks-config resolution the SDK performs inside
-// EnsureResolved: the effective user-supplied value (config/env/profile) as seen
-// before the SDK back-fills it, and the value the host advertises. It is filled
-// by the HostMetadataResolver wrapper installed by installWorkspaceIDCapture and
-// consumed after EnsureResolved to reconcile and seed the workspace_id.
+// capturedHostMeta holds the user-supplied and host-advertised workspace_id
+// observed during the SDK's single /.well-known/databricks-config resolution. The
+// user value is captured before EnsureResolved back-fills it from the host, so a
+// mismatch between the two can still be detected afterwards.
 type capturedHostMeta struct {
 	userWorkspaceID string
 	hostWorkspaceID string
@@ -61,12 +59,8 @@ func installWorkspaceIDCapture(cfg *config.Config) *capturedHostMeta {
 //   - ensuring the config is resolved
 //   - setting a default retry timeout if not set
 //   - setting a default HTTP timeout if not set
-//   - for workspace hosts, reconciling and seeding the workspace_id from the host's
-//     /.well-known/databricks-config metadata: a user-supplied workspace_id that
-//     disagrees with the host fails fast here (at configure, surfacing at plan), and
-//     the resolved workspace_id is cached so downstream resolution/validation never
-//     issues the SCIM GET /api/2.0/preview/scim/v2/Me request. Hosts whose metadata
-//     omits workspace_id keep the lazy SCIM /Me fallback.
+//   - for workspace hosts, reconciling and seeding the workspace_id from host metadata
+//     (see ReconcileWorkspaceIDFromHostMetadata)
 //
 // TODO: this should be colocated with the definition of DatabricksClient in common/client.go, but
 // this isn't possible without introducing a circular dependency. Fixing this will require refactoring

--- a/internal/providers/client/databricks_client_test.go
+++ b/internal/providers/client/databricks_client_test.go
@@ -2,9 +2,11 @@ package client
 
 import (
 	"context"
+	"sync/atomic"
 	"testing"
 
 	"github.com/databricks/databricks-sdk-go/config"
+	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -69,4 +71,144 @@ func TestPrepareDatabricksClient_NormalizesNoneWorkspaceID(t *testing.T) {
 			assert.Equal(t, tc.expectedWorkspaceID, pc.Config.WorkspaceID)
 		})
 	}
+}
+
+// workspaceHostMetadataResolver returns a resolver that reports a workspace host
+// advertising the given workspace_id via /.well-known/databricks-config.
+func workspaceHostMetadataResolver(workspaceID string) config.HostMetadataResolver {
+	return func(context.Context, string) (*config.HostMetadata, error) {
+		return &config.HostMetadata{
+			WorkspaceID: workspaceID,
+			HostType:    config.WorkspaceHost,
+		}, nil
+	}
+}
+
+// prepareForWorkspaceHost builds a hermetic client for a workspace host with the
+// given user-supplied workspace_id and a metadata resolver advertising
+// hostWorkspaceID. Ambient loaders are suppressed so the test is deterministic.
+func prepareForWorkspaceHost(t *testing.T, userWorkspaceID, hostWorkspaceID string) (*common.DatabricksClient, error) {
+	t.Helper()
+	cfg := &config.Config{
+		Host:                 "https://test.invalid",
+		Token:                "test-token",
+		WorkspaceID:          userWorkspaceID,
+		Loaders:              []config.Loader{noopLoader{}},
+		HostMetadataResolver: workspaceHostMetadataResolver(hostWorkspaceID),
+	}
+	return PrepareDatabricksClient(context.Background(), cfg, nil)
+}
+
+// TestPrepareDatabricksClient_WorkspaceIDFromHostMetadata verifies that for
+// workspace hosts the workspace_id is resolved/validated from the host's
+// /.well-known/databricks-config metadata and the cache is seeded so downstream
+// CurrentWorkspaceID is a hit that never calls SCIM /Me. A cache hit is provable
+// here because these clients have no usable workspace client, so any /Me attempt
+// would error.
+func TestPrepareDatabricksClient_WorkspaceIDFromHostMetadata(t *testing.T) {
+	t.Run("user empty is back-filled and seeded", func(t *testing.T) {
+		pc, err := prepareForWorkspaceHost(t, "", "12345")
+		require.NoError(t, err)
+		assert.Equal(t, "12345", pc.Config.WorkspaceID)
+		id, err := pc.CurrentWorkspaceID(context.Background())
+		require.NoError(t, err)
+		assert.Equal(t, int64(12345), id)
+	})
+
+	t.Run("user matches host is seeded", func(t *testing.T) {
+		pc, err := prepareForWorkspaceHost(t, "12345", "12345")
+		require.NoError(t, err)
+		id, err := pc.CurrentWorkspaceID(context.Background())
+		require.NoError(t, err)
+		assert.Equal(t, int64(12345), id)
+	})
+
+	t.Run("numeric mismatch fails fast at configure", func(t *testing.T) {
+		_, err := prepareForWorkspaceHost(t, "99999", "12345")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "workspace_id mismatch")
+	})
+
+	t.Run("none sentinel is cleared and seeded from host", func(t *testing.T) {
+		pc, err := prepareForWorkspaceHost(t, "none", "12345")
+		require.NoError(t, err)
+		assert.Equal(t, "", pc.Config.WorkspaceID)
+		id, err := pc.CurrentWorkspaceID(context.Background())
+		require.NoError(t, err)
+		assert.Equal(t, int64(12345), id)
+	})
+
+	t.Run("connection-id user with numeric host does not error and is seeded", func(t *testing.T) {
+		pc, err := prepareForWorkspaceHost(t, "my-connection-id", "12345")
+		require.NoError(t, err)
+		id, err := pc.CurrentWorkspaceID(context.Background())
+		require.NoError(t, err)
+		assert.Equal(t, int64(12345), id)
+	})
+}
+
+// TestPrepareDatabricksClient_HostMetadataUntouchedCases verifies the paths that
+// must NOT seed or fail: account/unified hosts, and hosts whose metadata omits
+// workspace_id (which preserves the lazy SCIM /Me fallback).
+func TestPrepareDatabricksClient_HostMetadataUntouchedCases(t *testing.T) {
+	t.Run("account host is untouched", func(t *testing.T) {
+		cfg := &config.Config{
+			Host:      "https://accounts.test.invalid",
+			AccountID: "abc",
+			Token:     "test-token",
+			Loaders:   []config.Loader{noopLoader{}},
+			HostMetadataResolver: func(context.Context, string) (*config.HostMetadata, error) {
+				return &config.HostMetadata{HostType: config.AccountHost}, nil
+			},
+		}
+		pc, err := PrepareDatabricksClient(context.Background(), cfg, nil)
+		require.NoError(t, err)
+		assert.Equal(t, config.AccountHost, pc.HostTypeForTerraform())
+	})
+
+	t.Run("unified host with metadata workspace_id is skipped", func(t *testing.T) {
+		cfg := &config.Config{
+			Host:        "https://test.invalid",
+			Token:       "test-token",
+			WorkspaceID: "99999",
+			Loaders:     []config.Loader{noopLoader{}},
+			HostMetadataResolver: func(context.Context, string) (*config.HostMetadata, error) {
+				return &config.HostMetadata{WorkspaceID: "12345", HostType: config.UnifiedHost}, nil
+			},
+		}
+		// Unified host: the numeric mismatch check is skipped, so no fail-fast.
+		pc, err := PrepareDatabricksClient(context.Background(), cfg, nil)
+		require.NoError(t, err)
+		assert.Equal(t, config.UnifiedHost, pc.HostTypeForTerraform())
+	})
+
+	t.Run("host omitting workspace_id does not seed", func(t *testing.T) {
+		pc, err := prepareForWorkspaceHost(t, "", "")
+		require.NoError(t, err)
+		// No seed happened, so CurrentWorkspaceID would attempt a lookup. We only
+		// assert the config was left empty (no back-fill from empty metadata).
+		assert.Equal(t, "", pc.Config.WorkspaceID)
+	})
+}
+
+// TestPrepareDatabricksClient_SingleMetadataFetch guards the hard constraint that
+// wrapping the resolver adds no /.well-known/databricks-config request: the
+// resolver must be invoked exactly once across PrepareDatabricksClient and a
+// subsequent CurrentWorkspaceID (which is a seeded cache hit).
+func TestPrepareDatabricksClient_SingleMetadataFetch(t *testing.T) {
+	var calls atomic.Int32
+	cfg := &config.Config{
+		Host:    "https://test.invalid",
+		Token:   "test-token",
+		Loaders: []config.Loader{noopLoader{}},
+		HostMetadataResolver: func(context.Context, string) (*config.HostMetadata, error) {
+			calls.Add(1)
+			return &config.HostMetadata{WorkspaceID: "12345", HostType: config.WorkspaceHost}, nil
+		},
+	}
+	pc, err := PrepareDatabricksClient(context.Background(), cfg, nil)
+	require.NoError(t, err)
+	_, err = pc.CurrentWorkspaceID(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), calls.Load(), "expected exactly one .well-known/databricks-config fetch")
 }

--- a/internal/providers/pluginfw/pluginfw_test.go
+++ b/internal/providers/pluginfw/pluginfw_test.go
@@ -99,6 +99,14 @@ func TestConfigure(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			// Keep the test hermetic against ambient developer state: point HOME at
+			// an empty temp dir so the SDK's ~/.databrickscfg loader finds no profile
+			// and no host is resolved. Without this, a developer's DEFAULT profile
+			// supplies a real host whose /.well-known/databricks-config workspace_id
+			// disagrees with the bogus workspace_id below, and PrepareDatabricksClient
+			// now fails fast on that mismatch (see ReconcileWorkspaceIDFromHostMetadata).
+			t.Setenv("HOME", t.TempDir())
+
 			// Create a provider instance
 			p := GetDatabricksProviderPluginFramework()
 


### PR DESCRIPTION
## Summary

For **workspace-level hosts**, the provider resolves and validates the provider's `workspace_id` by calling SCIM `GET /api/2.0/preview/scim/v2/Me` and reading the `X-Databricks-Org-Id` response header. This PR replaces that authenticated call with information the SDK **already** fetches during provider initialization: the `/.well-known/databricks-config` discovery metadata, which carries the host's `workspace_id` and `host_type`.

Benefits:

- **No SCIM `/Me` call on modern workspace hosts.** The `/Me` request fails for service principals that can manage resources but lack permission to call `/Me`; using unauthenticated host metadata avoids that class of failure.
- **Wrong `workspace_id` fails fast at configure (plan) instead of at apply.** A user-supplied numeric `workspace_id` that disagrees with the host is now rejected before any resource is destroyed.

Scope is **workspace hosts only** — account and unified hosts are untouched (a unified host multiplexes workspaces, so a single cached workspace_id must never be seeded there).

## How it works

`PrepareDatabricksClient` is the single shared entry point for both the SDKv2 and Plugin Framework providers. It calls `cfg.EnsureResolved()`, inside which the SDK fetches `/.well-known/databricks-config` exactly once and back-fills `cfg.WorkspaceID` **only when it is empty**. When the user set a `workspace_id`, the host's value is fetched and then discarded, so there is no way to compare the two by reading `cfg` afterwards.

To recover the host value **without adding a second fetch**, this PR wraps `cfg.HostMetadataResolver` before `EnsureResolved`. The wrapper delegates to the SDK's own default fetcher (the same single request), and captures both the user-supplied value (observed before back-fill) and the host-advertised value from that one response. Net `/.well-known` calls stay at exactly one — a unit test asserts this invariant with a counting resolver.

After resolution, `ReconcileWorkspaceIDFromHostMetadata` (workspace-host only):

- normalizes the `"none"` account-profile sentinel,
- fails fast when a **numeric** user-supplied `workspace_id` disagrees with the host (a connection ID is left to the existing apply-time check, which emits an actionable message),
- seeds the cached workspace ID so downstream `CurrentWorkspaceID` / mismatch validation are cache hits that never call `/Me`.

Hosts whose metadata omits `workspace_id` (older control planes, fetch failures) fall back to the previous lazy `/Me` behavior.

## Behavior change to note

A configuration with a **wrong numeric** provider-level `workspace_id` that happens to "work" today — for example, where every resource overrides `workspace_id`, so the apply-time mismatch check never fires — will now fail fast at configure time. This is the intended stricter behavior.

## Testing

- New table tests for `ReconcileWorkspaceIDFromHostMetadata` covering: empty user id (back-fill + seed), match, numeric mismatch (fail-fast), `"none"` sentinel, connection-id user with numeric host, host without workspace_id, and account/unified hosts (untouched).
- End-to-end tests through `PrepareDatabricksClient` for the wrapper wiring, plus a single-fetch invariant test (counting resolver invoked exactly once).
- Made an existing provider-configure test hermetic (`HOME` → temp dir) so it does not read an ambient local config file.
- `make fmt lint ws` clean; schema unchanged (verified via schema diff + classifier); full short test suite passes.

