### PR TITLE
Fix databricks_pipeline dropping serverless=false for classic ingestion pipelines

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Bug Fixes
 
+* Fixed `databricks_pipeline` dropping `serverless = false` from create/update requests. Because `serverless` is `omitempty` in the SDK and was never force-sent, classic (non-serverless) ingestion pipelines failed with `cannot provide cluster settings when using serverless compute` (the API defaults an omitted `serverless` to `true` for ingestion pipelines, then rejects the `cluster` block).
+
 ### Documentation
 
 ### Exporter

--- a/pipelines/resource_pipeline.go
+++ b/pipelines/resource_pipeline.go
@@ -39,6 +39,11 @@ func Create(w *databricks.WorkspaceClient, ctx context.Context, d *schema.Resour
 	var createPipelineRequest createPipelineRequestStruct
 	common.DataToStructPointer(d, pipelineSchema, &createPipelineRequest)
 	adjustForceSendFields(&createPipelineRequest.Clusters)
+	// `serverless` is `omitempty` in the SDK, so `serverless = false` is dropped
+	// from the request. For ingestion pipelines the API then defaults serverless
+	// to true and rejects the `clusters` block with "cannot provide cluster
+	// settings when using serverless compute". Always send the configured value.
+	createPipelineRequest.ForceSendFields = append(createPipelineRequest.ForceSendFields, "Serverless")
 
 	createdPipeline, err := w.Pipelines.Create(ctx, createPipelineRequest.CreatePipeline)
 	if err != nil {
@@ -71,6 +76,9 @@ func Update(w *databricks.WorkspaceClient, ctx context.Context, d *schema.Resour
 	common.DataToStructPointer(d, pipelineSchema, &updatePipelineRequest)
 	updatePipelineRequest.EditPipeline.PipelineId = d.Id()
 	adjustForceSendFields(&updatePipelineRequest.Clusters)
+	// See Create: force-send `serverless` so `serverless = false` is not dropped
+	// from the edit request (which would flip ingestion pipelines to serverless).
+	updatePipelineRequest.ForceSendFields = append(updatePipelineRequest.ForceSendFields, "Serverless")
 	err := w.Pipelines.Update(ctx, updatePipelineRequest.EditPipeline)
 	if err != nil {
 		return err

--- a/pipelines/resource_pipeline_test.go
+++ b/pipelines/resource_pipeline_test.go
@@ -45,8 +45,9 @@ var createRequest = pipelines.CreatePipeline{
 		Kind:             "BUNDLE",
 		MetadataFilePath: "/foo/bar",
 	},
-	Edition: "ADVANCED",
-	Channel: "CURRENT",
+	Edition:         "ADVANCED",
+	Channel:         "CURRENT",
+	ForceSendFields: []string{"Serverless"},
 }
 
 var updateRequest = pipelines.EditPipeline{
@@ -64,8 +65,9 @@ var updateRequest = pipelines.EditPipeline{
 	Filters: &pipelines.Filters{
 		Include: []string{"com.databricks.include"},
 	},
-	Channel: "CURRENT",
-	Edition: "ADVANCED",
+	Channel:         "CURRENT",
+	Edition:         "ADVANCED",
+	ForceSendFields: []string{"Serverless"},
 }
 
 var basicPipelineSpec = pipelines.PipelineSpec{
@@ -163,6 +165,86 @@ func TestResourcePipelineCreate(t *testing.T) {
 		"last_modified": 123456,
 		"state":         "RUNNING",
 	})
+}
+
+func TestResourcePipelineCreateClassicIngestion(t *testing.T) {
+	// Regression test: a classic (serverless = false) ingestion pipeline must
+	// send serverless=false explicitly. PipelineSpec.Serverless is `omitempty`,
+	// so without ForceSendFields the field is dropped from the request and the
+	// API defaults ingestion pipelines to serverless, then rejects the cluster
+	// block with "cannot provide cluster settings when using serverless compute".
+	d, err := qa.ResourceFixture{
+		MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
+			e := w.GetMockPipelinesAPI().EXPECT()
+			e.Create(mock.Anything, pipelines.CreatePipeline{
+				Name:    "test-ingestion",
+				Channel: "CURRENT",
+				Edition: "ADVANCED",
+				Clusters: []pipelines.PipelineCluster{
+					{
+						Label: "default",
+						Autoscale: &pipelines.PipelineClusterAutoscale{
+							MinWorkers: 1,
+							MaxWorkers: 2,
+							Mode:       "ENHANCED",
+						},
+					},
+				},
+				IngestionDefinition: &pipelines.IngestionPipelineDefinition{
+					ConnectionName: "my_connection",
+					Objects: []pipelines.IngestionConfig{
+						{
+							Table: &pipelines.TableSpec{
+								SourceSchema:       "public",
+								SourceTable:        "orders",
+								DestinationCatalog: "main",
+								DestinationSchema:  "bronze",
+							},
+						},
+					},
+				},
+				ForceSendFields: []string{"Serverless"},
+			}).Return(&pipelines.CreatePipelineResponse{
+				PipelineId: "abcd",
+			}, nil)
+			e.Get(mock.Anything, pipelines.GetPipelineRequest{
+				PipelineId: "abcd",
+			}).Return(&pipelines.GetPipelineResponse{
+				PipelineId: "abcd",
+				Name:       "test-ingestion",
+				State:      pipelines.PipelineStateRunning,
+				Spec: &pipelines.PipelineSpec{
+					Name: "test-ingestion",
+				},
+			}, nil)
+		},
+		Resource: ResourcePipeline(),
+		Create:   true,
+		HCL: `
+			name = "test-ingestion"
+			cluster {
+			  label = "default"
+			  autoscale {
+			    min_workers = 1
+			    max_workers = 2
+			    mode        = "ENHANCED"
+			  }
+			}
+			ingestion_definition {
+			  connection_name = "my_connection"
+			  objects {
+			    table {
+			      source_schema       = "public"
+			      source_table        = "orders"
+			      destination_catalog = "main"
+			      destination_schema  = "bronze"
+			    }
+			  }
+			}
+		`,
+	}.Apply(t)
+	assert.NoError(t, err)
+	assert.Equal(t, "abcd", d.Id())
 }
 
 func TestResourcePipelineCreate_Error(t *testing.T) {
@@ -675,6 +757,7 @@ func TestZeroWorkers(t *testing.T) {
 						ForceSendFields: []string{"NumWorkers"},
 					},
 				},
+				ForceSendFields: []string{"Serverless"},
 			}).Return(&pipelines.CreatePipelineResponse{
 				PipelineId: "abcd",
 			}, nil)
