### PR TITLE
Add support of UC Secrets in grant and grants TF resources.

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### New Features and Improvements
 
-* Add support for the `secret` securable in `databricks_grant` and `databricks_grants`.
+* Add support for the `secret` securable in `databricks_grant` and `databricks_grants`. ([#5996](https://github.com/databricks/terraform-provider-databricks/pull/5996))
 
 ### Bug Fixes
 * `databricks_app` can now manage `git_source`, `source_code_path`, and `git_repository.caller_credential_id`. These are input_only (the Apps API accepts them on write but does not echo them on read), so the resource now calls the generated `SyncFields` reconciliation to preserve the configured value across reads, and treats the nested `git_source` descendants (`git_repository`, `resolved_commit`) as non-Computed. This prevents the "Provider produced inconsistent result after apply" error and the perpetual diff that previously occurred when any of these fields was set.

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### New Features and Improvements
 
+* Add support for the `secret` securable in `databricks_grant` and `databricks_grants`.
+
 ### Bug Fixes
 * `databricks_app` can now manage `git_source`, `source_code_path`, and `git_repository.caller_credential_id`. These are input_only (the Apps API accepts them on write but does not echo them on read), so the resource now calls the generated `SyncFields` reconciliation to preserve the configured value across reads, and treats the nested `git_source` descendants (`git_repository`, `resolved_commit`) as non-Computed. This prevents the "Provider produced inconsistent result after apply" error and the perpetual diff that previously occurred when any of these fields was set.
 

--- a/catalog/grant_test.go
+++ b/catalog/grant_test.go
@@ -120,6 +120,20 @@ resource "databricks_grant" "some" {
 
 	principal  = "%s"
 	privileges = ["ALL_PRIVILEGES"]
+}
+
+resource "databricks_secret_uc" "this" {
+	catalog_name = databricks_catalog.sandbox.id
+	schema_name  = databricks_schema.things.name
+	name         = "secret-{var.STICKY_RANDOM}"
+	value        = "sensitive-value"
+}
+
+resource "databricks_grant" "secret" {
+	secret = databricks_secret_uc.this.full_name
+
+	principal  = "%s"
+	privileges = ["READ_SECRET"]
 }`
 
 func TestUcAccGrant(t *testing.T) {
@@ -192,5 +206,41 @@ func TestUcAccGrantForIdChange(t *testing.T) {
 	}, acceptance.Step{
 		Template:    grantTemplateForNamePermissionChange("-fail", "abc"),
 		ExpectError: regexp.MustCompile(`cannot create grant: Privilege ABC is not applicable to this entity`),
+	})
+}
+
+// secretGrantTemplate is a minimal-dependency variant that exercises only the secret securable
+// and READ_SECRET. Unlike grantTemplate it creates no storage credential or external location, so
+// it needs no TEST_METASTORE_DATA_ACCESS_ARN / TEST_BUCKET / TEST_METASTORE_ID, and grants to the
+// built-in "account users" group so no test group env var is required.
+var secretGrantTemplate = `
+resource "databricks_catalog" "sandbox" {
+	name    = "sandbox{var.STICKY_RANDOM}"
+	comment = "this catalog is managed by terraform"
+}
+
+resource "databricks_schema" "things" {
+	catalog_name = databricks_catalog.sandbox.id
+	name         = "things{var.STICKY_RANDOM}"
+	comment      = "this database is managed by terraform"
+}
+
+resource "databricks_secret_uc" "this" {
+	catalog_name = databricks_catalog.sandbox.id
+	schema_name  = databricks_schema.things.name
+	name         = "secret-{var.STICKY_RANDOM}"
+	value        = "sensitive-value"
+}
+
+resource "databricks_grant" "secret" {
+	secret = databricks_secret_uc.this.full_name
+
+	principal  = "account users"
+	privileges = ["READ_SECRET"]
+}`
+
+func TestUcAccSecretGrant(t *testing.T) {
+	acceptance.UnityWorkspaceLevel(t, acceptance.Step{
+		Template: secretGrantTemplate,
 	})
 }

--- a/catalog/grants_test.go
+++ b/catalog/grants_test.go
@@ -135,6 +135,21 @@ resource "databricks_grants" "some" {
 		principal  = "%s"
 		privileges = ["ALL_PRIVILEGES"]
 	}
+}
+
+resource "databricks_secret_uc" "this" {
+	catalog_name = databricks_catalog.sandbox.id
+	schema_name  = databricks_schema.things.name
+	name         = "secret-{var.STICKY_RANDOM}"
+	value        = "sensitive-value"
+}
+
+resource "databricks_grants" "secret" {
+	secret = databricks_secret_uc.this.full_name
+	grant {
+		principal  = "%s"
+		privileges = ["READ_SECRET"]
+	}
 }`
 
 func TestUcAccGrants(t *testing.T) {
@@ -211,5 +226,43 @@ func TestUcAccGrantsForIdChange(t *testing.T) {
 	}, acceptance.Step{
 		Template:    grantsTemplateForNamePermissionChange("-fail", "abc"),
 		ExpectError: regexp.MustCompile(`Error: cannot create grants: Privilege ABC is not applicable to this entity`),
+	})
+}
+
+// secretGrantsTemplate is a minimal-dependency variant that exercises only the secret securable
+// and READ_SECRET via the authoritative databricks_grants resource. It creates no storage
+// credential or external location, so it needs no TEST_METASTORE_DATA_ACCESS_ARN / TEST_BUCKET /
+// TEST_METASTORE_ID, and grants to the built-in "account users" group so no test group env var is
+// required.
+var secretGrantsTemplate = `
+resource "databricks_catalog" "sandbox" {
+	name    = "sandbox{var.STICKY_RANDOM}"
+	comment = "this catalog is managed by terraform"
+}
+
+resource "databricks_schema" "things" {
+	catalog_name = databricks_catalog.sandbox.id
+	name         = "things{var.STICKY_RANDOM}"
+	comment      = "this database is managed by terraform"
+}
+
+resource "databricks_secret_uc" "this" {
+	catalog_name = databricks_catalog.sandbox.id
+	schema_name  = databricks_schema.things.name
+	name         = "secret-{var.STICKY_RANDOM}"
+	value        = "sensitive-value"
+}
+
+resource "databricks_grants" "secret" {
+	secret = databricks_secret_uc.this.full_name
+	grant {
+		principal  = "account users"
+		privileges = ["READ_SECRET"]
+	}
+}`
+
+func TestUcAccSecretGrants(t *testing.T) {
+	acceptance.UnityWorkspaceLevel(t, acceptance.Step{
+		Template: secretGrantsTemplate,
 	})
 }

--- a/catalog/permissions/permissions.go
+++ b/catalog/permissions/permissions.go
@@ -139,6 +139,7 @@ var Mappings = SecurableMapping{
 	"pipeline":               catalog.SecurableType("pipeline"),
 	"recipient":              catalog.SecurableType("recipient"),
 	"schema":                 catalog.SecurableType("schema"),
+	"secret":                 catalog.SecurableType("secret"),
 	"share":                  catalog.SecurableType("share"),
 	"storage_credential":     catalog.SecurableType("storage_credential"),
 	"table":                  catalog.SecurableType("table"),

--- a/catalog/resource_grant_test.go
+++ b/catalog/resource_grant_test.go
@@ -933,6 +933,64 @@ func TestResourceGrantModelGrantCreate(t *testing.T) {
 	}.ApplyNoError(t)
 }
 
+func TestResourceGrantSecretGrantCreate(t *testing.T) {
+	qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "GET",
+				Resource: "/api/2.1/unity-catalog/permissions/secret/main.default.mysecret?",
+				Response: catalog.GetPermissionsResponse{
+					PrivilegeAssignments: []catalog.PrivilegeAssignment{},
+				},
+			},
+			{
+				Method:   "PATCH",
+				Resource: "/api/2.1/unity-catalog/permissions/secret/main.default.mysecret",
+				ExpectedRequest: catalog.UpdatePermissions{
+					Changes: []catalog.PermissionsChange{
+						{
+							Principal: "me",
+							Add:       []catalog.Privilege{"READ_SECRET"},
+						},
+					},
+				},
+			},
+			{
+				Method:   "GET",
+				Resource: "/api/2.1/unity-catalog/permissions/secret/main.default.mysecret?",
+				Response: catalog.GetPermissionsResponse{
+					PrivilegeAssignments: []catalog.PrivilegeAssignment{
+						{
+							Principal:  "me",
+							Privileges: []catalog.Privilege{"READ_SECRET"},
+						},
+					},
+				},
+			},
+			{
+				Method:   "GET",
+				Resource: "/api/2.1/unity-catalog/permissions/secret/main.default.mysecret?",
+				Response: catalog.GetPermissionsResponse{
+					PrivilegeAssignments: []catalog.PrivilegeAssignment{
+						{
+							Principal:  "me",
+							Privileges: []catalog.Privilege{"READ_SECRET"},
+						},
+					},
+				},
+			},
+		},
+		Resource: ResourceGrant(),
+		Create:   true,
+		HCL: `
+		secret = "main.default.mysecret"
+
+		principal = "me"
+		privileges = ["READ_SECRET"]
+		`,
+	}.ApplyNoError(t)
+}
+
 func TestResourceGrantShareGrantCreateNoChange(t *testing.T) {
 	qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{

--- a/catalog/resource_grant_test.go
+++ b/catalog/resource_grant_test.go
@@ -545,7 +545,7 @@ func TestResourceGrantCreateNoSecurable(t *testing.T) {
 		principal = "me"
 		privileges = ["MODIFY", "SELECT"]
 		`,
-	}.ExpectError(t, "invalid config supplied. [catalog] Missing required argument. [credential] Missing required argument. [external_location] Missing required argument. [foreign_connection] Missing required argument. [function] Missing required argument. [mcp_service] Missing required argument. [metastore] Missing required argument. [model] Missing required argument. [model_provider_service] Missing required argument. [model_service] Missing required argument. [pipeline] Missing required argument. [recipient] Missing required argument. [schema] Missing required argument. [share] Missing required argument. [storage_credential] Missing required argument. [table] Missing required argument. [volume] Missing required argument")
+	}.ExpectError(t, "invalid config supplied. [catalog] Missing required argument. [credential] Missing required argument. [external_location] Missing required argument. [foreign_connection] Missing required argument. [function] Missing required argument. [mcp_service] Missing required argument. [metastore] Missing required argument. [model] Missing required argument. [model_provider_service] Missing required argument. [model_service] Missing required argument. [pipeline] Missing required argument. [recipient] Missing required argument. [schema] Missing required argument. [secret] Missing required argument. [share] Missing required argument. [storage_credential] Missing required argument. [table] Missing required argument. [volume] Missing required argument")
 }
 
 func TestResourceGrantCreateOneSecurableOnly(t *testing.T) {

--- a/catalog/resource_grants_test.go
+++ b/catalog/resource_grants_test.go
@@ -870,3 +870,62 @@ func TestModelGrantCreate(t *testing.T) {
 		}`,
 	}.ApplyNoError(t)
 }
+
+func TestSecretGrantCreate(t *testing.T) {
+	qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "GET",
+				Resource: "/api/2.1/unity-catalog/permissions/secret/main.default.mysecret?",
+				Response: catalog.GetPermissionsResponse{
+					PrivilegeAssignments: []catalog.PrivilegeAssignment{},
+				},
+			},
+			{
+				Method:   "PATCH",
+				Resource: "/api/2.1/unity-catalog/permissions/secret/main.default.mysecret",
+				ExpectedRequest: catalog.UpdatePermissions{
+					Changes: []catalog.PermissionsChange{
+						{
+							Principal: "me",
+							Add:       []catalog.Privilege{"READ_SECRET"},
+						},
+					},
+				},
+			},
+			{
+				Method:   "GET",
+				Resource: "/api/2.1/unity-catalog/permissions/secret/main.default.mysecret?",
+				Response: catalog.GetPermissionsResponse{
+					PrivilegeAssignments: []catalog.PrivilegeAssignment{
+						{
+							Principal:  "me",
+							Privileges: []catalog.Privilege{"READ_SECRET"},
+						},
+					},
+				},
+			},
+			{
+				Method:   "GET",
+				Resource: "/api/2.1/unity-catalog/permissions/secret/main.default.mysecret?",
+				Response: catalog.GetPermissionsResponse{
+					PrivilegeAssignments: []catalog.PrivilegeAssignment{
+						{
+							Principal:  "me",
+							Privileges: []catalog.Privilege{"READ_SECRET"},
+						},
+					},
+				},
+			},
+		},
+		Resource: ResourceGrants(),
+		Create:   true,
+		HCL: `
+		secret = "main.default.mysecret"
+
+		grant {
+			principal = "me"
+			privileges = ["READ_SECRET"]
+		}`,
+	}.ApplyNoError(t)
+}

