### PR TITLE
Resolve workspace-host workspace_id eagerly at provider init to avoid downstream SCIM /Me

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -10,6 +10,10 @@
 
 * Add support for `model_service`, `mcp_service`, and `model_provider_service` securables in `databricks_grant` and `databricks_grants` ([#5941](https://github.com/databricks/terraform-provider-databricks/pull/5941)).
 
+* Resolve the workspace `workspace_id` once during provider configuration for workspace-level hosts, so no resource or data source operation issues a SCIM `/Me` call to resolve it ([#5939](https://github.com/databricks/terraform-provider-databricks/pull/5939)).
+
+  Builds on the host-metadata resolution added previously: when a workspace host advertises `workspace_id` in `/.well-known/databricks-config` it is used directly, and when the metadata omits it (older control planes) the id is resolved eagerly via a single `/Me` at configuration time. A failure to resolve now surfaces at provider configuration rather than at the first resource operation.
+
 ### Bug Fixes
 
 ### Documentation

--- a/common/client.go
+++ b/common/client.go
@@ -183,20 +183,12 @@ func (c *DatabricksClient) getWorkspaceClientForWorkspaceConfiguredProvider(
 		return nil, err
 	}
 
-	// Check if the workspace ID specified in the resource matches
-	// the workspace ID of the provider configured workspace client.
-	w, err := c.WorkspaceClient()
-	if err != nil {
-		return nil, err
-	}
-
-	err = c.validateWorkspaceIDFromProvider(ctx, parsedID, w)
-	if err != nil {
+	// Check that the workspace ID specified in the resource matches the provider's
+	// workspace (from the cache seeded at configuration), then return the client.
+	if err := c.validateWorkspaceIDFromProvider(parsedID); err != nil {
 		return nil, fmt.Errorf("failed to validate workspace_id: %w", err)
 	}
-	// The provider is configured at the workspace level and the
-	// workspace ID matches
-	return w, nil
+	return c.WorkspaceClient()
 }
 
 // parseWorkspaceID validates the workspace ID is non-empty and returns it verbatim.
@@ -221,21 +213,23 @@ func isNumericWorkspaceID(id string) bool {
 	return err == nil
 }
 
-// CurrentWorkspaceID returns the workspace ID for a workspace-level provider.
-// It uses the cached value if available, otherwise makes an API call to resolve it.
+// CurrentWorkspaceID returns the cached workspace ID for a workspace-level
+// provider. The cache is seeded once during provider configuration
+// (ReconcileWorkspaceIDFromHostMetadata) — from host metadata, or from a single
+// /Me for older hosts. Callers therefore never trigger a /Me here; an unseeded
+// cache is treated as an error rather than resolved lazily.
+//
+// Reaching this with an unseeded cache means either provider configuration did not
+// seed it (a workspace-host invariant violation) or the provider is not configured
+// against a workspace host — /Me is a workspace-level call and cannot resolve a
+// workspace id for an account host, so there is nothing to resolve here.
 func (c *DatabricksClient) CurrentWorkspaceID(ctx context.Context) (int64, error) {
 	if c.cachedWorkspaceID != 0 {
 		return c.cachedWorkspaceID, nil
 	}
-	w, err := c.WorkspaceClient()
-	if err != nil {
-		return 0, err
-	}
-	err = c.setCachedWorkspaceID(ctx, w)
-	if err != nil {
-		return 0, err
-	}
-	return c.cachedWorkspaceID, nil
+	return 0, fmt.Errorf("workspace_id is not available: it is resolved during provider " +
+		"configuration for workspace-level providers. Set workspace_id in the provider " +
+		"configuration, or configure the provider against a workspace host")
 }
 
 // validateWorkspaceIDFromProvider validates the workspace ID specified in the
@@ -243,8 +237,8 @@ func (c *DatabricksClient) CurrentWorkspaceID(ctx context.Context) (int64, error
 // Workspace-level providers (host+token scoped to one workspace) can only operate on that workspace;
 // connection IDs cannot be reconciled here because the server returns a canonical
 // numeric workspace ID via /Me that has no meaningful comparison with a connection ID.
-func (c *DatabricksClient) validateWorkspaceIDFromProvider(ctx context.Context, workspaceID string,
-	w *databricks.WorkspaceClient) error {
+// The comparison uses the cachedWorkspaceID seeded at provider configuration.
+func (c *DatabricksClient) validateWorkspaceIDFromProvider(workspaceID string) error {
 	// Reject connection IDs up-front. A workspace-level provider (host+token)
 	// is scoped to a single workspace; the server returns that workspace's
 	// canonical numeric workspace ID via /Me, which can never be compared
@@ -260,14 +254,13 @@ func (c *DatabricksClient) validateWorkspaceIDFromProvider(ctx context.Context, 
 			workspaceID)
 	}
 
-	// cachedWorkspaceID is normally seeded during provider configuration
-	// (ReconcileWorkspaceIDFromHostMetadata), so this is a no-op. It remains as a
-	// defensive fallback for the rare path where the cache was not seeded at init.
+	// cachedWorkspaceID is seeded during provider configuration
+	// (ReconcileWorkspaceIDFromHostMetadata) for workspace hosts. If it is unseeded
+	// here the workspace id could not be resolved at configure time, so there is
+	// nothing to validate against — error rather than issuing a lazy /Me.
 	if c.cachedWorkspaceID == 0 {
-		err := c.setCachedWorkspaceID(ctx, w)
-		if err != nil {
-			return err
-		}
+		return fmt.Errorf("workspace_id is not available to validate against: it is resolved " +
+			"during provider configuration for workspace-level providers")
 	}
 
 	cachedAsString := strconv.FormatInt(c.cachedWorkspaceID, 10)
@@ -337,12 +330,17 @@ func (c *DatabricksClient) ReconcileWorkspaceIDFromHostMetadata(ctx context.Cont
 		if userWorkspaceID != "" && !isNumericWorkspaceID(userWorkspaceID) {
 			return nil
 		}
-		// CurrentWorkspaceID seeds cachedWorkspaceID from /Me. Fatal on failure.
-		id, err := c.CurrentWorkspaceID(ctx)
+		// Seed the cache from /Me. This is the only place a /Me is issued to resolve
+		// the workspace id; downstream callers rely on the cache being seeded here
+		// and error rather than issuing their own /Me. Fatal on failure.
+		w, err := c.WorkspaceClient()
 		if err != nil {
 			return fmt.Errorf("failed to resolve workspace_id from the workspace host: %w", err)
 		}
-		hostWorkspaceID = strconv.FormatInt(id, 10)
+		if err := c.setCachedWorkspaceID(ctx, w); err != nil {
+			return fmt.Errorf("failed to resolve workspace_id from the workspace host: %w", err)
+		}
+		hostWorkspaceID = strconv.FormatInt(c.cachedWorkspaceID, 10)
 	}
 	// Only a numeric user-supplied ID is comparable to the host's canonical numeric
 	// ID. A connection ID is left to validateWorkspaceIDFromProvider at apply time,

--- a/common/client.go
+++ b/common/client.go
@@ -215,14 +215,8 @@ func isNumericWorkspaceID(id string) bool {
 
 // CurrentWorkspaceID returns the cached workspace ID for a workspace-level
 // provider. The cache is seeded once during provider configuration
-// (ReconcileWorkspaceIDFromHostMetadata) — from host metadata, or from a single
-// /Me for older hosts. Callers therefore never trigger a /Me here; an unseeded
-// cache is treated as an error rather than resolved lazily.
-//
-// Reaching this with an unseeded cache means either provider configuration did not
-// seed it (a workspace-host invariant violation) or the provider is not configured
-// against a workspace host — /Me is a workspace-level call and cannot resolve a
-// workspace id for an account host, so there is nothing to resolve here.
+// (ReconcileWorkspaceIDFromHostMetadata), so an unseeded cache is returned as an
+// error rather than resolved lazily via /Me.
 func (c *DatabricksClient) CurrentWorkspaceID(ctx context.Context) (int64, error) {
 	if c.cachedWorkspaceID != 0 {
 		return c.cachedWorkspaceID, nil

--- a/common/client.go
+++ b/common/client.go
@@ -260,8 +260,9 @@ func (c *DatabricksClient) validateWorkspaceIDFromProvider(ctx context.Context, 
 			workspaceID)
 	}
 
-	// If the workspace ID is not cached, we make an API call to the workspace to get
-	// the current workspace ID and cache it.
+	// cachedWorkspaceID is normally seeded during provider configuration
+	// (ReconcileWorkspaceIDFromHostMetadata), so this is a no-op. It remains as a
+	// defensive fallback for the rare path where the cache was not seeded at init.
 	if c.cachedWorkspaceID == 0 {
 		err := c.setCachedWorkspaceID(ctx, w)
 		if err != nil {
@@ -302,10 +303,15 @@ func (c *DatabricksClient) setCachedWorkspaceID(ctx context.Context, w *databric
 // the error at plan rather than at apply); otherwise it seeds cachedWorkspaceID so
 // downstream resolution never issues the SCIM GET /api/2.0/preview/scim/v2/Me call.
 //
+// When the host metadata omits workspace_id (older control planes), it resolves the
+// id eagerly via a single /Me call here, so no downstream code path ever needs to.
+// That /Me is fatal on failure: it aborts provider configuration rather than
+// deferring resolution to the first resource operation.
+//
 // userWorkspaceID is the effective value from config/env/profile observed before
 // the SDK's host-metadata back-fill; hostWorkspaceID is meta.WorkspaceID. Either
 // may be empty.
-func (c *DatabricksClient) ReconcileWorkspaceIDFromHostMetadata(hostType config.HostType, userWorkspaceID, hostWorkspaceID string) error {
+func (c *DatabricksClient) ReconcileWorkspaceIDFromHostMetadata(ctx context.Context, hostType config.HostType, userWorkspaceID, hostWorkspaceID string) error {
 	// Account and unified hosts multiplex workspaces, so a single cached
 	// workspace_id must never be seeded for them.
 	if hostType != config.WorkspaceHost {
@@ -316,10 +322,27 @@ func (c *DatabricksClient) ReconcileWorkspaceIDFromHostMetadata(hostType config.
 	if userWorkspaceID == "none" {
 		userWorkspaceID = ""
 	}
-	// Older hosts omit workspace_id from metadata; leave the lazy SCIM /Me
-	// fallback in place.
+	// Older hosts omit workspace_id from metadata. Resolve it eagerly via /Me so
+	// downstream paths never have to.
 	if hostWorkspaceID == "" {
-		return nil
+		// Without a host there is nothing to resolve against — an unconfigured or
+		// host-less client (the SDK's resolveHostMetadata likewise no-ops on an
+		// empty host). Leave the cache unseeded.
+		if c.Config == nil || c.Config.Host == "" {
+			return nil
+		}
+		// A non-numeric (connection) user id is rejected downstream by
+		// validateWorkspaceIDFromProvider without a /Me; don't resolve here, or the
+		// user would see a network error before that actionable message.
+		if userWorkspaceID != "" && !isNumericWorkspaceID(userWorkspaceID) {
+			return nil
+		}
+		// CurrentWorkspaceID seeds cachedWorkspaceID from /Me. Fatal on failure.
+		id, err := c.CurrentWorkspaceID(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to resolve workspace_id from the workspace host: %w", err)
+		}
+		hostWorkspaceID = strconv.FormatInt(id, 10)
 	}
 	// Only a numeric user-supplied ID is comparable to the host's canonical numeric
 	// ID. A connection ID is left to validateWorkspaceIDFromProvider at apply time,

--- a/common/client_test.go
+++ b/common/client_test.go
@@ -508,7 +508,7 @@ func TestValidateWorkspaceIDFromProvider_ConnectionIDOnWorkspaceLevelHardFails(t
 		},
 	}
 
-	err := dc.validateWorkspaceIDFromProvider(context.Background(), "cpdr-connection-id", nil)
+	err := dc.validateWorkspaceIDFromProvider("cpdr-connection-id")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(),
 		"Connection IDs are only supported when the provider is configured against an account-level")
@@ -789,4 +789,24 @@ func TestCurrentWorkspaceID_ReturnsCachedValue(t *testing.T) {
 	id2, err := c.CurrentWorkspaceID(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, int64(12345), id2)
+}
+
+// TestCurrentWorkspaceID_UnseededErrors verifies that CurrentWorkspaceID does not
+// resolve lazily via /Me: with an unseeded cache it returns an error instead of
+// making an API call. The cache is seeded once at provider configuration.
+func TestCurrentWorkspaceID_UnseededErrors(t *testing.T) {
+	c := &DatabricksClient{
+		DatabricksClient: &client.DatabricksClient{
+			Config: &config.Config{
+				Host:  "https://test.cloud.databricks.com",
+				Token: "test-token",
+			},
+		},
+		// cachedWorkspaceID left at 0 and no cachedWorkspaceClient: any /Me attempt
+		// would need a real network call, so a nil error would prove lazy resolution.
+	}
+
+	_, err := c.CurrentWorkspaceID(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "resolved during provider configuration")
 }

--- a/common/resource.go
+++ b/common/resource.go
@@ -64,7 +64,9 @@ func populateProviderConfigInState(ctx context.Context, d *schema.ResourceData, 
 	// Resolve from provider config to populate state for the first time:
 	// 1. provider_config.workspace_id from raw config
 	// 2. workspace_id from provider
-	// 3. Lazy resolution via CurrentWorkspaceID API call (GET /api/2.0/preview/scim/v2/Me)
+	// 3. CurrentWorkspaceID. On workspace hosts this is a cache hit seeded during
+	//    provider configuration (ReconcileWorkspaceIDFromHostMetadata), so no
+	//    SCIM /Me is issued here; account/unified hosts still resolve via this call.
 	//
 	// Account hosts without workspace_id never reach here: plan-time validation
 	// rejects them, and dual resources at account level are guarded by the api

--- a/common/unified_provider.go
+++ b/common/unified_provider.go
@@ -156,9 +156,11 @@ func namespaceForceNew(ctx context.Context, d *schema.ResourceDiff, c *Databrick
 		// Config does not have provider_config; use workspace_id
 		newEffective = c.Config.WorkspaceID
 	}
-	// Lazy resolution from workspace host: if newEffective is still empty and
-	// there's an old value in state to compare against, resolve the workspace ID
-	// via the cached workspace ID or SCIM /Me API call.
+	// Resolution from workspace host: if newEffective is still empty and there's an
+	// old value in state to compare against, resolve the workspace ID via
+	// CurrentWorkspaceID. On workspace hosts this is a cache hit seeded during
+	// provider configuration (ReconcileWorkspaceIDFromHostMetadata), so no SCIM /Me
+	// is issued here; other host types still resolve (or fail) via this call.
 	if newEffective == "" && oldEffective != "" {
 		resolvedID, err := c.CurrentWorkspaceID(ctx)
 		if err != nil || resolvedID == 0 {

--- a/common/unified_provider_test.go
+++ b/common/unified_provider_test.go
@@ -1373,8 +1373,9 @@ func TestNamespaceCustomizeDiff_ForceNew(t *testing.T) {
 		},
 		{
 			// Workspace host with old state value but no provider_config, no default,
-			// and no cached ID: lazy resolution attempts CurrentWorkspaceID which fails
-			// silently, then falls through to the "missing workspace_id" error.
+			// and no cached ID: CurrentWorkspaceID returns an error (the cache was not
+			// seeded at configuration), which falls through to the "missing
+			// workspace_id" error.
 			name: "workspace_id removed A to empty no default workspace host - error",
 			instanceState: map[string]string{
 				"name":                           "test",

--- a/common/workspace_id_reconcile_test.go
+++ b/common/workspace_id_reconcile_test.go
@@ -64,9 +64,12 @@ func TestReconcileWorkspaceIDFromHostMetadata(t *testing.T) {
 			wantCachedID:    12345,
 		},
 		{
-			name:            "workspace host, host omits workspace_id, no seed no error",
+			// Workspace host + connection-id user + metadata omits workspace_id:
+			// eager /Me is skipped (connection IDs are rejected downstream), so no
+			// seed and no error even though the client has no usable /Me.
+			name:            "workspace host, host omits workspace_id, connection-id user, no seed no error",
 			hostType:        config.WorkspaceHost,
-			userWorkspaceID: "12345",
+			userWorkspaceID: "some-connection-id",
 			hostWorkspaceID: "",
 			wantCachedID:    0,
 		},
@@ -89,7 +92,7 @@ func TestReconcileWorkspaceIDFromHostMetadata(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			c := newTestClientForReconcile()
-			err := c.ReconcileWorkspaceIDFromHostMetadata(tc.hostType, tc.userWorkspaceID, tc.hostWorkspaceID)
+			err := c.ReconcileWorkspaceIDFromHostMetadata(context.Background(), tc.hostType, tc.userWorkspaceID, tc.hostWorkspaceID)
 			if tc.wantErr != "" {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tc.wantErr)
@@ -108,7 +111,7 @@ func TestReconcileWorkspaceIDFromHostMetadata(t *testing.T) {
 // skipped.
 func TestReconcileWorkspaceIDFromHostMetadataSeedsCacheHit(t *testing.T) {
 	c := newTestClientForReconcile()
-	require.NoError(t, c.ReconcileWorkspaceIDFromHostMetadata(config.WorkspaceHost, "", "678910"))
+	require.NoError(t, c.ReconcileWorkspaceIDFromHostMetadata(context.Background(), config.WorkspaceHost, "", "678910"))
 
 	id, err := c.CurrentWorkspaceID(context.Background())
 	require.NoError(t, err)

--- a/internal/providers/client/databricks_client.go
+++ b/internal/providers/client/databricks_client.go
@@ -70,7 +70,8 @@ func installWorkspaceIDCapture(cfg *config.Config) *capturedHostMeta {
 //   - ensuring the config is resolved
 //   - setting a default retry timeout if not set
 //   - setting a default HTTP timeout if not set
-//   - for workspace hosts, reconciling and seeding the workspace_id from host metadata
+//   - for workspace hosts, reconciling and seeding the workspace_id from host metadata,
+//     resolving it eagerly via /Me when the metadata omits it — fatal on failure
 //     (see ReconcileWorkspaceIDFromHostMetadata)
 //
 // TODO: this should be colocated with the definition of DatabricksClient in common/client.go, but
@@ -126,8 +127,9 @@ func PrepareDatabricksClient(ctx context.Context, cfg *config.Config, configCust
 		DatabricksClient: client,
 	}
 	// For workspace hosts, reconcile the user-supplied workspace_id against the
-	// host's discovery metadata and seed the cache so the SCIM /Me call is avoided.
-	if err := pc.ReconcileWorkspaceIDFromHostMetadata(pc.HostTypeForTerraform(), captured.userWorkspaceID, captured.hostWorkspaceID); err != nil {
+	// host's discovery metadata and seed the cache so downstream SCIM /Me calls are
+	// avoided; when the metadata omits it, resolve eagerly via /Me here (fatal on failure).
+	if err := pc.ReconcileWorkspaceIDFromHostMetadata(ctx, pc.HostTypeForTerraform(), captured.userWorkspaceID, captured.hostWorkspaceID); err != nil {
 		return nil, err
 	}
 	pc.WithCommandExecutor(func(ctx context.Context, client *common.DatabricksClient) common.CommandExecutor {

--- a/internal/providers/client/databricks_client_test.go
+++ b/internal/providers/client/databricks_client_test.go
@@ -2,6 +2,8 @@ package client
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"sync/atomic"
 	"testing"
 
@@ -34,8 +36,10 @@ func (noopLoader) Configure(*config.Config) error { return nil }
 //
 // The test is hermetic against ambient developer state: Loaders is set to a
 // single no-op to suppress env-var and databrickscfg reads, HostMetadataResolver
-// is stubbed so EnsureResolved does not fetch /.well-known/databricks-config
-// or mutate config fields from discovery, and the host is a fake .invalid TLD.
+// reports an account host so EnsureResolved does not fetch
+// /.well-known/databricks-config and reconcile does not attempt an eager /Me
+// (the "none" sentinel is itself an account-profile concern), and the host is a
+// fake .invalid TLD.
 func TestPrepareDatabricksClient_NormalizesNoneWorkspaceID(t *testing.T) {
 	tests := []struct {
 		name                string
@@ -62,7 +66,7 @@ func TestPrepareDatabricksClient_NormalizesNoneWorkspaceID(t *testing.T) {
 				WorkspaceID: tc.workspaceID,
 				Loaders:     []config.Loader{noopLoader{}},
 				HostMetadataResolver: func(context.Context, string) (*config.HostMetadata, error) {
-					return nil, nil
+					return &config.HostMetadata{HostType: config.AccountHost}, nil
 				},
 			}
 			pc, err := PrepareDatabricksClient(context.Background(), cfg, nil)
@@ -182,12 +186,13 @@ func TestPrepareDatabricksClient_HostMetadataUntouchedCases(t *testing.T) {
 		assert.Equal(t, config.UnifiedHost, pc.HostTypeForTerraform())
 	})
 
-	t.Run("host omitting workspace_id does not seed", func(t *testing.T) {
-		pc, err := prepareForWorkspaceHost(t, "", "")
+	t.Run("host omits workspace_id, connection-id user skips eager /Me", func(t *testing.T) {
+		// A connection-id provider workspace_id is rejected downstream without a
+		// /Me, so reconcile must not attempt the eager /Me (which would fail against
+		// this unreachable host). Configure succeeds with the cache left unseeded.
+		pc, err := prepareForWorkspaceHost(t, "my-connection-id", "")
 		require.NoError(t, err)
-		// No seed happened, so CurrentWorkspaceID would attempt a lookup. We only
-		// assert the config was left empty (no back-fill from empty metadata).
-		assert.Equal(t, "", pc.Config.WorkspaceID)
+		assert.Equal(t, "my-connection-id", pc.Config.WorkspaceID)
 	})
 }
 
@@ -243,4 +248,102 @@ func TestPrepareDatabricksClient_HonorsHostMetadataResolverFactory(t *testing.T)
 	id, err := pc.CurrentWorkspaceID(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, int64(778899), id)
+}
+
+// meServer stands up an httptest server that answers the SCIM /Me request the SDK
+// issues to resolve a workspace id: it returns orgID in the X-Databricks-Org-Id
+// response header (or a 403 when orgID is empty, to simulate a limited principal),
+// and counts how many times /Me was hit.
+func meServer(t *testing.T, orgID string) (*httptest.Server, *atomic.Int32) {
+	t.Helper()
+	var meCalls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/2.0/preview/scim/v2/Me" {
+			meCalls.Add(1)
+			if orgID == "" {
+				w.WriteHeader(http.StatusForbidden)
+				return
+			}
+			w.Header().Set("X-Databricks-Org-Id", orgID)
+			_, _ = w.Write([]byte(`{}`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &meCalls
+}
+
+// prepareOlderWorkspaceHost builds a client whose host metadata reports a workspace
+// host that omits workspace_id (an older control plane), so reconcile must resolve
+// it eagerly via /Me against the given test server.
+func prepareOlderWorkspaceHost(t *testing.T, serverURL, userWorkspaceID string) (*common.DatabricksClient, error) {
+	t.Helper()
+	cfg := &config.Config{
+		Host:        serverURL,
+		Token:       "test-token",
+		WorkspaceID: userWorkspaceID,
+		Loaders:     []config.Loader{noopLoader{}},
+		HostMetadataResolver: func(context.Context, string) (*config.HostMetadata, error) {
+			return &config.HostMetadata{HostType: config.WorkspaceHost, WorkspaceID: ""}, nil
+		},
+	}
+	return PrepareDatabricksClient(context.Background(), cfg, nil)
+}
+
+// TestPrepareDatabricksClient_EagerMeWhenMetadataOmitsWorkspaceID verifies that on
+// a workspace host whose metadata omits workspace_id, the workspace id is resolved
+// eagerly via a single /Me at provider configuration, and that failures are fatal.
+func TestPrepareDatabricksClient_EagerMeWhenMetadataOmitsWorkspaceID(t *testing.T) {
+	t.Run("user empty resolves via eager /Me and seeds", func(t *testing.T) {
+		srv, meCalls := meServer(t, "12345")
+		pc, err := prepareOlderWorkspaceHost(t, srv.URL, "")
+		require.NoError(t, err)
+		// Seeded at init: CurrentWorkspaceID is a cache hit, issuing no further /Me.
+		id, err := pc.CurrentWorkspaceID(context.Background())
+		require.NoError(t, err)
+		assert.Equal(t, int64(12345), id)
+		assert.Equal(t, int32(1), meCalls.Load(), "expected exactly one /Me at init and none afterwards")
+	})
+
+	t.Run("user matches eager /Me result", func(t *testing.T) {
+		srv, _ := meServer(t, "12345")
+		pc, err := prepareOlderWorkspaceHost(t, srv.URL, "12345")
+		require.NoError(t, err)
+		id, err := pc.CurrentWorkspaceID(context.Background())
+		require.NoError(t, err)
+		assert.Equal(t, int64(12345), id)
+	})
+
+	t.Run("user mismatches eager /Me result fails fast", func(t *testing.T) {
+		srv, _ := meServer(t, "12345")
+		_, err := prepareOlderWorkspaceHost(t, srv.URL, "99999")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "workspace_id mismatch")
+	})
+
+	t.Run("eager /Me failure is fatal at configure", func(t *testing.T) {
+		// orgID "" makes /Me return 403 — the limited-service-principal case.
+		srv, meCalls := meServer(t, "")
+		_, err := prepareOlderWorkspaceHost(t, srv.URL, "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to resolve workspace_id from the workspace host")
+		assert.Equal(t, int32(1), meCalls.Load())
+	})
+
+	t.Run("no host does not attempt eager /Me", func(t *testing.T) {
+		// A host-less config (host defaults to a workspace host type) must not
+		// attempt /Me — there is nothing to resolve against. Configure succeeds.
+		cfg := &config.Config{
+			Token:       "test-token",
+			WorkspaceID: "1234567890",
+			Loaders:     []config.Loader{noopLoader{}},
+			HostMetadataResolver: func(context.Context, string) (*config.HostMetadata, error) {
+				return nil, nil
+			},
+		}
+		pc, err := PrepareDatabricksClient(context.Background(), cfg, nil)
+		require.NoError(t, err)
+		assert.Equal(t, "1234567890", pc.Config.WorkspaceID)
+	})
 }

--- a/internal/providers/pluginfw/tfschema/unified_provider.go
+++ b/internal/providers/pluginfw/tfschema/unified_provider.go
@@ -289,7 +289,9 @@ func WorkspaceDriftDetection(ctx context.Context, client UnifiedProviderClient, 
 	if newWsID == "" {
 		newWsID = client.GetProviderWorkspaceID()
 	}
-	// Fallback to cached workspace ID for workspace-level providers.
+	// Fallback to cached workspace ID for workspace-level providers. On workspace
+	// hosts this is a cache hit seeded during provider configuration
+	// (ReconcileWorkspaceIDFromHostMetadata), so no SCIM /Me is issued here.
 	if newWsID == "" {
 		if cachedID, err := client.CurrentWorkspaceID(ctx); err == nil && cachedID != 0 {
 			newWsID = strconv.FormatInt(cachedID, 10)
@@ -361,6 +363,9 @@ func PopulateProviderConfigInState(ctx context.Context, client UnifiedProviderCl
 	if wsID == "" {
 		wsID = client.GetProviderWorkspaceID()
 	}
+	// On workspace hosts CurrentWorkspaceID is a cache hit seeded during provider
+	// configuration (ReconcileWorkspaceIDFromHostMetadata), so no SCIM /Me is issued
+	// here; account/unified hosts still resolve via this call.
 	if wsID == "" {
 		id, err := client.CurrentWorkspaceID(ctx)
 		if err != nil {
@@ -391,6 +396,9 @@ func PopulateProviderConfigInStateForDataSource(ctx context.Context, client Unif
 	if wsID == "" {
 		wsID = client.GetProviderWorkspaceID()
 	}
+	// On workspace hosts CurrentWorkspaceID is a cache hit seeded during provider
+	// configuration (ReconcileWorkspaceIDFromHostMetadata), so no SCIM /Me is issued
+	// here; account/unified hosts still resolve via this call.
 	if wsID == "" {
 		id, err := client.CurrentWorkspaceID(ctx)
 		if err != nil {

--- a/internal/providers/providers_test.go
+++ b/internal/providers/providers_test.go
@@ -11,11 +11,30 @@ import (
 	"testing"
 	"time"
 
+	"github.com/databricks/databricks-sdk-go/config"
 	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/databricks/terraform-provider-databricks/internal/providers/sdkv2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// TestMain installs a host-metadata resolver factory for the whole package so
+// provider configuration does not perform network I/O against the fake hosts
+// these auth-resolution tests use. It reports a workspace host that already
+// advertises a workspace_id, so ReconcileWorkspaceIDFromHostMetadata seeds from
+// metadata and never attempts an eager SCIM /Me — while leaving host-type
+// inference as a workspace host (so OAuth/OIDC resolution is unaffected). Tests
+// here assert only auth/host/scopes, never workspace_id, so this weakens no
+// assertion. The resolver only fills empty fields, so it does not override a
+// host type an account/unified fixture sets.
+func TestMain(m *testing.M) {
+	config.DefaultHostMetadataResolverFactory = func(*config.Config) config.HostMetadataResolver {
+		return func(context.Context, string) (*config.HostMetadata, error) {
+			return &config.HostMetadata{HostType: config.WorkspaceHost, WorkspaceID: "12345"}, nil
+		}
+	}
+	os.Exit(m.Run())
+}
 
 func TestConfig_NoParams(t *testing.T) {
 	homeDir, err := os.UserHomeDir()


### PR DESCRIPTION
## Summary

Follow-up to #5922, which made workspace-level hosts resolve their `workspace_id` from the `/.well-known/databricks-config` metadata fetched at provider init and cache it, so downstream operations avoid the SCIM `GET /api/2.0/preview/scim/v2/Me` call. That change still fell back to a **lazy** `/Me` (the first time a resource needed the id) when the metadata omitted `workspace_id`, on older control planes.

This PR resolves the `workspace_id` **once, at provider configuration**, so no resource or data source operation ever issues a `/Me` to resolve it on a workspace host.

## Changes

- **Eager resolution.** When a workspace host's metadata omits `workspace_id`, `ReconcileWorkspaceIDFromHostMetadata` (called from `PrepareDatabricksClient`) now resolves it via a single `/Me` and seeds the cache, instead of deferring. It gains a `context` parameter and seeds through `setCachedWorkspaceID`, the sole `/Me` seeding site. When metadata already carries the id (modern hosts), no `/Me` is made. Guards: only workspace hosts; a host-less config attempts no `/Me`; a connection-id `workspace_id` is skipped (rejected downstream before any `/Me`).
- **No lazy fallback anywhere.** `CurrentWorkspaceID` and `validateWorkspaceIDFromProvider` now return an error on an unseeded cache instead of resolving lazily via `/Me`. Since the cache is seeded at configuration for workspace hosts, the downstream paths (SDKv2 post-read and CustomizeDiff, Plugin Framework ModifyPlan and post-read) are cache reads. `/Me` is workspace-level, so this is behavior-equivalent for account/unified hosts, which cannot use it.

Scope: this only concerns the `/Me` used to resolve the workspace **id** (the `X-Databricks-Org-Id` header). The unrelated use of `/Me` to fetch the current-user object (e.g. `databricks_current_user`) is untouched.

## Behavior change

The eager `/Me` is **fatal on failure**: if it errors, provider configuration fails (at `plan`) rather than deferring to the first operation. This is narrow — only a workspace host on an older control plane (metadata without `workspace_id`) authenticated as a principal that cannot call `/Me`. Modern hosts make no `/Me` call at all.

## Testing

Unit tests cover the eager path against a stub `/Me` server (empty/matching/mismatched user id, connection-id skip, fatal `/Me` failure, no-host, and a single-`/Me`-at-init invariant) and the cached-or-error behavior. `make fmt lint ws` clean; schema unchanged; full short test suite passes.

## Follow-up

An acceptance test for an older-host-style workspace provider (metadata omitting `workspace_id`) resolving at init with zero `/Me` during plan/apply, plus the #5922 gate that host-metadata `workspace_id` equals `/Me`'s value.
