### PR TITLE
Publish schema breaking-change report to job summary (visible on fork PRs)

### DIFF
--- a/.github/workflows/schema.yml
+++ b/.github/workflows/schema.yml
@@ -102,6 +102,24 @@ jobs:
           CLASSIFIER_GENERATION_ERROR_MARKER: /tmp/classifier-generation-error
         run: make diff-schema
 
+      # Publish the classifier report to the run's job summary. Unlike the
+      # sticky PR comment (posted by the status job), $GITHUB_STEP_SUMMARY needs
+      # no token permissions, so the report renders on the run summary page even
+      # for fork PRs — where the comment step can't post because fork
+      # `pull_request` runs get a read-only GITHUB_TOKEN. Also surfaces the
+      # report for workflow_dispatch runs, which have no PR to comment on.
+      - name: Publish classifier report to job summary
+        run: |
+          {
+            echo "## Provider schema breaking-change report"
+            echo
+            if [ -s /tmp/classifier-report.md ]; then
+              cat /tmp/classifier-report.md
+            else
+              echo "_Classifier report not generated — see the \"Run schema diff and breaking-change classifier\" step log above._"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
       # Persist the step outcome so the downstream status job can read it.
       - name: Write outcome marker
         run: |


### PR DESCRIPTION
## Changes

Publishes the schema breaking-change classifier report to the run's **job summary** (`$GITHUB_STEP_SUMMARY`) in the `classify` job, in addition to the existing sticky PR comment.

## Why

The sticky comment is posted by the `status` job via `gh pr comment`, which needs `pull-requests: write`. On **fork PRs**, GitHub caps the `pull_request` `GITHUB_TOKEN` to read-only, so that step fails with `Resource not accessible by integration (addComment)` and no comment appears — the contributor only sees a red check with the report buried in the classify job's raw log.

Writing the same report to `$GITHUB_STEP_SUMMARY` needs **no token permissions**, so the full rendered verdict (breaking / non-breaking tables, or the generation-failure notice) now shows on the run summary page for everyone — fork contributors included. It also surfaces the report for `workflow_dispatch` runs, which have no PR to comment on.

This is a lightweight complement, not a replacement: the sticky comment still posts on same-repo PRs, and the required check's pass/fail is unchanged. A full fix for inline fork-PR comments (the `workflow_run` split) can come separately.

## Notes

- The report file (`/tmp/classifier-report.md`) is already produced by `make diff-schema` via `CLASSIFIER_REPORT`; the new step just pipes it into the summary, with a fallback line if it wasn't generated.
- `if: always()` so the summary is written even when the classifier flags a breaking change (the classify step is `continue-on-error`).

NO_CHANGELOG=true