### PR TITLE
Allow MINUTES as a databricks_job periodic trigger unit

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -8,6 +8,10 @@
 
 ### New Features and Improvements
 
+* Allow `MINUTES` as a `unit` for the `databricks_job` `trigger.periodic` block ([#5972](https://github.com/databricks/terraform-provider-databricks/pull/5972)).
+
+  The Jobs API accepts and schedules minute-based periodic triggers, but the provider rejected them during validation.
+
 ### Bug Fixes
 * Default to a 600 second HTTP timeout for `databricks_repo` operations that run git commands inline (the clone on create and the branch/tag checkout on update), so larger repositories no longer fail with `request timed out after 1m5s of inactivity`. An explicitly configured `http_timeout_seconds` still takes precedence.
 

--- a/docs/resources/job.md
+++ b/docs/resources/job.md
@@ -437,7 +437,7 @@ This block describes the queue settings of the job:
 * `pause_status` - (Optional) Indicate whether this trigger is paused or not. Either `PAUSED` or `UNPAUSED`. When the `pause_status` field is omitted in the block, the server will default to using `UNPAUSED` as a value for `pause_status`.
 * `periodic` - (Optional) configuration block to define a trigger for Periodic Triggers consisting of the following attributes:
   * `interval` - (Required, integer) Specifies the interval at which the job should run.
-  * `unit` - (Required, string) The unit of time for the interval.  Possible values are: `DAYS`, `HOURS`, `WEEKS`.
+  * `unit` - (Required, string) The unit of time for the interval.  Possible values are: `DAYS`, `HOURS`, `MINUTES`, `WEEKS`.
 * `file_arrival` - (Optional) configuration block to define a trigger for [File Arrival events](https://learn.microsoft.com/en-us/azure/databricks/workflows/jobs/file-arrival-triggers) consisting of following attributes:
   * `url` - (Required) URL to be monitored for file arrivals. The path must point to the root or a subpath of the external location. Please note that the URL must have a trailing slash character (`/`).
   * `min_time_between_triggers_seconds` - (Optional, integer) If set, the trigger starts a run only after the specified amount of time passed since the last time the trigger fired. The minimum allowed value is 60 seconds.

--- a/jobs/resource_job.go
+++ b/jobs/resource_job.go
@@ -597,7 +597,7 @@ func (JobSettingsResource) CustomizeSchema(s *common.CustomizableSchema) *common
 	s.SchemaPath("trigger", "periodic").SetExactlyOneOf(trigger_eoo)
 
 	s.SchemaPath("trigger", "periodic", "interval").SetValidateDiagFunc(validation.ToDiagFunc(validation.IntAtLeast(1)))                          // .SetRequired()
-	s.SchemaPath("trigger", "periodic", "unit").SetValidateFunc(validation.StringInSlice([]string{"DAYS", "HOURS", "WEEKS"}, false))              //.SetRequired()
+	s.SchemaPath("trigger", "periodic", "unit").SetValidateFunc(validation.StringInSlice([]string{"DAYS", "HOURS", "MINUTES", "WEEKS"}, false))   //.SetRequired()
 	s.SchemaPath("trigger", "file_arrival", "url").SetValidateFunc(validation.StringIsNotEmpty)                                                   // .SetRequired()
 	s.SchemaPath("trigger", "table_update", "table_names").SetMinItems(1)                                                                         //.SetRequired()
 	s.SchemaPath("trigger", "table_update", "condition").SetValidateFunc(validation.StringInSlice([]string{"ANY_UPDATED", "ALL_UPDATED"}, false)) // .SetRequired()

--- a/jobs/resource_job_test.go
+++ b/jobs/resource_job_test.go
@@ -1795,6 +1795,62 @@ func TestResourceJobCreate_Trigger_PeriodicCreate(t *testing.T) {
 	}.ApplyNoError(t)
 }
 
+func TestResourceJobCreate_Trigger_PeriodicMinutesCreate(t *testing.T) {
+	qa.ResourceFixture{
+		Create:   true,
+		Resource: ResourceJob(),
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "POST",
+				Resource: "/api/2.0/jobs/create",
+				ExpectedRequest: JobSettings{
+					MaxConcurrentRuns: 1,
+					Name:              "Test",
+					Trigger: &Trigger{
+						PauseStatus: "UNPAUSED",
+						Periodic: &Periodic{
+							Interval: 15,
+							Unit:     "MINUTES",
+						},
+					},
+				},
+				Response: Job{
+					JobID: 1042,
+				},
+			},
+			{
+				Method:   "GET",
+				Resource: "/api/2.0/jobs/get?job_id=1042",
+				Response: Job{
+					JobID: 1042,
+					Settings: &JobSettings{
+						MaxConcurrentRuns: 1,
+						Name:              "Test",
+						Trigger: &Trigger{
+							PauseStatus: "UNPAUSED",
+							Periodic: &Periodic{
+								Interval: 15,
+								Unit:     "MINUTES",
+							},
+						},
+					},
+				},
+			},
+		},
+		HCL: `
+		trigger {
+			pause_status = "UNPAUSED"
+			periodic {
+				interval = 15
+				unit = "MINUTES"
+			}
+		}
+		max_concurrent_runs = 1
+		name = "Test"
+		`,
+	}.ApplyNoError(t)
+}
+
 func TestResourceJobUpdate_ControlRunState_ContinuousUpdateRunNow(t *testing.T) {
 	qa.ResourceFixture{
 		Update:   true,


### PR DESCRIPTION
## Changes

A `databricks_job` cannot be configured to run every N minutes, even though the Jobs API supports it.

The provider validates `trigger.periodic.unit` against `["DAYS", "HOURS", "WEEKS"]`, so a minute-based schedule fails at plan time:

```
Error: expected trigger.0.periodic.0.unit to be one of ["DAYS" "HOURS" "WEEKS"], got MINUTES
```

The API itself accepts and schedules it — a job created through the UI with

```json
{"trigger": {"periodic": {"interval": 15, "unit": "MINUTES"}}}
```

runs every 15 minutes. The Go SDK also already models the value: `PeriodicTriggerConfigurationTimeUnitMinutes = "MINUTES"` is defined in `service/jobs` and returned from that type's `Values()`. Only the provider's validation slice is out of date, so users have to fall back to a quartz cron string in `schedule` to express a sub-hourly period.

- Add `"MINUTES"` to the `validation.StringInSlice` for `trigger.periodic.unit` in `jobs/resource_job.go`.
- Document `MINUTES` as a possible value in `docs/resources/job.md`.

## Tests

New unit test `TestResourceJobCreate_Trigger_PeriodicMinutesCreate` in `jobs/resource_job_test.go`, covering create with `interval = 15` / `unit = "MINUTES"` (it fails against the old slice, since validation runs before the request is built).

```
$ go build ./...
$ go test ./jobs/... -run Trigger
--- PASS: TestResourceJobCreate_Trigger_PeriodicMinutesCreate (0.03s)
=== RUN   TestAccPeriodicTrigger
    init.go:391: Environment variable CLOUD_ENV is missing
--- SKIP: TestAccPeriodicTrigger (0.00s)
PASS
ok  	github.com/databricks/terraform-provider-databricks/jobs	1.283s
$ gofmt -l jobs/
(no output)
```

Acceptance tests were not run — no `CLOUD_ENV` / workspace available. `grep -rn '"WEEKS"' --include='*.go' --include='*.md' .` finds no other place enumerating these units.

- [x] `make test` run locally (`go build ./...` + `go test ./jobs/... -run Trigger`)
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [x] using Go SDK
- [ ] using TF Plugin Framework
- [x] has entry in `NEXT_CHANGELOG.md` file
