### PR TITLE
[Internal] Add TestAccEntitlementsSomeTrueSomeFalse/group to ignored_tests

### DIFF
--- a/test-config.yaml
+++ b/test-config.yaml
@@ -22,6 +22,9 @@ ignored_tests:
       test_name: TestAccEntitlementsSomeTrueSomeFalse/service_principal
       comment: Failures due to read-after-write inconsistency in the SCIM API; tracked internally.
     - package: github.com/databricks/terraform-provider-databricks/scim
+      test_name: TestAccEntitlementsSomeTrueSomeFalse/group
+      comment: Failures due to read-after-write inconsistency in the SCIM API; tracked internally.
+    - package: github.com/databricks/terraform-provider-databricks/scim
       test_name: TestAccEntitlementsRemoveExisting
       comment: Failures due to read-after-write inconsistency in the SCIM API; tracked internally.
     - package: github.com/databricks/terraform-provider-databricks/scim


### PR DESCRIPTION
`TestAccEntitlementsSomeTrueSomeFalse/group` fails intermittently in nightly CI due to read-after-write eventual consistency in the SCIM entitlements API: immediately after `databricks_entitlements` writes an entitlement, a read can briefly not reflect it, producing a spurious post-apply diff (`databricks_sql_access` / `workspace_access` flapping `false -> true`). The write always lands and the read converges within about a second.

The parent test and its `/user` and `/service_principal` subtests are already in `ignored_tests` for the same reason; `/group` was omitted, and because ignores are matched per (sub)test name it still fails the job. This adds the missing entry with the same comment.

Test-infra only — no provider behavior change.

This pull request and its description were written by Isaac.

NO_CHANGELOG=true