### PR TITLE
Document AWS Context ID rules for cluster policies

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -15,7 +15,7 @@
 
 ### Documentation
 
-* Document AWS Context ID rules in `databricks_cluster_policy` definitions and policy-family overrides.
+* Document AWS Context ID rules in `databricks_cluster_policy` definitions and policy-family overrides ([#6005](https://github.com/databricks/terraform-provider-databricks/pull/6005)).
 
 * Document the `auto_deploy` and `caller_credential_id` fields of the `databricks_app` `git_repository` block, the `git_source` block, and the top-level `source_code_path` argument. Clarify that `auto_deploy` requires `git_source` to specify a `branch`. These fields become manageable with [#5977](https://github.com/databricks/terraform-provider-databricks/pull/5977).
 

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -15,6 +15,8 @@
 
 ### Documentation
 
+* Document AWS Context ID rules in `databricks_cluster_policy` definitions and policy-family overrides.
+
 * Document the `auto_deploy` and `caller_credential_id` fields of the `databricks_app` `git_repository` block, the `git_source` block, and the top-level `source_code_path` argument. Clarify that `auto_deploy` requires `git_source` to specify a `branch`. These fields become manageable with [#5977](https://github.com/databricks/terraform-provider-databricks/pull/5977).
 
 ### Exporter

--- a/docs/resources/cluster_policy.md
+++ b/docs/resources/cluster_policy.md
@@ -141,6 +141,35 @@ resource "databricks_cluster_policy" "personal_vm" {
 }
 ```
 
+### AWS Context ID
+
+Use fixed rules in `definition` to configure the AWS EC2 Fleet context value for worker and driver nodes:
+
+```hcl
+variable "aws_context_id" {
+  type = string
+}
+
+resource "databricks_cluster_policy" "aws_context" {
+  name = "AWS Context ID"
+
+  definition = jsonencode({
+    "worker_node_type_flexibility.aws_context_id" = {
+      type  = "fixed"
+      value = var.aws_context_id
+    }
+    "driver_node_type_flexibility.aws_context_id" = {
+      type  = "fixed"
+      value = var.aws_context_id
+    }
+  })
+}
+```
+
+The worker and driver rules can be configured independently, with different context values if needed. When using `policy_family_id`, supply the same rules through `policy_family_definition_overrides` instead of `definition`.
+
+These are nested [Clusters API](https://docs.databricks.com/api/workspace/clusters/create) attributes expressed as dotted paths in the [policy definition language](https://docs.databricks.com/aws/en/admin/clusters/policy-definition). The provider passes these rules through as JSON; Databricks validates whether they are supported in the target AWS workspace. A non-empty context value is passed to the AWS CreateFleet API. Setting it alone does not configure alternate node types or establish eligibility for pricing benefits.
+
 ## Argument Reference
 
 The following arguments are supported:

--- a/policies/resource_cluster_policy_aws_context_test.go
+++ b/policies/resource_cluster_policy_aws_context_test.go
@@ -1,0 +1,149 @@
+package policies
+
+import (
+	"testing"
+
+	"github.com/databricks/databricks-sdk-go/experimental/mocks"
+	"github.com/databricks/databricks-sdk-go/service/compute"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/databricks/terraform-provider-databricks/qa"
+)
+
+const awsContextPolicyDefinition = `{"worker_node_type_flexibility.aws_context_id":{"type":"fixed","value":"context-worker"},"driver_node_type_flexibility.aws_context_id":{"type":"fixed","value":"context-driver"}}`
+
+func TestResourceClusterPolicyAWSContextCreate(t *testing.T) {
+	for _, mode := range []string{"definition", "family", "builtin"} {
+		t.Run(mode, func(t *testing.T) {
+			policy := compute.Policy{PolicyId: "abc", Name: "AWS Context ID", Definition: awsContextPolicyDefinition}
+			state := map[string]any{"name": policy.Name, "definition": awsContextPolicyDefinition}
+			request := compute.CreatePolicy{Name: policy.Name, Definition: awsContextPolicyDefinition}
+			if mode != "definition" {
+				delete(state, "definition")
+				state["policy_family_id"] = "personal-vm"
+				state["policy_family_definition_overrides"] = awsContextPolicyDefinition
+				policy.PolicyFamilyId = "personal-vm"
+				policy.PolicyFamilyDefinitionOverrides = awsContextPolicyDefinition
+				request.Definition = ""
+				request.PolicyFamilyId = "personal-vm"
+				request.PolicyFamilyDefinitionOverrides = awsContextPolicyDefinition
+			}
+			qa.ResourceFixture{
+				MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
+					policies := w.GetMockClusterPoliciesAPI().EXPECT()
+					if mode != "definition" {
+						familyName := "Personal Compute"
+						if mode == "builtin" {
+							familyName = policy.Name
+						}
+						w.GetMockPolicyFamiliesAPI().EXPECT().ListAll(mock.Anything, compute.ListPolicyFamiliesRequest{}).
+							Return([]compute.PolicyFamily{{PolicyFamilyId: "personal-vm", Name: familyName}}, nil).Once()
+					}
+					if mode == "builtin" {
+						policies.GetByName(mock.Anything, policy.Name).
+							Return(&compute.Policy{PolicyId: policy.PolicyId, Name: policy.Name}, nil).Once()
+						policies.Edit(mock.Anything, compute.EditPolicy{
+							PolicyId:                        policy.PolicyId,
+							Name:                            policy.Name,
+							PolicyFamilyId:                  policy.PolicyFamilyId,
+							PolicyFamilyDefinitionOverrides: awsContextPolicyDefinition,
+						}).Return(nil).Once()
+					} else {
+						policies.Create(mock.Anything, request).
+							Return(&compute.CreatePolicyResponse{PolicyId: policy.PolicyId}, nil).Once()
+					}
+					policies.GetByPolicyId(mock.Anything, policy.PolicyId).Return(&policy, nil).Once()
+				},
+				Resource: ResourceClusterPolicy(),
+				State:    state,
+				Create:   true,
+			}.ApplyAndExpectData(t, map[string]any{
+				"id":                                 policy.PolicyId,
+				"policy_id":                          policy.PolicyId,
+				"definition":                         awsContextPolicyDefinition,
+				"policy_family_id":                   policy.PolicyFamilyId,
+				"policy_family_definition_overrides": policy.PolicyFamilyDefinitionOverrides,
+			})
+		})
+	}
+}
+
+func TestResourceClusterPolicyAWSContextUpdate(t *testing.T) {
+	for _, field := range []string{"definition", "policy_family_definition_overrides"} {
+		for _, tc := range []struct {
+			name       string
+			definition string
+		}{
+			{"change", `{"worker_node_type_flexibility.aws_context_id":{"type":"fixed","value":"context-updated"},"driver_node_type_flexibility.aws_context_id":{"type":"fixed","value":"context-driver"}}`},
+			{"remove_worker", `{"driver_node_type_flexibility.aws_context_id":{"type":"fixed","value":"context-driver"}}`},
+			{"remove_driver", `{"worker_node_type_flexibility.aws_context_id":{"type":"fixed","value":"context-worker"}}`},
+		} {
+			t.Run(field+"/"+tc.name, func(t *testing.T) {
+				state := map[string]any{"name": "AWS Context ID", field: tc.definition}
+				oldState := map[string]string{"id": "abc", "name": "AWS Context ID", field: awsContextPolicyDefinition}
+				request := compute.EditPolicy{PolicyId: "abc", Name: "AWS Context ID", Definition: tc.definition}
+				policy := compute.Policy{PolicyId: "abc", Name: request.Name, Definition: tc.definition}
+				if field == "policy_family_definition_overrides" {
+					state["policy_family_id"] = "personal-vm"
+					oldState["policy_family_id"] = "personal-vm"
+					oldState["definition"] = awsContextPolicyDefinition
+					request.Definition = ""
+					request.PolicyFamilyId = "personal-vm"
+					request.PolicyFamilyDefinitionOverrides = tc.definition
+					policy.PolicyFamilyId = "personal-vm"
+					policy.PolicyFamilyDefinitionOverrides = tc.definition
+				}
+				qa.ResourceFixture{
+					MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
+						policies := w.GetMockClusterPoliciesAPI().EXPECT()
+						policies.Edit(mock.Anything, request).Return(nil).Once()
+						policies.GetByPolicyId(mock.Anything, policy.PolicyId).Return(&policy, nil).Once()
+					},
+					Resource:      ResourceClusterPolicy(),
+					State:         state,
+					InstanceState: oldState,
+					Update:        true,
+					ID:            policy.PolicyId,
+				}.ApplyAndExpectData(t, map[string]any{
+					"id":                                 policy.PolicyId,
+					"definition":                         tc.definition,
+					"policy_family_id":                   policy.PolicyFamilyId,
+					"policy_family_definition_overrides": policy.PolicyFamilyDefinitionOverrides,
+				})
+			})
+		}
+	}
+}
+
+func TestResourceClusterPolicyAWSContextRead(t *testing.T) {
+	for _, familyID := range []string{"", "personal-vm"} {
+		t.Run("family="+familyID, func(t *testing.T) {
+			policy := compute.Policy{
+				PolicyId:       "abc",
+				Name:           "AWS Context ID",
+				Definition:     awsContextPolicyDefinition,
+				PolicyFamilyId: familyID,
+			}
+			if familyID != "" {
+				policy.PolicyFamilyDefinitionOverrides = awsContextPolicyDefinition
+			}
+			qa.ResourceFixture{
+				MockWorkspaceClientFunc: func(w *mocks.MockWorkspaceClient) {
+					w.GetMockClusterPoliciesAPI().EXPECT().GetByPolicyId(mock.Anything, policy.PolicyId).
+						Return(&policy, nil).Once()
+				},
+				Resource: ResourceClusterPolicy(),
+				Read:     true,
+				New:      true,
+				ID:       policy.PolicyId,
+			}.ApplyAndExpectData(t, map[string]any{
+				"id":                                 policy.PolicyId,
+				"policy_id":                          policy.PolicyId,
+				"name":                               policy.Name,
+				"definition":                         awsContextPolicyDefinition,
+				"policy_family_id":                   policy.PolicyFamilyId,
+				"policy_family_definition_overrides": policy.PolicyFamilyDefinitionOverrides,
+			})
+		})
+	}
+}


### PR DESCRIPTION
## Changes

Document how to configure driver and worker AWS EC2 Fleet Context IDs in `databricks_cluster_policy.definition` and `policy_family_definition_overrides`. The existing JSON arguments already pass these rules through, so no production-code, schema, or SDK dependency changes are needed.

Add SDK-mock regression tests for create, update, removal of individual context rules, import/read, policy-family overrides, and the built-in override path. The tests check request contents and Terraform state, including distinct driver and worker context values.

## Tests

Passed locally:

- `go test ./policies` (with build parallelism limited)
- `make fmt lint ws`
- `make fmt-docs` and a focused `terrafmt diff --check docs/resources/cluster_policy.md`; unrelated formatter changes were discarded
- `git diff --check`

Live Databricks acceptance remains unverified because no AWS integration-test environment is configured. Mock tests verify provider passthrough, not backend acceptance of these policy paths. Terraform Registry preview was unavailable because no browser was connected.

- [ ] `make test` run locally
- [x] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [x] using Go SDK
- [ ] using TF Plugin Framework
- [x] has entry in `NEXT_CHANGELOG.md` file
