### PR TITLE
[DEMO — DO NOT MERGE] Verify breaking-schema-check passes on Required→Optional

### DIFF
--- a/workspace/resource_directory.go
+++ b/workspace/resource_directory.go
@@ -21,7 +21,7 @@ func ResourceDirectory() common.Resource {
 	s := map[string]*schema.Schema{
 		"path": {
 			Type:             schema.TypeString,
-			Required:         true,
+			Optional:         true,
 			ForceNew:         true,
 			DiffSuppressFunc: directoryPathSuppressDiff,
 		},


### PR DESCRIPTION
## Purpose

Demo PR — the non-breaking mirror of #5787. Exercises the `breaking-schema-check` workflow (#5786) and confirms it **passes** on a backward-compatible schema change. Not intended to merge.

## The change

One line in `workspace/resource_directory.go`:

```diff
 "path": {
     Type:             schema.TypeString,
-    Required:         true,
+    Optional:         true,
     ForceNew:         true,
     DiffSuppressFunc: directoryPathSuppressDiff,
 },
```

This flips `databricks_directory.path` from Required to Optional. Where #5787 went Optional→Required (breaking), this goes the other direction — strictly looser, so every previously-valid config remains valid.

## Expected behavior

- `breaking-schema-check` should **pass**. The classifier emits a `RequiredToOptional` change classified as **non-breaking** (surfaced for awareness under "Non-breaking changes", not blocking).
- No `ALLOW_SCHEMA_BREAKING_CHANGE=true` bypass is needed, and no failing sticky comment is posted.

NO_CHANGELOG=true