### PR TITLE
Use a 600s HTTP timeout for databricks_repo git operations

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -9,6 +9,7 @@
 ### New Features and Improvements
 
 ### Bug Fixes
+* Default to a 600 second HTTP timeout for `databricks_repo` operations that run git commands inline (the clone on create and the branch/tag checkout on update), so larger repositories no longer fail with `request timed out after 1m5s of inactivity`. An explicitly configured `http_timeout_seconds` still takes precedence.
 
 ### Documentation
 

--- a/common/client.go
+++ b/common/client.go
@@ -10,10 +10,12 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/databricks/databricks-sdk-go"
 	"github.com/databricks/databricks-sdk-go/client"
 	"github.com/databricks/databricks-sdk-go/config"
+	"github.com/databricks/databricks-sdk-go/httpclient"
 	"github.com/databricks/databricks-sdk-go/service/iam"
 	"github.com/databricks/databricks-sdk-go/service/provisioning"
 	"github.com/golang-jwt/jwt/v4"
@@ -91,6 +93,20 @@ type DatabricksClient struct {
 	// This is used by legacy SDKv2 resources and data sources not using Go SDK where
 	// a new client is created.
 	muLegacy sync.Mutex
+
+	// httpTimeoutSetByUser records whether http_timeout_seconds came from the
+	// provider configuration rather than the built-in default. Endpoints that
+	// raise their own default timeout must not override an explicit choice —
+	// see ClientWithDefaultHTTPTimeout. This cannot be inferred from
+	// Config.HTTPTimeoutSeconds, which is always populated by the time resource
+	// code runs.
+	httpTimeoutSetByUser bool
+}
+
+// SetHTTPTimeoutSetByUser records that http_timeout_seconds was explicitly
+// configured. Called once during provider configuration.
+func (c *DatabricksClient) SetHTTPTimeoutSetByUser(v bool) {
+	c.httpTimeoutSetByUser = v
 }
 
 // GetWorkspaceClientForUnifiedProviderWithDiagnostics returns the Databricks
@@ -839,8 +855,54 @@ func (c *DatabricksClient) ClientForHost(ctx context.Context, url string) (*Data
 	}
 	// copy all client configuration options except Databricks CLI profile
 	return &DatabricksClient{
-		DatabricksClient: client,
-		commandFactory:   c.commandFactory,
+		DatabricksClient:     client,
+		commandFactory:       c.commandFactory,
+		httpTimeoutSetByUser: c.httpTimeoutSetByUser,
+	}, nil
+}
+
+// ClientWithDefaultHTTPTimeout returns a DatabricksClient whose HTTP inactivity
+// timeout is defaultTimeoutSeconds, for endpoints whose own default should be
+// higher than the provider-wide one because they are inherently slow.
+//
+// An explicit http_timeout_seconds always wins, in either direction: a user who
+// lowered it to fail fast keeps that, and one who raised it keeps that too. The
+// endpoint default only applies when the setting was left unset.
+//
+// The SDK reads HTTPTimeout once, when the underlying http client is built, and
+// offers no per-request override, so a derived client is required.
+//
+// Prefer this over raising the provider-wide default. That default is
+// deliberately just above the ~60s server-side timeout most APIs have, so the
+// server's own error message wins the race and reaches the user instead of a
+// generic client-side timeout (see #4628). Raising it globally would forfeit
+// that for every fast endpoint.
+func (c *DatabricksClient) ClientWithDefaultHTTPTimeout(defaultTimeoutSeconds int) (*DatabricksClient, error) {
+	// A nil inner client means the wrapper was hand-built without a config
+	// (some unit-test harnesses do this); there is no timeout to change.
+	if c.DatabricksClient == nil || c.Config == nil {
+		return c, nil
+	}
+	if c.httpTimeoutSetByUser || c.Config.HTTPTimeoutSeconds == defaultTimeoutSeconds {
+		return c, nil
+	}
+	// Reuse the same *config.Config rather than copying it: the config carries
+	// resolved auth state behind a mutex, so only the derived httpclient config
+	// (a plain value) is adjusted. This also preserves any custom HTTPTransport,
+	// which unit-test fixtures rely on to intercept requests.
+	clientCfg, err := config.HTTPClientConfigFromConfig(c.Config)
+	if err != nil {
+		return nil, fmt.Errorf("cannot derive client config: %w", err)
+	}
+	clientCfg.HTTPTimeout = time.Duration(defaultTimeoutSeconds) * time.Second
+	inner, err := client.NewWithClient(c.Config, httpclient.NewApiClient(clientCfg))
+	if err != nil {
+		return nil, fmt.Errorf("cannot configure client with %ds HTTP timeout: %w", defaultTimeoutSeconds, err)
+	}
+	return &DatabricksClient{
+		DatabricksClient:     inner,
+		commandFactory:       c.commandFactory,
+		httpTimeoutSetByUser: c.httpTimeoutSetByUser,
 	}, nil
 }
 

