### PR TITLE
Post schema breaking-change comment on fork PRs via a workflow_run companion

### DIFF
--- a/.github/workflows/schema-comment.yml
+++ b/.github/workflows/schema-comment.yml
@@ -1,0 +1,143 @@
+name: Provider schema comment
+
+# Companion to the "Provider schema" workflow (schema.yml).
+#
+# That workflow's `status` job posts the sticky breaking-change comment, but on
+# fork PRs the `pull_request` GITHUB_TOKEN is read-only, so its comment step
+# 403s (swallowed by continue-on-error) and no comment appears. This workflow
+# runs on `workflow_run`, which executes from the copy of this file on the
+# repo's DEFAULT BRANCH, in the base-repo context, with a read-write token even
+# for fork-originated runs — because it never checks out or runs the PR's code,
+# it only downloads the classifier artifact and calls the API. It posts the
+# sticky comment for fork PRs; same-repo PRs are still handled inline by the
+# status job (whose token can write), and the fork-only guard below prevents a
+# duplicate comment.
+#
+# NOTE: `workflow_run` only triggers from the default branch's copy of the
+# workflow, so this file does nothing until it is merged to the default branch.
+
+on:
+  workflow_run:
+    workflows: ["Provider schema"]
+    types: [completed]
+
+permissions:
+  contents: read
+  actions: read # download the artifact from the triggering run
+  pull-requests: write # post/update/delete the sticky comment
+
+jobs:
+  comment:
+    # Fork PRs only (same-repo PRs are commented inline by the status job).
+    # Skip workflow_dispatch-triggered runs, which have no PR to comment on.
+    if: |
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.head_repository.full_name != github.repository
+    # Protected runner is IP-allowlisted for the GitHub API; ubuntu-latest is
+    # not, and gh CLI calls from there hit the databricks org's IP allow list.
+    runs-on:
+      group: databricks-protected-runner-group
+      labels: linux-ubuntu-latest
+
+    steps:
+      - name: Download classifier artifact from the triggering run
+        id: download
+        continue-on-error: true
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: classifier-output
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path: /tmp
+
+      - name: Post or update the sticky breaking-change comment
+        # No artifact means classify was skipped (e.g. a non-body PR edit) —
+        # there is nothing to comment on.
+        if: steps.download.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          REPO: ${{ github.repository }}
+          MARKER: "<!-- SCHEMA_BREAKING_CHECK -->"
+        run: |
+          set -euo pipefail
+
+          PR_NUMBER=$(tr -d '\n' < /tmp/classifier-pr-number 2>/dev/null || true)
+          if [ -z "${PR_NUMBER}" ]; then
+            echo "No PR number in the artifact; nothing to comment on."
+            exit 0
+          fi
+
+          if [ -f /tmp/classifier-outcome.txt ]; then
+            CLASSIFY_OUTCOME=$(tr -d '\n' < /tmp/classifier-outcome.txt)
+          else
+            CLASSIFY_OUTCOME="unknown"
+          fi
+          if [ -f /tmp/classifier-generation-error ]; then
+            GENERATION_ERROR=true
+          else
+            GENERATION_ERROR=false
+          fi
+
+          # The workflow_run event carries no PR body, so read the bypass
+          # directive via the API. Line-anchored, matching the status job.
+          PR_BODY=$(gh pr view "${PR_NUMBER}" --json body --jq '.body' 2>/dev/null || true)
+          if printf '%s\n' "${PR_BODY}" | grep -qE '^[[:space:]]*ALLOW_SCHEMA_BREAKING_CHANGE=true[[:space:]]*$'; then
+            BYPASS_ALLOWED=true
+          else
+            BYPASS_ALLOWED=false
+          fi
+
+          prev=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
+            --jq ".[] | select(.body | startswith(\"${MARKER}\")) | .id")
+
+          # success outcome = classifier exited 0 = no breaking changes -> remove
+          # any stale sticky and stop.
+          if [ "${CLASSIFY_OUTCOME}" = "success" ]; then
+            for id in ${prev}; do
+              gh api "repos/${REPO}/issues/comments/${id}" --method DELETE
+            done
+            exit 0
+          fi
+
+          body=$(mktemp)
+          {
+            echo "${MARKER}"
+            echo
+            if [ "${GENERATION_ERROR}" = "true" ]; then
+              # The report already carries its own generation-failure header.
+              cat /tmp/classifier-report.md
+            else
+              if [ "${BYPASS_ALLOWED}" = "true" ]; then
+                echo "## Breaking schema changes detected (bypass active)"
+                echo
+                echo "This PR carries \`ALLOW_SCHEMA_BREAKING_CHANGE=true\` on its own line in the description, so the breaking-schema check is **not blocking**. Please review the changes below carefully."
+              else
+                echo "## Breaking schema changes detected"
+              fi
+              echo
+              if [ -s /tmp/classifier-report.md ]; then
+                cat /tmp/classifier-report.md
+              else
+                echo "_(classifier report missing — see the classify job's log for details)_"
+              fi
+              if [ "${BYPASS_ALLOWED}" != "true" ]; then
+                echo
+                echo "<details><summary>How to bypass this check</summary>"
+                echo
+                echo "If the break is intentional, add \`ALLOW_SCHEMA_BREAKING_CHANGE=true\` on its own line in the PR description."
+                echo
+                echo "</details>"
+              fi
+            fi
+          } > "${body}"
+
+          if [ -z "${prev}" ]; then
+            gh pr comment "${PR_NUMBER}" --body-file "${body}"
+          else
+            first=$(echo "${prev}" | head -1)
+            gh api "repos/${REPO}/issues/comments/${first}" --method PATCH -F body=@"${body}"
+            for id in $(echo "${prev}" | tail -n +2); do
+              gh api "repos/${REPO}/issues/comments/${id}" --method DELETE
+            done
+          fi

