### PR TITLE
docs: fix service principal authentication link

### DIFF
--- a/docs/resources/service_principal_secret.md
+++ b/docs/resources/service_principal_secret.md
@@ -9,7 +9,7 @@ With this resource you can create a secret for a given [Service Principals](http
 
 -> This resource can only be used with an account-level or workspace-level provider!
 
-This secret can be used to configure the Databricks Terraform Provider to authenticate with the service principal. See [Authenticating with service principal](../index.md#authenticating-with-service-principal).
+This secret can be used to configure the Databricks Terraform Provider to authenticate with the service principal. See [Authenticating with a Databricks-managed service principal](https://registry.terraform.io/providers/databricks/databricks/latest/docs#authenticating-with-databricks-managed-service-principal).
 
 Additionally, the secret can be used to request OAuth tokens for the service principal, which can be used to authenticate to Databricks REST APIs. See [Authentication using OAuth tokens for service principals](https://docs.databricks.com/dev-tools/authentication-oauth.html).
 


### PR DESCRIPTION
## Changes

Fix the authentication link in the `databricks_service_principal_secret` documentation so Terraform Registry routes to the provider overview and the current Databricks-managed service principal section.

Fixes #3218

NO_CHANGELOG=true

## Tests

- [ ] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] using Go SDK
- [ ] using TF Plugin Framework
- [ ] has entry in `NEXT_CHANGELOG.md` file

Validation performed:
- `terrafmt diff --check docs/resources/service_principal_secret.md`
- `make ws`
- `git diff --check`