### PR TITLE
Fix CDF Drift in databricks_share

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Bug Fixes
 
+* Fixed perpetual `databricks_share` drift when CDF and history sharing are enabled ([#5949](https://github.com/databricks/terraform-provider-databricks/pull/5949)).
+
 ### Documentation
 
 ### Exporter

--- a/internal/providers/pluginfw/products/sharing/resource_share.go
+++ b/internal/providers/pluginfw/products/sharing/resource_share.go
@@ -293,6 +293,12 @@ func (r *ShareResource) Read(ctx context.Context, req resource.ReadRequest, resp
 		return
 	}
 
+	var stateGoSDK sharing.ShareInfo
+	resp.Diagnostics.Append(converters.TfSdkToGoSdkStruct(ctx, existingState, &stateGoSDK)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	var getShareRequest sharing.GetShareRequest
 	getShareRequest.IncludeSharedData = true
 	resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("name"), &getShareRequest.Name)...)
@@ -322,34 +328,21 @@ func (r *ShareResource) Read(ctx context.Context, req resource.ReadRequest, resp
 		return
 	}
 
-	newState, d := r.readShareState(ctx, existingState, shareInfo)
+	matchOrder(shareInfo.Objects, stateGoSDK.Objects, func(obj sharing.SharedDataObject) string { return obj.Name })
+
+	var newState ShareInfoExtended
+	resp.Diagnostics.Append(converters.GoSdkToTfSdkStruct(ctx, shareInfo, &newState)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	newState, d := r.syncEffectiveFields(ctx, existingState, newState, effectiveFieldsActionRead{})
 	resp.Diagnostics.Append(d...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, newState)...)
-}
-
-func (r *ShareResource) readShareState(ctx context.Context, existingState ShareInfoExtended, shareInfo *sharing.ShareInfo) (ShareInfoExtended, diag.Diagnostics) {
-	var d diag.Diagnostics
-	var existingGoSDK sharing.ShareInfo
-	d.Append(converters.TfSdkToGoSdkStruct(ctx, existingState, &existingGoSDK)...)
-	if d.HasError() {
-		return ShareInfoExtended{}, d
-	}
-
-	matchOrder(shareInfo.Objects, existingGoSDK.Objects, func(obj sharing.SharedDataObject) string { return obj.Name })
-
-	var newState ShareInfoExtended
-	d.Append(converters.GoSdkToTfSdkStruct(ctx, shareInfo, &newState)...)
-	if d.HasError() {
-		return ShareInfoExtended{}, d
-	}
-
-	newState, syncDiags := r.syncEffectiveFields(ctx, existingState, newState, effectiveFieldsActionRead{})
-	d.Append(syncDiags...)
-	return newState, d
 }
 
 func (r *ShareResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {

--- a/internal/providers/pluginfw/products/sharing/resource_share.go
+++ b/internal/providers/pluginfw/products/sharing/resource_share.go
@@ -293,12 +293,6 @@ func (r *ShareResource) Read(ctx context.Context, req resource.ReadRequest, resp
 		return
 	}
 
-	var stateGoSDK sharing.ShareInfo
-	resp.Diagnostics.Append(converters.TfSdkToGoSdkStruct(ctx, existingState, &stateGoSDK)...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
 	var getShareRequest sharing.GetShareRequest
 	getShareRequest.IncludeSharedData = true
 	resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("name"), &getShareRequest.Name)...)
@@ -328,22 +322,34 @@ func (r *ShareResource) Read(ctx context.Context, req resource.ReadRequest, resp
 		return
 	}
 
-	matchOrder(shareInfo.Objects, stateGoSDK.Objects, func(obj sharing.SharedDataObject) string { return obj.Name })
-	suppressCDFEnabledDiff(shareInfo)
-
-	var newState ShareInfoExtended
-	resp.Diagnostics.Append(converters.GoSdkToTfSdkStruct(ctx, shareInfo, &newState)...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	newState, d := r.syncEffectiveFields(ctx, existingState, newState, effectiveFieldsActionRead{})
+	newState, d := r.readShareState(ctx, existingState, shareInfo)
 	resp.Diagnostics.Append(d...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, newState)...)
+}
+
+func (r *ShareResource) readShareState(ctx context.Context, existingState ShareInfoExtended, shareInfo *sharing.ShareInfo) (ShareInfoExtended, diag.Diagnostics) {
+	var d diag.Diagnostics
+	var existingGoSDK sharing.ShareInfo
+	d.Append(converters.TfSdkToGoSdkStruct(ctx, existingState, &existingGoSDK)...)
+	if d.HasError() {
+		return ShareInfoExtended{}, d
+	}
+
+	matchOrder(shareInfo.Objects, existingGoSDK.Objects, func(obj sharing.SharedDataObject) string { return obj.Name })
+
+	var newState ShareInfoExtended
+	d.Append(converters.GoSdkToTfSdkStruct(ctx, shareInfo, &newState)...)
+	if d.HasError() {
+		return ShareInfoExtended{}, d
+	}
+
+	newState, syncDiags := r.syncEffectiveFields(ctx, existingState, newState, effectiveFieldsActionRead{})
+	d.Append(syncDiags...)
+	return newState, d
 }
 
 func (r *ShareResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {

--- a/internal/providers/pluginfw/products/sharing/resource_share_test.go
+++ b/internal/providers/pluginfw/products/sharing/resource_share_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/databricks/terraform-provider-databricks/internal/service/sharing_tf"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestShareCommentChanged(t *testing.T) {
@@ -230,6 +231,40 @@ func TestShareSyncEffectiveFields(t *testing.T) {
 			assert.False(t, diagnostics.HasError())
 		})
 	}
