### PR TITLE
Add Lakebase database credential ephemeral resource

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### New Features and Improvements
 
+* Add the `databricks_postgres_database_credential` ephemeral resource for securely passing short-lived Lakebase credentials to PostgreSQL providers ([#TBD](https://github.com/databricks/terraform-provider-databricks/pull/TBD)).
+
 ### Bug Fixes
 
 ### Documentation

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### New Features and Improvements
 
-* Add the `databricks_postgres_database_credential` ephemeral resource for securely passing short-lived Lakebase credentials to PostgreSQL providers ([#TBD](https://github.com/databricks/terraform-provider-databricks/pull/TBD)).
+* Add the `databricks_postgres_database_credential` ephemeral resource for securely passing short-lived Lakebase credentials to PostgreSQL providers ([#5993](https://github.com/databricks/terraform-provider-databricks/pull/5993)).
 
 ### Bug Fixes
 

--- a/docs/ephemeral-resources/postgres_database_credential.md
+++ b/docs/ephemeral-resources/postgres_database_credential.md
@@ -1,0 +1,51 @@
+---
+subcategory: "Postgres"
+---
+# databricks_postgres_database_credential Ephemeral Resource
+
+[![Public Beta](https://img.shields.io/badge/Release_Stage-Public_Beta-orange)](https://docs.databricks.com/aws/en/release-notes/release-types)
+
+The `databricks_postgres_database_credential` ephemeral resource generates a short-lived OAuth credential for a Lakebase Postgres endpoint. The credential is available only during the current Terraform phase and is not stored in plan or state files.
+
+This ephemeral resource requires Terraform 1.10 or later.
+
+## Example Usage
+
+The token can be supplied as the password for the [`cyrilgdn/postgresql`](https://registry.terraform.io/providers/cyrilgdn/postgresql/latest/docs) provider. The Databricks provider and the Postgres role named by `username` must represent the same Databricks user or service principal.
+
+```hcl
+data "databricks_postgres_endpoint" "this" {
+  name = "projects/my-project/branches/production/endpoints/primary"
+}
+
+ephemeral "databricks_postgres_database_credential" "this" {
+  endpoint = data.databricks_postgres_endpoint.this.name
+}
+
+provider "postgresql" {
+  host             = data.databricks_postgres_endpoint.this.status.hosts.host
+  port             = 5432
+  database         = "application"
+  username         = var.service_principal_application_id
+  password         = ephemeral.databricks_postgres_database_credential.this.token
+  sslmode          = "verify-full"
+  superuser        = false
+  expected_version = "17"
+}
+```
+
+Lakebase credentials cannot be renewed without changing the token. A Terraform operation that opens a new Postgres connection after the credential expires can fail. Use the maximum one-hour lifetime for provider authentication and keep each Terraform operation within that lifetime.
+
+## Arguments
+
+The following arguments are supported:
+
+* `endpoint` (string, required) - The full Lakebase endpoint resource name. Format: `projects/{project_id}/branches/{branch_id}/endpoints/{endpoint_id}`.
+* `ttl` (string, optional) - The requested credential lifetime as a Go duration. Must be between 5 minutes and 1 hour. Defaults to `1h`.
+
+## Attributes
+
+The following attributes are exported:
+
+* `token` (string, sensitive) - The OAuth token to use as the Postgres password.
+* `expire_time` (string) - The UTC timestamp when the credential expires.

--- a/internal/providers/pluginfw/context/context_test.go
+++ b/internal/providers/pluginfw/context/context_test.go
@@ -27,3 +27,12 @@ func TestSetUserAgentInDataSourceContext(t *testing.T) {
 	expectedContext = useragent.InContext(expectedContext, dataSourceKey, dataSourceName)
 	assert.Equal(t, expectedContext, actualContext)
 }
+
+func TestSetUserAgentInEphemeralResourceContext(t *testing.T) {
+	ctx := context.Background()
+	ephemeralResourceName := "test-ephemeral-resource"
+	actualContext := SetUserAgentInEphemeralResourceContext(ctx, ephemeralResourceName)
+	expectedContext := useragent.InContext(ctx, "sdk", "pluginframework")
+	expectedContext = useragent.InContext(expectedContext, "ephemeral", ephemeralResourceName)
+	assert.Equal(t, expectedContext, actualContext)
+}

--- a/internal/providers/pluginfw/context/ephemeral.go
+++ b/internal/providers/pluginfw/context/ephemeral.go
@@ -1,0 +1,13 @@
+package context
+
+import (
+	"context"
+
+	"github.com/databricks/databricks-sdk-go/useragent"
+	"github.com/databricks/terraform-provider-databricks/internal/providers/common"
+)
+
+func SetUserAgentInEphemeralResourceContext(ctx context.Context, ephemeralResourceName string) context.Context {
+	ctx = common.SetSDKInContext(ctx, sdkName)
+	return useragent.InContext(ctx, "ephemeral", ephemeralResourceName)
+}

--- a/internal/providers/pluginfw/pluginfw.go
+++ b/internal/providers/pluginfw/pluginfw.go
@@ -14,8 +14,10 @@ import (
 	"github.com/databricks/terraform-provider-databricks/common"
 	"github.com/databricks/terraform-provider-databricks/internal/providers/client"
 	providercommon "github.com/databricks/terraform-provider-databricks/internal/providers/common"
+	"github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/products/postgres_database_credential"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/ephemeral"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
@@ -48,7 +50,10 @@ type DatabricksProviderPluginFramework struct {
 	configCustomizer         func(*config.Config) error
 }
 
-var _ provider.Provider = (*DatabricksProviderPluginFramework)(nil)
+var (
+	_ provider.Provider                       = (*DatabricksProviderPluginFramework)(nil)
+	_ provider.ProviderWithEphemeralResources = (*DatabricksProviderPluginFramework)(nil)
+)
 
 func (p *DatabricksProviderPluginFramework) Resources(ctx context.Context) []func() resource.Resource {
 	return getPluginFrameworkResourcesToRegister(p.sdkV2ResourceFallbacks, p.resourceOptIns)
@@ -56,6 +61,12 @@ func (p *DatabricksProviderPluginFramework) Resources(ctx context.Context) []fun
 
 func (p *DatabricksProviderPluginFramework) DataSources(ctx context.Context) []func() datasource.DataSource {
 	return getPluginFrameworkDataSourcesToRegister(p.sdkV2DataSourceFallbacks, p.dataSourceOptIns)
+}
+
+func (p *DatabricksProviderPluginFramework) EphemeralResources(ctx context.Context) []func() ephemeral.EphemeralResource {
+	return []func() ephemeral.EphemeralResource{
+		postgres_database_credential.New,
+	}
 }
 
 func (p *DatabricksProviderPluginFramework) Schema(ctx context.Context, req provider.SchemaRequest, resp *provider.SchemaResponse) {
@@ -70,6 +81,7 @@ func (p *DatabricksProviderPluginFramework) Metadata(ctx context.Context, req pr
 func (p *DatabricksProviderPluginFramework) Configure(ctx context.Context, req provider.ConfigureRequest, resp *provider.ConfigureResponse) {
 	client := p.configureDatabricksClient(ctx, req, resp)
 	resp.DataSourceData = client
+	resp.EphemeralResourceData = client
 	resp.ResourceData = client
 }
 

--- a/internal/providers/pluginfw/pluginfw_test.go
+++ b/internal/providers/pluginfw/pluginfw_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/databricks/terraform-provider-databricks/common"
+	"github.com/hashicorp/terraform-plugin-framework/ephemeral"
 	"github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
@@ -63,6 +64,21 @@ func TestGetPluginFrameworkResources_NoFallbackNoWarning(t *testing.T) {
 	_ = getPluginFrameworkResourcesToRegister(nil, nil)
 
 	assert.Empty(t, buf.String(), "no warning should be emitted when no fallback is configured")
+}
+
+func TestEphemeralResources(t *testing.T) {
+	p, ok := GetDatabricksProviderPluginFramework().(provider.ProviderWithEphemeralResources)
+	if !assert.True(t, ok) {
+		return
+	}
+
+	resources := p.EphemeralResources(context.Background())
+	if !assert.Len(t, resources, 1) {
+		return
+	}
+	response := &ephemeral.MetadataResponse{}
+	resources[0]().Metadata(context.Background(), ephemeral.MetadataRequest{}, response)
+	assert.Equal(t, "databricks_postgres_database_credential", response.TypeName)
 }
 
 func TestConfigure(t *testing.T) {
@@ -134,6 +150,7 @@ func TestConfigure(t *testing.T) {
 			// Get the client from the response
 			client, ok := resp.ResourceData.(*common.DatabricksClient)
 			assert.True(t, ok, "ResourceData should be a DatabricksClient")
+			assert.Same(t, client, resp.EphemeralResourceData, "EphemeralResourceData should use the configured DatabricksClient")
 			tc.validateResourceData(client)
 		})
 	}

--- a/internal/providers/pluginfw/products/postgres_database_credential/ephemeral_postgres_database_credential.go
+++ b/internal/providers/pluginfw/products/postgres_database_credential/ephemeral_postgres_database_credential.go
@@ -1,0 +1,223 @@
+package postgres_database_credential
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"time"
+
+	"github.com/databricks/databricks-sdk-go/common/types/duration"
+	sdktime "github.com/databricks/databricks-sdk-go/common/types/time"
+	"github.com/databricks/databricks-sdk-go/service/postgres"
+	"github.com/databricks/terraform-provider-databricks/common"
+	pluginfwcommon "github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/common"
+	pluginfwcontext "github.com/databricks/terraform-provider-databricks/internal/providers/pluginfw/context"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/ephemeral"
+	"github.com/hashicorp/terraform-plugin-framework/ephemeral/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+const (
+	ephemeralResourceName = "postgres_database_credential"
+	defaultTTL            = time.Hour
+	minimumTTL            = 5 * time.Minute
+	maximumTTL            = time.Hour
+)
+
+var endpointPattern = regexp.MustCompile(`^projects/[^/]+/branches/[^/]+/endpoints/[^/]+$`)
+
+var (
+	_ ephemeral.EphemeralResource              = (*databaseCredentialResource)(nil)
+	_ ephemeral.EphemeralResourceWithConfigure = (*databaseCredentialResource)(nil)
+	_ validator.String                         = databaseCredentialTTLValidator{}
+)
+
+type databaseCredentialResource struct {
+	client *common.DatabricksClient
+}
+
+type databaseCredentialModel struct {
+	Endpoint   types.String `tfsdk:"endpoint"`
+	TTL        types.String `tfsdk:"ttl"`
+	Token      types.String `tfsdk:"token"`
+	ExpireTime types.String `tfsdk:"expire_time"`
+}
+
+func New() ephemeral.EphemeralResource {
+	return &databaseCredentialResource{}
+}
+
+func (r *databaseCredentialResource) Metadata(
+	ctx context.Context,
+	req ephemeral.MetadataRequest,
+	resp *ephemeral.MetadataResponse,
+) {
+	resp.TypeName = pluginfwcommon.GetDatabricksProductionName(ephemeralResourceName)
+}
+
+func (r *databaseCredentialResource) Schema(
+	ctx context.Context,
+	req ephemeral.SchemaRequest,
+	resp *ephemeral.SchemaResponse,
+) {
+	resp.Schema = schema.Schema{
+		Description: "Generates a short-lived OAuth credential for a Lakebase Postgres endpoint.",
+		Attributes: map[string]schema.Attribute{
+			"endpoint": schema.StringAttribute{
+				Required:    true,
+				Description: "The Lakebase endpoint resource name in projects/{project_id}/branches/{branch_id}/endpoints/{endpoint_id} format.",
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(endpointPattern, "must be a Lakebase endpoint resource name"),
+				},
+			},
+			"ttl": schema.StringAttribute{
+				Optional:    true,
+				Computed:    true,
+				Description: "The credential lifetime as a Go duration. Must be between 5 minutes and 1 hour. Defaults to 1 hour.",
+				Validators:  []validator.String{databaseCredentialTTLValidator{}},
+			},
+			"token": schema.StringAttribute{
+				Computed:    true,
+				Sensitive:   true,
+				Description: "The OAuth token to use as the Postgres password.",
+			},
+			"expire_time": schema.StringAttribute{
+				Computed:    true,
+				Description: "The UTC timestamp when the credential expires.",
+			},
+		},
+	}
+}
+
+func (r *databaseCredentialResource) Configure(
+	ctx context.Context,
+	req ephemeral.ConfigureRequest,
+	resp *ephemeral.ConfigureResponse,
+) {
+	if req.ProviderData == nil {
+		return
+	}
+	client, ok := req.ProviderData.(*common.DatabricksClient)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Ephemeral Resource Configure Type",
+			fmt.Sprintf("Expected *common.DatabricksClient, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+	r.client = client
+}
+
+func (r *databaseCredentialResource) Open(
+	ctx context.Context,
+	req ephemeral.OpenRequest,
+	resp *ephemeral.OpenResponse,
+) {
+	ctx = pluginfwcontext.SetUserAgentInEphemeralResourceContext(ctx, ephemeralResourceName)
+	var config databaseCredentialModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	ttl, diags := credentialTTL(config.TTL)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	if config.TTL.IsNull() {
+		config.TTL = types.StringValue(defaultTTL.String())
+	}
+
+	credential, diags := r.generateCredential(ctx, config.Endpoint.ValueString(), ttl)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	config.Token = types.StringValue(credential.Token)
+	config.ExpireTime = types.StringPointerValue(timePointerToString(credential.ExpireTime))
+	resp.Diagnostics.Append(resp.Result.Set(ctx, &config)...)
+}
+
+func (r *databaseCredentialResource) generateCredential(
+	ctx context.Context,
+	endpoint string,
+	ttl time.Duration,
+) (*postgres.DatabaseCredential, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	if r.client == nil {
+		diags.AddError("Provider not configured", "The Databricks provider must be configured before generating a database credential.")
+		return nil, diags
+	}
+	workspaceClient, clientDiags := r.client.GetWorkspaceClientForUnifiedProviderWithDiagnostics(ctx, "")
+	diags.Append(clientDiags...)
+	if diags.HasError() {
+		return nil, diags
+	}
+	credential, err := workspaceClient.Postgres.GenerateDatabaseCredential(ctx, postgres.GenerateDatabaseCredentialRequest{
+		Endpoint: endpoint,
+		Ttl:      duration.New(ttl),
+	})
+	if err != nil {
+		diags.AddError("Unable to generate Lakebase database credential", err.Error())
+		return nil, diags
+	}
+	return credential, diags
+}
+
+func timePointerToString(value *sdktime.Time) *string {
+	if value == nil {
+		return nil
+	}
+	formatted := value.AsTime().UTC().Format(time.RFC3339)
+	return &formatted
+}
+
+type databaseCredentialTTLValidator struct{}
+
+func (databaseCredentialTTLValidator) Description(context.Context) string {
+	return "value must be a duration between 5 minutes and 1 hour"
+}
+
+func (v databaseCredentialTTLValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+func (databaseCredentialTTLValidator) ValidateString(
+	ctx context.Context,
+	req validator.StringRequest,
+	resp *validator.StringResponse,
+) {
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+		return
+	}
+	_, diags := credentialTTL(req.ConfigValue)
+	for _, diagnostic := range diags {
+		resp.Diagnostics.AddAttributeError(req.Path, diagnostic.Summary(), diagnostic.Detail())
+	}
+}
+
+func credentialTTL(value types.String) (time.Duration, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	if value.IsNull() {
+		return defaultTTL, diags
+	}
+	if value.IsUnknown() {
+		diags.AddError("Unknown credential TTL", "The credential TTL must be known before the credential can be generated.")
+		return 0, diags
+	}
+	ttl, err := time.ParseDuration(value.ValueString())
+	if err != nil {
+		diags.AddError("Invalid credential TTL", fmt.Sprintf("The credential TTL must be a valid Go duration: %s", err))
+		return 0, diags
+	}
+	if ttl < minimumTTL || ttl > maximumTTL {
+		diags.AddError("Invalid credential TTL", "The credential TTL must be between 5 minutes and 1 hour.")
+		return 0, diags
+	}
+	return ttl, diags
+}

--- a/internal/providers/pluginfw/products/postgres_database_credential/ephemeral_postgres_database_credential_test.go
+++ b/internal/providers/pluginfw/products/postgres_database_credential/ephemeral_postgres_database_credential_test.go
@@ -1,0 +1,150 @@
+package postgres_database_credential
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	sdktime "github.com/databricks/databricks-sdk-go/common/types/time"
+	"github.com/databricks/databricks-sdk-go/experimental/mocks"
+	"github.com/databricks/databricks-sdk-go/service/postgres"
+	"github.com/databricks/terraform-provider-databricks/common"
+	"github.com/databricks/terraform-provider-databricks/qa"
+	"github.com/hashicorp/terraform-plugin-framework/ephemeral"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+const testEndpoint = "projects/my-project/branches/production/endpoints/primary"
+
+func TestDatabaseCredentialSchema(t *testing.T) {
+	resource := New()
+	response := &ephemeral.SchemaResponse{}
+	resource.Schema(context.Background(), ephemeral.SchemaRequest{}, response)
+
+	assert.False(t, response.Diagnostics.HasError())
+	assert.True(t, response.Schema.Attributes["endpoint"].IsRequired())
+	assert.True(t, response.Schema.Attributes["ttl"].IsOptional())
+	assert.True(t, response.Schema.Attributes["ttl"].IsComputed())
+	assert.True(t, response.Schema.Attributes["token"].IsSensitive())
+	assert.True(t, response.Schema.Attributes["token"].IsComputed())
+	assert.True(t, response.Schema.Attributes["expire_time"].IsComputed())
+}
+
+func TestDatabaseCredentialMetadata(t *testing.T) {
+	response := &ephemeral.MetadataResponse{}
+	New().Metadata(context.Background(), ephemeral.MetadataRequest{}, response)
+
+	assert.Equal(t, "databricks_postgres_database_credential", response.TypeName)
+}
+
+func TestDatabaseCredentialConfigure(t *testing.T) {
+	resource := &databaseCredentialResource{}
+	client := &common.DatabricksClient{}
+	response := &ephemeral.ConfigureResponse{}
+	resource.Configure(context.Background(), ephemeral.ConfigureRequest{ProviderData: client}, response)
+
+	require.False(t, response.Diagnostics.HasError(), response.Diagnostics.Errors())
+	assert.Same(t, client, resource.client)
+}
+
+func TestDatabaseCredentialConfigureRejectsUnexpectedProviderData(t *testing.T) {
+	resource := &databaseCredentialResource{}
+	response := &ephemeral.ConfigureResponse{}
+	resource.Configure(context.Background(), ephemeral.ConfigureRequest{ProviderData: "unexpected"}, response)
+
+	require.True(t, response.Diagnostics.HasError())
+	assert.Contains(t, response.Diagnostics.Errors()[0].Detail(), "Expected *common.DatabricksClient")
+}
+
+func TestDatabaseCredentialOpen(t *testing.T) {
+	expireTime := time.Date(2026, time.September, 7, 23, 0, 0, 0, time.UTC)
+	qa.MockWorkspaceApply(t, func(w *mocks.MockWorkspaceClient) {
+		w.GetMockPostgresAPI().EXPECT().
+			GenerateDatabaseCredential(mock.Anything, mock.MatchedBy(func(request postgres.GenerateDatabaseCredentialRequest) bool {
+				return request.Endpoint == testEndpoint && request.Ttl.AsDuration() == defaultTTL
+			})).
+			Return(&postgres.DatabaseCredential{Token: "test-token", ExpireTime: sdktime.New(expireTime)}, nil)
+	}, func(ctx context.Context, client *common.DatabricksClient) {
+		resource := &databaseCredentialResource{client: client}
+		request, response := openRequest(t, resource, types.StringNull())
+
+		resource.Open(ctx, request, response)
+
+		require.False(t, response.Diagnostics.HasError(), response.Diagnostics.Errors())
+		var result databaseCredentialModel
+		response.Diagnostics.Append(response.Result.Get(ctx, &result)...)
+		require.False(t, response.Diagnostics.HasError(), response.Diagnostics.Errors())
+		assert.Equal(t, "test-token", result.Token.ValueString())
+		assert.Equal(t, defaultTTL.String(), result.TTL.ValueString())
+		assert.Equal(t, expireTime.Format(time.RFC3339), result.ExpireTime.ValueString())
+	})
+}
+
+func TestDatabaseCredentialOpenReturnsAPIError(t *testing.T) {
+	qa.MockWorkspaceApply(t, func(w *mocks.MockWorkspaceClient) {
+		w.GetMockPostgresAPI().EXPECT().
+			GenerateDatabaseCredential(mock.Anything, mock.Anything).
+			Return(nil, errors.New("credential service unavailable"))
+	}, func(ctx context.Context, client *common.DatabricksClient) {
+		resource := &databaseCredentialResource{client: client}
+		request, response := openRequest(t, resource, types.StringValue("10m"))
+
+		resource.Open(ctx, request, response)
+
+		require.True(t, response.Diagnostics.HasError())
+		assert.Contains(t, response.Diagnostics.Errors()[0].Detail(), "credential service unavailable")
+	})
+}
+
+func TestCredentialTTL(t *testing.T) {
+	tests := []struct {
+		name      string
+		value     types.String
+		expected  time.Duration
+		hasErrors bool
+	}{
+		{name: "default", value: types.StringNull(), expected: time.Hour},
+		{name: "minimum", value: types.StringValue("5m"), expected: 5 * time.Minute},
+		{name: "maximum", value: types.StringValue("1h"), expected: time.Hour},
+		{name: "too short", value: types.StringValue("299s"), hasErrors: true},
+		{name: "too long", value: types.StringValue("3601s"), hasErrors: true},
+		{name: "invalid", value: types.StringValue("one hour"), hasErrors: true},
+		{name: "unknown", value: types.StringUnknown(), hasErrors: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual, diagnostics := credentialTTL(test.value)
+			assert.Equal(t, test.hasErrors, diagnostics.HasError())
+			assert.Equal(t, test.expected, actual)
+		})
+	}
+}
+
+func openRequest(
+	t *testing.T,
+	resource *databaseCredentialResource,
+	ttl types.String,
+) (ephemeral.OpenRequest, *ephemeral.OpenResponse) {
+	t.Helper()
+	ctx := context.Background()
+	schemaResponse := &ephemeral.SchemaResponse{}
+	resource.Schema(ctx, ephemeral.SchemaRequest{}, schemaResponse)
+	schemaType := schemaResponse.Schema.Type().TerraformType(ctx)
+	ttlValue, err := ttl.ToTerraformValue(ctx)
+	require.NoError(t, err)
+	raw := tftypes.NewValue(schemaType, map[string]tftypes.Value{
+		"endpoint":    tftypes.NewValue(tftypes.String, testEndpoint),
+		"ttl":         ttlValue,
+		"token":       tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+		"expire_time": tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+	})
+	return ephemeral.OpenRequest{Config: tfsdk.Config{Raw: raw, Schema: schemaResponse.Schema}}, &ephemeral.OpenResponse{
+		Result: tfsdk.EphemeralResultData{Raw: raw, Schema: schemaResponse.Schema},
+	}
+}


### PR DESCRIPTION
## Changes

- Add the `databricks_postgres_database_credential` ephemeral resource backed by the Lakebase database credential API. This can be used as a password into the various PG providers (like `cyrilgdn/postgresql`), allowing users to manage their Lakebase resources without having to manage passwords.
- Keep the generated OAuth token out of Terraform plan and state while supporting configurable lifetimes from 5 minutes to 1 hour.
- Register the resource with the Plugin Framework provider and document using it as the password for `cyrilgdn/postgresql`.

## Tests

- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [x] using Go SDK
- [x] using TF Plugin Framework
- [x] has entry in `NEXT_CHANGELOG.md` file

Focused package tests, `make fmt`, `make lint`, and `make ws` pass. The full test run passed 3,196 tests; `exporter/TestInteractivePrompts` timed out while invoking ambient Databricks CLI authentication and passed when rerun in isolation with PAT authentication selected. The API behavior is covered by mocked unit tests.
