### PR TITLE
Add resolve-by-external-id data sources for users, groups, and service principals

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### New Features and Improvements
 
-* Added `databricks_user_by_external_id`, `databricks_group_by_external_id`, and `databricks_service_principal_by_external_id` data sources to resolve principals by the external ID assigned to them by the customer's Identity Provider ([#TODO](https://github.com/databricks/terraform-provider-databricks/pull/TODO)).
+* Added `databricks_user_by_external_id`, `databricks_group_by_external_id`, and `databricks_service_principal_by_external_id` data sources to resolve principals by the external ID assigned to them by the customer's Identity Provider ([#5926](https://github.com/databricks/terraform-provider-databricks/pull/5926)).
 
   These data sources work with both the account-level and workspace-level provider. They call the Databricks `resolve-by-external-id` APIs, which create the principal in the account if one with the given `external_id` does not already exist, and require the account to be onboarded to Automatic Identity Management (AIM).
 

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -8,6 +8,10 @@
 
 ### New Features and Improvements
 
+* Added `databricks_user_by_external_id`, `databricks_group_by_external_id`, and `databricks_service_principal_by_external_id` data sources to resolve principals by the external ID assigned to them by the customer's Identity Provider ([#TODO](https://github.com/databricks/terraform-provider-databricks/pull/TODO)).
+
+  These data sources work with both the account-level and workspace-level provider. They call the Databricks `resolve-by-external-id` APIs, which create the principal in the account if one with the given `external_id` does not already exist, and require the account to be onboarded to Automatic Identity Management (AIM).
+
 ### Bug Fixes
 
 ### Documentation

--- a/docs/data-sources/group_by_external_id.md
+++ b/docs/data-sources/group_by_external_id.md
@@ -1,0 +1,46 @@
+---
+subcategory: "Security"
+---
+
+# databricks_group_by_external_id Data Source
+
+Resolves a [databricks_group](../resources/group.md) using the external ID assigned to it by the customer's Identity Provider (IdP).
+
+-> This data source works with both the account-level and workspace-level provider.
+
+-> **Get-or-create semantics.** This data source calls the Databricks `resolve-by-external-id` API, which creates the group in the account if no group with the given `external_id` exists yet. It is not a pure read: the first `terraform plan`/`apply` against a previously unseen `external_id` has the side effect of provisioning a new group. This API also requires the account to be onboarded to Automatic Identity Management (AIM); otherwise it returns an error.
+
+## Example Usage
+
+```hcl
+data "databricks_group_by_external_id" "this" {
+  external_id = "11111111-2222-3333-4444-555555555555"
+}
+
+resource "databricks_group_member" "member" {
+  group_id  = data.databricks_group_by_external_id.this.group_id
+  member_id = databricks_user.this.id
+}
+```
+
+## Argument Reference
+
+- `external_id` - (Required) The ID of the group in the customer's IdP (for example, the object ID assigned by Microsoft Entra ID).
+- `api` - (Optional) Specifies whether to use account-level or workspace-level API. Valid values are `account` and `workspace`. When not set, the API level is inferred from the provider host.
+- `provider_config` - (Optional) Configure the provider for management through account provider. This block consists of the following fields:
+  - `workspace_id` - (Required) Workspace ID which the resource belongs to. This workspace must be part of the account which the provider is configured with.
+
+## Attribute Reference
+
+This data source exposes the following attributes:
+
+- `group_id` - Internal ID of the group in Databricks.
+- `account_id` - The parent account ID for the group in Databricks.
+- `group_name` - Display name of the group.
+
+## Related Resources
+
+The following resources are used in the same context:
+
+- [**databricks_group**](../resources/group.md): Resource to manage groups in Databricks.
+- [**databricks_group_member**](../resources/group_member.md): Resource to manage group memberships by adding users to groups.

--- a/docs/data-sources/service_principal_by_external_id.md
+++ b/docs/data-sources/service_principal_by_external_id.md
@@ -1,0 +1,48 @@
+---
+subcategory: "Security"
+---
+
+# databricks_service_principal_by_external_id Data Source
+
+Resolves a [databricks_service_principal](../resources/service_principal.md) using the external ID assigned to it by the customer's Identity Provider (IdP).
+
+-> This data source works with both the account-level and workspace-level provider.
+
+-> **Get-or-create semantics.** This data source calls the Databricks `resolve-by-external-id` API, which creates the service principal in the account if no service principal with the given `external_id` exists yet. It is not a pure read: the first `terraform plan`/`apply` against a previously unseen `external_id` has the side effect of provisioning a new service principal. This API also requires the account to be onboarded to Automatic Identity Management (AIM); otherwise it returns an error.
+
+## Example Usage
+
+```hcl
+data "databricks_service_principal_by_external_id" "this" {
+  external_id = "11111111-2222-3333-4444-555555555555"
+}
+
+resource "databricks_group_member" "member" {
+  group_id  = databricks_group.this.id
+  member_id = data.databricks_service_principal_by_external_id.this.service_principal_id
+}
+```
+
+## Argument Reference
+
+- `external_id` - (Required) The ID of the service principal in the customer's IdP (for example, the object ID assigned by Microsoft Entra ID).
+- `api` - (Optional) Specifies whether to use account-level or workspace-level API. Valid values are `account` and `workspace`. When not set, the API level is inferred from the provider host.
+- `provider_config` - (Optional) Configure the provider for management through account provider. This block consists of the following fields:
+  - `workspace_id` - (Required) Workspace ID which the resource belongs to. This workspace must be part of the account which the provider is configured with.
+
+## Attribute Reference
+
+This data source exposes the following attributes:
+
+- `service_principal_id` - Internal ID of the service principal in Databricks.
+- `account_id` - The parent account ID for the service principal in Databricks.
+- `application_id` - Application ID of the service principal.
+- `display_name` - Display name of the service principal.
+- `account_sp_status` - The activity status of the service principal in the Databricks account.
+
+## Related Resources
+
+The following resources are used in the same context:
+
+- [**databricks_service_principal**](../resources/service_principal.md): Resource to manage service principals in Databricks.
+- [**databricks_group_member**](../resources/group_member.md): Resource to manage group memberships by adding service principals to groups.