+}
+
+func TestReadShareStatePreservesUnsetCDF(t *testing.T) {
+	ctx := context.Background()
+	objectName := "catalog.schema.table"
+	apiShare := &sharing.ShareInfo{
+		Name: "share",
+		Objects: []sharing.SharedDataObject{
+			{
+				Name:                     objectName,
+				DataObjectType:           "TABLE",
+				CdfEnabled:               true,
+				HistoryDataSharingStatus: "ENABLED",
+			},
+		},
+	}
+
+	var existingState ShareInfoExtended
+	require.False(t, converters.GoSdkToTfSdkStruct(ctx, apiShare, &existingState).HasError())
+	existingObjects, ok := existingState.GetObjects(ctx)
+	require.True(t, ok)
+	existingObjects[0].CdfEnabled = types.BoolNull()
+	existingObjects[0].EffectiveCdfEnabled = types.BoolValue(true)
+	existingObjects[0].HistoryDataSharingStatus = types.StringNull()
+	existingObjects[0].EffectiveHistoryDataSharingStatus = types.StringValue("ENABLED")
+	existingState.SetObjects(ctx, existingObjects)
+
+	state, diagnostics := (&ShareResource{}).readShareState(ctx, existingState, apiShare)
+	require.False(t, diagnostics.HasError())
+	objects, ok := state.GetObjects(ctx)
+	require.True(t, ok)
+	require.Len(t, objects, 1)
+	assert.True(t, objects[0].CdfEnabled.IsNull(), "cdf_enabled should remain unset")
+	assert.True(t, objects[0].EffectiveCdfEnabled.ValueBool(), "effective_cdf_enabled should reflect the API")
 }
 
 func TestShareSyncEffectiveFieldsCreateOrUpdateSyncsObjectsOnceByName(t *testing.T) {

--- a/internal/providers/pluginfw/products/sharing/resource_share_test.go
+++ b/internal/providers/pluginfw/products/sharing/resource_share_test.go
@@ -258,7 +258,9 @@ func TestReadShareStatePreservesUnsetCDF(t *testing.T) {
 	existingObjects[0].EffectiveHistoryDataSharingStatus = types.StringValue("ENABLED")
 	existingState.SetObjects(ctx, existingObjects)
 
-	state, diagnostics := (&ShareResource{}).readShareState(ctx, existingState, apiShare)
+	var refreshedState ShareInfoExtended
+	require.False(t, converters.GoSdkToTfSdkStruct(ctx, apiShare, &refreshedState).HasError())
+	state, diagnostics := (&ShareResource{}).syncEffectiveFields(ctx, existingState, refreshedState, effectiveFieldsActionRead{})
 	require.False(t, diagnostics.HasError())
 	objects, ok := state.GetObjects(ctx)
 	require.True(t, ok)


### PR DESCRIPTION
This PR fixes perpetual `databricks_share` drift when a shared table reports CDF and history sharing as enabled while both fields are unset in Terraform configuration. During refresh, the provider rewrote the server CDF value before syncing effective fields, leaving `false` in state against a null configuration.

The Read path now preserves the raw server value so the existing effective-field logic can restore the configured null. Update-time suppression remains in place because the API does not accept both request fields together.

## Review Guide

- Core change: Read-state construction no longer suppresses the server CDF value.
- Regression coverage: models unset configured fields with enabled effective server values and verifies the state converges.
- Verification: full unit suite, lint, formatting, and whitespace checks pass.