### PR TITLE
Fix AI Gateway securable grants: strip resource-name prefix

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -11,6 +11,7 @@
 * Add support for the `secret` securable in `databricks_grant` and `databricks_grants`. ([#5996](https://github.com/databricks/terraform-provider-databricks/pull/5996))
 
 ### Bug Fixes
+* Fix `databricks_grant` and `databricks_grants` for the AI Gateway securables (`model_service`, `mcp_service`, `model_provider_service`). Wiring `databricks_ai_gateway_*.<x>.name` into the corresponding grant field previously failed on apply with `No API found for 'GET /unity-catalog/permissions/model_provider_service/model-provider-services/<full_name>'`, because that `name` attribute carries a resource-name prefix (e.g. `model-provider-services/`) that the permissions API does not expect. The prefix is now stripped before it reaches the API path and the resource ID, and a `DiffSuppressFunc` treats the prefixed and bare forms as equal, so both the `.name` reference and a bare full name apply cleanly with no perpetual diff.
 * `databricks_app` can now manage `git_source`, `source_code_path`, and `git_repository.caller_credential_id`. These are input_only (the Apps API accepts them on write but does not echo them on read), so the resource now calls the generated `SyncFields` reconciliation to preserve the configured value across reads, and treats the nested `git_source` descendants (`git_repository`, `resolved_commit`) as non-Computed. This prevents the "Provider produced inconsistent result after apply" error and the perpetual diff that previously occurred when any of these fields was set.
 
 ### Documentation

--- a/catalog/grants_test.go
+++ b/catalog/grants_test.go
@@ -266,3 +266,57 @@ func TestUcAccSecretGrants(t *testing.T) {
 		Template: secretGrantsTemplate,
 	})
 }
+
+// grantsAiGatewayModelProviderServiceTemplate references the securable by the resource's `name`
+// attribute, which is the prefixed resource name
+// (model-provider-services/{catalog}.{schema}.{name}). The grants/permissions API addresses these
+// securables by their bare full name, so the provider must strip the prefix; otherwise apply fails
+// with "No API found ... /model_provider_service/model-provider-services/...". A dummy Bedrock
+// credential is enough to create the service (the credential is not validated at create time).
+var grantsAiGatewayModelProviderServiceTemplate = `
+resource "databricks_catalog" "sandbox" {
+	name    = "sandbox{var.STICKY_RANDOM}"
+	comment = "this catalog is managed by terraform"
+}
+
+resource "databricks_schema" "things" {
+	catalog_name = databricks_catalog.sandbox.id
+	name         = "things{var.STICKY_RANDOM}"
+}
+
+resource "databricks_ai_gateway_model_provider_service" "this" {
+	parent                    = "schemas/${databricks_catalog.sandbox.name}.${databricks_schema.things.name}"
+	model_provider_service_id = "mps{var.STICKY_RANDOM}"
+	config = {
+		allow_all_targets = true
+		provider_type     = "EXTERNAL_MODEL_PROVIDER_TYPE_AMAZON_BEDROCK"
+		amazon_bedrock = {
+			direct = {
+				region = "us-east-1"
+				aws_access_key = {
+					access_key_id     = "dummy-access-key-id"
+					secret_access_key = { plaintext = "dummy-secret" }
+				}
+			}
+		}
+	}
+}
+
+resource "databricks_grants" "this" {
+	model_provider_service = databricks_ai_gateway_model_provider_service.this.name
+	grant {
+		principal  = "{env.TEST_DATA_ENG_GROUP}"
+		privileges = ["EXECUTE"]
+	}
+}
+`
+
+// TestUcAccGrantsAiGatewayModelProviderServiceByName is the regression for the grants path on AI
+// Gateway securables. A clean apply plus the framework's default empty follow-up plan proves both
+// that the prefixed `.name` reaches the permissions API as the bare full name and that referencing
+// it does not force a perpetual replace (the securable fields are ForceNew).
+func TestUcAccGrantsAiGatewayModelProviderServiceByName(t *testing.T) {
+	acceptance.UnityWorkspaceLevel(t, acceptance.Step{
+		Template: grantsAiGatewayModelProviderServiceTemplate,
+	})
+}

--- a/catalog/permissions/permissions.go
+++ b/catalog/permissions/permissions.go
@@ -106,13 +106,51 @@ func (sm SecurableMapping) GetSecurableType(securable string) catalog.SecurableT
 	return sm[securable]
 }
 