--- a/docs/resources/grant.md
+++ b/docs/resources/grant.md
@@ -238,6 +238,19 @@ resource "databricks_grant" "udf_data_analysts" {
 }
 ```
 
+## Secret grants
+
+See [databricks_grants Secret grants](grants.md#secret-grants) for the list of privileges that apply to Secrets.
+
+```hcl
+resource "databricks_grant" "secret" {
+  secret = "main.default.my_secret"
+
+  principal  = "Data Engineers"
+  privileges = ["READ_SECRET"]
+}
+```
+
 ## Model service grants
 
 See [databricks_grants Model service grants](grants.md#model-service-grants) for the list of privileges that apply to model services.

--- a/docs/resources/grants.md
+++ b/docs/resources/grants.md
@@ -231,6 +231,20 @@ resource "databricks_grants" "udf" {
 }
 ```
 
+## Secret grants
+
+You can grant `ALL_PRIVILEGES`, `MANAGE`, and `READ_SECRET` privileges to a Unity Catalog secret ([databricks_secret_uc](secret_uc.md)) specified in the `secret` attribute.
+
+```hcl
+resource "databricks_grants" "secret" {
+  secret = "main.default.my_secret"
+  grant {
+    principal  = "Data Engineers"
+    privileges = ["READ_SECRET"]
+  }
+}
+```
+
 ## Model service grants
 
 You can grant `ALL_PRIVILEGES`, `APPLY_TAG`, `EXECUTE`, `MANAGE`, and `READ_METADATA` privileges to a Unity AI Gateway model service ([databricks_ai_gateway_model_service](ai_gateway_model_service.md)) specified in the `model_service` attribute.


### PR DESCRIPTION
## Changes
The change adds secret UC securable support to grant and grants Databricks TF resources.

## Tests
- [x] `make test` run locally
- [x] relevant change in `docs/` folder
- [x] covered with integration tests in `internal/acceptance`
- [x] using Go SDK
- [ ] using TF Plugin Framework
- [x] has entry in `NEXT_CHANGELOG.md` file