@@ -728,6 +811,7 @@ func TestAutoscaling(t *testing.T) {
 						},
 					},
 				},
+				ForceSendFields: []string{"Serverless"},
 			}).Return(&pipelines.CreatePipelineResponse{
 				PipelineId: "abcd",
 			}, nil)
@@ -777,6 +861,7 @@ func TestDefault(t *testing.T) {
 						Label: "default",
 					},
 				},
+				ForceSendFields: []string{"Serverless"},
 			}).Return(&pipelines.CreatePipelineResponse{
 				PipelineId: "abcd",
 			}, nil)
@@ -846,8 +931,9 @@ func TestUpdatePipelineCatalogInPlace(t *testing.T) {
 				Filters: &pipelines.Filters{
 					Include: []string{"com.databricks.include"},
 				},
-				Channel: "CURRENT",
-				Edition: "ADVANCED",
+				Channel:         "CURRENT",
+				Edition:         "ADVANCED",
+				ForceSendFields: []string{"Serverless"},
 			}).Return(nil)
 			e.Get(mock.Anything, pipelines.GetPipelineRequest{
 				PipelineId: "abcd",


### PR DESCRIPTION
### Changes

`PipelineSpec.Serverless` is `json:"serverless,omitempty"` in databricks-sdk-go and the pipeline resource never adds it to `ForceSendFields` (it only force-sends `NumWorkers`). As a result `serverless = false` is dropped from create/update requests. For managed ingestion pipelines (`ingestion_definition`) the API defaults an omitted `serverless` to `true`, then rejects the `cluster` block with:

> cannot provide cluster settings when using serverless compute

This makes classic (non-serverless) ingestion pipelines impossible to **create or update** via Terraform - even though `databricks pipelines get` shows `serverless: false` with a valid `clusters` block, and such pipelines run fine when created in the UI. Classic compute is required when the ingestion source lives in a private VPC that serverless compute cannot reach.

The fix force-sends `Serverless` in both `Create` and `Update` so the configured value (including `false`) is always sent.

### Tests

- Updated existing create/update request assertions to expect `ForceSendFields: ["Serverless"]`.
- Added `TestResourcePipelineCreateClassicIngestion` covering a classic `serverless = false` pipeline with a `cluster` + `ingestion_definition`.
- `make fmt`, `go build ./...`, `go test ./pipelines/...` all pass.