--- a/docs/data-sources/user_by_external_id.md
+++ b/docs/data-sources/user_by_external_id.md
@@ -1,0 +1,51 @@
+---
+subcategory: "Security"
+---
+
+# databricks_user_by_external_id Data Source
+
+Resolves a [databricks_user](../resources/user.md) using the external ID assigned to it by the customer's Identity Provider (IdP).
+
+-> This data source works with both the account-level and workspace-level provider.
+
+-> **Get-or-create semantics.** This data source calls the Databricks `resolve-by-external-id` API, which creates the user in the account if no user with the given `external_id` exists yet. It is not a pure read: the first `terraform plan`/`apply` against a previously unseen `external_id` has the side effect of provisioning a new user. This API also requires the account to be onboarded to Automatic Identity Management (AIM); otherwise it returns an error.
+
+## Example Usage
+
+```hcl
+data "databricks_user_by_external_id" "this" {
+  external_id = "11111111-2222-3333-4444-555555555555"
+}
+
+resource "databricks_group_member" "member" {
+  group_id  = databricks_group.this.id
+  member_id = data.databricks_user_by_external_id.this.user_id
+}
+```
+
+## Argument Reference
+
+- `external_id` - (Required) The ID of the user in the customer's IdP (for example, the object ID assigned by Microsoft Entra ID).
+- `api` - (Optional) Specifies whether to use account-level or workspace-level API. Valid values are `account` and `workspace`. When not set, the API level is inferred from the provider host.
+- `provider_config` - (Optional) Configure the provider for management through account provider. This block consists of the following fields:
+  - `workspace_id` - (Required) Workspace ID which the resource belongs to. This workspace must be part of the account which the provider is configured with.
+
+## Attribute Reference
+
+This data source exposes the following attributes:
+
+- `user_id` - Internal ID of the user in Databricks.
+- `account_id` - The parent account ID for the user in Databricks.
+- `username` - Username/email of the user.
+- `account_user_status` - The activity status of the user in the Databricks account.
+- `full_name` - The full name of the user.
+  - `given_name` - Given name of the user.
+  - `family_name` - Family name of the user.
+
+## Related Resources
+
+The following resources are used in the same context:
+
+- [**databricks_user**](../resources/user.md): Resource to manage individual users in Databricks.
+- [**databricks_group_member**](../resources/group_member.md): Resource to manage group memberships by adding users to groups.
+- [**databricks_users**](users.md): Data source to retrieve information about multiple users.

