### PR TITLE
Add `refresh_token` to sensitive `databricks_connection` options

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -16,7 +16,7 @@
 * Add resource and data source for `databricks_postgres_snapshot_schedule`.
 
 ### Bug Fixes
-* Preserve the `refresh_token` option when refreshing `databricks_connection` to prevent permanent configuration drift.
+* Preserve the `refresh_token` option when refreshing `databricks_connection` to prevent permanent configuration drift ([#5987](https://github.com/databricks/terraform-provider-databricks/pull/5987)).
 
 ### Documentation
 

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -16,6 +16,7 @@
 * Add resource and data source for `databricks_postgres_snapshot_schedule`.
 
 ### Bug Fixes
+* Preserve the `refresh_token` option when refreshing `databricks_connection` to prevent permanent configuration drift.
 
 ### Documentation
 

--- a/catalog/resource_connection.go
+++ b/catalog/resource_connection.go
@@ -11,7 +11,7 @@ import (
 )
 
 var sensitiveOptions = []string{"user", "password", "personalAccessToken", "access_token", "client_secret",
-	"pem_private_key", "OAuthPvtKey", "GoogleServiceAccountKeyJson", "bearer_token"}
+	"pem_private_key", "OAuthPvtKey", "GoogleServiceAccountKeyJson", "bearer_token", "refresh_token"}
 
 var computedOptions = []string{"pem_private_key_expiration_epoch_sec", "access_token_expiration"}
 


### PR DESCRIPTION
## Changes

Add `refresh_token` to the sensitive connection options preserved during reads. The Databricks API does not return this credential, causing permanent configuration drift for `WORKDAY_RAAS` connections.

This follows the existing handling for `client_secret`, `access_token`, and `bearer_token`.

## Tests

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [x] using Go SDK
- [ ] using Go Plugin Framework
- [x] has entry in `NEXT_CHANGELOG.md` file

`make fmt lint ws` passes. The affected `catalog` package passes with `go test ./catalog`. The full `make test` run completed 3,181 tests successfully, but the unrelated exporter `TestInteractivePrompts` timed out while invoking the locally configured Databricks CLI OAuth flow.