### PR TITLE
[Exporter] Resolve references embedded in `databricks_cluster_policy` definitions instead of emitting hardcoded values

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -19,5 +19,6 @@
 * Add an `exporter` dimension to the user agent ([#5954](https://github.com/databricks/terraform-provider-databricks/pull/5954)).
 * Allow to generate named variables from references; introduce `databricks_account_id` variable for account-level exports; bug fixes ([#5952](https://github.com/databricks/terraform-provider-databricks/pull/5952)).
 * Preserve zero `value` fields when exporting `databricks_workspace_setting_v2` and `databricks_account_setting_v2` ([#5955](https://github.com/databricks/terraform-provider-databricks/issues/5955)).
+* Resolve references embedded in `databricks_cluster_policy` definitions instead of emitting hardcoded values ([#5953](https://github.com/databricks/terraform-provider-databricks/issues/5953)).
 
 ### Internal Changes

--- a/exporter/codegen.go
+++ b/exporter/codegen.go
@@ -344,6 +344,43 @@ func varTraversalTokens(name string) hclwrite.Tokens {
 	})
 }
 
+// referenceSubstitutions computes all substitutions a single reference produces
+// for a value. Normally that's zero or one; for a MultiMatch regexp reference it's
+// one per occurrence, each captured token resolved independently to its own target
+// resource (e.g. several distinct `{{secrets/scope/key}}` tokens in one value).
+func (ic *importContext) referenceSubstitutions(d reference, path []string, value string,
+	origResource *resource, origPath string) []substitution {
+	if d.MultiMatch && d.MatchTypeValue() == MatchRegexp && !d.Variable {
+		if d.Regexp == nil {
+			return nil
+		}
+		attr := d.MatchAttribute()
+		// Resolve each captured token via an exact lookup so we don't re-run the
+		// reference regexp against the captured substring in isolation (which, for
+		// context-anchored regexps such as init-script destinations, wouldn't match).
+		lookup := d
+		lookup.MatchType = MatchExact
+		lookup.Regexp = nil
+		var subs []substitution
+		for _, idx := range d.Regexp.FindAllStringSubmatchIndex(value, -1) {
+			if len(idx) < 4 || idx[2] < 0 {
+				continue
+			}
+			captured := value[idx[2]:idx[3]]
+			_, traversal, _ := ic.Find(captured, attr, lookup, origResource, origPath)
+			if traversal == nil {
+				continue
+			}
+			subs = append(subs, substitution{Start: idx[2], End: idx[3], Inner: hclwrite.TokensForTraversal(traversal)})
+		}
+		return subs
+	}
+	if sub, ok := ic.referenceSubstitution(d, path, value, origResource, origPath); ok {
+		return []substitution{sub}
+	}
+	return nil
+}
+
 // referenceSubstitution computes, for a single reference and value, the span of
 // the value it replaces and the traversal tokens to substitute in its place. It
 // returns ok=false when the reference doesn't apply to the value.
@@ -406,8 +443,8 @@ func (ic *importContext) combineReferences(i importable, match string, path []st
 		if d.Path != match {
 			continue
 		}
-		sub, ok := ic.referenceSubstitution(d, path, value, origResource, pathString)
-		if ok {
+		refSubs := ic.referenceSubstitutions(d, path, value, origResource, pathString)
+		for _, sub := range refSubs {
 			overlaps := false
 			for _, existing := range subs {
 				if sub.Start < existing.End && sub.End > existing.Start {
@@ -418,9 +455,9 @@ func (ic *importContext) combineReferences(i importable, match string, path []st
 			if !overlaps {
 				subs = append(subs, sub)
 			}
-			if !d.ContinueMatch {
-				break // terminal reference
-			}
+		}
+		if len(refSubs) > 0 && !d.ContinueMatch {
+			break // terminal reference
 		}
 	}
 	if len(subs) == 0 {

--- a/exporter/codegen_test.go
+++ b/exporter/codegen_test.go
@@ -303,6 +303,119 @@ func TestCombineReferencesChain(t *testing.T) {
 	assert.Equal(t, `"a/${var.v1}/b/${var.v2}/c/${var.v3}"`, renderTokens(t, toks))
 }
 
+// TestCombineReferencesMultiMatchSecrets verifies that a single MultiMatch regexp
+// reference substitutes every occurrence in the value, resolving each captured
+// token to its own resource (two different secrets, in this case).
+func TestCombineReferencesMultiMatchSecrets(t *testing.T) {
+	ic := importContextForTest()
+	ic.State.Append(resourceApproximation{
+		Type: "databricks_secret", Name: "s_a",
+		Instances: []instanceApproximation{
+			{Attributes: map[string]any{"config_reference": "{{secrets/scopeA/keyA}}"}},
+		},
+	})
+	ic.State.Append(resourceApproximation{
+		Type: "databricks_secret", Name: "s_b",
+		Instances: []instanceApproximation{
+			{Attributes: map[string]any{"config_reference": "{{secrets/scopeB/keyB}}"}},
+		},
+	})
+	value := `x={{secrets/scopeA/keyA}};y={{secrets/scopeB/keyB}}`
+	imp := importable{Depends: []reference{
+		{Path: "f", Resource: "databricks_secret", Match: "config_reference",
+			MatchType: MatchRegexp, Regexp: regexp.MustCompile(`(\{\{secrets/[^/]+/[^}]+\}\})`),
+			MultiMatch: true, ContinueMatch: true},
+	}}
+	toks := ic.reference(imp, []string{"f"}, value, cty.StringVal(value), &resource{})
+	assert.Equal(t,
+		`"x=${databricks_secret.s_a.config_reference};y=${databricks_secret.s_b.config_reference}"`,
+		renderTokens(t, toks))
+}
+
+// TestCombineReferencesMultiMatchSkipsUnresolved verifies that occurrences whose
+// captured value doesn't resolve to a resource are left as literal text, while
+// resolvable ones are still substituted.
+func TestCombineReferencesMultiMatchSkipsUnresolved(t *testing.T) {
+	ic := importContextForTest()
+	ic.State.Append(resourceApproximation{
+		Type: "databricks_secret", Name: "s_a",
+		Instances: []instanceApproximation{
+			{Attributes: map[string]any{"config_reference": "{{secrets/scopeA/keyA}}"}},
+		},
+	})
+	value := `x={{secrets/scopeA/keyA}};y={{secrets/unknown/key}}`
+	imp := importable{Depends: []reference{
+		{Path: "f", Resource: "databricks_secret", Match: "config_reference",
+			MatchType: MatchRegexp, Regexp: regexp.MustCompile(`(\{\{secrets/[^/]+/[^}]+\}\})`),
+			MultiMatch: true, ContinueMatch: true},
+	}}
+	toks := ic.reference(imp, []string{"f"}, value, cty.StringVal(value), &resource{})
+	assert.Equal(t,
+		`"x=${databricks_secret.s_a.config_reference};y={{secrets/unknown/key}}"`,
+		renderTokens(t, toks))
+}
+
+// TestClusterPolicyDefinitionReferences exercises the full set of references the
+// cluster-policy importable extracts from a definition JSON string: instance pools,
+// instance profile ARN, multiple distinct secrets, and an init-script destination.
+func TestClusterPolicyDefinitionReferences(t *testing.T) {
+	ic := importContextForTest()
+	ic.State.Append(resourceApproximation{Type: "databricks_instance_pool", Name: "pool_a",
+		Instances: []instanceApproximation{{Attributes: map[string]any{"id": "pool1"}}}})
+	ic.State.Append(resourceApproximation{Type: "databricks_instance_pool", Name: "pool_b",
+		Instances: []instanceApproximation{{Attributes: map[string]any{"id": "pool2"}}}})
+	ic.State.Append(resourceApproximation{Type: "databricks_instance_profile", Name: "ip",
+		Instances: []instanceApproximation{{Attributes: map[string]any{"id": "arn:aws:iam::123:instance-profile/my"}}}})
+	ic.State.Append(resourceApproximation{Type: "databricks_secret", Name: "s_a",
+		Instances: []instanceApproximation{{Attributes: map[string]any{"config_reference": "{{secrets/scopeA/keyA}}"}}}})
+	ic.State.Append(resourceApproximation{Type: "databricks_secret", Name: "s_b",
+		Instances: []instanceApproximation{{Attributes: map[string]any{"config_reference": "{{secrets/scopeB/keyB}}"}}}})
+	ic.State.Append(resourceApproximation{Type: "databricks_dbfs_file", Name: "init",
+		Instances: []instanceApproximation{{Attributes: map[string]any{"dbfs_path": "dbfs:/FileStore/init.sh"}}}})
+
+	definition := `{"instance_pool_id":{"type":"fixed","value":"pool1"},` +
+		`"driver_instance_pool_id":{"type":"fixed","value":"pool2"},` +
+		`"aws_attributes.instance_profile_arn":{"type":"fixed","value":"arn:aws:iam::123:instance-profile/my"},` +
+		`"spark_conf.k1":{"type":"fixed","value":"{{secrets/scopeA/keyA}}"},` +
+		`"spark_conf.k2":{"type":"fixed","value":"{{secrets/scopeB/keyB}}"},` +
+		`"init_scripts.0.dbfs.destination":{"type":"fixed","value":"dbfs:/FileStore/init.sh"}}`
+
+	imp := ic.Importables["databricks_cluster_policy"]
+	toks := ic.reference(imp, []string{"definition"}, definition, cty.StringVal(definition), &resource{})
+	out := renderTokens(t, toks)
+	assert.Contains(t, out, "${databricks_instance_pool.pool_a.id}")
+	assert.Contains(t, out, "${databricks_instance_pool.pool_b.id}")
+	assert.Contains(t, out, "${databricks_instance_profile.ip.id}")
+	assert.Contains(t, out, "${databricks_secret.s_a.config_reference}")
+	assert.Contains(t, out, "${databricks_secret.s_b.config_reference}")
+	assert.Contains(t, out, "${databricks_dbfs_file.init.dbfs_path}")
+}
+
+// TestClusterPolicySecretScopeFallback verifies that a secret whose specific
+// databricks_secret resource is available resolves to config_reference, while a
+// token backed only by a secret scope (e.g. Azure Key Vault) falls back to
+// substituting just the scope and keeping the key literal.
+func TestClusterPolicySecretScopeFallback(t *testing.T) {
+	ic := importContextForTest()
+	// Databricks-managed secret: both the secret and its scope exist.
+	ic.State.Append(resourceApproximation{Type: "databricks_secret", Name: "s_managed",
+		Instances: []instanceApproximation{{Attributes: map[string]any{"config_reference": "{{secrets/managed/key1}}"}}}})
+	// AKV-backed scope: only the scope exists, no per-secret resource.
+	ic.State.Append(resourceApproximation{Type: "databricks_secret_scope", Name: "akv",
+		Instances: []instanceApproximation{{Attributes: map[string]any{"id": "akv_scope"}}}})
+
+	definition := `{"spark_conf.a":{"type":"fixed","value":"{{secrets/managed/key1}}"},` +
+		`"spark_conf.b":{"type":"fixed","value":"{{secrets/akv_scope/key2}}"}}`
+
+	imp := ic.Importables["databricks_cluster_policy"]
+	toks := ic.reference(imp, []string{"definition"}, definition, cty.StringVal(definition), &resource{})
+	out := renderTokens(t, toks)
+	assert.Contains(t, out, "${databricks_secret.s_managed.config_reference}")
+	assert.Contains(t, out, "{{secrets/${databricks_secret_scope.akv.id}/key2}}")
+	// The AKV token must NOT be resolved to a databricks_secret.
+	assert.NotContains(t, out, "databricks_secret.akv")
+}
+
 func renderTokens(t *testing.T, tokens hclwrite.Tokens) string {
 	t.Helper()
 	f := hclwrite.NewEmptyFile()

--- a/exporter/impl_compute.go
+++ b/exporter/impl_compute.go
@@ -179,6 +179,61 @@ func listClusterPolicies(ic *importContext) error {
 	return nil
 }
 
+// clusterPolicyReferences builds the Depends references for databricks_cluster_policy.
+// The policy JSON is stored escaped in a single string attribute (either `definition`
+// or `policy_family_definition_overrides`), so references to other objects embedded in
+// it are extracted with regexps. The same set of references applies to both fields.
+// All definition references set ContinueMatch so every one is evaluated and their
+// non-overlapping substitutions are combined; secret and init-script references also
+// set MultiMatch because a single definition can embed several of them, each pointing
+// to a different object.
+func clusterPolicyReferences() []reference {
+	var refs []reference
+	for _, f := range []string{"definition", "policy_family_definition_overrides"} {
+		refs = append(refs,
+			reference{Path: f, Resource: "databricks_instance_pool", ContinueMatch: true,
+				MatchType: MatchRegexp, Regexp: policyInstancePoolIdRegex},
+			reference{Path: f, Resource: "databricks_instance_pool", ContinueMatch: true,
+				MatchType: MatchRegexp, Regexp: policyDriverInstancePoolIdRegex},
+			reference{Path: f, Resource: "databricks_instance_profile", ContinueMatch: true,
+				MatchType: MatchRegexp, Regexp: policyInstanceProfileArnRegex},
+			reference{Path: f, Resource: "databricks_secret", Match: "config_reference",
+				ContinueMatch: true, MultiMatch: true, MatchType: MatchRegexp, Regexp: policySecretRegex},
+			// Fallback for scopes without per-secret resources (e.g. Azure Key Vault
+			// backed scopes): substitute only the scope, keeping the key literal. It
+			// runs after the databricks_secret reference, so tokens already resolved to
+			// a secret are left untouched (their span overlaps and is skipped).
+			reference{Path: f, Resource: "databricks_secret_scope",
+				ContinueMatch: true, MultiMatch: true, MatchType: MatchRegexp, Regexp: policySecretScopeRegex},
+			reference{Path: f, Resource: "databricks_dbfs_file", Match: "dbfs_path",
+				ContinueMatch: true, MultiMatch: true, MatchType: MatchRegexp, Regexp: policyInitScriptDbfsRegex},
+			reference{Path: f, Resource: "databricks_workspace_file", Match: "workspace_path",
+				ContinueMatch: true, MultiMatch: true, MatchType: MatchRegexp, Regexp: policyInitScriptWorkspaceRegex},
+			reference{Path: f, Resource: "databricks_workspace_file", Match: "path",
+				ContinueMatch: true, MultiMatch: true, MatchType: MatchRegexp, Regexp: policyInitScriptWorkspaceRegex},
+			reference{Path: f, Resource: "databricks_file", Match: "path",
+				ContinueMatch: true, MultiMatch: true, MatchType: MatchRegexp, Regexp: policyInitScriptVolumesRegex},
+		)
+	}
+	refs = append(refs,
+		reference{Path: "libraries.jar", Resource: "databricks_dbfs_file", Match: "dbfs_path"},
+		reference{Path: "libraries.jar", Resource: "databricks_file"},
+		reference{Path: "libraries.jar", Resource: "databricks_workspace_file", Match: "workspace_path"},
+		reference{Path: "libraries.whl", Resource: "databricks_dbfs_file", Match: "dbfs_path"},
+		reference{Path: "libraries.whl", Resource: "databricks_file"},
+		reference{Path: "libraries.whl", Resource: "databricks_workspace_file", Match: "workspace_path"},
+		reference{Path: "libraries.egg", Resource: "databricks_dbfs_file", Match: "dbfs_path"},
+		reference{Path: "libraries.egg", Resource: "databricks_workspace_file", Match: "workspace_path"},
+		reference{Path: "libraries.whl", Resource: "databricks_repo", Match: "workspace_path",
+			MatchType: MatchPrefix, SearchValueTransformFunc: appendEndingSlashToDirName},
+		reference{Path: "libraries.egg", Resource: "databricks_repo", Match: "workspace_path",
+			MatchType: MatchPrefix, SearchValueTransformFunc: appendEndingSlashToDirName},
+		reference{Path: "libraries.jar", Resource: "databricks_repo", Match: "workspace_path",
+			MatchType: MatchPrefix, SearchValueTransformFunc: appendEndingSlashToDirName},
+	)
+	return refs
+}
+
 func importClusterPolicy(ic *importContext, r *resource) error {
 	ic.emitPermissionsIfNotIgnored(r, fmt.Sprintf("/cluster-policies/%s", r.ID),
 		"cluster_policy_"+ic.Importables["databricks_cluster_policy"].Name(ic, r.Data))
@@ -263,9 +318,11 @@ func importClusterPolicy(ic *importContext, r *resource) error {
 			strings.HasSuffix(k, ".workspace.destination") {
 			ic.emitWorkspaceFileOrRepo(eitherString(value, defaultValue))
 		}
-		if typ == "fixed" && (strings.HasPrefix(k, "spark_conf.") || strings.HasPrefix(k, "spark_env_vars.")) {
-			ic.emitSecretsFromSecretPathString(eitherString(value, defaultValue))
-		}
+		// Secret references may appear in any attribute (spark_conf, spark_env_vars,
+		// docker_image credentials, ...) and with any type - notably policy families
+		// often store them in `defaultValue` with a non-fixed type - so emit the scope
+		// for every `{{secrets/scope/key}}` token regardless of key or type.
+		ic.emitSecretScopesFromString(eitherString(value, defaultValue))
 	}
 
 	for _, lib := range clusterPolicy.Libraries {

--- a/exporter/impl_compute_test.go
+++ b/exporter/impl_compute_test.go
@@ -77,6 +77,32 @@ func TestClusterPolicy(t *testing.T) {
 	assert.True(t, ic.testEmits["databricks_dbfs_file[<unknown>] (id: dbfs:/FileStore/init-script.sh)"])
 }
 
+func TestClusterPolicyEmitsSecretScopes(t *testing.T) {
+	d := policies.ResourceClusterPolicy().ToResource().TestResourceData()
+	d.Set("name", "sec")
+	definition := map[string]map[string]string{
+		// non-fixed type with the secret in defaultValue (typical for policy families)
+		"spark_conf.fs.azure.account.oauth2.client.id": {
+			"type":         "unlimited",
+			"defaultValue": "{{secrets/akv/app-id}}",
+		},
+		// secret in docker image credentials
+		"docker_image.basic_auth.password": {
+			"type":  "fixed",
+			"value": "{{secrets/dkr/pass}}",
+		},
+	}
+	policy, _ := json.Marshal(definition)
+	d.Set("definition", string(policy))
+	ic := importContextForTest()
+	ic.enableServices("secrets,policies,access")
+	ic.meAdmin = true
+	err := ic.Importables["databricks_cluster_policy"].Import(ic, &resource{ID: "abc", Data: d})
+	assert.NoError(t, err)
+	assert.True(t, ic.testEmits["databricks_secret_scope[<unknown>] (id: akv)"])
+	assert.True(t, ic.testEmits["databricks_secret_scope[<unknown>] (id: dkr)"])
+}
+
 func TestPredefinedClusterPolicy(t *testing.T) {
 	d := policies.ResourceClusterPolicy().ToResource().TestResourceData()
 	d.Set("policy_family_id", "job-cluster")

--- a/exporter/importables.go
+++ b/exporter/importables.go
@@ -42,8 +42,23 @@ var (
 	ignoreIdeFolderRegex             = regexp.MustCompile(`^/Users/[^/]+/\.ide/.*$`)
 	servedEntityFieldExtractionRegex = regexp.MustCompile(`^config\.[0-9]+\.served_entities\.([0-9]+)\.(.*)$`)
 	uc3LevelIdRegex                  = regexp.MustCompile(`^([^.]+\.[^.]+\.[^.]+)$`)
-	globIncludeDirectoryRegex        = regexp.MustCompile(`^(/.+)/\*\*$`)
-	fileExtensionLanguageMapping     = map[string]string{
+	policyInstancePoolIdRegex        = regexp.MustCompile(`"instance_pool_id":\s*\{[^}]*"(?:value|defaultValue)":\s*"([^"]+)"`)
+	policyDriverInstancePoolIdRegex  = regexp.MustCompile(`"driver_instance_pool_id":\s*\{[^}]*"(?:value|defaultValue)":\s*"([^"]+)"`)
+	policyInstanceProfileArnRegex    = regexp.MustCompile(`"aws_attributes\.instance_profile_arn":\s*\{[^}]*"(?:value|defaultValue)":\s*"([^"]+)"`)
+	// policySecretRegex captures a whole `{{secrets/scope/key}}` token so it matches
+	// the computed `config_reference` attribute of a databricks_secret. Used with
+	// MultiMatch to substitute every secret reference embedded in a policy definition.
+	policySecretRegex = regexp.MustCompile(`(\{\{secrets/[^/]+/[^}]+\}\})`)
+	// policySecretScopeRegex captures just the scope of an embedded `{{secrets/scope/key}}`
+	// token. It's the fallback used when the specific secret can't be resolved to a
+	// databricks_secret resource (e.g. Azure Key Vault backed scopes, where individual
+	// secrets aren't managed by Databricks) - only the scope is substituted.
+	policySecretScopeRegex         = regexp.MustCompile(`\{\{secrets/([^/]+)/[^}]+\}\}`)
+	policyInitScriptDbfsRegex      = regexp.MustCompile(`"init_scripts\.\d+\.dbfs\.destination":\s*\{[^}]*"(?:value|defaultValue)":\s*"([^"]+)"`)
+	policyInitScriptWorkspaceRegex = regexp.MustCompile(`"init_scripts\.\d+\.workspace\.destination":\s*\{[^}]*"(?:value|defaultValue)":\s*"([^"]+)"`)
+	policyInitScriptVolumesRegex   = regexp.MustCompile(`"init_scripts\.\d+\.volumes\.destination":\s*\{[^}]*"(?:value|defaultValue)":\s*"([^"]+)"`)
+	globIncludeDirectoryRegex      = regexp.MustCompile(`^(/.+)/\*\*$`)
+	fileExtensionLanguageMapping   = map[string]string{
 		"SCALA":  ".scala",
 		"PYTHON": ".py",
 		"SQL":    ".sql",
@@ -223,22 +238,7 @@ var resourcesMap map[string]importable = map[string]importable{
 			}
 			return defaultShouldOmitFieldFunc(ic, pathString, as, d, r)
 		},
-		Depends: []reference{
-			{Path: "libraries.jar", Resource: "databricks_dbfs_file", Match: "dbfs_path"},
-			{Path: "libraries.jar", Resource: "databricks_file"},
-			{Path: "libraries.jar", Resource: "databricks_workspace_file", Match: "workspace_path"},
-			{Path: "libraries.whl", Resource: "databricks_dbfs_file", Match: "dbfs_path"},
-			{Path: "libraries.whl", Resource: "databricks_file"},
-			{Path: "libraries.whl", Resource: "databricks_workspace_file", Match: "workspace_path"},
-			{Path: "libraries.egg", Resource: "databricks_dbfs_file", Match: "dbfs_path"},
-			{Path: "libraries.egg", Resource: "databricks_workspace_file", Match: "workspace_path"},
-			{Path: "libraries.whl", Resource: "databricks_repo", Match: "workspace_path",
-				MatchType: MatchPrefix, SearchValueTransformFunc: appendEndingSlashToDirName},
-			{Path: "libraries.egg", Resource: "databricks_repo", Match: "workspace_path",
-				MatchType: MatchPrefix, SearchValueTransformFunc: appendEndingSlashToDirName},
-			{Path: "libraries.jar", Resource: "databricks_repo", Match: "workspace_path",
-				MatchType: MatchPrefix, SearchValueTransformFunc: appendEndingSlashToDirName},
-		},
+		Depends: clusterPolicyReferences(),
 		// TODO: implement a custom Body that will write with special formatting, where
 		// JSON is written line by line so that we're able to do the references
 	},

--- a/exporter/model.go
+++ b/exporter/model.go
@@ -209,6 +209,13 @@ type reference struct {
 	// Used, for example, to substitute both the account ID and a resource reference
 	// within one attribute like `accounts/<id>/budgetPolicies/<policy>/ruleSets/default`.
 	ContinueMatch bool
+	// MultiMatch, when true together with MatchType == MatchRegexp, tells the
+	// reference resolver to substitute every occurrence of the regexp in the value
+	// (not just the first), resolving each captured group independently to its own
+	// target resource. Used for values that embed several references to different
+	// objects, such as multiple `{{secrets/scope/key}}` tokens inside a cluster
+	// policy definition. Only supported on the ContinueMatch (combine) path.
+	MultiMatch bool
 	// true if given reference denote a reference to a generated file
 	File bool
 	// regular expression (if MatchType == "regexp") must define a group that will be used to extract value to match

--- a/exporter/util_compute.go
+++ b/exporter/util_compute.go
@@ -39,6 +39,19 @@ func (ic *importContext) emitSecretsFromSecretPathString(v string) {
 	}
 }
 
+// emitSecretScopesFromString emits the databricks_secret_scope for every
+// `{{secrets/scope/key}}` reference embedded anywhere in v. Unlike
+// emitSecretsFromSecretPathString it handles tokens embedded in a larger string and
+// multiple tokens in one value, which is the case for cluster policy definitions.
+func (ic *importContext) emitSecretScopesFromString(v string) {
+	for _, m := range policySecretScopeRegex.FindAllStringSubmatch(v, -1) {
+		ic.Emit(&resource{
+			Resource: "databricks_secret_scope",
+			ID:       m[1],
+		})
+	}
+}
+
 func (ic *importContext) emitSecretsFromSecretsPathMap(m map[string]string) {
 	for _, v := range m {
 		ic.emitSecretsFromSecretPathString(v)


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

The `definition` and `policy_family_definition_overrides` attributes now reference exported resources for instance pools (`instance_pool_id`, `driver_instance_pool_id`), instance profiles (`aws_attributes.instance_profile_arn`), secrets (`{{secrets/scope/key}}`, falling back to the secret scope for Azure Key Vault backed scopes), and init-script destinations (DBFS, workspace, and UC volume files). References are resolved only for objects that were also exported (i.e. when the corresponding services are included).

Resolves #3371, shoulde be merged after #5952


## Tests
<!--
How is this tested? Please see the checklist below and also describe any other relevant tests
-->

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] using Go SDK
- [ ] using TF Plugin Framework
- [x] has entry in `NEXT_CHANGELOG.md` file
