### PR TITLE
Honor DefaultHostMetadataResolverFactory in host-metadata resolver wrapper

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Bug Fixes
 
-* Honor `config.DefaultHostMetadataResolverFactory` during provider configuration ([#NNNN](https://github.com/databricks/terraform-provider-databricks/pull/NNNN)).
+* Honor `config.DefaultHostMetadataResolverFactory` during provider configuration ([#5940](https://github.com/databricks/terraform-provider-databricks/pull/5940)).
 
   The provider installs a wrapper around the SDK's host-metadata resolver to observe the host's `workspace_id`. Because the wrapper always set `HostMetadataResolver`, the SDK never consulted the `DefaultHostMetadataResolverFactory` global, so a resolver installed through that factory was silently ignored. The wrapper now replicates the SDK's resolver precedence (a pre-existing resolver, then the factory, then the built-in fetch).
 

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -10,6 +10,10 @@
 
 ### Bug Fixes
 
+* Honor `config.DefaultHostMetadataResolverFactory` during provider configuration ([#NNNN](https://github.com/databricks/terraform-provider-databricks/pull/NNNN)).
+
+  The provider installs a wrapper around the SDK's host-metadata resolver to observe the host's `workspace_id`. Because the wrapper always set `HostMetadataResolver`, the SDK never consulted the `DefaultHostMetadataResolverFactory` global, so a resolver installed through that factory was silently ignored. The wrapper now replicates the SDK's resolver precedence (a pre-existing resolver, then the factory, then the built-in fetch).
+
 ### Documentation
 
 ### Exporter

--- a/internal/providers/client/databricks_client.go
+++ b/internal/providers/client/databricks_client.go
@@ -32,8 +32,7 @@ type capturedHostMeta struct {
 // wrapper writes into; the caller reads it only after EnsureResolved returns.
 func installWorkspaceIDCapture(cfg *config.Config) *capturedHostMeta {
 	captured := &capturedHostMeta{}
-	// A pre-existing resolver (set by a customizer) takes precedence, matching the
-	// SDK. Captured now because the wrapper overwrites cfg.HostMetadataResolver.
+	// Captured before the wrapper overwrites cfg.HostMetadataResolver below.
 	prev := cfg.HostMetadataResolver
 	cfg.HostMetadataResolver = func(ctx context.Context, host string) (*config.HostMetadata, error) {
 		// Observed post-loaders, pre-back-fill: the effective user value from

--- a/internal/providers/client/databricks_client.go
+++ b/internal/providers/client/databricks_client.go
@@ -23,21 +23,33 @@ type capturedHostMeta struct {
 // installWorkspaceIDCapture wraps cfg.HostMetadataResolver so the provider can
 // observe both the user-supplied and host-advertised workspace_id from the single
 // metadata fetch the SDK already performs during EnsureResolved. It does NOT add a
-// /.well-known/databricks-config request: the wrapper delegates to any
-// pre-existing resolver, or to the SDK's own default fetcher, so the total number
-// of metadata fetches is unchanged.
+// /.well-known/databricks-config request: the wrapper delegates to whatever
+// resolver the SDK would otherwise have used, so the total number of metadata
+// fetches is unchanged.
 //
 // Must be installed after any configCustomizer (which may replace the config or
 // set its own resolver) and before EnsureResolved. Returns the capture struct the
 // wrapper writes into; the caller reads it only after EnsureResolved returns.
 func installWorkspaceIDCapture(cfg *config.Config) *capturedHostMeta {
 	captured := &capturedHostMeta{}
+	// A pre-existing resolver (set by a customizer) takes precedence, matching the
+	// SDK. Captured now because the wrapper overwrites cfg.HostMetadataResolver.
 	prev := cfg.HostMetadataResolver
 	cfg.HostMetadataResolver = func(ctx context.Context, host string) (*config.HostMetadata, error) {
 		// Observed post-loaders, pre-back-fill: the effective user value from
 		// config/env/profile (including any host query param promoted by the SDK).
 		captured.userWorkspaceID = cfg.WorkspaceID
+		// Delegate with the SAME precedence the SDK's resolveHostMetadata uses when
+		// HostMetadataResolver is nil: a pre-existing resolver, then the
+		// DefaultHostMetadataResolverFactory global, then the built-in HTTP fetch.
+		// Without the factory tier, installing this wrapper (which always sets
+		// HostMetadataResolver) would silently bypass a factory a caller installed.
 		delegate := prev
+		if delegate == nil {
+			if factory := config.DefaultHostMetadataResolverFactory; factory != nil {
+				delegate = factory(cfg)
+			}
+		}
 		if delegate == nil {
 			delegate = cfg.DefaultHostMetadataResolver()
 		}

--- a/internal/providers/client/databricks_client_test.go
+++ b/internal/providers/client/databricks_client_test.go
@@ -212,3 +212,38 @@ func TestPrepareDatabricksClient_SingleMetadataFetch(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, int32(1), calls.Load(), "expected exactly one .well-known/databricks-config fetch")
 }
+
+// TestPrepareDatabricksClient_HonorsHostMetadataResolverFactory verifies that the
+// resolver wrapper installed during configuration honors
+// config.DefaultHostMetadataResolverFactory. The wrapper always sets
+// cfg.HostMetadataResolver, so the SDK never consults the factory itself; the
+// wrapper must replicate the SDK's precedence and consult it. A resolver returning
+// the factory's metadata is proven by the config being back-filled from it. Without
+// the fix the wrapper falls through to the built-in HTTP fetch (against the fake
+// host), which yields no metadata and no back-fill.
+func TestPrepareDatabricksClient_HonorsHostMetadataResolverFactory(t *testing.T) {
+	var factoryCalls atomic.Int32
+	prevFactory := config.DefaultHostMetadataResolverFactory
+	t.Cleanup(func() { config.DefaultHostMetadataResolverFactory = prevFactory })
+	config.DefaultHostMetadataResolverFactory = func(*config.Config) config.HostMetadataResolver {
+		return func(context.Context, string) (*config.HostMetadata, error) {
+			factoryCalls.Add(1)
+			return &config.HostMetadata{WorkspaceID: "778899", HostType: config.WorkspaceHost}, nil
+		}
+	}
+
+	cfg := &config.Config{
+		Host:    "https://test.invalid",
+		Token:   "test-token",
+		Loaders: []config.Loader{noopLoader{}},
+		// HostMetadataResolver deliberately left nil so the factory is the source.
+	}
+	pc, err := PrepareDatabricksClient(context.Background(), cfg, nil)
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), factoryCalls.Load(), "factory resolver must be consulted exactly once")
+	// Back-filled from the factory's metadata (empty on main, where the factory is bypassed).
+	assert.Equal(t, "778899", pc.Config.WorkspaceID)
+	id, err := pc.CurrentWorkspaceID(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, int64(778899), id)
+}

--- a/internal/providers/client/databricks_client_test.go
+++ b/internal/providers/client/databricks_client_test.go
@@ -214,13 +214,10 @@ func TestPrepareDatabricksClient_SingleMetadataFetch(t *testing.T) {
 }
 
 // TestPrepareDatabricksClient_HonorsHostMetadataResolverFactory verifies that the
-// resolver wrapper installed during configuration honors
+// resolver wrapper installed during configuration consults
 // config.DefaultHostMetadataResolverFactory. The wrapper always sets
-// cfg.HostMetadataResolver, so the SDK never consults the factory itself; the
-// wrapper must replicate the SDK's precedence and consult it. A resolver returning
-// the factory's metadata is proven by the config being back-filled from it. Without
-// the fix the wrapper falls through to the built-in HTTP fetch (against the fake
-// host), which yields no metadata and no back-fill.
+// cfg.HostMetadataResolver, so it (not the SDK) must apply the factory; without the
+// fix it falls through to the built-in fetch and the factory is never used.
 func TestPrepareDatabricksClient_HonorsHostMetadataResolverFactory(t *testing.T) {
 	var factoryCalls atomic.Int32
 	prevFactory := config.DefaultHostMetadataResolverFactory


### PR DESCRIPTION
## Summary

Fixes a pre-existing bug where the provider silently ignored `config.DefaultHostMetadataResolverFactory`.

During provider configuration the provider installs a wrapper around the SDK's host-metadata resolver (`cfg.HostMetadataResolver`) so it can observe the host's `workspace_id` from the single `/.well-known/databricks-config` fetch. The SDK only consults the `DefaultHostMetadataResolverFactory` global when `cfg.HostMetadataResolver` is `nil` — but because the wrapper **always** sets `cfg.HostMetadataResolver`, that factory was never reached. The wrapper's own fallback went straight to the built-in HTTP fetch, so any resolver installed through the factory was silently bypassed.

## Fix

The wrapper now replicates the SDK's resolver precedence when choosing what to delegate to: a pre-existing resolver, then `DefaultHostMetadataResolverFactory`, then the built-in HTTP fetch. It still performs exactly one metadata fetch.

## Testing

Adds a regression test that installs a factory and asserts it is consulted (the config is back-filled from the factory's metadata). The test fails without the fix — the factory is called zero times and no back-fill happens — and passes with it. `make fmt lint ws` clean; existing configuration tests pass.

## Note

This is the standalone fix for a bug that predates and is independent of the eager-workspace-id work; it is being sent separately so it can be reviewed and merged on its own.