--- a/common/client_test.go
+++ b/common/client_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -789,4 +790,89 @@ func TestCurrentWorkspaceID_ReturnsCachedValue(t *testing.T) {
 	id2, err := c.CurrentWorkspaceID(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, int64(12345), id2)
+}
+
+func TestClientWithDefaultHTTPTimeout_RaisesUnsetTimeout(t *testing.T) {
+	c := &DatabricksClient{
+		DatabricksClient: &client.DatabricksClient{
+			Config: &config.Config{
+				Host:  "https://e2-workspace.cloud.databricks.com/",
+				Token: "dapi123",
+				// 65 is the provider default, not a user choice.
+				HTTPTimeoutSeconds: 65,
+			},
+		},
+	}
+	cc, err := c.ClientWithDefaultHTTPTimeout(600)
+	require.NoError(t, err)
+	assert.NotSame(t, c, cc, "a new client is required, as the SDK reads the timeout once")
+	// The config is shared, so raising the timeout must not mutate the original
+	// client's view of it.
+	assert.Equal(t, 65, c.Config.HTTPTimeoutSeconds)
+}
+
+func TestClientWithDefaultHTTPTimeout_RespectsUserTimeout(t *testing.T) {
+	// An explicit http_timeout_seconds wins in either direction: a user who
+	// lowered it to fail fast keeps that, and one who raised it keeps that too.
+	for _, userTimeout := range []int{30, 1200} {
+		c := &DatabricksClient{
+			DatabricksClient: &client.DatabricksClient{
+				Config: &config.Config{
+					Host:               "https://e2-workspace.cloud.databricks.com/",
+					Token:              "dapi123",
+					HTTPTimeoutSeconds: userTimeout,
+				},
+			},
+		}
+		c.SetHTTPTimeoutSetByUser(true)
+		cc, err := c.ClientWithDefaultHTTPTimeout(600)
+		require.NoError(t, err)
+		assert.Same(t, c, cc, "explicit http_timeout_seconds=%d must not be overridden", userTimeout)
+	}
+}
+
+func TestClientWithDefaultHTTPTimeout_NoConfig(t *testing.T) {
+	c := &DatabricksClient{}
+	cc, err := c.ClientWithDefaultHTTPTimeout(600)
+	require.NoError(t, err)
+	assert.Same(t, c, cc)
+}
+
+// TestClientWithDefaultHTTPTimeout_OutlastsShortTimeout proves the derived
+// client actually waits longer: the server stalls past the original timeout,
+// which would fail the request on the parent client.
+func TestClientWithDefaultHTTPTimeout_OutlastsShortTimeout(t *testing.T) {
+	// HTTPTimeoutSeconds has second granularity, so the stall has to exceed 1s
+	// to be distinguishable from the shortest configurable timeout.
+	serverDelay := 1200 * time.Millisecond
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(serverDelay)
+		w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+
+	newClient := func(timeoutSeconds int) *DatabricksClient {
+		cfg := &config.Config{
+			Host:               server.URL,
+			Token:              "dapi123",
+			HTTPTimeoutSeconds: timeoutSeconds,
+			// Fail fast instead of retrying the timed-out request for minutes.
+			RetryTimeoutSeconds: 1,
+		}
+		inner, err := client.New(cfg)
+		require.NoError(t, err)
+		return &DatabricksClient{DatabricksClient: inner}
+	}
+
+	// A timeout shorter than the server delay fails...
+	var resp map[string]any
+	short := newClient(1)
+	shortErr := short.Get(context.Background(), "/repos", nil, &resp)
+	require.Error(t, shortErr)
+	assert.Contains(t, shortErr.Error(), "inactivity")
+
+	// ...and the same request succeeds once the timeout is raised.
+	raised, err := short.ClientWithDefaultHTTPTimeout(600)
+	require.NoError(t, err)
+	require.NoError(t, raised.Get(context.Background(), "/repos", nil, &resp))
 }

