### PR TITLE
[Fix] [Security Impact] Mark plaintext credential fields as sensitive in `databricks_secret_uc`

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -11,6 +11,7 @@
 * Add support for `model_service`, `mcp_service`, and `model_provider_service` securables in `databricks_grant` and `databricks_grants` ([#5941](https://github.com/databricks/terraform-provider-databricks/pull/5941)).
 
 ### Bug Fixes
+* Mark `value` and `effective_value` as sensitive in `databricks_secret_uc` and its data sources. These fields hold Unity Catalog secret material but were rendered in cleartext in `terraform plan` and `terraform apply` output, which could leak secrets into CI/CD logs and terminal history.
 * Fixed `databricks_share` failing with `produced an unexpected new value: .comment` when a share's comment is set or removed outside of Terraform (e.g. in the UI). The `comment` attribute is now `Optional`+`Computed`, so an out-of-band value is adopted into state instead of erroring, while `comment = ""` still explicitly clears the description.
 
 ### Documentation

--- a/internal/providers/pluginfw/products/secret_uc/data_secret_uc.go
+++ b/internal/providers/pluginfw/products/secret_uc/data_secret_uc.go
@@ -240,7 +240,14 @@ func (r *SecretDataSource) Metadata(ctx context.Context, req datasource.Metadata
 }
 
 func (r *SecretDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
-	attrs, blocks := tfschema.DataSourceStructToSchemaMap(ctx, SecretData{}, nil)
+	attrs, blocks := tfschema.DataSourceStructToSchemaMap(ctx, SecretData{}, func(c tfschema.CustomizableSchema) tfschema.CustomizableSchema {
+		// The secret payload must never be rendered in plan/apply output. `value` is the
+		// write path and `effective_value` the read path, so both carry secret material.
+		c.SetSensitive("value")
+		c.SetSensitive("effective_value")
+
+		return c
+	})
 	resp.Schema = schema.Schema{
 		Description: "Terraform schema for Databricks Secret",
 		Attributes:  attrs,

--- a/internal/providers/pluginfw/products/secret_uc/data_secret_ucs.go
+++ b/internal/providers/pluginfw/products/secret_uc/data_secret_ucs.go
@@ -72,7 +72,15 @@ func (r *SecretsDataSource) Metadata(ctx context.Context, req datasource.Metadat
 }
 
 func (r *SecretsDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
-	attrs, blocks := tfschema.DataSourceStructToSchemaMap(ctx, SecretsData{}, nil)
+	attrs, blocks := tfschema.DataSourceStructToSchemaMap(ctx, SecretsData{}, func(c tfschema.CustomizableSchema) tfschema.CustomizableSchema {
+		// The secret payload must never be rendered in plan/apply output. `value` is the
+		// write path and `effective_value` the read path, so both carry secret material.
+		// Nested under `secrets`, so every listed secret is masked.
+		c.SetSensitive("secrets", "value")
+		c.SetSensitive("secrets", "effective_value")
+
+		return c
+	})
 	resp.Schema = schema.Schema{
 		Description: "Terraform schema for Databricks Secret",
 		Attributes:  attrs,

--- a/internal/providers/pluginfw/products/secret_uc/resource_secret_uc.go
+++ b/internal/providers/pluginfw/products/secret_uc/resource_secret_uc.go
@@ -288,7 +288,14 @@ func (r *SecretResource) Metadata(ctx context.Context, req resource.MetadataRequ
 }
 
 func (r *SecretResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
-	attrs, blocks := tfschema.ResourceStructToSchemaMap(ctx, Secret{}, nil)
+	attrs, blocks := tfschema.ResourceStructToSchemaMap(ctx, Secret{}, func(c tfschema.CustomizableSchema) tfschema.CustomizableSchema {
+		// The secret payload must never be rendered in plan/apply output. `value` is the
+		// write path and `effective_value` the read path, so both carry secret material.
+		c.SetSensitive("value")
+		c.SetSensitive("effective_value")
+
+		return c
+	})
 	resp.Schema = schema.Schema{
 		Description: "Terraform schema for Databricks secret_uc",
 		Attributes:  attrs,

--- a/internal/providers/pluginfw/products/secret_uc/resource_secret_uc_schema_test.go
+++ b/internal/providers/pluginfw/products/secret_uc/resource_secret_uc_schema_test.go
@@ -1,0 +1,66 @@
+package secret_uc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	dsschema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// secretValueAttrs are the attributes that carry secret material: `value` is the
+// write path and `effective_value` the read path. Both must be masked in
+// plan/apply output.
+var secretValueAttrs = []string{"value", "effective_value"}
+
+func TestResourceSecret_SecretValuesAreSensitive(t *testing.T) {
+	r := ResourceSecret()
+	resp := &resource.SchemaResponse{}
+	r.Schema(context.Background(), resource.SchemaRequest{}, resp)
+
+	for _, name := range secretValueAttrs {
+		attr, ok := resp.Schema.Attributes[name]
+		require.True(t, ok, "%s attribute must exist", name)
+		strAttr, ok := attr.(schema.StringAttribute)
+		require.True(t, ok, "%s must be a string attribute", name)
+		assert.True(t, strAttr.Sensitive, "%s must be sensitive so the secret is not shown in plan/apply output", name)
+	}
+}
+
+func TestDataSourceSecret_SecretValuesAreSensitive(t *testing.T) {
+	d := DataSourceSecret()
+	resp := &datasource.SchemaResponse{}
+	d.Schema(context.Background(), datasource.SchemaRequest{}, resp)
+
+	for _, name := range secretValueAttrs {
+		attr, ok := resp.Schema.Attributes[name]
+		require.True(t, ok, "%s attribute must exist", name)
+		strAttr, ok := attr.(dsschema.StringAttribute)
+		require.True(t, ok, "%s must be a string attribute", name)
+		assert.True(t, strAttr.Sensitive, "%s must be sensitive so the secret is not shown in plan/apply output", name)
+	}
+}
+
+func TestDataSourceSecrets_SecretValuesAreSensitive(t *testing.T) {
+	d := DataSourceSecrets()
+	resp := &datasource.SchemaResponse{}
+	d.Schema(context.Background(), datasource.SchemaRequest{}, resp)
+
+	secrets, ok := resp.Schema.Attributes["secrets"]
+	require.True(t, ok, "secrets attribute must exist")
+	list, ok := secrets.(dsschema.ListNestedAttribute)
+	require.True(t, ok, "secrets must be a list nested attribute")
+
+	// Every listed secret is rendered, so masking must apply to the nested attributes.
+	for _, name := range secretValueAttrs {
+		attr, ok := list.NestedObject.Attributes[name]
+		require.True(t, ok, "secrets.%s attribute must exist", name)
+		strAttr, ok := attr.(dsschema.StringAttribute)
+		require.True(t, ok, "secrets.%s must be a string attribute", name)
+		assert.True(t, strAttr.Sensitive, "secrets.%s must be sensitive so the secret is not shown in plan/apply output", name)
+	}
+}


### PR DESCRIPTION
## Security Impact

`value` and `effective_value` on `databricks_secret_uc` hold Unity Catalog secret material — passwords, tokens, keys. Without `Sensitive: true`, these values are displayed in plain text in CLI output, which can leak into CI/CD logs, terminal history, screen recordings, and any system that captures Terraform output, giving unauthorised users access.

Affected fields:
- `databricks_secret_uc.value`
- `databricks_secret_uc.effective_value`
- `data.databricks_secret_uc.value` / `.effective_value`
- `data.databricks_secret_ucs.secrets[*].value` / `.effective_value`

The plural data source is the widest exposure: it renders every secret in a schema as unredacted list elements in a single plan.

## Changes

The secret value fields are not marked `Sensitive: true` in the Terraform schema. This causes the secret to be displayed in plain text in `terraform plan` and `terraform apply` output instead of being displayed as `(sensitive value)`.

For the Terraform script:
```hcl
resource "databricks_secret_uc" "this" {
  catalog_name = "my_catalog"
  schema_name  = "my_schema"
  name         = "my_secret"
  value        = "SUPER_SECRET_SENTINEL_12345"
  comment      = "Sample secret"
}
```

Terraform plan outputs:
```
Terraform will perform the following actions:

  # databricks_secret_uc.this will be created
  + resource "databricks_secret_uc" "this" {
      + catalog_name    = "my_catalog"
      + comment         = "Sample secret"
      + effective_value = (known after apply)
      + name            = "my_secret"
      + schema_name     = "my_schema"
      + value           = "SUPER_SECRET_SENTINEL_12345"
    }

Plan: 1 to add, 0 to change, 0 to destroy.
```

**Root cause:** these fields are not set as sensitive. `resource_secret_uc.go:276` calls `SetRequired()` on `value` but never `SetSensitive()`, and the resource passes `nil` as the schema-customization callback, so there was no hand-editable place to set it.

**Fix:** replace the `nil` customization argument with a callback calling `.SetSensitive()` on both fields, in the resource and both data sources.

After the fix:
```
      + effective_value = (sensitive value)
      + value           = (sensitive value)
```

Note: this is the same class of issue as #5395 (`databricks_git_credential.personal_access_token`) and #5409 (`databricks_model_serving` plaintext credentials). Unlike those, `databricks_secret_uc` is an auto-generated Plugin Framework resource — see Caveat below.

---

## Detailed Changes

### Mark secret value fields as sensitive (`internal/providers/pluginfw/products/secret_uc/resource_secret_uc.go:291`)

**Before:**
```go
attrs, blocks := tfschema.ResourceStructToSchemaMap(ctx, Secret{}, nil)
```

**After:**
```go
attrs, blocks := tfschema.ResourceStructToSchemaMap(ctx, Secret{}, func(c tfschema.CustomizableSchema) tfschema.CustomizableSchema {
	// The secret payload must never be rendered in plan/apply output. `value` is the
	// write path and `effective_value` the read path, so both carry secret material.
	c.SetSensitive("value")
	c.SetSensitive("effective_value")

	return c
})
```

**Why:** Ensures the secret is masked as `(sensitive value)` in plan/apply output. The customization callback runs after the generated `ApplySchemaCustomizations` (`tfschema/struct_to_schema.go:158` then `:181`), so it composes with the generated `SetRequired`/`SetComputed` instead of conflicting with them.

The same change is applied to `data_secret_uc.go:243`. For the plural data source, `data_secret_ucs.go:75` uses the nested path so every listed secret is masked:

```go
c.SetSensitive("secrets", "value")
c.SetSensitive("secrets", "effective_value")
```

**Why `effective_value` too:** it is currently always null, because `GetSecretRequest` has no `include_value` field to request the value. But it is declared as the read path for the secret, so it will carry real secret material if that is ever wired up. Marking it now avoids reintroducing the leak later.

---

## Caveat: auto-generated files

All three files are auto-generated (`// Code generated from OpenAPI specs by Databricks SDK Generator. DO NOT EDIT.`, `linguist-generated=true` in `.gitattributes:306-308`), so this fix can be overwritten by the next `Update SDK API to <sha>` regeneration. The three schema tests are the safety net — they fail loudly if the customization callback is lost, turning a silent security regression into a red build.

The durable fix is generator-side. Worth noting the gap is provider-wide, not specific to this resource: `grep -rn "SetSensitive" internal/providers/pluginfw/products/` returns zero hits across all 155 generated files, so any generated resource with a credential field has the same exposure. Happy to split that into a separate issue.

---

## Tests

### Unit Tests

- **TestResourceSecret_SecretValuesAreSensitive**: Builds the `databricks_secret_uc` resource schema and asserts `value` and `effective_value` are `Sensitive`. This test would have caught the original bug.
- **TestDataSourceSecret_SecretValuesAreSensitive**: Same assertion for the `databricks_secret_uc` data source schema.
- **TestDataSourceSecrets_SecretValuesAreSensitive**: Asserts the nested `secrets[*].value` and `secrets[*].effective_value` in the `databricks_secret_ucs` data source are `Sensitive`.

Verified these fail without the fix: reverting the three source files produces 6 failing assertions across all 3 tests.

### Validation

Whole-provider schema comparison (binaries built from `af211e28` vs this branch, `terraform providers schema -json` diffed key by key) shows **exactly 6 differences, all additive `sensitive: true` flags** — no attribute added, removed, retyped, or changed in required/optional/computed status. No breaking changes.

Sentinel occurrences in `terraform plan -no-color` output: **1 before the fix, 0 after.**

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder — N/A, `docs/resources/secret_uc.md` is generated and does not document sensitivity
- [ ] covered with integration tests in `internal/acceptance`
- [x] using Go SDK
- [x] using TF Plugin Framework
- [x] has entry in `NEXT_CHANGELOG.md` file