+// securableResourceNamePrefixes maps a grants field to the resource-name prefix
+// its databricks_ai_gateway_* resource carries on the `name` attribute (e.g.
+// "model-provider-services/{catalog}.{schema}.{name}"). The grants/permissions
+// API addresses these securables by their bare full name
+// ({catalog}.{schema}.{name}), but users naturally wire
+// databricks_ai_gateway_*.<x>.name into databricks_grant(s), so the prefix must
+// be stripped before it reaches the API path and the resource ID.
+var securableResourceNamePrefixes = map[string]string{
+	"mcp_service":            "mcp-services/",
+	"model_provider_service": "model-provider-services/",
+	"model_service":          "model-services/",
+}
+
+// normalizeSecurableName strips the AI Gateway resource-name prefix so a caller
+// can pass either the bare full name or the databricks_ai_gateway_*.name
+// attribute. A bare name, or any non-AI-Gateway securable, is returned unchanged.
+func normalizeSecurableName(field, name string) string {
+	if prefix, ok := securableResourceNamePrefixes[field]; ok {
+		return strings.TrimPrefix(name, prefix)
+	}
+	return name
+}
+
+// SuppressResourceNamePrefixDiff returns a DiffSuppressFunc that treats an AI
+// Gateway securable value as equal whether or not it carries the resource-name
+// prefix. Without it, referencing databricks_ai_gateway_*.<x>.name (prefixed) in
+// config perpetually diffs against the bare full name that Read stores back,
+// forcing replacement on every plan. Returns nil for securables without a
+// prefix, so callers can attach it unconditionally.
+func SuppressResourceNamePrefixDiff(field string) schema.SchemaDiffSuppressFunc {
+	if _, ok := securableResourceNamePrefixes[field]; !ok {
+		return nil
+	}
+	return func(_, old, new string, _ *schema.ResourceData) bool {
+		return normalizeSecurableName(field, old) == normalizeSecurableName(field, new)
+	}
+}
+
 func (sm SecurableMapping) KeyValue(d attributeGetter) (string, string) {
 	for field := range sm {
 		v := d.Get(field).(string)
 		if v == "" {
 			continue
 		}
-		return field, v
+		return field, normalizeSecurableName(field, v)
 	}
 	log.Printf("[WARN] Unexpected resource or permissions. Please proceed at your own risk.")
 	return "unknown", "unknown"

--- a/catalog/permissions/permissions_test.go
+++ b/catalog/permissions/permissions_test.go
@@ -1,0 +1,58 @@
+package permissions
+
+import (
+	"testing"
+
+	"github.com/databricks/databricks-sdk-go/service/catalog"
+	"github.com/stretchr/testify/assert"
+)
+
+// fakeAttributeGetter is a minimal attributeGetter backed by a map; absent keys
+// return "" so KeyValue skips them.
+type fakeAttributeGetter map[string]any
+
+func (f fakeAttributeGetter) Get(key string) any {
+	if v, ok := f[key]; ok {
+		return v
+	}
+	return ""
+}
+
+func TestNormalizeSecurableNameStripsAiGatewayPrefix(t *testing.T) {
+	for field, prefix := range securableResourceNamePrefixes {
+		// The databricks_ai_gateway_*.name attribute carries the prefix.
+		assert.Equal(t, "main.default.x", normalizeSecurableName(field, prefix+"main.default.x"))
+		// A bare full name is left unchanged.
+		assert.Equal(t, "main.default.x", normalizeSecurableName(field, "main.default.x"))
+	}
+	// Non-AI-Gateway securables are never touched, even if the value happens to
+	// look prefixed.
+	assert.Equal(t, "model-provider-services/x",
+		normalizeSecurableName("catalog", "model-provider-services/x"))
+	assert.Equal(t, "main.default.tbl", normalizeSecurableName("table", "main.default.tbl"))
+}
+
+func TestSuppressResourceNamePrefixDiff(t *testing.T) {
+	f := SuppressResourceNamePrefixDiff("model_provider_service")
+	assert.NotNil(t, f)
+	// config (prefixed, from .name) vs state (bare, from read) => suppressed.
+	assert.True(t, f("model_provider_service", "main.default.x",
+		"model-provider-services/main.default.x", nil))
+	// genuinely different securables are not suppressed.
+	assert.False(t, f("model_provider_service", "main.default.x",
+		"model-provider-services/main.default.y", nil))
+	// non-AI-Gateway securables get no suppressor.
+	assert.Nil(t, SuppressResourceNamePrefixDiff("catalog"))
+}
+
+func TestSecurableMappingKeyValueStripsPrefix(t *testing.T) {
+	sm := SecurableMapping{"model_provider_service": catalog.SecurableType("model_provider_service")}
+	d := fakeAttributeGetter{
+		"model_provider_service": "model-provider-services/main.default.openai_prod",
+	}
+	field, name := sm.KeyValue(d)
+	assert.Equal(t, "model_provider_service", field)
+	// The prefix is stripped so the permissions API receives the bare full name,
+	// and the resource ID does not gain an extra "/" segment.
+	assert.Equal(t, "main.default.openai_prod", name)
+}

--- a/catalog/resource_grant.go
+++ b/catalog/resource_grant.go
@@ -154,11 +154,12 @@ func ResourceGrant() common.Resource {
 			}
 			for field := range permissions.Mappings {
 				m[field] = &schema.Schema{
-					Type:          schema.TypeString,
-					Optional:      true,
-					ForceNew:      true,
-					AtLeastOneOf:  allFields,
-					ConflictsWith: permissions.SliceWithoutString(allFields, field),
+					Type:             schema.TypeString,
+					Optional:         true,
+					ForceNew:         true,
+					AtLeastOneOf:     allFields,
+					ConflictsWith:    permissions.SliceWithoutString(allFields, field),
+					DiffSuppressFunc: permissions.SuppressResourceNamePrefixDiff(field),
 				}
 			}
 			common.NamespaceCustomizeSchemaMap(m)

--- a/catalog/resource_grants.go
+++ b/catalog/resource_grants.go
@@ -153,9 +153,10 @@ func ResourceGrants() common.Resource {
 			alof := []string{}
 			for field := range permissions.Mappings {
 				s[field] = &schema.Schema{
-					Type:     schema.TypeString,
-					ForceNew: true,
-					Optional: true,
+					Type:             schema.TypeString,
+					ForceNew:         true,
+					Optional:         true,
+					DiffSuppressFunc: permissions.SuppressResourceNamePrefixDiff(field),
 				}
 				alof = append(alof, field)
 			}

--- a/docs/resources/grants.md
+++ b/docs/resources/grants.md
@@ -247,7 +247,7 @@ resource "databricks_grants" "secret" {
 
 ## Model service grants
 
-You can grant `ALL_PRIVILEGES`, `APPLY_TAG`, `EXECUTE`, `MANAGE`, and `READ_METADATA` privileges to a Unity AI Gateway model service ([databricks_ai_gateway_model_service](ai_gateway_model_service.md)) specified in the `model_service` attribute.
+You can grant `ALL_PRIVILEGES`, `APPLY_TAG`, `EXECUTE`, `MANAGE`, and `READ_METADATA` privileges to a Unity AI Gateway model service ([databricks_ai_gateway_model_service](ai_gateway_model_service.md)) specified in the `model_service` attribute. Pass either the bare full name (`catalog.schema.name`) or the resource's `name` attribute (`databricks_ai_gateway_model_service.this.name`); the provider strips the `model-services/` resource-name prefix that `name` carries.
 
 ```hcl
 resource "databricks_grants" "model_service" {
@@ -261,7 +261,7 @@ resource "databricks_grants" "model_service" {
 
 ## Model provider service grants
 
-You can grant `ALL_PRIVILEGES`, `APPLY_TAG`, `EXECUTE`, `MANAGE`, and `READ_METADATA` privileges to a Unity AI Gateway model provider service ([databricks_ai_gateway_model_provider_service](ai_gateway_model_provider_service.md)) specified in the `model_provider_service` attribute.
+You can grant `ALL_PRIVILEGES`, `APPLY_TAG`, `EXECUTE`, `MANAGE`, and `READ_METADATA` privileges to a Unity AI Gateway model provider service ([databricks_ai_gateway_model_provider_service](ai_gateway_model_provider_service.md)) specified in the `model_provider_service` attribute. Pass either the bare full name (`catalog.schema.name`) or the resource's `name` attribute (`databricks_ai_gateway_model_provider_service.this.name`); the provider strips the `model-provider-services/` resource-name prefix that `name` carries.
 
 ```hcl
 resource "databricks_grants" "model_provider_service" {
@@ -275,7 +275,7 @@ resource "databricks_grants" "model_provider_service" {
 
 ## MCP service grants
 
-You can grant `ALL_PRIVILEGES`, `APPLY_TAG`, `EXECUTE`, `MANAGE`, and `READ_METADATA` privileges to a Unity AI Gateway MCP service ([databricks_ai_gateway_mcp_service](ai_gateway_mcp_service.md)) specified in the `mcp_service` attribute.
+You can grant `ALL_PRIVILEGES`, `APPLY_TAG`, `EXECUTE`, `MANAGE`, and `READ_METADATA` privileges to a Unity AI Gateway MCP service ([databricks_ai_gateway_mcp_service](ai_gateway_mcp_service.md)) specified in the `mcp_service` attribute. Pass either the bare full name (`catalog.schema.name`) or the resource's `name` attribute (`databricks_ai_gateway_mcp_service.this.name`); the provider strips the `mcp-services/` resource-name prefix that `name` carries.
 
 ```hcl
 resource "databricks_grants" "mcp_service" {


### PR DESCRIPTION
databricks_grant / databricks_grants for the AI Gateway securables (model_service, mcp_service, model_provider_service) failed on apply when the securable was wired from the resource's `name` attribute, e.g. databricks_ai_gateway_model_provider_service.x.name. That attribute is the prefixed resource name (model-provider-services/{catalog}.{schema}.{name}), but the grants/permissions API addresses these securables by their bare full name, so apply errored with:

  No API found for
  'GET /unity-catalog/permissions/model_provider_service/model-provider-services/<full_name>'

Strip the known resource-name prefix in SecurableMapping.KeyValue, which is the single point feeding both the permissions API calls and the Terraform resource ID. This also keeps the ID free of the extra "/" segment the prefix would introduce, which otherwise breaks databricks_grant's three-part ID parsing. A bare full name (the documented form) and non-AI-Gateway securables are unaffected.

## Changes
<!-- Summary of your changes that are easy to understand -->

## Tests
<!--
How is this tested? Please see the checklist below and also describe any other relevant tests
-->

- [ ] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] using Go SDK
- [ ] using TF Plugin Framework
- [ ] has entry in `NEXT_CHANGELOG.md` file
