### PR TITLE
[Fix] Fix column handling on a `VIEW` in `databricks_sql_table`

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Bug Fixes
 
+* Fix column handling on a `VIEW` in `databricks_sql_table` ([#5958](https://github.com/databricks/terraform-provider-databricks/pull/5958)). A view's columns are derived from its query, but the provider treated them like table columns and emitted DDL that Databricks rejects with a `PARSE_SYNTAX_ERROR`: `NOT NULL` in `CREATE VIEW`, and `ALTER VIEW ... ADD COLUMN` / `DROP COLUMN` / `RENAME COLUMN` / `ALTER COLUMN ... SET|DROP NOT NULL` on update. Editing the query of a view that has column comments also dropped those comments, because `ALTER VIEW ... AS` clears them and the provider did not re-apply them in the same run. For views, the provider now applies only column comments (via `COMMENT ON COLUMN`), matches columns by name rather than by position, re-applies the configured comments whenever the view definition changes, and suppresses diffs on `column.nullable`, whose server-derived value cannot be set from the configuration.
+
 ### Documentation
 
 ### Exporter

--- a/catalog/resource_sql_table.go
+++ b/catalog/resource_sql_table.go
@@ -94,6 +94,13 @@ func (ti SqlTableInfo) CustomizeSchema(s *common.CustomizableSchema) *common.Cus
 	s.SchemaPath("column", "type").SetCustomSuppressDiff(func(k, old, new string, d *schema.ResourceData) bool {
 		return getColumnType(old) == getColumnType(new)
 	})
+	s.SchemaPath("column", "nullable").SetCustomSuppressDiff(func(k, old, new string, d *schema.ResourceData) bool {
+		// A view column's nullability is derived from the view query, so the
+		// server-reported value regularly differs from the configured one (SELECT 1 AS
+		// id yields a NOT NULL column, while the schema default is nullable = true).
+		// Nothing can be applied to reconcile that, so suppress the diff for views.
+		return d.Get("table_type") == "VIEW"
+	})
 	common.NamespaceCustomizeSchema(s)
 	return s
 }
@@ -232,7 +239,9 @@ func (ti *SqlTableInfo) serializeColumnInfo(col SqlColumnInfo) string {
 	var colType = col.getColumnType()
 
 	notNull := ""
-	if !col.Nullable {
+	// Views don't support NOT NULL column constraints: a view column's nullability is
+	// derived from the view query, so CREATE VIEW ... (col NOT NULL) is rejected.
+	if !col.Nullable && ti.TableType != "VIEW" {
 		notNull = " NOT NULL"
 	}
 
@@ -359,10 +368,56 @@ func (ti *SqlTableInfo) getWrappedClusterKeys() string {
 }
 
 func (ti *SqlTableInfo) getStatementsForColumnDiffs(oldti *SqlTableInfo, statements []string, typestring string) []string {
+	if ti.TableType == "VIEW" {
+		// A view's columns are derived from its query. They cannot be added, dropped,
+		// renamed, or have their nullability changed independently of that query, and
+		// ALTER VIEW has no ADD COLUMN, DROP COLUMN, RENAME COLUMN or ALTER COLUMN
+		// clause: Databricks rejects all of them with a PARSE_SYNTAX_ERROR. The only
+		// column attribute the provider can set on a view is the comment.
+		return ti.viewColumnCommentStatements(oldti, statements)
+	}
 	if len(ti.ColumnInfos) != len(oldti.ColumnInfos) {
 		statements = ti.addOrRemoveColumnStatements(oldti, statements, typestring)
 	} else {
 		statements = ti.alterExistingColumnStatements(oldti, statements, typestring)
+	}
+	return statements
+}
+
+// viewColumnCommentStatements returns the COMMENT ON COLUMN statements that bring a
+// view's column comments to the configured state.
+//
+// Columns are matched by name rather than by position: a view's column list comes from
+// the server, so a query change can reorder it without the configuration having said
+// anything about it.
+//
+// When the view definition changed, the ALTER VIEW ... AS queued earlier in diff() drops
+// every column comment as a side effect, so the configured comments are re-emitted
+// unconditionally instead of being compared against the pre-ALTER state. Without this the
+// comments silently disappear on any apply that edits the query, and only come back on
+// the following apply.
+func (ti *SqlTableInfo) viewColumnCommentStatements(oldti *SqlTableInfo, statements []string) []string {
+	viewDefinitionChanged := ti.ViewDefinition != oldti.ViewDefinition
+
+	oldComments := make(map[string]string, len(oldti.ColumnInfos))
+	for _, oldCi := range oldti.ColumnInfos {
+		oldComments[oldCi.Name] = oldCi.Comment
+	}
+
+	for _, ci := range ti.ColumnInfos {
+		oldComment, exists := oldComments[ci.Name]
+		if viewDefinitionChanged {
+			// The comment is about to be dropped by ALTER VIEW ... AS, so the only
+			// thing worth emitting is a non-empty configured comment.
+			if ci.Comment == "" {
+				continue
+			}
+		} else if !exists || ci.Comment == oldComment {
+			// Nothing to do, or the column is not part of the view: commenting on a
+			// column that does not exist would fail the whole apply.
+			continue
+		}
+		statements = append(statements, fmt.Sprintf("COMMENT ON COLUMN %s.%s IS '%s'", ti.SQLFullName(), ci.getWrappedColumnName(), parseComment(ci.Comment)))
 	}
 	return statements
 }
@@ -414,14 +469,7 @@ func (ti *SqlTableInfo) alterExistingColumnStatements(oldti *SqlTableInfo, state
 			statements = append(statements, fmt.Sprintf("ALTER %s %s RENAME COLUMN %s to %s", typestring, ti.SQLFullName(), oldCi.getWrappedColumnName(), ci.getWrappedColumnName()))
 		}
 		if ci.Comment != oldCi.Comment {
-			if ti.TableType == "VIEW" {
-				// ALTER VIEW ... ALTER COLUMN ... COMMENT is not valid Databricks SQL
-				// (it fails with PARSE_SYNTAX_ERROR). COMMENT ON COLUMN updates a view
-				// column comment in place.
-				statements = append(statements, fmt.Sprintf("COMMENT ON COLUMN %s.%s IS '%s'", ti.SQLFullName(), ci.getWrappedColumnName(), parseComment(ci.Comment)))
-			} else {
-				statements = append(statements, fmt.Sprintf("ALTER %s %s ALTER COLUMN %s COMMENT '%s'", typestring, ti.SQLFullName(), ci.getWrappedColumnName(), parseComment(ci.Comment)))
-			}
+			statements = append(statements, fmt.Sprintf("ALTER %s %s ALTER COLUMN %s COMMENT '%s'", typestring, ti.SQLFullName(), ci.getWrappedColumnName(), parseComment(ci.Comment)))
 		}
 		if ci.Nullable != oldCi.Nullable {
 			var keyWord string

--- a/catalog/resource_sql_table_test.go
+++ b/catalog/resource_sql_table_test.go
@@ -115,11 +115,115 @@ func TestResourceSqlTableCreateStatement_ViewWithComments(t *testing.T) {
 	}
 	stmt := ti.buildTableCreateStatement()
 	assert.Contains(t, stmt, "CREATE VIEW `main`.`foo`.`bar`")
-	assert.Contains(t, stmt, "(`id`  NOT NULL, `name`  NOT NULL COMMENT 'a comment')")
+	// Views don't support NOT NULL column constraints, so it must not be emitted.
+	assert.Contains(t, stmt, "(`id` , `name`  COMMENT 'a comment')")
+	assert.NotContains(t, stmt, "NOT NULL")
 	assert.NotContains(t, stmt, "USING DELTA")
 	assert.NotContains(t, stmt, "LOCATION 's3://ext-main/foo/bar1' WITH CREDENTIAL somecred")
 	assert.Contains(t, stmt, "COMMENT 'terraform managed'")
 	assert.Contains(t, stmt, "'one'='two'")
+}
+
+// newViewInfo builds a VIEW SqlTableInfo for the column-handling tests below.
+func newViewInfo(definition string, columns ...SqlColumnInfo) *SqlTableInfo {
+	return &SqlTableInfo{
+		Name:           "v",
+		CatalogName:    "main",
+		SchemaName:     "foo",
+		TableType:      "VIEW",
+		ViewDefinition: definition,
+		ColumnInfos:    columns,
+	}
+}
+
+func TestResourceSqlTableView_NullabilityIsNotManaged(t *testing.T) {
+	view := newViewInfo("SELECT 1 AS id", SqlColumnInfo{Name: "id", Nullable: false})
+
+	// CREATE VIEW must not emit a NOT NULL constraint, which views don't support.
+	create := view.buildTableCreateStatement()
+	assert.Contains(t, create, "CREATE VIEW `main`.`foo`.`v`")
+	assert.NotContains(t, create, "NOT NULL")
+
+	// A change in a view column's nullability must not emit
+	// ALTER VIEW ... ALTER COLUMN ..., which Databricks rejects.
+	old := newViewInfo("SELECT 1 AS id", SqlColumnInfo{Name: "id", Nullable: true})
+	statements, err := view.diff(old)
+	assert.NoError(t, err)
+	assert.NotContains(t, strings.Join(statements, "\n"), "ALTER COLUMN")
+}
+
+func TestResourceSqlTableView_ColumnCommentsRestoredAfterDefinitionChange(t *testing.T) {
+	// ALTER VIEW ... AS drops every column comment as a side effect, so a definition
+	// change must re-emit the configured comments in the same apply.
+	old := newViewInfo("SELECT id, name FROM main.foo.bar",
+		SqlColumnInfo{Name: "id", Comment: "identifier"},
+		SqlColumnInfo{Name: "name", Comment: "display name"},
+	)
+	view := newViewInfo("SELECT id, name FROM main.foo.baz",
+		SqlColumnInfo{Name: "id", Comment: "identifier"},
+		SqlColumnInfo{Name: "name", Comment: "display name"},
+	)
+
+	statements, err := view.diff(old)
+	assert.NoError(t, err)
+	joined := strings.Join(statements, "\n")
+	assert.Contains(t, joined, "ALTER VIEW `main`.`foo`.`v` AS SELECT id, name FROM main.foo.baz")
+	assert.Contains(t, joined, "COMMENT ON COLUMN `main`.`foo`.`v`.`id` IS 'identifier'")
+	assert.Contains(t, joined, "COMMENT ON COLUMN `main`.`foo`.`v`.`name` IS 'display name'")
+}
+
+func TestResourceSqlTableView_ColumnMembershipChangeEmitsNoDDL(t *testing.T) {
+	// A view's columns follow its query, so a column appearing or disappearing must
+	// not produce ALTER VIEW ... ADD/DROP COLUMN, which Databricks rejects. Only the
+	// comments of the configured columns are applied.
+	old := newViewInfo("SELECT id FROM main.foo.bar",
+		SqlColumnInfo{Name: "id", Comment: "identifier"},
+	)
+	view := newViewInfo("SELECT id, extra FROM main.foo.bar",
+		SqlColumnInfo{Name: "id", Comment: "identifier"},
+		SqlColumnInfo{Name: "extra", Comment: "added by the new query"},
+	)
+
+	statements, err := view.diff(old)
+	assert.NoError(t, err)
+	joined := strings.Join(statements, "\n")
+	assert.NotContains(t, joined, "ADD COLUMN")
+	assert.NotContains(t, joined, "DROP COLUMN")
+	assert.Contains(t, joined, "COMMENT ON COLUMN `main`.`foo`.`v`.`extra` IS 'added by the new query'")
+}
+
+func TestResourceSqlTableView_ColumnsMatchedByNameNotPosition(t *testing.T) {
+	// Reordering the columns of a view is not a rename: the column list comes from
+	// the server, so matching by position would emit a bogus RENAME COLUMN.
+	old := newViewInfo("SELECT id, name FROM main.foo.bar",
+		SqlColumnInfo{Name: "id", Comment: "identifier"},
+		SqlColumnInfo{Name: "name", Comment: "display name"},
+	)
+	view := newViewInfo("SELECT id, name FROM main.foo.bar",
+		SqlColumnInfo{Name: "name", Comment: "display name"},
+		SqlColumnInfo{Name: "id", Comment: "identifier"},
+	)
+
+	statements, err := view.diff(old)
+	assert.NoError(t, err)
+	assert.NotContains(t, strings.Join(statements, "\n"), "RENAME COLUMN")
+	// Nothing changed but the order, so there is nothing to apply.
+	assert.Empty(t, statements)
+}
+
+func TestResourceSqlTableView_UnknownColumnIsNotCommented(t *testing.T) {
+	// Commenting on a column the view does not have would fail the whole apply.
+	old := newViewInfo("SELECT id FROM main.foo.bar",
+		SqlColumnInfo{Name: "id", Comment: "identifier"},
+	)
+	view := newViewInfo("SELECT id FROM main.foo.bar",
+		SqlColumnInfo{Name: "id", Comment: "identifier"},
+		SqlColumnInfo{Name: "stale", Comment: "no longer selected"},
+	)
+
+	statements, err := view.diff(old)
+	assert.NoError(t, err)
+	assert.NotContains(t, strings.Join(statements, "\n"), "`stale`")
 }
 
 func TestResourceSqlTableCreateStatement_Partition(t *testing.T) {


### PR DESCRIPTION
## Changes

A view's columns are **derived from its query**. The provider treated them like table columns, and emitted DDL that Databricks rejects with `[PARSE_SYNTAX_ERROR] SQLSTATE: 42601`:

| Situation | Statement emitted | Valid for a view? |
|---|---|---|
| `CREATE` with `nullable = false` | `CREATE VIEW ... (col NOT NULL)` | no |
| Column added/removed by a query change | `ALTER VIEW ... ADD COLUMN` / `DROP COLUMN` | no |
| Column order changed | `ALTER VIEW ... RENAME COLUMN` | no (and it isn't a rename) |
| Nullability differs from the server | `ALTER VIEW ... ALTER COLUMN ... SET\|DROP NOT NULL` | no |

Two further consequences:

1. **Column comments were silently dropped when the query changed.** `ALTER VIEW ... AS` clears every column comment, but the column statements are computed against the state read *before* that statement runs, so the provider saw no comment diff and emitted nothing. The comments came back only on the *next* apply — and only if one happened.
2. **A permanent, un-appliable diff on `column.nullable`.** A view column's nullability is server-derived and regularly differs from the configured value (`SELECT 1 AS id` yields a `NOT NULL` column, while the schema default is `nullable = true`).

### Fix

For views, the provider now:

- applies **only** column comments, via `COMMENT ON COLUMN`
- matches columns **by name** instead of by position
- **re-applies the configured comments whenever the view definition changes**, so an edit to the query converges in a single apply
- never emits `NOT NULL`, `ADD COLUMN`, `DROP COLUMN`, `RENAME COLUMN` or `ALTER COLUMN`
- suppresses diffs on `column.nullable`

Table behaviour is unchanged: `NOT NULL` in `CREATE`, positional matching, and `ALTER TABLE ... ALTER COLUMN ... SET/DROP NOT NULL` on update all still apply.

### Relationship to #5855 and #5856

- #5855 (merged) fixed the comment path by special-casing `VIEW` inside `alterExistingColumnStatements`. **This PR subsumes that**: views no longer reach that function, so the branch is removed and the whole VIEW column path lives in one place. That fix's behaviour is preserved and covered by the existing `TestResourceSqlTableUpdateView_ColumnComment`.
- #5856 covered only the nullability half of this. I am closing it in favour of this PR, since the two halves are the same root cause and splitting them means the second one has to be rebased onto the first.

## Note on a changed assertion

`TestResourceSqlTableCreateStatement_ViewWithComments` asserted that `CREATE VIEW` emits `NOT NULL`:

```go
assert.Contains(t, stmt, "(`id`  NOT NULL, `name`  NOT NULL COMMENT 'a comment')")
```

That is the bug — Databricks rejects the statement — so the assertion is inverted rather than kept.

## Tests

Five new tests in `catalog/resource_sql_table_test.go`:

| Test | Covers |
|---|---|
| `..._NullabilityIsNotManaged` | no `NOT NULL` in `CREATE VIEW`, no `ALTER COLUMN` on update |
| `..._ColumnCommentsRestoredAfterDefinitionChange` | comments re-applied in the same run as `ALTER VIEW ... AS` |
| `..._ColumnMembershipChangeEmitsNoDDL` | no `ADD`/`DROP COLUMN` when the query changes the column set |
| `..._ColumnsMatchedByNameNotPosition` | reordering emits no `RENAME COLUMN` |
| `..._UnknownColumnIsNotCommented` | a configured column the view lacks is skipped rather than failing the apply |

All five fail without the change; the `catalog` package passes with it.

## How the SQL surface was established

Run against a live Databricks workspace (SQL warehouse, throwaway view in a sandbox schema, since removed):

| Statement | Result |
|---|---|
| `ALTER VIEW v AS <new query>`, then read `information_schema.columns` | every column comment becomes `NULL` |
| `COMMENT ON COLUMN v.col IS '...'` | succeeds, including on a `NOT NULL` view column |
| `ALTER VIEW v ADD COLUMN c INT` | `PARSE_SYNTAX_ERROR` |
| `ALTER VIEW v AS SELECT 1 AS a COMMENT 'x'` | `PARSE_SYNTAX_ERROR` (comments cannot be carried in the query) |

The last row is why the comments have to be re-applied as separate statements after `ALTER VIEW ... AS` rather than folded into it.
