### PR TITLE
[Internal] Ignore updated_at/updated_by in catalog force-destroy import-verify test

### DIFF
--- a/catalog/catalog_test.go
+++ b/catalog/catalog_test.go
@@ -27,9 +27,10 @@ func TestUcAccCatalogForceDestroyConsistentAfterImport(t *testing.T) {
 			Template: template,
 		},
 		acceptance.Step{
-			ImportState:       true,
-			ResourceName:      "databricks_catalog.test",
-			ImportStateVerify: true,
+			ImportState:             true,
+			ResourceName:            "databricks_catalog.test",
+			ImportStateVerify:       true,
+			ImportStateVerifyIgnore: []string{"updated_at", "updated_by"},
 		},
 	)
 }

--- a/internal/acceptance/init.go
+++ b/internal/acceptance/init.go
@@ -109,6 +109,7 @@ type Step struct {
 	ImportStateId                        string
 	ImportStateIdFunc                    func(*terraform.State) (string, error)
 	ImportStateVerify                    bool
+	ImportStateVerifyIgnore              []string
 	ImportStateVerifyIdentifierAttribute string
 	ResourceName                         string
 
@@ -281,6 +282,7 @@ func run(t *testing.T, steps []Step) {
 			ImportStateId:                        s.ImportStateId,
 			ImportStateIdFunc:                    s.ImportStateIdFunc,
 			ImportStateVerify:                    s.ImportStateVerify,
+			ImportStateVerifyIgnore:              s.ImportStateVerifyIgnore,
 			ImportStateVerifyIdentifierAttribute: s.ImportStateVerifyIdentifierAttribute,
 			ResourceName:                         s.ResourceName,
 			ExpectError:                          s.ExpectError,


### PR DESCRIPTION
`TestUcAccCatalogForceDestroyConsistentAfterImport` fails intermittently in nightly CI. Its second step uses `ImportStateVerify`, which compares every attribute between the pre-import state and the imported state. `updated_at` / `updated_by` drift between those two points because the platform touches a freshly-created catalog a few seconds after creation (predictive-optimization auto-enablement, which is expected behavior). Those two fields aren't what the test asserts — it verifies that `force_destroy` and predictive-optimization settings survive import — so this ignores them during import verification.

To do that, this adds an `ImportStateVerifyIgnore` passthrough to the `acceptance.Step` test helper (wired to the underlying `resource.TestStep`) and uses it in the test.

Test-infra only — no provider behavior change. Not customer-facing: `updated_at` and `updated_by` are read-only, server-computed fields that users never set, so ignoring them only relaxes the test's exact-match import assertion and changes nothing observable in a user's `plan`/`apply`/`import`.

This pull request and its description were written by Isaac.
NO_CHANGELOG=true