### PR TITLE
[Doc] Fix VPC endpoint security group rules in the AWS Private Link guide

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Bug Fixes
 
 ### Documentation
+* Fix the VPC endpoint security group rules in the AWS Private Link guide: add the missing inbound ports (5432 and 8443-8451), source the rules from the workspace security group, and drop the unnecessary egress rules ([#5930](https://github.com/databricks/terraform-provider-databricks/pull/5930)).
 
 ### Exporter
 

--- a/docs/guides/aws-private-link-workspace.md
+++ b/docs/guides/aws-private-link-workspace.md
@@ -161,21 +161,16 @@ resource "aws_route_table_association" "dataplane_vpce_rtb" {
 }
 ```
 
-Define security group for data plane VPC endpoint backend/relay connections:
+Define security group for data plane VPC endpoint backend/relay connections.
+
+The endpoint security group only needs inbound rules, sourced from the workspace
+security group. Security groups are stateful, so return traffic is allowed
+automatically. The ports below follow the [customer-managed VPC security group
+requirements](https://docs.databricks.com/aws/en/security/network/classic/customer-managed-vpc#security-groups)
+and the least-privilege pattern described in [Configure classic private
+connectivity to Databricks](https://docs.databricks.com/aws/en/security/network/classic/privatelink).
 
 ```hcl
-data "aws_subnet" "ws_vpc_subnets" {
-  for_each = toset(var.subnet_ids)
-  id       = each.value
-}
-
-locals {
-  vpc_cidr_blocks = [
-    for subnet in data.aws_subnet.ws_vpc_subnets :
-    subnet.cidr_block
-  ]
-}
-
 resource "aws_security_group" "dataplane_vpce" {
   name        = "Data Plane VPC endpoint security group"
   description = "Security group shared with relay and workspace endpoints"
@@ -183,34 +178,27 @@ resource "aws_security_group" "dataplane_vpce" {
 
   dynamic "ingress" {
     for_each = toset([
-      443,
+      443,  # workspace REST API
       2443, # FIPS port for CSP
-      6666,
+      5432, # classic compute plane to Lakebase
+      6666, # secure cluster connectivity relay
     ])
 
     content {
-      description = "Inbound rules"
-      from_port   = ingress.value
-      to_port     = ingress.value
-      protocol    = "tcp"
-      cidr_blocks = concat([var.vpce_subnet_cidr], local.vpc_cidr_blocks)
+      description     = "Inbound rules"
+      from_port       = ingress.value
+      to_port         = ingress.value
+      protocol        = "tcp"
+      security_groups = [var.security_group_id]
     }
   }
 
-  dynamic "egress" {
-    for_each = toset([
-      443,
-      2443, # FIPS port for CSP
-      6666,
-    ])
-
-    content {
-      description = "Outbound rules"
-      from_port   = egress.value
-      to_port     = egress.value
-      protocol    = "tcp"
-      cidr_blocks = concat([var.vpce_subnet_cidr], local.vpc_cidr_blocks)
-    }
+  ingress {
+    description     = "Compute plane to control plane API (8443, 8445), Unity Catalog logging and lineage (8444), 8446-8451 reserved for future use"
+    from_port       = 8443
+    to_port         = 8451
+    protocol        = "tcp"
+    security_groups = [var.security_group_id]
   }
 
   tags = merge(data.aws_vpc.prod.tags, {


### PR DESCRIPTION
## Changes

The `aws_security_group.dataplane_vpce` example in the AWS Private Link guide does not open all the ports the classic compute plane uses to reach the control plane through the back-end endpoints.

- Add missing inbound ports 8443, 8444, 8445-8451 and 5432. Ports 8443/8445 carry internal compute plane to control plane API calls and 8444 carries Unity Catalog logging and lineage. With only 443/2443/6666 open, those packets are dropped at the endpoint ENI while the workspace still comes up and clusters still start, so the gap is easy to miss.
- Source the inbound rules from the workspace security group instead of the VPC and endpoint subnet CIDRs, matching the least-privilege configuration described in the documentation. The guide already registers `var.security_group_id` as the workspace security group in `databricks_mws_networks`, so this keeps the example internally consistent.
- Drop the egress rules. Security groups are stateful and the documentation states that outbound rules are not required for the endpoint security group.
- Remove `data.aws_subnet.ws_vpc_subnets` and `local.vpc_cidr_blocks`, which are no longer referenced after the change.
- Link the guide to the authoritative port list.

References:

- https://docs.databricks.com/aws/en/security/network/classic/customer-managed-vpc#security-groups
- https://docs.databricks.com/aws/en/security/network/classic/privatelink
- https://github.com/databricks/terraform-databricks-sra/blob/main/aws/tf/privatelink.tf

Documentation-only change, no provider behavior is affected.

## Tests

- [ ] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] using Go SDK
- [ ] using TF Plugin Framework
- [x] has entry in `NEXT_CHANGELOG.md` file

Verified locally:

- `terraform fmt` reports no changes on the edited HCL block (`terrafmt` applies the same formatting)
- `python3 tools/validate_whitespace.py` passes: 1169 checked, 378 skipped, 0 failed
