### PR TITLE
[DEMO — DO NOT MERGE] Test job-summary output on a breaking schema change

### DIFF
--- a/.github/workflows/schema.yml
+++ b/.github/workflows/schema.yml
@@ -102,6 +102,24 @@ jobs:
           CLASSIFIER_GENERATION_ERROR_MARKER: /tmp/classifier-generation-error
         run: make diff-schema
 
+      # Publish the classifier report to the run's job summary. Unlike the
+      # sticky PR comment (posted by the status job), $GITHUB_STEP_SUMMARY needs
+      # no token permissions, so the report renders on the run summary page even
+      # for fork PRs — where the comment step can't post because fork
+      # `pull_request` runs get a read-only GITHUB_TOKEN. Also surfaces the
+      # report for workflow_dispatch runs, which have no PR to comment on.
+      - name: Publish classifier report to job summary
+        run: |
+          {
+            echo "## Provider schema breaking-change report"
+            echo
+            if [ -s /tmp/classifier-report.md ]; then
+              cat /tmp/classifier-report.md
+            else
+              echo "_Classifier report not generated — see the \"Run schema diff and breaking-change classifier\" step log above._"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
       # Persist the step outcome so the downstream status job can read it.
       - name: Write outcome marker
         run: |

--- a/tokens/resource_token.go
+++ b/tokens/resource_token.go
@@ -107,7 +107,7 @@ func ResourceToken() common.Resource {
 		},
 		"comment": {
 			Type:     schema.TypeString,
-			Optional: true,
+			Required: true,
 			ForceNew: true,
 		},
 		"token_value": {


### PR DESCRIPTION
## Purpose

Demo/test on top of #5988 (job-summary publishing). Not intended to merge. Verifies the new "Publish classifier report to job summary" step renders a real **breaking-change** report on the run summary page.

## The change

Flips `databricks_token.comment` from Optional to Required (an `OptionalToRequired` breaking change), on a branch that also carries the job-summary step from #5988.

## Expected behavior

- `breaking-schema-check` **fails** (breaking change, no bypass).
- The classifier report — the breaking-change table for `databricks_token.comment` — appears on the **run summary page** via `$GITHUB_STEP_SUMMARY`, in addition to the sticky PR comment (this is a same-repo branch, so the comment posts too).

NO_CHANGELOG=true