### PR TITLE
[WIP]Add `serverless_compute_id` to `databricks_permissions`

### DIFF
--- a/docs/resources/permissions.md
+++ b/docs/resources/permissions.md
@@ -112,6 +112,25 @@ resource "databricks_permissions" "policy_usage" {
 }
 ```
 
+## Serverless compute usage
+
+Valid [permission levels](https://docs.databricks.com/compute/serverless/manage-serverless-compute.html) for serverless compute objects are: `CAN_USE`.
+
+```hcl
+resource "databricks_group" "ds" {
+  display_name = "Data Science"
+}
+
+resource "databricks_permissions" "serverless_automated" {
+  serverless_compute_id = "<default-automated-compute-id>"
+
+  access_control {
+    group_name       = databricks_group.ds.display_name
+    permission_level = "CAN_USE"
+  }
+}
+```
+
 ## Instance Pool usage
 
 [Instance Pools](instance_pool.md) access control [allows to](https://docs.databricks.com/security/access-control/pool-acl.html) assign `CAN_ATTACH_TO` and `CAN_MANAGE` permissions to users, service principals, and groups. It's also possible to grant creation of Instance Pools to individual [groups](group.md#allow_instance_pool_create) and [users](user.md#allow_instance_pool_create), [service principals](service_principal.md#allow_instance_pool_create).
@@ -1066,6 +1085,7 @@ Exactly one of the following arguments is required:
 - `app_name` - [app](app.md) name
 - `cluster_id` - [cluster](cluster.md) id
 - `cluster_policy_id` - [cluster policy](cluster_policy.md) id
+- `serverless_compute_id` - serverless compute object id (`Default Interactive Compute` or `Default Automated Compute`)
 - `instance_pool_id` - [instance pool](instance_pool.md) id
 - `job_id` - [job](job.md) id
 - `pipeline_id` - [pipeline](pipeline.md) id

--- a/docs/resources/permissions.md
+++ b/docs/resources/permissions.md
@@ -114,7 +114,7 @@ resource "databricks_permissions" "policy_usage" {
 
 ## Serverless compute usage
 
-Valid [permission levels](https://docs.databricks.com/compute/serverless/manage-serverless-compute.html) for serverless compute objects are: `CAN_USE`.
+Valid [permission levels](https://docs.databricks.com/compute/serverless/manage-serverless-compute.html) for serverless compute objects are: `CAN_USE` and `CAN_MANAGE`.
 
 ```hcl
 resource "databricks_group" "ds" {

--- a/permissions/permission_definitions.go
+++ b/permissions/permission_definitions.go
@@ -358,7 +358,8 @@ func allResourcePermissions() []resourcePermissions {
 			objectType:        "serverless-compute",
 			requestObjectType: "serverless-compute",
 			allowedPermissionLevels: map[string]permissionLevelOptions{
-				"CAN_USE": {isManagementPermission: true},
+				"CAN_USE":    {isManagementPermission: false},
+				"CAN_MANAGE": {isManagementPermission: true},
 			},
 		},
 		{

--- a/permissions/permission_definitions.go
+++ b/permissions/permission_definitions.go
@@ -354,6 +354,14 @@ func allResourcePermissions() []resourcePermissions {
 			},
 		},
 		{
+			field:             "serverless_compute_id",
+			objectType:        "serverless-compute",
+			requestObjectType: "serverless-compute",
+			allowedPermissionLevels: map[string]permissionLevelOptions{
+				"CAN_USE": {isManagementPermission: true},
+			},
+		},
+		{
 			field:             "instance_pool_id",
 			objectType:        "instance-pool",
 			requestObjectType: "instance-pools",

--- a/permissions/resource_permissions_test.go
+++ b/permissions/resource_permissions_test.go
@@ -645,7 +645,7 @@ func TestResourcePermissionsCreate_invalid(t *testing.T) {
 	qa.ResourceFixture{
 		Resource: ResourcePermissions(),
 		Create:   true,
-	}.ExpectError(t, "at least one type of resource identifier must be set; allowed fields: alert_v2_id, app_name, authorization, cluster_id, cluster_policy_id, dashboard_id, database_instance_name, database_project_name, directory_id, directory_path, experiment_id, instance_pool_id, job_id, knowledge_assistant_id, notebook_id, notebook_path, pipeline_id, registered_model_id, repo_id, repo_path, serving_endpoint_id, sql_alert_id, sql_dashboard_id, sql_endpoint_id, sql_query_id, supervisor_agent_id, vector_search_endpoint_id, workspace_file_id, workspace_file_path")
+	}.ExpectError(t, "at least one type of resource identifier must be set; allowed fields: alert_v2_id, app_name, authorization, cluster_id, cluster_policy_id, dashboard_id, database_instance_name, database_project_name, directory_id, directory_path, experiment_id, instance_pool_id, job_id, knowledge_assistant_id, notebook_id, notebook_path, pipeline_id, registered_model_id, repo_id, repo_path, serverless_compute_id, serving_endpoint_id, sql_alert_id, sql_dashboard_id, sql_endpoint_id, sql_query_id, supervisor_agent_id, vector_search_endpoint_id, workspace_file_id, workspace_file_path")
 }
 
 func TestResourcePermissionsCreate_no_access_control(t *testing.T) {


### PR DESCRIPTION
Serverless compute access control (GA 2026-08-03) introduces the `Default Interactive Compute` and `Default Automated Compute` objects, but their permissions cannot be managed in Terraform today. This adds the mapping so `databricks_permissions` can manage and import them.

Verified against a live workspace:

- `GET /api/2.0/permissions/serverless-compute/<id>` returns `200` with `object_type: "serverless-compute"`
- `GET /api/2.0/permissions/serverless-compute/<id>/permissionLevels` returns `CAN_USE` and `CAN_MANAGE`

### Open design question — the id is a poor interface

As written this requires the user to hardcode `serverless_compute_id`, and the ids are **per-workspace UUIDs with no public way to look them up**. The only enumeration I could find is the GraphQL call the Compute → Serverless UI makes (`serverlessCompute_serverlessComputes`), which a provider cannot use. In practice that means pasting a UUID read out of browser devtools, once per workspace — not portable, and nothing can validate or refresh it.

The interface this should have is `serverless_compute_type = "AUTOMATED"` resolved via `idRetriever` (the same way `notebook_path` resolves to an id), and/or a `databricks_serverless_compute` data source. Both need a list/get endpoint that does not exist yet.

So: is a REST list API planned for these objects? If it is, I am happy to extend this PR with `idRetriever` + a data source so users never handle the UUID. If it is not, this mapping is still useful for anyone who can obtain an id, but the resource stays awkward to use at scale.

### Two docs issues found along the way

- the [GET permissions reference](https://docs.databricks.com/api/gcp/workspace/permissions/get) lists 24 `request_object_type` values; the live API accepts 28, including `serverless-compute`, `apps`, `app-spaces` and `database-instances`.
- [Manage serverless compute](https://docs.databricks.com/gcp/en/compute/serverless/manage-serverless-compute) says these permissions can be managed via the Account Access Control API, but the rule-sets endpoint only accepts `budgetPolicies` and `tagPolicies` as resource types — every serverless variant returns `Invalid resource`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)