--- a/common/unified_provider.go
+++ b/common/unified_provider.go
@@ -387,8 +387,9 @@ func (c *DatabricksClient) getDatabricksClientForUnifiedProvider(ctx context.Con
 	//    cache so that WorkspaceClient() returns it without recreating.
 	newDatabricksClient := func(dc *client.DatabricksClient) *DatabricksClient {
 		result := &DatabricksClient{
-			DatabricksClient: dc,
-			commandFactory:   c.commandFactory,
+			DatabricksClient:     dc,
+			commandFactory:       c.commandFactory,
+			httpTimeoutSetByUser: c.httpTimeoutSetByUser,
 		}
 		if wc, ok := c.cachedWorkspaceClients[parsedID]; ok {
 			result.cachedWorkspaceClient = wc

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -278,4 +278,5 @@ You may see several different kinds of timeout messages when using the Terraform
      http_timeout_seconds = 120
    }
    ```
+   A few endpoints that are inherently slow default to a longer timeout, because 65 seconds is not enough to complete them. `databricks_repo` runs git commands inline — cloning on create and checking out a branch or tag on update — so those calls default to 600 seconds. Setting `http_timeout_seconds` explicitly always takes precedence, whether higher or lower.
 3. The **API proxy timeout** is a server-side timeout that controls how long to wait for backend service to handle an API request. This timeout is configured by each API team at Databricks for their API endpoints. If this timeout is exceeded, users see a message like `The service at ... is taking too long to process your request. Please try again later or try a faster operation.`. Users cannot modify this timeout: it is configured by a Databricks team responsible for the backend service. If users see this error, they should reach out to Databricks support to investigate the issue.

--- a/internal/providers/client/databricks_client.go
+++ b/internal/providers/client/databricks_client.go
@@ -98,6 +98,7 @@ func PrepareDatabricksClient(ctx context.Context, cfg *config.Config, configCust
 	}
 	// If not set, the default provider timeout is 65 seconds. Most APIs have a server-side timeout of 60 seconds.
 	// The additional 5 seconds is to account for network latency.
+	httpTimeoutSetByUser := cfg.HTTPTimeoutSeconds != 0
 	if cfg.HTTPTimeoutSeconds == 0 {
 		cfg.HTTPTimeoutSeconds = 65
 	}
@@ -125,6 +126,7 @@ func PrepareDatabricksClient(ctx context.Context, cfg *config.Config, configCust
 	pc := &common.DatabricksClient{
 		DatabricksClient: client,
 	}
+	pc.SetHTTPTimeoutSetByUser(httpTimeoutSetByUser)
 	// For workspace hosts, reconcile the user-supplied workspace_id against the
 	// host's discovery metadata and seed the cache so the SCIM /Me call is avoided.
 	if err := pc.ReconcileWorkspaceIDFromHostMetadata(pc.HostTypeForTerraform(), captured.userWorkspaceID, captured.hostWorkspaceID); err != nil {

--- a/internal/providers/sdkv2/sdkv2_test.go
+++ b/internal/providers/sdkv2/sdkv2_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestPluginFrameworkOptInsExistInSdkV2 asserts that every resource and data
@@ -44,6 +45,10 @@ func TestConfigureDatabricksClient(t *testing.T) {
 			config: map[string]interface{}{},
 			validateResourceData: func(dc *common.DatabricksClient) {
 				assert.Equal(t, 65, dc.Config.HTTPTimeoutSeconds, "HTTP timeout should be 65 seconds by default")
+				// An unset timeout lets slow endpoints apply their own default.
+				raised, err := dc.ClientWithDefaultHTTPTimeout(600)
+				require.NoError(t, err)
+				assert.NotSame(t, dc, raised, "endpoint default should apply when http_timeout_seconds is unset")
 			},
 		},
 		{
@@ -53,6 +58,11 @@ func TestConfigureDatabricksClient(t *testing.T) {
 			},
 			validateResourceData: func(dc *common.DatabricksClient) {
 				assert.Equal(t, 30, dc.Config.HTTPTimeoutSeconds, "HTTP timeout should be overridden when set")
+				// An explicit timeout wins over any endpoint default, so a user
+				// who lowered it to fail fast keeps that behavior.
+				raised, err := dc.ClientWithDefaultHTTPTimeout(600)
+				require.NoError(t, err)
+				assert.Same(t, dc, raised, "explicit http_timeout_seconds must not be overridden")
 			},
 		},
 		{

--- a/repos/resource_repo.go
+++ b/repos/resource_repo.go
@@ -14,6 +14,13 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
+// repoCloneTimeoutSeconds is the HTTP inactivity timeout used for calls that do
+// git work inline: the clone in CreateRepo and the checkout in UpdateRepo. Both
+// are synchronous and unbounded by repo size, and the backend budgets ~10
+// minutes for checkout, so the provider default of 65s is not enough for larger
+// repositories.
+const repoCloneTimeoutSeconds = 600
+
 // ReposAPI exposes the Repos API
 type ReposAPI struct {
 	client  *common.DatabricksClient
@@ -68,7 +75,13 @@ func (a ReposAPI) Create(r reposCreateRequest) (ReposInformation, error) {
 		}
 	}
 
-	err := a.client.Post(a.context, "/repos", r, &resp, a.client.AddWorkspaceIdHeader)
+	// The clone happens inline in this request, so it needs a longer HTTP
+	// timeout than the rest of the Repos API.
+	client, err := a.client.ClientWithDefaultHTTPTimeout(repoCloneTimeoutSeconds)
+	if err != nil {
+		return resp, err
+	}
+	err = client.Post(a.context, "/repos", r, &resp, client.AddWorkspaceIdHeader)
 	return resp, err
 }
 
@@ -82,6 +95,7 @@ func (a ReposAPI) Update(id string, r map[string]any) error {
 	}
 	// TODO: update may change ONE OF (url AND provider (optional)), (path), or (branch OR tag).
 	// for URL/provider force re-create as there are limits on what could be done for changing URL/provider
+	// Moving a Git folder only renames it, so it keeps the default timeout.
 	if path, ok := r["path"]; ok {
 		err := a.client.Patch(a.context, fmt.Sprintf("/repos/%s", id), map[string]any{"path": path}, a.client.AddWorkspaceIdHeader)
 		if err != nil {
@@ -89,7 +103,13 @@ func (a ReposAPI) Update(id string, r map[string]any) error {
 		}
 		delete(r, "path")
 	}
-	return a.client.Patch(a.context, fmt.Sprintf("/repos/%s", id), r, a.client.AddWorkspaceIdHeader)
+	// Switching branch or tag checks out the new ref inline, so this needs the
+	// same longer timeout as the clone in Create.
+	client, err := a.client.ClientWithDefaultHTTPTimeout(repoCloneTimeoutSeconds)
+	if err != nil {
+		return err
+	}
+	return client.Patch(a.context, fmt.Sprintf("/repos/%s", id), r, client.AddWorkspaceIdHeader)
 }
 
 func (a ReposAPI) Read(id string) (ReposInformation, error) {

--- a/repos/resource_repo_test.go
+++ b/repos/resource_repo_test.go
@@ -4,10 +4,15 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/databricks/databricks-sdk-go/apierr"
+	"github.com/databricks/databricks-sdk-go/client"
+	"github.com/databricks/databricks-sdk-go/config"
 
+	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/databricks/terraform-provider-databricks/qa"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -650,4 +655,62 @@ func TestReposListWithPrefix(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, len(reposList), 1)
 	assert.Equal(t, resp.Branch, reposList[0].Branch)
+}
+
+// TestReposCreateRaisesHTTPTimeout verifies the clone performed by CreateRepo
+// survives a stall longer than the client's configured HTTP timeout, which is
+// the failure customers hit with the provider's 65s default.
+func TestReposCreateRaisesHTTPTimeout(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/2.0/repos" && r.Method == http.MethodPost {
+			// Stall past the 1s timeout configured below.
+			time.Sleep(1200 * time.Millisecond)
+			w.Write([]byte(`{"id": 123, "url": "https://github.com/user/repo.git", "provider": "gitHub"}`))
+			return
+		}
+		w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+
+	inner, err := client.New(&config.Config{
+		Host:               server.URL,
+		Token:              "dapi123",
+		HTTPTimeoutSeconds: 1,
+		// Fail fast rather than retrying a timed-out request for minutes.
+		RetryTimeoutSeconds: 1,
+	})
+	require.NoError(t, err)
+
+	api := NewReposAPI(context.Background(), &common.DatabricksClient{DatabricksClient: inner})
+	resp, err := api.Create(reposCreateRequest{Url: "https://github.com/user/repo.git", Provider: "gitHub"})
+	require.NoError(t, err)
+	assert.Equal(t, int64(123), resp.ID)
+}
+
+// TestReposUpdateRaisesHTTPTimeout verifies switching branch survives a stall
+// longer than the configured timeout: the checkout happens inline, just like
+// the clone in Create.
+func TestReposUpdateRaisesHTTPTimeout(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/2.0/repos/123" && r.Method == http.MethodPatch {
+			// Stall past the 1s timeout configured below.
+			time.Sleep(1200 * time.Millisecond)
+			w.Write([]byte(`{}`))
+			return
+		}
+		w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+
+	inner, err := client.New(&config.Config{
+		Host:               server.URL,
+		Token:              "dapi123",
+		HTTPTimeoutSeconds: 1,
+		// Fail fast rather than retrying a timed-out request for minutes.
+		RetryTimeoutSeconds: 1,
+	})
+	require.NoError(t, err)
+
+	api := NewReposAPI(context.Background(), &common.DatabricksClient{DatabricksClient: inner})
+	require.NoError(t, api.Update("123", map[string]any{"branch": "releases"}))
 }


### PR DESCRIPTION
## Changes

This change carries the work from #5912.

`databricks_repo` runs git inline on create (`POST /repos` clone) and update (`PATCH /repos/{id}` branch/tag checkout), but both were capped by the provider's default 65s HTTP timeout. The backend budgets ~10 minutes, so cloning a larger repo failed client-side (`request timed out after 1m5s of inactivity`) even though it would have succeeded.

Both calls now default to a 600s timeout via `ClientWithDefaultHTTPTimeout`. Raising it per-endpoint rather than globally is deliberate — the provider-wide 65s sits just above the ~60s server timeout so the server's own error reaches the user (#4628); repos is the exception because its budget is ~10 min. An explicit `http_timeout_seconds` still wins in either direction. The `path`-move `PATCH` only renames a folder, so it keeps the default.

## Tests

- `TestReposCreate/UpdateRaisesHTTPTimeout`: stall past the timeout, assert the call still succeeds (both verified to fail without the fix).
- `common` tests: unset case, explicit override in both directions, and that the derived client outlasts a stall the parent fails on.

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] using Go SDK
- [ ] using TF Plugin Framework
- [x] has entry in `NEXT_CHANGELOG.md` file

This pull request and its description were written by Isaac.
