### PR TITLE
Document roles/group.assumer for group rule sets

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Documentation
 
+* Document the `roles/group.assumer` role for group rule sets in `databricks_access_control_rule_set` ([#TBD](https://github.com/databricks/terraform-provider-databricks/pull/TBD)).
+
 ### Exporter
 
 ### Internal Changes

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### Documentation
 
-* Document the `roles/group.assumer` role for group rule sets in `databricks_access_control_rule_set` ([#TBD](https://github.com/databricks/terraform-provider-databricks/pull/TBD)).
+* Document the `roles/group.assumer` role for group rule sets in `databricks_access_control_rule_set` ([#5924](https://github.com/databricks/terraform-provider-databricks/pull/5924)).
 
 ### Exporter
 

--- a/docs/resources/access_control_rule_set.md
+++ b/docs/resources/access_control_rule_set.md
@@ -161,12 +161,23 @@ data "databricks_user" "john" {
   user_name = "john.doe@example.com"
 }
 
-resource "databricks_access_control_rule_set" "ds_group_rule_set" {
-  name = "accounts/${local.account_id}/groups/${databricks_group.ds.id}/ruleSets/default"
+data "databricks_user" "jane" {
+  user_name = "jane.doe@example.com"
+}
 
+resource "databricks_access_control_rule_set" "ds_group_rule_set" {
+  name = "accounts/${local.account_id}/groups/${data.databricks_group.ds.id}/ruleSets/default"
+
+  // user john can manage the group
   grant_rules {
     principals = [data.databricks_user.john.acl_principal_id]
     role       = "roles/group.manager"
+  }
+
+  // user jane can assume the group as a role
+  grant_rules {
+    principals = [data.databricks_user.jane.acl_principal_id]
+    role       = "roles/group.assumer"
   }
 }
 ```
@@ -349,6 +360,7 @@ Arguments of the `grant_rules` block are:
     * `roles/servicePrincipal.user` - User of a service principal.
   * `accounts/{account_id}/groups/{group_id}/ruleSets/default`
     * `roles/group.manager` - Manager of a group.
+    * `roles/group.assumer` - Assumer of a group, i.e. can assume the group as a role.
   * `accounts/{account_id}/budgetPolicies/{budget_policy_id}/ruleSets/default`
     * `roles/budgetPolicy.manager` - Manager of a budget policy.
     * `roles/budgetPolicy.user` - User of a budget policy.


### PR DESCRIPTION
Add the roles/group.assumer role to the documented roles for accounts/{account_id}/groups/{group_id}/ruleSets/default, and show it alongside roles/group.manager in the group rule set example. The role grants the Assume permission on a group, which underpins RBAC.

The provider passes grant_rules.role through to the API without validation, so no code change is needed.

Also fixes the group rule set example to reference the group through data.databricks_group.ds.id -- the block is declared as a data source, so the previous databricks_group.ds.id reference would not resolve.

Granting assume permission is in our customer docs - https://docs.databricks.com/aws/en/admin/users-groups/manage-groups#manage-permissions-on-a-group

Co-authored-by: Isaac

## Changes
<!-- Summary of your changes that are easy to understand -->

## Tests
<!--
How is this tested? Please see the checklist below and also describe any other relevant tests
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] using Go SDK
- [ ] using TF Plugin Framework
- [x] has entry in `NEXT_CHANGELOG.md` file
