### PR TITLE
Use Stable Metastore Fixture in D2D Recipient Test

### DIFF
--- a/sharing/recipient_test.go
+++ b/sharing/recipient_test.go
@@ -26,23 +26,11 @@ func TestUcAccCreateRecipientDb2Open(t *testing.T) {
 func TestUcAccCreateRecipientDb2DbAws(t *testing.T) {
 	acceptance.UnityWorkspaceLevel(t, acceptance.Step{
 		Template: `
-		resource "databricks_metastore" "recipient_metastore" {
-			name = "{var.RANDOM}-terraform-recipient-metastore"
-			storage_root = "s3://{env.TEST_BUCKET}/test{var.RANDOM}"
-			delta_sharing_scope = "INTERNAL"
-			delta_sharing_recipient_token_lifetime_in_seconds = "60000"
-			force_destroy = true
-			lifecycle {
-			// fake storage root is causing issues
-			ignore_changes = [storage_root]
-			}
-		}
-
 		resource "databricks_recipient" "db2db" {
 			name = "{var.RANDOM}-terraform-db2db-recipient"
 			comment = "made by terraform"
 			authentication_type = "DATABRICKS"
-			data_recipient_global_metastore_id = databricks_metastore.recipient_metastore.global_metastore_id
+			data_recipient_global_metastore_id = "{env.TEST_RECIPIENT_GLOBAL_METASTORE_ID}"
 		}`,
 	})
 }


### PR DESCRIPTION
This PR changes the Databricks-to-Databricks recipient acceptance test to use a stable recipient-side metastore supplied by the integration-test environment.

The test previously created a temporary metastore through the workspace provider. A recent backend rollout made that operation use the cross-metastore management path, which is unavailable in the AWS isolated UC workspace because Global UC is disabled. The failure happened during test setup, before the recipient resource was exercised.

## Review guide

- Removes temporary databricks_metastore creation from the test.
- Reads TEST_RECIPIENT_GLOBAL_METASTORE_ID from the test environment.
- Leaves Global UC coverage unchanged because this test is about recipient CRUD, not metastore-management permutations.

NO_CHANGELOG=true