### PR TITLE
Mark Azure Provisioned Throughput Test Flaky

### DIFF
--- a/test-config.yaml
+++ b/test-config.yaml
@@ -138,6 +138,10 @@ ignored_tests:
     - package: github.com/databricks/terraform-provider-databricks/serving
       test_name: TestUcAccModelServingProvisionedThroughputResource
       comment: Failure due to limited capacity in specific regions
+    - package: github.com/databricks/terraform-provider-databricks/serving
+      test_name: TestUcAccModelServingProvisionedThroughput
+      comment: Azure provisioned throughput endpoints remain in progress until the creation timeout.
+      cloud_env: azure
     - package: github.com/databricks/terraform-provider-databricks/secrets
       test_name: TestAccSecretAclResourceDefaultPrincipal
       comment: Failures due to 500s in secrets ACLs APIs.


### PR DESCRIPTION
This PR marks `TestUcAccModelServingProvisionedThroughput` as flaky only when `CLOUD_ENV` is `azure`. Azure provisioned-throughput endpoints are currently remaining `IN_PROGRESS` until the 45-minute creation timeout, and two retries extend the isolated integration-test jobs to roughly 2.5 hours.

The test is a Unity Catalog workspace acceptance test, so the cloud filter limits the exemption to the Azure UC workspace suite while AWS and GCP coverage remains unchanged.

NO_CHANGELOG=true