--- a/.github/workflows/schema.yml
+++ b/.github/workflows/schema.yml
@@ -16,11 +16,12 @@ name: Provider schema
 # workflow and the bypass takes effect without needing a new commit.
 #
 # Fork-PR caveat: GITHUB_TOKEN is intentionally read-only on `pull_request`
-# events from forks, so the sticky-comment step can't post on fork PRs. The
-# step uses `continue-on-error` so the workflow's overall pass/fail still
-# reflects the breaking-vs-not decision; only the in-PR sticky is missing.
-# Fork contributors see the failed check status and the classifier report
-# in the Action log.
+# events from forks, so the status job's sticky-comment step can't post on fork
+# PRs. The step uses `continue-on-error` so the workflow's overall pass/fail
+# still reflects the breaking-vs-not decision. The schema-comment.yml companion
+# (a workflow_run workflow that runs from the default branch with a writable
+# token) posts the sticky comment on fork PRs; fork contributors also see the
+# failed check status and the classifier report in the Action log.
 
 on:
   pull_request:
@@ -108,6 +109,14 @@ jobs:
           echo "${{ steps.classify.outcome }}" > /tmp/classifier-outcome.txt
           cat /tmp/classifier-outcome.txt
 
+      # Record the PR number so the schema-comment.yml companion (a workflow_run
+      # workflow) can post the sticky comment on fork PRs — the workflow_run
+      # event payload carries an empty `pull_requests` array for forks, so the
+      # number has to travel in the artifact.
+      - name: Record PR number for the comment workflow
+        if: github.event_name == 'pull_request'
+        run: echo "${{ github.event.pull_request.number }}" > /tmp/classifier-pr-number
+
       - name: Upload classifier artifact
         if: github.event_name == 'pull_request'
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
@@ -117,6 +126,7 @@ jobs:
             /tmp/classifier-report.md
             /tmp/classifier-outcome.txt
             /tmp/classifier-generation-error
+            /tmp/classifier-pr-number
           if-no-files-found: warn
           retention-days: 3
 


### PR DESCRIPTION
## Purpose

Restore the inline sticky breaking-change comment on **fork PRs**, where it's currently missing. On `pull_request` events from forks, GitHub caps `GITHUB_TOKEN` to read-only, so the `status` job's comment step 403s (`Resource not accessible by integration`) and no comment is posted — the required check still fails correctly, but the contributor only sees the report in the classify job's log.

## Approach — `workflow_run` companion

The GitHub-recommended pattern for commenting on fork PRs: keep the untrusted build in the read-only `pull_request` workflow, and post the comment from a separate workflow that runs from the **default branch** with a writable token. That second workflow never checks out or runs the PR's code — it only downloads the classifier artifact and calls the API — so it's safe to give it write access.

- **`schema.yml` (classify):** records the PR number into the artifact. The `workflow_run` event payload has an empty `pull_requests` array for forks, so the number has to travel in the artifact.
- **`schema-comment.yml` (new):** triggers on `workflow_run` completion of "Provider schema", **fork-PRs only** (same-repo PRs are still commented inline by the `status` job — the guard prevents a duplicate), downloads the artifact from the triggering run, reads the outcome/generation-error/report, reads the bypass directive via the API (the event carries no PR body), and posts/updates/deletes the sticky comment. Runs on the protected runner group, since gh API calls need the IP allowlist.

The `status` job is unchanged and remains the required gate (it already fails correctly on fork PRs). This change is purely additive.

## Important limitation — can't fully run until merged

`workflow_run` workflows **only trigger from the copy on the repo's default branch**, so `schema-comment.yml` does nothing while this PR is open — it goes live only after merge to `main`. What *is* exercised on this PR: the `classify` job records the PR number and uploads it in the artifact (verifiable), and the `status` gate is unaffected.

Post-merge verification would be a fork PR with a breaking change → confirm the companion posts the sticky.

## Caveats for review

- The comment-building logic is duplicated between the `status` job and the companion. Kept separate here to leave the working `status` path untouched; can be factored into a shared script as a follow-up.
- The companion uses the `databricks-protected-runner-group` (same as `status`) for GitHub API access — this assumes the runner group permits this new workflow.

NO_CHANGELOG=true