--- a/internal/providers/pluginfw/pluginfw_rollout_utils.go
+++ b/internal/providers/pluginfw/pluginfw_rollout_utils.go
@@ -30,6 +30,7 @@ import (
 	"github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/products/catalog"
 	"github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/products/cluster"
 	"github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/products/dashboards"
+	"github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/products/iamv2"
 	"github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/products/library"
 	"github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/products/networks/privateendpointrule"
 	"github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/products/notificationdestinations"
@@ -95,6 +96,9 @@ var pluginFwOnlyDataSources = append(
 		app.DataSourceApps,
 		catalog.DataSourceFunctions,
 		dashboards.DataSourceDashboards,
+		iamv2.DataSourceGroupByExternalId,
+		iamv2.DataSourceServicePrincipalByExternalId,
+		iamv2.DataSourceUserByExternalId,
 		notificationdestinations.DataSourceNotificationDestinations,
 		registered_model.DataSourceRegisteredModel,
 		registered_model.DataSourceRegisteredModelVersions,

--- a/internal/providers/pluginfw/products/iamv2/data_group_by_external_id.go
+++ b/internal/providers/pluginfw/products/iamv2/data_group_by_external_id.go
@@ -1,0 +1,146 @@
+package iamv2
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	"github.com/databricks/databricks-sdk-go/service/iamv2"
+	"github.com/databricks/terraform-provider-databricks/common"
+	pluginfwcommon "github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/common"
+	pluginfwcontext "github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/context"
+	"github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/converters"
+	"github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/tfschema"
+	"github.com/databricks/terraform-provider-databricks/internal/service/iamv2_tf"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+const groupByExternalIdDataSourceName = "group_by_external_id"
+
+var _ datasource.DataSourceWithConfigure = &GroupByExternalIdDataSource{}
+
+func DataSourceGroupByExternalId() datasource.DataSource {
+	return &GroupByExternalIdDataSource{}
+}
+
+type GroupByExternalIdDataSource struct {
+	Client *common.DatabricksClient
+}
+
+// GroupByExternalIdData resolves a Databricks group from an external ID
+// assigned by the customer's IdP, at either the account or workspace level.
+type GroupByExternalIdData struct {
+	iamv2_tf.Group
+	// Whether to use the account or workspace API. Inferred from the
+	// provider's host when unset; required on a unified host.
+	Api types.String `tfsdk:"api"`
+	tfschema.Namespace
+}
+
+func (GroupByExternalIdData) GetComplexFieldTypes(context.Context) map[string]reflect.Type {
+	return map[string]reflect.Type{
+		"provider_config": reflect.TypeOf(tfschema.ProviderConfigData{}),
+	}
+}
+
+func (GroupByExternalIdData) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
+	attrs["external_id"] = attrs["external_id"].SetRequired()
+	attrs["account_id"] = attrs["account_id"].SetComputed()
+	attrs["group_id"] = attrs["group_id"].SetComputed()
+	attrs["group_name"] = attrs["group_name"].SetComputed()
+	attrs["api"] = attrs["api"].SetOptional()
+	attrs["provider_config"] = attrs["provider_config"].SetOptional()
+
+	return attrs
+}
+
+func (d *GroupByExternalIdDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = pluginfwcommon.GetDatabricksProductionName(groupByExternalIdDataSourceName)
+}
+
+func (d *GroupByExternalIdDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	attrs, blocks := tfschema.DataSourceStructToSchemaMap(ctx, GroupByExternalIdData{}, nil)
+	resp.Schema = schema.Schema{
+		Description: "Resolves a Databricks group from an external ID assigned by the customer's IdP. " +
+			"If no group with the given external ID exists yet, Databricks creates one as a side effect of this call.",
+		Attributes: attrs,
+		Blocks:     blocks,
+	}
+}
+
+func (d *GroupByExternalIdDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if d.Client == nil {
+		d.Client = pluginfwcommon.ConfigureDataSource(req, resp)
+	}
+}
+
+func (d *GroupByExternalIdDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	ctx = pluginfwcontext.SetUserAgentInDataSourceContext(ctx, groupByExternalIdDataSourceName)
+
+	var data GroupByExternalIdData
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	isAccount, diags := resolveApiLevel(d.Client, data.Api)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	externalId := data.ExternalId.ValueString()
+	var group *iamv2.Group
+	if isAccount {
+		a, clientDiags := d.Client.GetAccountClient()
+		resp.Diagnostics.Append(clientDiags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		response, err := a.IamV2.ResolveGroup(ctx, iamv2.ResolveGroupRequest{ExternalId: externalId})
+		if err != nil {
+			resp.Diagnostics.AddError("failed to resolve group by external id", err.Error())
+			return
+		}
+		group = response.Group
+	} else {
+		workspaceID, wsDiags := tfschema.GetWorkspaceIDDataSource(ctx, data.ProviderConfig)
+		resp.Diagnostics.Append(wsDiags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		w, clientDiags := d.Client.GetWorkspaceClientForUnifiedProviderWithDiagnostics(ctx, workspaceID)
+		resp.Diagnostics.Append(clientDiags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		response, err := w.WorkspaceIamV2.ResolveGroupProxy(ctx, iamv2.ResolveGroupProxyRequest{ExternalId: externalId})
+		if err != nil {
+			resp.Diagnostics.AddError("failed to resolve group by external id", err.Error())
+			return
+		}
+		group = response.Group
+	}
+
+	if group == nil {
+		resp.Diagnostics.AddError("failed to resolve group by external id",
+			fmt.Sprintf("no group was returned for external_id %q", externalId))
+		return
+	}
+
+	resp.Diagnostics.Append(converters.GoSdkToTfSdkStruct(ctx, group, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if !isAccount {
+		resp.Diagnostics.Append(tfschema.PopulateProviderConfigInStateForDataSource(ctx, d.Client, data.ProviderConfig, &resp.State)...)
+	}
+}

--- a/internal/providers/pluginfw/products/iamv2/data_group_by_external_id_acc_test.go
+++ b/internal/providers/pluginfw/products/iamv2/data_group_by_external_id_acc_test.go
@@ -1,0 +1,48 @@
+package iamv2_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/databricks/terraform-provider-databricks/internal/acceptance"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests require the workspace/account to be onboarded to Automatic
+// Identity Management (AIM) and a real external ID from the configured IdP,
+// so they cannot provision their own fixture data and are gated on an env var.
+func groupByExternalIdTemplate(externalId string) string {
+	return fmt.Sprintf(`
+		data "databricks_group_by_external_id" "this" {
+			external_id = "%s"
+		}
+	`, externalId)
+}
+
+func checkGroupByExternalIdPopulated(t *testing.T, externalId string) func(s *terraform.State) error {
+	return func(s *terraform.State) error {
+		ds, ok := s.Modules[0].Resources["data.databricks_group_by_external_id.this"]
+		require.True(t, ok, "data.databricks_group_by_external_id.this has to be there")
+		require.Equal(t, externalId, ds.Primary.Attributes["external_id"])
+		require.NotEmpty(t, ds.Primary.Attributes["group_id"])
+		require.NotEmpty(t, ds.Primary.Attributes["group_name"])
+		return nil
+	}
+}
+
+func TestAccDataSourceGroupByExternalId(t *testing.T) {
+	externalId := acceptance.GetEnvOrSkipTest(t, "TEST_IDP_EXTERNAL_GROUP_ID")
+	acceptance.WorkspaceLevel(t, acceptance.Step{
+		Template: groupByExternalIdTemplate(externalId),
+		Check:    checkGroupByExternalIdPopulated(t, externalId),
+	})
+}
+
+func TestMwsAccDataSourceGroupByExternalId(t *testing.T) {
+	externalId := acceptance.GetEnvOrSkipTest(t, "TEST_IDP_EXTERNAL_GROUP_ID")
+	acceptance.AccountLevel(t, acceptance.Step{
+		Template: groupByExternalIdTemplate(externalId),
+		Check:    checkGroupByExternalIdPopulated(t, externalId),
+	})
+}

--- a/internal/providers/pluginfw/products/iamv2/data_service_principal_by_external_id.go
+++ b/internal/providers/pluginfw/products/iamv2/data_service_principal_by_external_id.go
@@ -1,0 +1,149 @@
+package iamv2
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	"github.com/databricks/databricks-sdk-go/service/iamv2"
+	"github.com/databricks/terraform-provider-databricks/common"
+	pluginfwcommon "github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/common"
+	pluginfwcontext "github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/context"
+	"github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/converters"
+	"github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/tfschema"
+	"github.com/databricks/terraform-provider-databricks/internal/service/iamv2_tf"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+const servicePrincipalByExternalIdDataSourceName = "service_principal_by_external_id"
+
+var _ datasource.DataSourceWithConfigure = &ServicePrincipalByExternalIdDataSource{}
+
+func DataSourceServicePrincipalByExternalId() datasource.DataSource {
+	return &ServicePrincipalByExternalIdDataSource{}
+}
+
+type ServicePrincipalByExternalIdDataSource struct {
+	Client *common.DatabricksClient
+}
+
+// ServicePrincipalByExternalIdData resolves a Databricks service principal
+// from an external ID assigned by the customer's IdP, at either the account
+// or workspace level.
+type ServicePrincipalByExternalIdData struct {
+	iamv2_tf.ServicePrincipal
+	// Whether to use the account or workspace API. Inferred from the
+	// provider's host when unset; required on a unified host.
+	Api types.String `tfsdk:"api"`
+	tfschema.Namespace
+}
+
+func (ServicePrincipalByExternalIdData) GetComplexFieldTypes(context.Context) map[string]reflect.Type {
+	return map[string]reflect.Type{
+		"provider_config": reflect.TypeOf(tfschema.ProviderConfigData{}),
+	}
+}
+
+func (ServicePrincipalByExternalIdData) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
+	attrs["external_id"] = attrs["external_id"].SetRequired()
+	attrs["account_id"] = attrs["account_id"].SetComputed()
+	attrs["account_sp_status"] = attrs["account_sp_status"].SetComputed()
+	attrs["application_id"] = attrs["application_id"].SetComputed()
+	attrs["display_name"] = attrs["display_name"].SetComputed()
+	attrs["service_principal_id"] = attrs["service_principal_id"].SetComputed()
+	attrs["api"] = attrs["api"].SetOptional()
+	attrs["provider_config"] = attrs["provider_config"].SetOptional()
+
+	return attrs
+}
+
+func (d *ServicePrincipalByExternalIdDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = pluginfwcommon.GetDatabricksProductionName(servicePrincipalByExternalIdDataSourceName)
+}
+
+func (d *ServicePrincipalByExternalIdDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	attrs, blocks := tfschema.DataSourceStructToSchemaMap(ctx, ServicePrincipalByExternalIdData{}, nil)
+	resp.Schema = schema.Schema{
+		Description: "Resolves a Databricks service principal from an external ID assigned by the customer's IdP. " +
+			"If no service principal with the given external ID exists yet, Databricks creates one as a side effect of this call.",
+		Attributes: attrs,
+		Blocks:     blocks,
+	}
+}
+
+func (d *ServicePrincipalByExternalIdDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if d.Client == nil {
+		d.Client = pluginfwcommon.ConfigureDataSource(req, resp)
+	}
+}
+
+func (d *ServicePrincipalByExternalIdDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	ctx = pluginfwcontext.SetUserAgentInDataSourceContext(ctx, servicePrincipalByExternalIdDataSourceName)
+
+	var data ServicePrincipalByExternalIdData
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	isAccount, diags := resolveApiLevel(d.Client, data.Api)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	externalId := data.ExternalId.ValueString()
+	var servicePrincipal *iamv2.ServicePrincipal
+	if isAccount {
+		a, clientDiags := d.Client.GetAccountClient()
+		resp.Diagnostics.Append(clientDiags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		response, err := a.IamV2.ResolveServicePrincipal(ctx, iamv2.ResolveServicePrincipalRequest{ExternalId: externalId})
+		if err != nil {
+			resp.Diagnostics.AddError("failed to resolve service principal by external id", err.Error())
+			return
+		}
+		servicePrincipal = response.ServicePrincipal
+	} else {
+		workspaceID, wsDiags := tfschema.GetWorkspaceIDDataSource(ctx, data.ProviderConfig)
+		resp.Diagnostics.Append(wsDiags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		w, clientDiags := d.Client.GetWorkspaceClientForUnifiedProviderWithDiagnostics(ctx, workspaceID)
+		resp.Diagnostics.Append(clientDiags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		response, err := w.WorkspaceIamV2.ResolveServicePrincipalProxy(ctx, iamv2.ResolveServicePrincipalProxyRequest{ExternalId: externalId})
+		if err != nil {
+			resp.Diagnostics.AddError("failed to resolve service principal by external id", err.Error())
+			return
+		}
+		servicePrincipal = response.ServicePrincipal
+	}
+
+	if servicePrincipal == nil {
+		resp.Diagnostics.AddError("failed to resolve service principal by external id",
+			fmt.Sprintf("no service principal was returned for external_id %q", externalId))
+		return
+	}
+
+	resp.Diagnostics.Append(converters.GoSdkToTfSdkStruct(ctx, servicePrincipal, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if !isAccount {
+		resp.Diagnostics.Append(tfschema.PopulateProviderConfigInStateForDataSource(ctx, d.Client, data.ProviderConfig, &resp.State)...)
+	}
+}

--- a/internal/providers/pluginfw/products/iamv2/data_service_principal_by_external_id_acc_test.go
+++ b/internal/providers/pluginfw/products/iamv2/data_service_principal_by_external_id_acc_test.go
@@ -1,0 +1,48 @@
+package iamv2_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/databricks/terraform-provider-databricks/internal/acceptance"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests require the workspace/account to be onboarded to Automatic
+// Identity Management (AIM) and a real external ID from the configured IdP,
+// so they cannot provision their own fixture data and are gated on an env var.
+func servicePrincipalByExternalIdTemplate(externalId string) string {
+	return fmt.Sprintf(`
+		data "databricks_service_principal_by_external_id" "this" {
+			external_id = "%s"
+		}
+	`, externalId)
+}
+
+func checkServicePrincipalByExternalIdPopulated(t *testing.T, externalId string) func(s *terraform.State) error {
+	return func(s *terraform.State) error {
+		ds, ok := s.Modules[0].Resources["data.databricks_service_principal_by_external_id.this"]
+		require.True(t, ok, "data.databricks_service_principal_by_external_id.this has to be there")
+		require.Equal(t, externalId, ds.Primary.Attributes["external_id"])
+		require.NotEmpty(t, ds.Primary.Attributes["service_principal_id"])
+		require.NotEmpty(t, ds.Primary.Attributes["application_id"])
+		return nil
+	}
+}
+
+func TestAccDataSourceServicePrincipalByExternalId(t *testing.T) {
+	externalId := acceptance.GetEnvOrSkipTest(t, "TEST_IDP_EXTERNAL_SP_ID")
+	acceptance.WorkspaceLevel(t, acceptance.Step{
+		Template: servicePrincipalByExternalIdTemplate(externalId),
+		Check:    checkServicePrincipalByExternalIdPopulated(t, externalId),
+	})
+}
+
+func TestMwsAccDataSourceServicePrincipalByExternalId(t *testing.T) {
+	externalId := acceptance.GetEnvOrSkipTest(t, "TEST_IDP_EXTERNAL_SP_ID")
+	acceptance.AccountLevel(t, acceptance.Step{
+		Template: servicePrincipalByExternalIdTemplate(externalId),
+		Check:    checkServicePrincipalByExternalIdPopulated(t, externalId),
+	})
+}

--- a/internal/providers/pluginfw/products/iamv2/data_user_by_external_id.go
+++ b/internal/providers/pluginfw/products/iamv2/data_user_by_external_id.go
@@ -1,0 +1,149 @@
+package iamv2
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	"github.com/databricks/databricks-sdk-go/service/iamv2"
+	"github.com/databricks/terraform-provider-databricks/common"
+	pluginfwcommon "github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/common"
+	pluginfwcontext "github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/context"
+	"github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/converters"
+	"github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/tfschema"
+	"github.com/databricks/terraform-provider-databricks/internal/service/iamv2_tf"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+const userByExternalIdDataSourceName = "user_by_external_id"
+
+var _ datasource.DataSourceWithConfigure = &UserByExternalIdDataSource{}
+
+func DataSourceUserByExternalId() datasource.DataSource {
+	return &UserByExternalIdDataSource{}
+}
+
+type UserByExternalIdDataSource struct {
+	Client *common.DatabricksClient
+}
+
+// UserByExternalIdData resolves a Databricks user from an external ID
+// assigned by the customer's IdP, at either the account or workspace level.
+type UserByExternalIdData struct {
+	iamv2_tf.User
+	// Whether to use the account or workspace API. Inferred from the
+	// provider's host when unset; required on a unified host.
+	Api types.String `tfsdk:"api"`
+	tfschema.Namespace
+}
+
+func (UserByExternalIdData) GetComplexFieldTypes(context.Context) map[string]reflect.Type {
+	return map[string]reflect.Type{
+		"full_name":       reflect.TypeOf(iamv2_tf.UserFullName{}),
+		"provider_config": reflect.TypeOf(tfschema.ProviderConfigData{}),
+	}
+}
+
+func (UserByExternalIdData) ApplySchemaCustomizations(attrs map[string]tfschema.AttributeBuilder) map[string]tfschema.AttributeBuilder {
+	attrs["external_id"] = attrs["external_id"].SetRequired()
+	attrs["account_id"] = attrs["account_id"].SetComputed()
+	attrs["account_user_status"] = attrs["account_user_status"].SetComputed()
+	attrs["full_name"] = attrs["full_name"].SetComputed()
+	attrs["user_id"] = attrs["user_id"].SetComputed()
+	attrs["username"] = attrs["username"].SetComputed()
+	attrs["api"] = attrs["api"].SetOptional()
+	attrs["provider_config"] = attrs["provider_config"].SetOptional()
+
+	return attrs
+}
+
+func (d *UserByExternalIdDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = pluginfwcommon.GetDatabricksProductionName(userByExternalIdDataSourceName)
+}
+
+func (d *UserByExternalIdDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	attrs, blocks := tfschema.DataSourceStructToSchemaMap(ctx, UserByExternalIdData{}, nil)
+	resp.Schema = schema.Schema{
+		Description: "Resolves a Databricks user from an external ID assigned by the customer's IdP. " +
+			"If no user with the given external ID exists yet, Databricks creates one as a side effect of this call.",
+		Attributes: attrs,
+		Blocks:     blocks,
+	}
+}
+
+func (d *UserByExternalIdDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if d.Client == nil {
+		d.Client = pluginfwcommon.ConfigureDataSource(req, resp)
+	}
+}
+
+func (d *UserByExternalIdDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	ctx = pluginfwcontext.SetUserAgentInDataSourceContext(ctx, userByExternalIdDataSourceName)
+
+	var data UserByExternalIdData
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	isAccount, diags := resolveApiLevel(d.Client, data.Api)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	externalId := data.ExternalId.ValueString()
+	var user *iamv2.User
+	if isAccount {
+		a, clientDiags := d.Client.GetAccountClient()
+		resp.Diagnostics.Append(clientDiags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		response, err := a.IamV2.ResolveUser(ctx, iamv2.ResolveUserRequest{ExternalId: externalId})
+		if err != nil {
+			resp.Diagnostics.AddError("failed to resolve user by external id", err.Error())
+			return
+		}
+		user = response.User
+	} else {
+		workspaceID, wsDiags := tfschema.GetWorkspaceIDDataSource(ctx, data.ProviderConfig)
+		resp.Diagnostics.Append(wsDiags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		w, clientDiags := d.Client.GetWorkspaceClientForUnifiedProviderWithDiagnostics(ctx, workspaceID)
+		resp.Diagnostics.Append(clientDiags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		response, err := w.WorkspaceIamV2.ResolveUserProxy(ctx, iamv2.ResolveUserProxyRequest{ExternalId: externalId})
+		if err != nil {
+			resp.Diagnostics.AddError("failed to resolve user by external id", err.Error())
+			return
+		}
+		user = response.User
+	}
+
+	if user == nil {
+		resp.Diagnostics.AddError("failed to resolve user by external id",
+			fmt.Sprintf("no user was returned for external_id %q", externalId))
+		return
+	}
+
+	resp.Diagnostics.Append(converters.GoSdkToTfSdkStruct(ctx, user, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if !isAccount {
+		resp.Diagnostics.Append(tfschema.PopulateProviderConfigInStateForDataSource(ctx, d.Client, data.ProviderConfig, &resp.State)...)
+	}
+}

--- a/internal/providers/pluginfw/products/iamv2/data_user_by_external_id_acc_test.go
+++ b/internal/providers/pluginfw/products/iamv2/data_user_by_external_id_acc_test.go
@@ -1,0 +1,48 @@
+package iamv2_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/databricks/terraform-provider-databricks/internal/acceptance"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests require the workspace/account to be onboarded to Automatic
+// Identity Management (AIM) and a real external ID from the configured IdP,
+// so they cannot provision their own fixture data and are gated on an env var.
+func userByExternalIdTemplate(externalId string) string {
+	return fmt.Sprintf(`
+		data "databricks_user_by_external_id" "this" {
+			external_id = "%s"
+		}
+	`, externalId)
+}
+
+func checkUserByExternalIdPopulated(t *testing.T, externalId string) func(s *terraform.State) error {
+	return func(s *terraform.State) error {
+		ds, ok := s.Modules[0].Resources["data.databricks_user_by_external_id.this"]
+		require.True(t, ok, "data.databricks_user_by_external_id.this has to be there")
+		require.Equal(t, externalId, ds.Primary.Attributes["external_id"])
+		require.NotEmpty(t, ds.Primary.Attributes["user_id"])
+		require.NotEmpty(t, ds.Primary.Attributes["username"])
+		return nil
+	}
+}
+
+func TestAccDataSourceUserByExternalId(t *testing.T) {
+	externalId := acceptance.GetEnvOrSkipTest(t, "TEST_IDP_EXTERNAL_USER_ID")
+	acceptance.WorkspaceLevel(t, acceptance.Step{
+		Template: userByExternalIdTemplate(externalId),
+		Check:    checkUserByExternalIdPopulated(t, externalId),
+	})
+}
+
+func TestMwsAccDataSourceUserByExternalId(t *testing.T) {
+	externalId := acceptance.GetEnvOrSkipTest(t, "TEST_IDP_EXTERNAL_USER_ID")
+	acceptance.AccountLevel(t, acceptance.Step{
+		Template: userByExternalIdTemplate(externalId),
+		Check:    checkUserByExternalIdPopulated(t, externalId),
+	})
+}

--- a/internal/providers/pluginfw/products/iamv2/iamv2.go
+++ b/internal/providers/pluginfw/products/iamv2/iamv2.go
@@ -1,0 +1,30 @@
+package iamv2
+
+import (
+	"github.com/databricks/databricks-sdk-go/config"
+	"github.com/databricks/terraform-provider-databricks/common"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// resolveApiLevel decides whether a resolve-by-external-id data source should
+// call the account API or the workspace (proxy) API. It mirrors
+// common.validateApiLevelForUnifiedHost (common/unified_provider.go) for the
+// plugin framework: an explicit `api` argument always wins; otherwise the
+// choice is inferred from the provider's configured host, except on a
+// UnifiedHost, where the host alone is ambiguous and `api` must be set.
+func resolveApiLevel(client *common.DatabricksClient, api types.String) (isAccount bool, diags diag.Diagnostics) {
+	if !api.IsNull() && !api.IsUnknown() {
+		apiLevel := api.ValueString()
+		if apiLevel != "account" && apiLevel != "workspace" {
+			diags.AddError("Invalid api value", "api must be either \"account\" or \"workspace\"")
+			return false, diags
+		}
+		return apiLevel == "account", diags
+	}
+	if client.HostTypeForTerraform() == config.UnifiedHost {
+		diags.AddError("Missing api value", "please set api to account or workspace")
+		return false, diags
+	}
+	return client.HostTypeForTerraform() == config.AccountHost, diags
+}

--- a/internal/providers/pluginfw/products/iamv2/iamv2_test.go
+++ b/internal/providers/pluginfw/products/iamv2/iamv2_test.go
@@ -1,0 +1,99 @@
+package iamv2
+
+import (
+	"context"
+	"testing"
+
+	"github.com/databricks/databricks-sdk-go/client"
+	"github.com/databricks/databricks-sdk-go/config"
+	"github.com/databricks/terraform-provider-databricks/common"
+	"github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/tfschema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func clientWithHost(t *testing.T, host string) *common.DatabricksClient {
+	t.Helper()
+	return &common.DatabricksClient{
+		DatabricksClient: &client.DatabricksClient{Config: &config.Config{Host: host}},
+	}
+}
+
+func clientWithUnifiedHost(t *testing.T) *common.DatabricksClient {
+	t.Helper()
+	cfg := &config.Config{
+		Host: "https://unifiedhost.databricks.com",
+		HostMetadataResolver: func(ctx context.Context, _ string) (*config.HostMetadata, error) {
+			return &config.HostMetadata{HostType: config.UnifiedHost}, nil
+		},
+	}
+	require.NoError(t, cfg.EnsureResolved())
+	return &common.DatabricksClient{DatabricksClient: &client.DatabricksClient{Config: cfg}}
+}
+
+func TestResolveApiLevel_ExplicitAccount(t *testing.T) {
+	isAccount, diags := resolveApiLevel(clientWithHost(t, "https://accounts.cloud.databricks.com"), types.StringValue("account"))
+	assert.False(t, diags.HasError())
+	assert.True(t, isAccount)
+}
+
+func TestResolveApiLevel_ExplicitWorkspace(t *testing.T) {
+	isAccount, diags := resolveApiLevel(clientWithHost(t, "https://accounts.cloud.databricks.com"), types.StringValue("workspace"))
+	assert.False(t, diags.HasError())
+	assert.False(t, isAccount)
+}
+
+func TestResolveApiLevel_InvalidValue(t *testing.T) {
+	_, diags := resolveApiLevel(clientWithHost(t, "https://accounts.cloud.databricks.com"), types.StringValue("bogus"))
+	assert.True(t, diags.HasError())
+	assert.Equal(t, diag.Diagnostics{diag.NewErrorDiagnostic("Invalid api value", "api must be either \"account\" or \"workspace\"")}, diags)
+}
+
+func TestResolveApiLevel_UnsetAccountHost(t *testing.T) {
+	isAccount, diags := resolveApiLevel(clientWithHost(t, "https://accounts.cloud.databricks.com"), types.StringNull())
+	assert.False(t, diags.HasError())
+	assert.True(t, isAccount)
+}
+
+func TestResolveApiLevel_UnsetWorkspaceHost(t *testing.T) {
+	isAccount, diags := resolveApiLevel(clientWithHost(t, "https://myworkspace.cloud.databricks.com"), types.StringNull())
+	assert.False(t, diags.HasError())
+	assert.False(t, isAccount)
+}
+
+func TestResolveApiLevel_UnsetUnifiedHost(t *testing.T) {
+	_, diags := resolveApiLevel(clientWithUnifiedHost(t), types.StringNull())
+	assert.True(t, diags.HasError())
+	assert.Equal(t, diag.Diagnostics{diag.NewErrorDiagnostic("Missing api value", "please set api to account or workspace")}, diags)
+}
+
+func TestResolveApiLevel_UnknownValue(t *testing.T) {
+	isAccount, diags := resolveApiLevel(clientWithHost(t, "https://accounts.cloud.databricks.com"), types.StringUnknown())
+	assert.False(t, diags.HasError())
+	assert.True(t, isAccount)
+}
+
+func TestUserByExternalIdSchema(t *testing.T) {
+	attrs, _ := tfschema.DataSourceStructToSchemaMap(context.Background(), UserByExternalIdData{}, nil)
+	assertHasAttributes(t, attrs, "external_id", "account_id", "account_user_status", "full_name", "user_id", "username", "api", "provider_config")
+}
+
+func TestGroupByExternalIdSchema(t *testing.T) {
+	attrs, _ := tfschema.DataSourceStructToSchemaMap(context.Background(), GroupByExternalIdData{}, nil)
+	assertHasAttributes(t, attrs, "external_id", "account_id", "group_id", "group_name", "api", "provider_config")
+}
+
+func TestServicePrincipalByExternalIdSchema(t *testing.T) {
+	attrs, _ := tfschema.DataSourceStructToSchemaMap(context.Background(), ServicePrincipalByExternalIdData{}, nil)
+	assertHasAttributes(t, attrs, "external_id", "account_id", "account_sp_status", "application_id", "display_name", "service_principal_id", "api", "provider_config")
+}
+
+func assertHasAttributes[V any](t *testing.T, attrs map[string]V, names ...string) {
+	t.Helper()
+	assert.Len(t, attrs, len(names))
+	for _, name := range names {
+		assert.Contains(t, attrs, name)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `databricks_user_by_external_id`, `databricks_group_by_external_id`, and `databricks_service_principal_by_external_id` data sources, wrapping the Databricks `iamv2` `resolve-by-external-id` APIs to resolve a Databricks principal from the external ID assigned to it by the customer's IdP.
- Each data source works with both the account-level and workspace-level provider, inferring the API level from the provider host with an optional `api = "account" | "workspace"` override (same pattern as `databricks_users`).
- **Note (get-or-create semantics):** these APIs create the principal if one with the given `external_id` does not already exist yet, and require the account to be onboarded to Automatic Identity Management (AIM). This is called out in each data source's documentation.

## Test plan
- [x] `go test ./internal/providers/pluginfw/products/iamv2/...` — unit tests covering `resolveApiLevel` dispatch (account/workspace/unified-host/invalid values) and schema generation for all three data sources
- [x] `go test ./internal/providers/pluginfw/...` — full plugin framework suite passes
- [x] `make build`, `make lint`, `make ws`, `go vet ./...`
- [x] `make fmt-docs`
- [ ] Acceptance tests (`TestAcc*` / `TestMwsAcc*` in `data_*_by_external_id_acc_test.go`) require a workspace/account onboarded to AIM and real IdP external IDs (`TEST_IDP_EXTERNAL_USER_ID`, `TEST_IDP_EXTERNAL_GROUP_ID`, `TEST_IDP_EXTERNAL_SP_ID`); they skip cleanly without these env vars and have not been run against a live AIM-onboarded environment
- [ ] `make diff-schema` — additive-only schema change, not yet run against `main` in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NicJXos6wf2X7HZZYguHV4